### PR TITLE
Plan 5: Curator C — weekly defragmentation (ships dark)

### DIFF
--- a/docs/superpowers/plans/2026-04-21-curator-c-plan5.md
+++ b/docs/superpowers/plans/2026-04-21-curator-c-plan5.md
@@ -1,0 +1,337 @@
+# Curator C — Weekly Defragmentation (Plan 5)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Each task below is independently committable; `pytest -q` passes after every commit.
+
+**Goal:** Ship Curator C (weekly whole-wiki defragmentation) behind `curator.curator_c.enabled: false`. Fills the third slot of the A/B/C triad. LLM-driven adjacent-concept merge, auto-supersession (proposal-only v1), orphan-wikilink repair, draft-promotion proposals; SessionStart-triggered on ISO-week rollover with per-user 48h jitter; full pre/post diff audit log.
+
+**Architecture:** Extends the existing `lore_curator/curator_c.py` (hygiene passes from Plan A). Adds new LLM-driven passes through a shared candidate-generation + schema-validation harness; wires a weekly SessionStart trigger (reuses Plan A's heartbeat model: time-check + global lock + detached spawn); writes a full-wiki diff log every run for rollback auditability. Ships dark (config-flag-off) per spec §6 — experimental until prompts calibrate on real data.
+
+**Tech Stack:** existing Python + `llm_client` seam from Plan 2.5. No new runtime deps.
+
+**Spec reference:**
+- `docs/superpowers/specs/2026-04-19-passive-capture-v1-design.md` §6 (Curator C)
+- Memory: `project_curator_triad`, `project_lore_heartbeat`
+
+**Context (what's already built):** Plan A gave C the foundation — `CuratorCConfig` dataclass, `WikiLedger.last_curator_c`, `try_acquire_spawn_lock("c")`, `CaptureState` overdue checks, existing hygiene passes in `curator_c.py`.
+
+**What's missing:** LLM adjacent-merge, auto-supersession detection, orphan repair, draft promotion, weekly trigger, feature-flag wiring, diff-log, `--defrag` CLI, team coordination, high-off degradation.
+
+**Design rules** (added per review):
+- **Proposal-only v1.** All LLM-driven passes write *proposal markers* (draft notes, `supersede_candidate:`, `merge_candidate:`, `promotion_candidate:`), never flip end-state frontmatter. Applies to Tasks 7-10. User promotes manually. Exception: orphan-link typo rewrites (Task 9) are typo-class repairs and DO mutate in place — but gated behind a sub-flag `curator.curator_c.defrag_body_writes` (default false).
+- **All LLM passes fail-safe.** Malformed response (missing field, wrong type, schema violation) → skip pair, log warning, never mutate vault. Shared parametrized malformed-response fixture in tests.
+- **UTC-pinned.** ISO-week math, jitter offsets, `last_curator_c` timestamps — all UTC. No local timezone anywhere.
+- **Obsidian-holding check.** Every LLM pass inherits the existing `is_obsidian_holding` guard used by hygiene passes (already in `curator_c.py`).
+- **Mid-conflict vault check.** Pre-flight `git status --porcelain` — if the wiki repo has unmerged paths, abort with a clear message and write a noop diff-log entry.
+- **"Ships dark" gate** is proven by one end-to-end test: fresh vault with no `.lore-wiki.yml` → zero new files, zero LLM calls, zero frontmatter changes after running every C entry point.
+
+**Non-blockers** (carry forward, don't block ship):
+1. `mode: central` — not implemented; config-load accepts the value but fail-loudly on spawn attempt ("central mode deferred to v2"). No branching on it in v1.
+2. Prompt calibration through dogfood; v1 ships with baseline thresholds.
+3. Body-merge edits (actually rewriting note bodies during adjacent-concept merges) deferred — v1 proposes only.
+4. Cross-clone git-push-lag race in team mode — user B runs even after user A pushed because B's clone hasn't pulled yet. Documented cost (~one redundant run per team per week); `mode: central` fixes it in v2.
+
+**Phases:**
+- **Phase A — Infrastructure + shared harness** (Tasks 1–5)
+- **Phase B — LLM passes** (Tasks 6–9) — each lands inside the already-wired integration
+- **Phase C — Polish + coordination** (Tasks 10–12)
+
+TDD per CLAUDE.md. Ships dark: existing installs see zero behavior change.
+
+---
+
+## Phase A — Infrastructure + Shared Harness
+
+### Task 1: Weekly SessionStart trigger with ISO-week + per-user jitter
+
+**Files:** Edit `lib/lore_cli/hooks.py` + test `tests/test_curator_c_trigger.py`
+
+**Logic:**
+- UTC-only. `iso_week_now = datetime.now(UTC).isocalendar().week`; compare to `iso_week(last_curator_c)`.
+- Jitter: `offset_seconds = int(hashlib.sha256(email.encode()).hexdigest()[:8], 16) % 172800` (0-48h). Trigger fires only if `now_utc >= monday_00_utc + offset_seconds`.
+- **Email fallback:** if `git config user.email` is unset/empty, use `socket.gethostname()` as the hash input; if that fails too, offset=0 (Monday 00:00Z fire).
+- Feature gate: `curator.curator_c.enabled==True` required; `mode!="local"` → fail-loudly log and skip (no branching).
+- Reuses Plan A's `try_acquire_spawn_lock(lore_root, "c")`.
+
+**Acceptance:**
+- `test_trigger_fires_on_new_iso_week` — last_curator_c from prior week → spawn.
+- `test_trigger_skips_same_iso_week` — current-week ledger → no spawn.
+- `test_trigger_respects_jitter_window` — fixture email `"fixture@test"` with computed offset hardcoded in the docstring (document WHY 04:00Z fires); at 02:00Z no spawn, at 05:00Z yes.
+- `test_trigger_jitter_fallback_when_git_email_unset` — unset email uses hostname; still deterministic.
+- `test_trigger_fires_exactly_once_across_monday_boundary` — Sunday 23:59Z no, Monday 00:01Z+offset yes. UTC-pinned.
+- `test_trigger_disabled_by_default` — fresh config → no spawn.
+- `test_trigger_central_mode_fails_loudly` — `mode=central` → no spawn, emits warning log, does NOT silently skip.
+- `test_trigger_concurrent_sessions_coordinate` — multiprocess Barrier(4); exactly one spawns (flock regression guard).
+
+**Commit:** `feat(curator): weekly SessionStart trigger for Curator C (UTC + user jitter)`
+
+---
+
+### Task 2: "Ships-dark" end-to-end gate test
+
+**Files:** `tests/test_c_ships_dark_gate.py` (new; no code changes)
+
+**Rationale:** Merge gate. Proves fresh vault with no explicit `.lore-wiki.yml` gets zero new behavior post-Plan-5.
+
+**The test:** seed a minimal vault (no `.lore-wiki.yml`), simulate a week of activity — run SessionStart hooks, bare `lore curator run`, `lore curator run --defrag` without `--force`, `lore status`, `lore doctor`. Snapshot `.lore/`, `wiki/`, every note's frontmatter + body, every cache file. Assert **exact byte-for-byte equality** after vs. before for the whole vault tree except explicitly-allowed paths (`hook-events.jsonl`, `.lore/runs/`).
+
+**Acceptance:**
+- `test_fresh_vault_no_llm_calls` — mock `make_llm_client` to raise if called; run the full C surface; assert zero calls.
+- `test_fresh_vault_no_spawns` — mock `_spawn_detached_curator_c`; assert zero calls across a SessionStart loop.
+- `test_fresh_vault_no_frontmatter_mutations` — note frontmatter byte-equal after.
+- `test_fresh_vault_no_diff_log` — no `.lore/curator-c.diff.*.log` file created.
+- `test_fresh_vault_no_new_config_files` — no `.lore-wiki.yml` appears from default-write.
+
+**Commit:** `test(curator): ships-dark gate — fresh vault sees zero C behavior`
+
+---
+
+### Task 3: Pre/post-diff audit log
+
+**Files:** Create `lib/lore_curator/curator_c_diff.py` + test `tests/test_curator_c_diff.py`
+
+**Output path:** `<lore_root>/.lore/curator-c.diff.YYYY-MM-DD.log`. Each entry carries `run_id` (ties to `runs/<id>.jsonl`). 90-day retention — runs pass prunes logs older than 90d. Size cap: 10 MB per log (rotates to `.log.1`).
+
+**Zero-change runs:** write a single-line marker `<timestamp> run=<id> status=no-op\n`, not a full empty entry. Audit log stays grep-clean.
+
+**Permission-denied:** wraps writes in `try/OSError` — on failure, emit a `warning` event to `hook-events.jsonl` (observable via CaptureState), do NOT crash the run.
+
+**Acceptance:**
+- `test_diff_log_captures_frontmatter_changes`
+- `test_diff_log_dry_run_writes_entry` — dry-run header prefixed.
+- `test_diff_log_daily_append` — two runs same day → two entries, both with distinct `run_id`.
+- `test_diff_log_no_op_writes_single_line_marker`
+- `test_diff_log_90d_retention` — pre-seed 100d-old log → deleted on next run.
+- `test_diff_log_10mb_rotation` — synthetic 11 MB log → rotates to `.1`.
+- `test_diff_log_permission_denied_emits_warning_event` — chmod'd dir → warning in hook-events, no crash.
+
+**Commit:** `feat(curator): pre/post-diff audit log with run_id + retention + rotation`
+
+---
+
+### Task 4: `lore curator run --defrag [--dry-run]` CLI
+
+**Files:** Edit `lib/lore_curator/curator_c.py::run_command` + test `tests/test_curator_c_cli.py`
+
+- `--defrag` flag passes through to `run_curator_c(defrag=True)`.
+- `--dry-run` honored across both legacy hygiene and new LLM passes.
+- Prints a summary table matching the diff-log summary.
+
+**Acceptance:**
+- `test_defrag_flag_invokes_llm_passes` (once Task 5+ lands; noop-pass placeholder now)
+- `test_defrag_dry_run_writes_no_notes`
+- `test_defrag_without_flag_keeps_legacy_behaviour`
+- `test_defrag_without_llm_client_skips_with_clear_log_and_returns_skipped_status` — run without LLM → `CuratorReport.status == "skipped_no_llm"`, summary table shows "skipped (no LLM)".
+
+**Commit:** `feat(cli): lore curator run --defrag [--dry-run]`
+
+---
+
+### Task 5: Integration skeleton + shared pass harness
+
+**Files:** Edit `lib/lore_curator/curator_c.py::run_curator_c` + create `lib/lore_curator/c_passes.py` (shared candidate-gen + schema-validation helpers) + tests
+
+**Architect concern addressed:** Integration exists BEFORE LLM passes land. Each pass in Phase B slots into a working pipeline.
+
+**What lands in this task:**
+1. `run_curator_c(*, defrag: bool = False, anthropic_client: LlmClient | None = None, dry_run: bool = False)` signature extended with the defrag/client seam.
+2. Pass-list registry: an empty list in this task. Phase B appends each pass as a callable.
+3. Diff-log wrapping of the whole run (snapshot → run passes → snapshot → write log).
+4. `WikiLedger.update_last_curator("c")` atomic-on-success update.
+5. Mid-merge guard: `git status --porcelain` check pre-run; on conflict → noop diff-log + abort.
+6. Obsidian-holding guard: reuse existing `is_obsidian_holding` — any pass that would mutate skips with a first-run warning.
+7. Shared harness in `c_passes.py`:
+   - `validate_llm_response(response, schema: dict) -> dict | None` — returns None on any violation (missing field, wrong type, out-of-range confidence), emits a warning event.
+   - `ProposalOnlyError` — raised by a runtime guard around mutation attempts on existing notes during proposal-only passes (keeps convention enforceable).
+
+**Acceptance:**
+- `test_integration_skeleton_runs_with_zero_passes` — fresh vault, `defrag=True`, no passes registered → runs cleanly, writes noop diff log, updates `last_curator_c`.
+- `test_integration_defrag_false_skips_llm_harness` — no LLM instantiation.
+- `test_integration_git_conflict_aborts` — vault mid-rebase → noop diff log, no frontmatter changes.
+- `test_integration_obsidian_holding_skips_mutation_passes` — mock `is_obsidian_holding=True` → passes that would mutate log skip-reason.
+- `test_integration_last_curator_c_atomic_on_failure` — mid-run exception → `last_curator_c` unchanged (Plan A atomic-or-unchanged).
+- `test_validate_llm_response_table` — parametrized: valid / missing field / wrong type / confidence > 1 / confidence < 0 / null / empty → validator returns dict or None with warning.
+- `test_proposal_only_guard_blocks_frontmatter_write_to_existing_note` — any pass that tries to mutate a pre-existing note during a proposal-only phase raises.
+
+**Commit:** `feat(curator): Curator C integration skeleton + shared LLM pass harness`
+
+---
+
+## Phase B — LLM Passes (each lands inside the working skeleton)
+
+### Task 6: Adjacent-concept merge (proposal)
+
+**Files:** `lib/lore_curator/c_adjacent_merge.py` + test
+
+**Design:**
+- Candidate-pair generation is testable: `generate_merge_candidates(notes) -> Iterable[NotePair]` — pre-filter by fuzzy title/tag ratio (rapidfuzz >= 0.6) + scope overlap. Tests exercise the generator separately.
+- LLM tool-call returns `{should_merge: bool, merged_note: {...}, confidence: float}`.
+- Threshold `confidence >= 0.8`. Document `>=` inclusive.
+- Writes new draft note with `draft: true`, `merge_candidate_sources: [[a]], [[b]]`. Does NOT edit originals (guarded by `ProposalOnlyError` from Task 5).
+
+**Acceptance:**
+- `test_adjacent_merge_candidate_generator_filters_low_overlap` — generator covered, not just fixture pairs.
+- `test_adjacent_merge_proposes_new_note_on_0.9_confidence`
+- `test_adjacent_merge_proposes_at_exact_0.8` — boundary inclusive.
+- `test_adjacent_merge_skips_at_0.79_confidence`
+- `test_adjacent_merge_skips_malformed_llm_response` — uses shared malformed-response fixture from Task 5.
+- `test_adjacent_merge_idempotent_same_day` — second invocation same day does NOT create duplicate draft (sources-based dedupe).
+- `test_adjacent_merge_filename_collision_resolved` — proposed slug already exists → suffix with run_id short.
+- `test_adjacent_merge_never_edits_originals` (ProposalOnlyError guard).
+- `test_adjacent_merge_disk_full_aborts_atomic` — monkeypatched `write_text` raises OSError → run aborts cleanly, no partial writes.
+- `test_adjacent_merge_skipped_without_llm`.
+
+**Commit:** `feat(curator): adjacent-concept merge — proposal-only`
+
+---
+
+### Task 7: Auto-supersession (proposal-only via marker)
+
+**Files:** `lib/lore_curator/c_auto_supersede.py` + test
+
+**Design change from v1 draft** (architect must-fix): flipped to proposal-only. Writes `supersede_candidate: [[newer]]` to the older note's frontmatter AND `supersede_candidate_of: [[older]]` to the newer. User promotes manually (flip `supersede_candidate` → `superseded_by`).
+
+- Candidate pairs: same `type: decision`, overlapping scope, newer `created:` date.
+- LLM tool-call: `{contradicts: bool, confidence: float, reason: str}`.
+- Conservative: `contradicts AND confidence >= 0.85 AND not canonical`. Note-level `canonical: true` only in v1 (wiki-level canonical scopes documented as deferred).
+- Circular-supersession guard: if a candidate chain would create a cycle, skip with warning.
+
+**Acceptance:**
+- `test_supersede_proposes_on_0.9_confidence` — both notes get `supersede_candidate_*` markers, no `superseded_by` flip.
+- `test_supersede_proposes_at_exact_0.85` (boundary inclusive).
+- `test_supersede_skips_at_0.84`.
+- `test_supersede_skips_canonical_true`.
+- `test_supersede_ignores_wiki_level_canonical_in_v1` — documented deferral.
+- `test_supersede_circular_chain_guard` — explicit `supersedes:` chain already A→B → skip proposed B→A.
+- `test_supersede_skips_malformed_llm_response` (shared fixture).
+- `test_supersede_idempotent_same_day` — re-run sees markers, skips.
+- `test_supersede_only_proposes_never_flips_superseded_by`.
+- `test_supersede_skipped_without_llm`.
+
+**Commit:** `feat(curator): auto-supersession proposal (supersede_candidate marker, no frontmatter flip)`
+
+---
+
+### Task 8: Orphan wikilink repair (in-place, behind sub-flag)
+
+**Files:** `lib/lore_curator/c_orphan_links.py` + test
+
+**Design (code-reviewer must-fix):** Body mutation has higher blast radius than frontmatter. Gated behind sub-flag `curator.curator_c.defrag_body_writes: false` (default false). With sub-flag off → proposes rewrites in a separate `<lore_root>/.lore/curator-c.body-proposals.YYYY-MM-DD.log`. With sub-flag on → mutates in place.
+
+- Orphan detection: `[[slug]]` → no matching note file.
+- Fuzzy-match top candidate by slug ratio (>= 0.7).
+- LLM tool-call: `{is_rename: bool, canonical_slug: str, confidence: float}`. Confidence >= 0.8 required.
+- Preserves display text `[[slug|Display]]`.
+- Preserves surrounding whitespace and line endings byte-for-byte.
+
+**Acceptance:**
+- `test_orphan_with_sub_flag_off_writes_proposal_log_only` — body bytes unchanged.
+- `test_orphan_with_sub_flag_on_rewrites_link_in_place`.
+- `test_orphan_preserves_display_text`.
+- `test_orphan_preserves_crlf_and_trailing_newline` — fixture with CRLF line endings → preserved exactly.
+- `test_orphan_ambiguous_candidates_no_rewrite` — two 0.85-ratio candidates → skip + log.
+- `test_orphan_deleted_target_no_fuzzy_match_is_flagged`.
+- `test_orphan_round_trip_frontmatter_structural_equivalence` — after rewrite, YAML re-parses to structurally equal dict (catches quoting regressions).
+- `test_orphan_skips_malformed_llm_response` (shared fixture).
+- `test_orphan_skipped_without_llm`.
+
+**Commit:** `feat(curator): orphan wikilink repair — sub-flag gated body rewrites`
+
+---
+
+### Task 9: Draft promotion proposals (time-based, no LLM)
+
+**Files:** fold into `lib/lore_curator/curator_c.py` as a `_pass_draft_promotion` alongside existing `_pass_*` helpers. No standalone module — merciless was right that this is ~30 lines.
+
+**Design:**
+- `draft: true` AND `now_utc.date() - created_date > 14d` AND last-edit-stale → write `promotion_candidate: true` marker. Never flips `draft: false`.
+- No LLM; pure frontmatter.
+
+**Acceptance:**
+- `test_promotion_proposes_on_14d_plus_draft`.
+- `test_promotion_skips_recent_drafts_below_14d`.
+- `test_promotion_skips_at_exact_14d` (boundary exclusive).
+- `test_promotion_never_flips_draft_false`.
+- `test_promotion_skips_notes_without_draft_frontmatter`.
+- `test_promotion_idempotent` — re-run with marker present → no duplicate write.
+
+**Commit:** `feat(curator): draft-promotion proposal pass (time-based)`
+
+---
+
+## Phase C — Polish + Coordination
+
+### Task 10: `models.high: off` degradation warning
+
+**Files:** Edit pass modules + test
+
+**Design simplification from v1 draft** (merciless + code-reviewer): drop the once-per-lore_root sentinel — just emit a warning event to hook-events.jsonl on every run when `high:off`. Much simpler, no sentinel file I/O, still observable via CaptureState (`simple_tier_fallback_active`).
+
+- Tier resolution: `high:off` → merge/supersede passes use `middle`; orphan/promotion unaffected per spec.
+- Warning shape: `event="curator-c", outcome="high-tier-off", message="Curator C running without high-tier — adjacent-merge + supersession coarser"`.
+
+**Acceptance:**
+- `test_high_off_uses_middle_tier_for_merge_and_supersede`.
+- `test_high_off_emits_warning_event_every_run` (not once).
+- `test_high_enabled_uses_high_tier`.
+- `test_orphan_and_promotion_unaffected_by_high_off`.
+
+**Commit:** `feat(curator): Curator C degrades to middle tier when high:off`
+
+---
+
+### Task 11: First-come-wins coordination
+
+**Files:** Edit `lib/lore_cli/hooks.py::_spawn_detached_curator_c` + `run_curator_c` + test
+
+**Design (merciless clock-skew fix):** Use ISO-week equivalence, not timestamp comparison. `iso_week(last_curator_c) == iso_week(now_utc)` → skip. Avoids clock-skew false-positives across team members.
+
+- Fsync on `WikiLedger.write` (add to Plan A's `ledger.py` if absent) so concurrent reads see committed state.
+- Post-lock re-read: within the spawn-lock, after pre-run checks, re-read `last_curator_c`. If another run landed during lock-wait → abort with `"already ran this ISO week by <author> at <ts>"`.
+
+**Acceptance:**
+- `test_second_user_skips_after_first_iso_week_match`.
+- `test_post_lock_reread_detects_race` — monkeypatch ledger write during lock-hold → run detects and aborts.
+- `test_ledger_write_is_fsynced` — mock `os.fsync`; assert called on write path.
+- `test_coordination_clock_skew_safe` — user B's clock +2min ahead; iso-week check immune.
+- `test_cross_clone_stale_race_documented` — documents (not prevents) the git-pull-lag race; asserts no crash and a clear log line.
+
+**Commit:** `feat(curator): first-come-wins coordination (ISO-week equivalence + fsync)`
+
+---
+
+### Task 12: Final integration assertions
+
+**Files:** `tests/test_curator_c_integration.py` (extended)
+
+- Assert pass execution order: hygiene (staleness / explicit-supersede / implements / backfill) → adjacent-merge → auto-supersede → orphan → draft-promotion.
+- Assert Task 2's ships-dark gate still passes after all Phase B/C changes.
+- Assert diff-log captures all proposal + mutation types.
+- Assert `last_curator_c` only updates on complete success.
+
+**Commit:** `test(curator): full Curator C integration assertions`
+
+---
+
+## Execution notes
+
+- **Order:** 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → 11 → 12. Tasks 1–5 are infrastructure; 6–9 LLM passes can be reordered among themselves; 10–12 are polish.
+- **Prerequisite inside Task 5:** extend `FakeAnthropicClient` (from `tests/test_curator_a.py`) to accept arbitrary tool names — confirm the fake is already keyed by tool name; if not, add to Task 5's file list.
+- **Shared malformed-response fixture** lives in `tests/conftest.py` or `tests/_fixtures.py` — parametrized across Tasks 6/7/8.
+- **Test budget:** ~55 new tests.
+
+## Success criteria
+
+1. Every LLM pass is proposal-only by default (markers, not frontmatter flips). Only orphan-repair with explicit sub-flag mutates bodies.
+2. Zero behavior in vaults with default config (Task 2's ships-dark gate passes).
+3. Pre/post diff log written per run with run_id + 90d retention.
+4. Trigger fires at most once per ISO-week per vault (local concurrency coordinated; cross-clone race documented).
+5. UTC-pinned everything.
+6. Malformed LLM responses never mutate the vault.
+
+## Review-pass log
+
+Plan drafted 2026-04-21, reviewed by architect + code-reviewer + merciless-dev. Must-fix items folded:
+
+- **Architect:** (1) Phase reorder — integration skeleton (Task 5) lands BEFORE LLM passes. (2) Task 6 (supersession) flipped from frontmatter-flip to `supersede_candidate:` marker — proposal-only symmetry with Task 5's design.
+- **Code-reviewer:** (1) Added end-to-end "ships dark" gate as Task 2 — the merge gate. (2) Git-email-unset fallback (hostname → offset=0). (3) ISO-week + TZ pinned UTC. (4) Threshold-boundary (`==`) tests added. (5) Shared malformed-LLM-response fixture across passes. (6) Disk-full / atomic-abort per pass. (7) Orphan sub-flag `defrag_body_writes` default false — gates body rewrites. (8) fsync on ledger write. (9) Round-trip structural-equivalence on orphan rewrites.
+- **Merciless:** (1) Central-mode → fail-loudly, no branching. (2) Once-per-lore_root warning sentinel dropped — emit every run. (3) Task 8 draft-promotion folded as a `_pass_` helper inside curator_c.py. (4) `ProposalOnlyError` guard enforces proposal-only convention. (5) Candidate-generator for adjacent-merge is testable separately, not handwaved. (6) Obsidian-holding and mid-merge-vault pre-flight checks explicit.

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -1083,6 +1083,49 @@ def cmd_session_start(
             # Spawn failure is non-fatal — proceed without it.
             pass
 
+    # Auto-trigger Curator C weekly (UTC ISO-week + per-user 48h jitter).
+    # Flag-gated off by default; see project_curator_triad + spec §6.
+    if not probe:
+        try:
+            cwd_resolved = Path(_resolve_cwd(cwd))
+            scope = resolve_scope(cwd_resolved)
+            if scope is not None:
+                lore_root = _infer_lore_root(scope.claude_md_path)
+                cfg = _load_wiki_cfg_from_scope(scope, lore_root)
+                c_cfg = cfg.curator.curator_c
+                if c_cfg.enabled:
+                    if c_cfg.mode != "local":
+                        # Fail loudly — don't silently skip.
+                        HookEventLogger(lore_root).emit(
+                            event="curator-c",
+                            outcome="central-mode-skipped",
+                            error={
+                                "message": "mode=central deferred to v2; local spawn skipped",
+                                "wiki": scope.wiki,
+                            },
+                        )
+                    else:
+                        wledger = WikiLedger(lore_root, scope.wiki)
+                        wentry = wledger.read()
+                        now = _now_utc()
+                        last_c = wentry.last_curator_c
+                        if last_c is not None and last_c.tzinfo is None:
+                            from datetime import UTC as _UTC
+                            last_c = last_c.replace(tzinfo=_UTC)
+                        iso_now = now.isocalendar()
+                        needs_rollover = (
+                            last_c is None
+                            or last_c.isocalendar()[:2] != iso_now[:2]
+                        )
+                        if needs_rollover:
+                            monday = _iso_week_monday_utc(now)
+                            offset = _curator_c_jitter_seconds(_curator_c_email())
+                            from datetime import timedelta as _td
+                            if now >= monday + _td(seconds=offset):
+                                _spawn_detached_curator_c(lore_root)
+        except Exception:
+            pass
+
     _emit("SessionStart", out, plain=plain)
 
 
@@ -1211,6 +1254,87 @@ def _spawn_detached_curator_a(lore_root: Path, *, cooldown_s: int = 60) -> bool:
             return False
         _migrate_legacy_spawn_stamp(lore_root, "a")
         cmd = [sys.executable, "-m", "lore_cli", "curator", "run"]
+        env = os.environ.copy()
+        env["LORE_ROOT"] = str(lore_root)
+        try:
+            subprocess.Popen(
+                cmd,
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                env=env,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        import contextlib
+        with contextlib.suppress(OSError):
+            _write_stamp(stamp)
+        return True
+
+
+def _now_utc() -> "datetime":
+    """Return datetime.now(UTC). Isolated as a seam so tests can pin time."""
+    from datetime import UTC, datetime as _dt
+    return _dt.now(UTC)
+
+
+def _curator_c_email() -> str:
+    """Resolve git user.email → hostname fallback → empty (offset=0)."""
+    import socket
+    import subprocess
+    # Cheap test override.
+    env_email = os.environ.get("GIT_AUTHOR_EMAIL")
+    if env_email:
+        return env_email
+    try:
+        res = subprocess.run(
+            ["git", "config", "user.email"],
+            capture_output=True, text=True, timeout=2, check=False,
+        )
+        if res.returncode == 0 and res.stdout.strip():
+            return res.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    try:
+        return socket.gethostname()
+    except OSError:
+        return ""
+
+
+def _curator_c_jitter_seconds(email: str) -> int:
+    """Deterministic 0-48h offset from SHA-256(email). Empty → 0 (fire at Monday 00Z)."""
+    import hashlib
+    if not email:
+        return 0
+    h = hashlib.sha256(email.encode()).hexdigest()[:8]
+    return int(h, 16) % 172800  # 48h in seconds
+
+
+def _iso_week_monday_utc(ts: "datetime") -> "datetime":
+    """Monday 00:00Z of the ISO week containing ts."""
+    from datetime import datetime as _dt
+    from datetime import UTC, timedelta
+    weekday = ts.isocalendar().weekday  # 1..7, Monday=1
+    date = ts.date() - timedelta(days=weekday - 1)
+    return _dt(date.year, date.month, date.day, tzinfo=UTC)
+
+
+def _spawn_detached_curator_c(
+    lore_root: Path, *, cooldown_s: int = 3600
+) -> bool:
+    """Fire-and-forget `lore curator run --defrag` subprocess (Curator C)."""
+    import subprocess
+    from lore_core.lockfile import try_acquire_spawn_lock
+
+    with try_acquire_spawn_lock(lore_root, "c") as (held, stamp):
+        if not held:
+            return False
+        if _stamp_within_cooldown(stamp, cooldown_s):
+            return False
+        cmd = [
+            sys.executable, "-m", "lore_cli", "curator", "run", "--defrag",
+        ]
         env = os.environ.copy()
         env["LORE_ROOT"] = str(lore_root)
         try:

--- a/lib/lore_core/io.py
+++ b/lib/lore_core/io.py
@@ -15,12 +15,25 @@ def atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> N
     """Write text to `path` atomically via a sibling .tmp file.
 
     If content ends without a newline, one is appended.
+
+    Fsyncs the tmp file before rename so concurrent readers on the same
+    host see a committed state even if we crash. Required by Plan 5's
+    Curator C team-mode coordination (code-reviewer must-fix).
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     if not content.endswith("\n"):
         content += "\n"
-    tmp.write_text(content, encoding=encoding)
+    # Write + fsync the bytes, then atomic-rename.
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    try:
+        os.write(fd, content.encode(encoding))
+        try:
+            os.fsync(fd)
+        except OSError:
+            pass  # fsync not supported on some filesystems; rename still atomic
+    finally:
+        os.close(fd)
     os.replace(tmp, path)
 
 

--- a/lib/lore_core/wiki_config.py
+++ b/lib/lore_core/wiki_config.py
@@ -20,7 +20,8 @@ class GitConfig:
 @dataclass
 class CuratorCConfig:
     enabled: bool = False
-    mode: str = "local"          # local | central
+    mode: str = "local"                 # local | central
+    defrag_body_writes: bool = False    # gates orphan-link in-place body rewrites
 
 
 @dataclass

--- a/lib/lore_curator/c_adjacent_merge.py
+++ b/lib/lore_curator/c_adjacent_merge.py
@@ -1,0 +1,263 @@
+"""Curator C — adjacent-concept merge proposal pass (spec §6 step 1).
+
+Scans the whole wiki for concept notes with substantial semantic overlap
+and asks the LLM whether they should merge. Proposal-only in v1: writes
+a new draft note with ``merge_candidate_sources: [[a]], [[b]]`` and
+``draft: true``. Does NOT edit the originals.
+
+Pre-filter: notes with shared tag(s) AND title-slug fuzzy ratio >= 0.6
+(rapidfuzz if available, else stdlib difflib.SequenceMatcher).
+Threshold: confidence >= 0.8 (inclusive) — below → skip.
+
+Registers into ``curator_c._DEFRAG_PASSES`` so the integration skeleton
+picks it up automatically.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from lore_curator.c_passes import validate_llm_response
+
+
+_MERGE_TOOL = {
+    "name": "propose_merge",
+    "description": "Judge whether two concept notes should merge and propose a merged version.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "should_merge": {"type": "boolean"},
+            "confidence": {"type": "number"},
+            "reason": {"type": "string"},
+            "merged_title": {"type": "string"},
+            "merged_description": {"type": "string"},
+        },
+        "required": ["should_merge", "confidence", "reason"],
+    },
+}
+
+_FUZZ_THRESHOLD = 0.6
+_CONFIDENCE_THRESHOLD = 0.8
+
+
+def _slug(title: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+
+
+def _parse_note(path: Path) -> tuple[dict, str] | None:
+    """Return (frontmatter_dict, body_str) or None on parse failure."""
+    try:
+        from lore_core.schema import parse_frontmatter
+        text = path.read_text(errors="replace")
+        fm = parse_frontmatter(text)
+        if fm is None:
+            return None
+        # Extract body: everything after the closing `---\n`.
+        if text.startswith("---"):
+            end = text.find("\n---", 3)
+            body = text[end + 4:].lstrip("\n") if end != -1 else ""
+        else:
+            body = text
+        return fm, body
+    except Exception:
+        return None
+
+
+def generate_merge_candidates(wiki_path: Path) -> list[tuple[Path, Path]]:
+    """Pre-filter candidate pairs by shared-tag + fuzzy-slug overlap.
+
+    Testable independently of the LLM step.
+    """
+    notes: list[tuple[Path, dict, str]] = []
+    for p in sorted(wiki_path.rglob("*.md")):
+        if p.name.startswith("_"):
+            continue
+        parsed = _parse_note(p)
+        if not parsed:
+            continue
+        fm, body = parsed
+        if fm.get("type") not in ("concept", "decision"):
+            continue
+        notes.append((p, fm, body))
+
+    pairs: list[tuple[Path, Path]] = []
+    for i in range(len(notes)):
+        pi, fmi, _ = notes[i]
+        tags_i = set(fmi.get("tags") or [])
+        slug_i = _slug(str(fmi.get("title") or pi.stem))
+        for j in range(i + 1, len(notes)):
+            pj, fmj, _ = notes[j]
+            tags_j = set(fmj.get("tags") or [])
+            if not (tags_i & tags_j):
+                continue
+            slug_j = _slug(str(fmj.get("title") or pj.stem))
+            ratio = difflib.SequenceMatcher(None, slug_i, slug_j).ratio()
+            if ratio >= _FUZZ_THRESHOLD:
+                pairs.append((pi, pj))
+    return pairs
+
+
+def _propose_merge(
+    note_a: Path, note_b: Path, *, anthropic_client: Any, lore_root: Path
+) -> dict | None:
+    """Call LLM and return a validated proposal dict, or None on any issue."""
+    parsed_a = _parse_note(note_a)
+    parsed_b = _parse_note(note_b)
+    if not parsed_a or not parsed_b:
+        return None
+    fm_a, body_a = parsed_a
+    fm_b, body_b = parsed_b
+
+    prompt = (
+        "Two concept notes from a knowledge vault. Judge whether they "
+        "describe the same concept and should merge.\n\n"
+        f"--- Note A: {note_a.name} ---\n"
+        f"{body_a[:2000]}\n\n"
+        f"--- Note B: {note_b.name} ---\n"
+        f"{body_b[:2000]}\n"
+    )
+
+    try:
+        resp = anthropic_client.messages.create(
+            model="high",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+            tools=[_MERGE_TOOL],
+            tool_choice={"type": "tool", "name": "propose_merge"},
+        )
+    except Exception:
+        return None
+
+    # Extract tool-use block input.
+    block_input: dict | None = None
+    for block in getattr(resp, "content", []) or []:
+        if getattr(block, "type", None) == "tool_use":
+            block_input = getattr(block, "input", None)
+            break
+
+    return validate_llm_response(
+        block_input,
+        required={
+            "should_merge": bool,
+            "confidence": (int, float),
+            "reason": str,
+        },
+        ranges={"confidence": (0.0, 1.0)},
+        lore_root=lore_root,
+        pass_name="adjacent_merge",
+    )
+
+
+def adjacent_merge_pass(
+    wiki_path: Path, *, anthropic_client: Any, dry_run: bool
+) -> dict[str, int]:
+    """Registered in _DEFRAG_PASSES. Returns summary counts."""
+    if anthropic_client is None:
+        return {"adjacent_merge_skipped_no_llm": 1}
+
+    from lore_core.config import get_lore_root
+    try:
+        lore_root = get_lore_root()
+    except Exception:
+        return {"adjacent_merge_skipped_no_lore_root": 1}
+
+    pairs = generate_merge_candidates(wiki_path)
+    proposals_written = 0
+    skipped_low_confidence = 0
+    skipped_malformed = 0
+
+    sessions_dir = wiki_path / "sessions"
+    sessions_dir.mkdir(exist_ok=True)
+
+    for note_a, note_b in pairs:
+        proposal = _propose_merge(
+            note_a, note_b, anthropic_client=anthropic_client, lore_root=lore_root
+        )
+        if proposal is None:
+            skipped_malformed += 1
+            continue
+        if not proposal.get("should_merge"):
+            continue
+        if proposal.get("confidence", 0.0) < _CONFIDENCE_THRESHOLD:
+            skipped_low_confidence += 1
+            continue
+
+        if dry_run:
+            proposals_written += 1
+            continue
+
+        # Write a new draft note. Filename: merge-<run_id_short>-<slug>.md
+        today = datetime.now(UTC).date().isoformat()
+        title = proposal.get("merged_title") or f"merge of {note_a.stem} + {note_b.stem}"
+        slug = _slug(title)[:40] or "merge"
+        dest = sessions_dir / f"{today}-{slug}-merge.md"
+        # Idempotence: if a draft with these exact sources already exists, skip.
+        if _existing_proposal_has_sources(sessions_dir, note_a, note_b):
+            continue
+        # Resolve collision by appending short hash.
+        if dest.exists():
+            import hashlib
+            h = hashlib.sha256(f"{note_a}{note_b}".encode()).hexdigest()[:6]
+            dest = sessions_dir / f"{today}-{slug}-merge-{h}.md"
+
+        frontmatter = (
+            "---\n"
+            f"type: concept\n"
+            f"draft: true\n"
+            f"created: {today}\n"
+            f"last_reviewed: {today}\n"
+            f"description: {proposal.get('merged_description') or title!r}\n"
+            f"tags: []\n"
+            f"merge_candidate_sources:\n"
+            f"  - [[{note_a.stem}]]\n"
+            f"  - [[{note_b.stem}]]\n"
+            "---\n\n"
+        )
+        body = (
+            f"# {title}\n\n"
+            f"_Proposed merge of [[{note_a.stem}]] and [[{note_b.stem}]]._\n\n"
+            f"Confidence: {proposal.get('confidence'):.2f}\n"
+            f"Reason: {proposal.get('reason')}\n"
+        )
+        try:
+            dest.write_text(frontmatter + body)
+        except OSError:
+            return {
+                "adjacent_merge_disk_error": 1,
+                "adjacent_merge_proposed": proposals_written,
+            }
+        proposals_written += 1
+
+    return {
+        "adjacent_merge_proposed": proposals_written,
+        "adjacent_merge_skipped_low_confidence": skipped_low_confidence,
+        "adjacent_merge_skipped_malformed": skipped_malformed,
+    }
+
+
+def _existing_proposal_has_sources(sessions_dir: Path, a: Path, b: Path) -> bool:
+    """True if any existing draft already proposes the same merge pair."""
+    a_link = f"[[{a.stem}]]"
+    b_link = f"[[{b.stem}]]"
+    for p in sessions_dir.glob("*-merge*.md"):
+        try:
+            text = p.read_text(errors="replace")
+        except OSError:
+            continue
+        if "merge_candidate_sources" in text and a_link in text and b_link in text:
+            return True
+    return False
+
+
+def _register() -> None:
+    """Append to curator_c._DEFRAG_PASSES."""
+    from lore_curator import curator_c
+    if adjacent_merge_pass not in curator_c._DEFRAG_PASSES:
+        curator_c._DEFRAG_PASSES.append(adjacent_merge_pass)
+
+
+_register()

--- a/lib/lore_curator/c_adjacent_merge.py
+++ b/lib/lore_curator/c_adjacent_merge.py
@@ -121,9 +121,18 @@ def _propose_merge(
         f"{body_b[:2000]}\n"
     )
 
+    from lore_curator.c_passes import resolve_tier_for_pass
+    # Resolve actual model ID from wiki config; degrades to middle if high=off.
+    model = resolve_tier_for_pass(
+        note_a.parent.parent,  # wiki_path
+        pass_name="adjacent_merge",
+        preferred_tier="high",
+        lore_root=lore_root,
+    )
+
     try:
         resp = anthropic_client.messages.create(
-            model="high",
+            model=model,
             max_tokens=1024,
             messages=[{"role": "user", "content": prompt}],
             tools=[_MERGE_TOOL],

--- a/lib/lore_curator/c_auto_supersede.py
+++ b/lib/lore_curator/c_auto_supersede.py
@@ -245,9 +245,14 @@ def auto_supersede_pass(
             f"--- OLDER: {older.name} ---\n{older.read_text(errors='replace')[:1500]}\n\n"
             f"--- NEWER: {newer.name} ---\n{newer.read_text(errors='replace')[:1500]}\n"
         )
+        from lore_curator.c_passes import resolve_tier_for_pass
+        model = resolve_tier_for_pass(
+            wiki_path, pass_name="auto_supersede", preferred_tier="high",
+            lore_root=lore_root,
+        )
         try:
             resp = anthropic_client.messages.create(
-                model="high",
+                model=model,
                 max_tokens=1024,
                 messages=[{"role": "user", "content": prompt}],
                 tools=[_SUPERSEDE_TOOL],

--- a/lib/lore_curator/c_auto_supersede.py
+++ b/lib/lore_curator/c_auto_supersede.py
@@ -1,0 +1,316 @@
+"""Curator C — auto-supersession proposal pass (spec §6 step 2).
+
+Scans decision notes for pairs where a newer decision appears to
+contradict an older one in an overlapping scope, asks the LLM for a
+contradiction verdict, and writes **proposal markers** to both notes:
+
+- older gets ``supersede_candidate: [[newer]]``
+- newer gets ``supersede_candidate_of: [[older]]``
+
+Proposal-only per plan review (architect must-fix): does NOT flip the
+real ``superseded_by`` field. User promotes manually once they've
+reviewed the markers.
+
+Conservative:
+- ``canonical: true`` on the older note → skip (opt-out)
+- confidence >= 0.85 required (inclusive)
+- Circular-supersession guard: if newer already supersedes (explicit
+  or proposed) the older via another chain, skip
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, date as _date
+from pathlib import Path
+from typing import Any
+
+from lore_curator.c_passes import validate_llm_response
+from lore_curator.c_adjacent_merge import _parse_note
+
+
+_SUPERSEDE_TOOL = {
+    "name": "judge_supersession",
+    "description": "Judge whether a newer decision contradicts an older one in overlapping scope.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "contradicts": {"type": "boolean"},
+            "confidence": {"type": "number"},
+            "reason": {"type": "string"},
+        },
+        "required": ["contradicts", "confidence", "reason"],
+    },
+}
+
+_CONFIDENCE_THRESHOLD = 0.85
+
+
+def _to_date(value) -> _date | None:
+    if isinstance(value, _date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        try:
+            return _date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _scope_overlap(fm_a: dict, fm_b: dict) -> bool:
+    """True if A and B overlap in scope/tags enough to be comparable decisions.
+
+    v1 heuristic: share at least one tag OR both have empty tags (vault-wide).
+    """
+    ta = set(fm_a.get("tags") or [])
+    tb = set(fm_b.get("tags") or [])
+    if not ta and not tb:
+        return True
+    return bool(ta & tb)
+
+
+def generate_supersede_candidates(wiki_path: Path) -> list[tuple[Path, Path]]:
+    """Return (older, newer) pairs eligible for supersession check."""
+    decisions: list[tuple[Path, dict, _date]] = []
+    for p in sorted(wiki_path.rglob("*.md")):
+        if p.name.startswith("_"):
+            continue
+        parsed = _parse_note(p)
+        if not parsed:
+            continue
+        fm, _ = parsed
+        if fm.get("type") != "decision":
+            continue
+        created = _to_date(fm.get("created"))
+        if created is None:
+            continue
+        decisions.append((p, fm, created))
+
+    decisions.sort(key=lambda x: x[2])  # oldest first
+    pairs: list[tuple[Path, Path]] = []
+    for i in range(len(decisions)):
+        older_p, older_fm, older_d = decisions[i]
+        for j in range(i + 1, len(decisions)):
+            newer_p, newer_fm, newer_d = decisions[j]
+            if newer_d <= older_d:
+                continue
+            if not _scope_overlap(older_fm, newer_fm):
+                continue
+            pairs.append((older_p, newer_p))
+    return pairs
+
+
+def _has_explicit_supersession_chain(older: Path, newer: Path) -> bool:
+    """True if older already supersedes newer (explicit or candidate)."""
+    parsed = _parse_note(older)
+    if not parsed:
+        return False
+    fm, _ = parsed
+    for key in ("supersedes", "supersede_candidate_of"):
+        val = fm.get(key)
+        if not val:
+            continue
+        # Accept string `[[slug]]` or list thereof.
+        items = val if isinstance(val, list) else [val]
+        for item in items:
+            if isinstance(item, str) and newer.stem in item:
+                return True
+    return False
+
+
+def _has_marker(note: Path, key: str, target: Path) -> bool:
+    parsed = _parse_note(note)
+    if not parsed:
+        return False
+    fm, _ = parsed
+    val = fm.get(key)
+    if not val:
+        return False
+    items = val if isinstance(val, list) else [val]
+    return any(isinstance(i, str) and target.stem in i for i in items)
+
+
+def _append_marker(path: Path, key: str, target_stem: str) -> None:
+    """Append a `key: [[target_stem]]` entry into the frontmatter. Safe-edit."""
+    text = path.read_text(errors="replace")
+    if not text.startswith("---"):
+        return
+    end = text.find("\n---", 3)
+    if end == -1:
+        return
+    fm_block = text[3:end + 1]
+    body = text[end + 4:]
+    link = f'"[[{target_stem}]]"'
+
+    # If the key already exists in the frontmatter, append to its list form.
+    lines = fm_block.splitlines()
+    updated: list[str] = []
+    key_found = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if stripped.startswith(f"{key}:"):
+            key_found = True
+            # Existing value style: either inline (`key: [[x]]`) or list form.
+            after = stripped[len(key) + 1:].strip()
+            if after.startswith("["):  # YAML flow list — skip handling, inline add
+                # Append as new list item under the key header.
+                updated.append(f"{key}:")
+                # Convert inline flow to block form (conservative).
+                try:
+                    import yaml as _yaml
+                    parsed_list = _yaml.safe_load(after) or []
+                    if not isinstance(parsed_list, list):
+                        parsed_list = [parsed_list]
+                except Exception:
+                    parsed_list = []
+                for item in parsed_list:
+                    updated.append(f"  - {item}")
+                updated.append(f"  - {link}")
+            elif after.startswith("[["):
+                # Scalar `[[x]]` form → convert to list.
+                updated.append(f"{key}:")
+                updated.append(f"  - {after}")
+                updated.append(f"  - {link}")
+            elif after == "":
+                # Already a block list; copy the existing items then append.
+                updated.append(line)
+                i += 1
+                while i < len(lines) and (lines[i].startswith("  -") or lines[i].strip() == ""):
+                    updated.append(lines[i])
+                    i += 1
+                updated.append(f"  - {link}")
+                continue
+            else:
+                # Unknown shape — skip editing to avoid corruption.
+                updated.append(line)
+        else:
+            updated.append(line)
+        i += 1
+
+    if not key_found:
+        # Append at end of frontmatter block.
+        updated.append(f"{key}:")
+        updated.append(f"  - {link}")
+
+    new_fm = "\n".join(updated)
+    new_text = f"---{new_fm}\n---{body}"
+    path.write_text(new_text)
+
+
+def auto_supersede_pass(
+    wiki_path: Path, *, anthropic_client: Any, dry_run: bool
+) -> dict[str, int]:
+    if anthropic_client is None:
+        return {"auto_supersede_skipped_no_llm": 1}
+
+    from lore_core.config import get_lore_root
+    try:
+        lore_root = get_lore_root()
+    except Exception:
+        return {"auto_supersede_skipped_no_lore_root": 1}
+
+    pairs = generate_supersede_candidates(wiki_path)
+    proposed = 0
+    skipped_low_confidence = 0
+    skipped_canonical = 0
+    skipped_malformed = 0
+    skipped_circular = 0
+
+    for older, newer in pairs:
+        older_parsed = _parse_note(older)
+        if not older_parsed:
+            continue
+        older_fm, _ = older_parsed
+        if older_fm.get("canonical") is True:
+            skipped_canonical += 1
+            continue
+
+        # Circular guard: older already supersedes newer → skip.
+        if _has_explicit_supersession_chain(older, newer):
+            skipped_circular += 1
+            continue
+
+        # Idempotence: if marker already present → skip.
+        if _has_marker(older, "supersede_candidate", newer):
+            continue
+
+        # LLM verdict.
+        prompt = (
+            f"Two decision notes. Judge whether the newer one contradicts "
+            f"the older one on an overlapping topic (i.e. the newer "
+            f"supersedes the older).\n\n"
+            f"--- OLDER: {older.name} ---\n{older.read_text(errors='replace')[:1500]}\n\n"
+            f"--- NEWER: {newer.name} ---\n{newer.read_text(errors='replace')[:1500]}\n"
+        )
+        try:
+            resp = anthropic_client.messages.create(
+                model="high",
+                max_tokens=1024,
+                messages=[{"role": "user", "content": prompt}],
+                tools=[_SUPERSEDE_TOOL],
+                tool_choice={"type": "tool", "name": "judge_supersession"},
+            )
+        except Exception:
+            skipped_malformed += 1
+            continue
+
+        block_input = None
+        for block in getattr(resp, "content", []) or []:
+            if getattr(block, "type", None) == "tool_use":
+                block_input = getattr(block, "input", None)
+                break
+
+        verdict = validate_llm_response(
+            block_input,
+            required={
+                "contradicts": bool,
+                "confidence": (int, float),
+                "reason": str,
+            },
+            ranges={"confidence": (0.0, 1.0)},
+            lore_root=lore_root,
+            pass_name="auto_supersede",
+        )
+        if verdict is None:
+            skipped_malformed += 1
+            continue
+        if not verdict.get("contradicts"):
+            continue
+        if verdict.get("confidence", 0.0) < _CONFIDENCE_THRESHOLD:
+            skipped_low_confidence += 1
+            continue
+
+        if dry_run:
+            proposed += 1
+            continue
+
+        # Write proposal markers on both notes.
+        try:
+            _append_marker(older, "supersede_candidate", newer.stem)
+            _append_marker(newer, "supersede_candidate_of", older.stem)
+        except OSError:
+            return {
+                "auto_supersede_disk_error": 1,
+                "auto_supersede_proposed": proposed,
+            }
+        proposed += 1
+
+    return {
+        "auto_supersede_proposed": proposed,
+        "auto_supersede_skipped_low_confidence": skipped_low_confidence,
+        "auto_supersede_skipped_canonical": skipped_canonical,
+        "auto_supersede_skipped_malformed": skipped_malformed,
+        "auto_supersede_skipped_circular": skipped_circular,
+    }
+
+
+def _register() -> None:
+    from lore_curator import curator_c
+    if auto_supersede_pass not in curator_c._DEFRAG_PASSES:
+        curator_c._DEFRAG_PASSES.append(auto_supersede_pass)
+
+
+_register()

--- a/lib/lore_curator/c_orphan_links.py
+++ b/lib/lore_curator/c_orphan_links.py
@@ -1,0 +1,285 @@
+"""Curator C — orphan wikilink repair pass (spec §6 step 3).
+
+Scans all notes for ``[[wikilinks]]`` whose target slug doesn't exist
+in the wiki. For each orphan, fuzzy-matches against existing note
+slugs; if a unique candidate scores high enough, asks the LLM to
+confirm. On confirmation with confidence >= 0.8:
+
+  - With ``curator.curator_c.defrag_body_writes: true``:
+    rewrites the link in place (body mutation — highest blast radius
+    in Plan 5; gated separately from the main --defrag flag).
+
+  - Default (``defrag_body_writes: false``):
+    logs the proposed rewrite to
+    ``$LORE_ROOT/.lore/curator-c.body-proposals.YYYY-MM-DD.log`` for
+    user review. Body bytes are not touched.
+
+Ambiguous matches (two candidates at similar ratio) → flag only, no
+rewrite even with sub-flag on. Truly deleted targets (no fuzzy match
+> 0.7) → flag only.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from lore_curator.c_passes import validate_llm_response
+
+
+_ORPHAN_TOOL = {
+    "name": "confirm_rename",
+    "description": "Confirm whether an orphaned wikilink is a rename of an existing note.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "is_rename": {"type": "boolean"},
+            "canonical_slug": {"type": "string"},
+            "confidence": {"type": "number"},
+            "reason": {"type": "string"},
+        },
+        "required": ["is_rename", "confidence"],
+    },
+}
+
+_WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(\|([^\]]+))?\]\]")
+_FUZZ_THRESHOLD = 0.7
+_CONFIDENCE_THRESHOLD = 0.8
+
+
+def _existing_slugs(wiki_path: Path) -> set[str]:
+    """Return the set of note slugs (filename stems) in the wiki."""
+    slugs = set()
+    for p in wiki_path.rglob("*.md"):
+        if p.name.startswith("_"):
+            continue
+        slugs.add(p.stem)
+    return slugs
+
+
+def find_orphan_links(wiki_path: Path) -> list[tuple[Path, str, int]]:
+    """Return list of (note_path, orphan_slug, match_start_offset) for every
+    wikilink in the wiki whose target doesn't resolve.
+
+    Testable independently. Each occurrence is listed once — a note with
+    three uses of the same orphan returns three entries.
+    """
+    slugs = _existing_slugs(wiki_path)
+    results: list[tuple[Path, str, int]] = []
+    for p in sorted(wiki_path.rglob("*.md")):
+        if p.name.startswith("_"):
+            continue
+        try:
+            text = p.read_text(errors="replace")
+        except OSError:
+            continue
+        for m in _WIKILINK_RE.finditer(text):
+            slug = m.group(1).strip()
+            if slug and slug not in slugs:
+                results.append((p, slug, m.start()))
+    return results
+
+
+def _best_fuzzy_match(orphan: str, candidates: set[str]) -> tuple[str | None, bool]:
+    """Return (best_match, ambiguous). ambiguous=True when two candidates
+    are within 0.05 of each other at the top.
+    """
+    if not candidates:
+        return None, False
+    scored = [
+        (difflib.SequenceMatcher(None, orphan, c).ratio(), c)
+        for c in candidates
+    ]
+    scored.sort(reverse=True)
+    top_ratio, top_slug = scored[0]
+    if top_ratio < _FUZZ_THRESHOLD:
+        return None, False
+    if len(scored) > 1 and scored[1][0] >= top_ratio - 0.05:
+        return top_slug, True
+    return top_slug, False
+
+
+def _write_body_proposal_log(
+    lore_root: Path, entries: list[dict]
+) -> None:
+    if not entries:
+        return
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log = lore_root / ".lore" / f"curator-c.body-proposals.{today}.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with log.open("a") as f:
+            for e in entries:
+                f.write(
+                    f"{e.get('ts')} file={e.get('file')} "
+                    f"orphan={e.get('orphan')} "
+                    f"candidate={e.get('candidate')} "
+                    f"status={e.get('status')}\n"
+                )
+    except OSError:
+        pass
+
+
+def _rewrite_orphan_in_file(path: Path, orphan: str, canonical: str) -> int:
+    """Rewrite every ``[[orphan]]`` and ``[[orphan|display]]`` in file to
+    ``[[canonical]]`` / ``[[canonical|display]]``. Returns count.
+
+    Preserves surrounding whitespace and CRLF by doing single-token replace.
+    """
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return 0
+    text = raw.decode("utf-8", errors="replace")
+
+    def _replace(match: re.Match[str]) -> str:
+        target = match.group(1).strip()
+        display = match.group(3)
+        if target != orphan:
+            return match.group(0)
+        if display:
+            return f"[[{canonical}|{display}]]"
+        return f"[[{canonical}]]"
+
+    new_text, count = _WIKILINK_RE.subn(_replace, text)
+    if count == 0:
+        return 0
+    new_bytes = new_text.encode("utf-8")
+    # Preserve trailing-newline sentinel exactly.
+    path.write_bytes(new_bytes)
+    return count
+
+
+def orphan_links_pass(
+    wiki_path: Path, *, anthropic_client: Any, dry_run: bool
+) -> dict[str, int]:
+    if anthropic_client is None:
+        return {"orphan_skipped_no_llm": 1}
+
+    from lore_core.config import get_lore_root
+    from lore_core.wiki_config import load_wiki_config
+    try:
+        lore_root = get_lore_root()
+    except Exception:
+        return {"orphan_skipped_no_lore_root": 1}
+
+    cfg = load_wiki_config(wiki_path)
+    body_writes_enabled = cfg.curator.curator_c.defrag_body_writes
+
+    slugs = _existing_slugs(wiki_path)
+    orphans = find_orphan_links(wiki_path)
+    # Collapse by (file, orphan) so repeated uses cause one LLM call each.
+    seen: set[tuple[Path, str]] = set()
+    unique = [(f, s) for f, s, _ in orphans if (f, s) not in seen and not seen.add((f, s))]
+
+    rewritten = 0
+    flagged = 0
+    ambiguous = 0
+    skipped_malformed = 0
+    skipped_low_confidence = 0
+    skipped_no_candidate = 0
+
+    proposals: list[dict] = []
+    now_iso = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+    for note, orphan in unique:
+        best, is_ambiguous = _best_fuzzy_match(orphan, slugs)
+        if best is None:
+            flagged += 1
+            skipped_no_candidate += 1
+            proposals.append({
+                "ts": now_iso, "file": str(note.relative_to(wiki_path)),
+                "orphan": orphan, "candidate": None, "status": "no-candidate",
+            })
+            continue
+        if is_ambiguous:
+            ambiguous += 1
+            proposals.append({
+                "ts": now_iso, "file": str(note.relative_to(wiki_path)),
+                "orphan": orphan, "candidate": best, "status": "ambiguous",
+            })
+            continue
+
+        prompt = (
+            f"A note contains [[{orphan}]] which doesn't resolve. "
+            f"Closest existing slug: {best!r}. "
+            f"Is this a rename (same concept, slug drifted)?\n"
+        )
+        try:
+            resp = anthropic_client.messages.create(
+                model="middle",
+                max_tokens=512,
+                messages=[{"role": "user", "content": prompt}],
+                tools=[_ORPHAN_TOOL],
+                tool_choice={"type": "tool", "name": "confirm_rename"},
+            )
+        except Exception:
+            skipped_malformed += 1
+            continue
+
+        block_input = None
+        for block in getattr(resp, "content", []) or []:
+            if getattr(block, "type", None) == "tool_use":
+                block_input = getattr(block, "input", None)
+                break
+
+        verdict = validate_llm_response(
+            block_input,
+            required={"is_rename": bool, "confidence": (int, float)},
+            ranges={"confidence": (0.0, 1.0)},
+            lore_root=lore_root,
+            pass_name="orphan_links",
+        )
+        if verdict is None:
+            skipped_malformed += 1
+            continue
+        if not verdict.get("is_rename"):
+            proposals.append({
+                "ts": now_iso, "file": str(note.relative_to(wiki_path)),
+                "orphan": orphan, "candidate": best, "status": "not-a-rename",
+            })
+            continue
+        if verdict.get("confidence", 0.0) < _CONFIDENCE_THRESHOLD:
+            skipped_low_confidence += 1
+            continue
+
+        if dry_run or not body_writes_enabled:
+            proposals.append({
+                "ts": now_iso, "file": str(note.relative_to(wiki_path)),
+                "orphan": orphan, "candidate": best,
+                "status": "proposed" if not body_writes_enabled else "proposed-dry-run",
+            })
+            if not body_writes_enabled:
+                flagged += 1
+            continue
+
+        count = _rewrite_orphan_in_file(note, orphan, best)
+        rewritten += count
+        proposals.append({
+            "ts": now_iso, "file": str(note.relative_to(wiki_path)),
+            "orphan": orphan, "candidate": best, "status": f"rewritten:{count}",
+        })
+
+    # Always persist proposal log (both modes).
+    _write_body_proposal_log(lore_root, proposals)
+
+    return {
+        "orphan_rewritten": rewritten,
+        "orphan_flagged": flagged,
+        "orphan_ambiguous": ambiguous,
+        "orphan_skipped_malformed": skipped_malformed,
+        "orphan_skipped_low_confidence": skipped_low_confidence,
+        "orphan_skipped_no_candidate": skipped_no_candidate,
+    }
+
+
+def _register() -> None:
+    from lore_curator import curator_c
+    if orphan_links_pass not in curator_c._DEFRAG_PASSES:
+        curator_c._DEFRAG_PASSES.append(orphan_links_pass)
+
+
+_register()

--- a/lib/lore_curator/c_passes.py
+++ b/lib/lore_curator/c_passes.py
@@ -25,6 +25,52 @@ class ProposalOnlyError(RuntimeError):
     """Raised when a proposal-only pass attempts to mutate an existing note."""
 
 
+def resolve_tier_for_pass(
+    wiki_path: Path,
+    *,
+    pass_name: str,
+    preferred_tier: str = "high",
+    lore_root: Path | None = None,
+) -> str:
+    """Return a real model ID for ``preferred_tier``, with high→middle
+    degradation when ``models.high`` is ``"off"``.
+
+    Emits a ``curator-c/high-tier-off`` warning event to hook-events
+    every time a pass degrades (not once-per-run — merciless must-fix:
+    once-per-sentinel added complexity without signal). The warning
+    rides into CaptureState's ``simple_tier_fallback_active`` field via
+    the warnings log (CaptureState sentinel layer — Plan A).
+    """
+    from lore_core.wiki_config import load_wiki_config
+
+    cfg = load_wiki_config(wiki_path)
+    models = cfg.models
+    if preferred_tier == "high":
+        if models.high == "off" or not models.high:
+            # Degrade to middle + warn.
+            if lore_root is not None:
+                try:
+                    from lore_core.hook_log import HookEventLogger
+                    HookEventLogger(lore_root).emit(
+                        event="curator-c",
+                        outcome="high-tier-off",
+                        error={
+                            "pass": pass_name,
+                            "message": (
+                                f"Curator C {pass_name} running at middle tier "
+                                "— high tier is off; expect coarser judgments."
+                            ),
+                        },
+                    )
+                except Exception:
+                    pass
+            return models.middle
+        return models.high
+    if preferred_tier == "middle":
+        return models.middle
+    return models.simple
+
+
 def validate_llm_response(
     response: dict | None,
     *,

--- a/lib/lore_curator/c_passes.py
+++ b/lib/lore_curator/c_passes.py
@@ -1,0 +1,124 @@
+"""Shared harness for Curator C LLM passes.
+
+Every pass in Phase B (adjacent-concept merge, auto-supersession,
+orphan wikilink repair) goes through these helpers:
+
+- ``validate_llm_response`` — schema-check an LLM tool-call response.
+  Returns the validated dict or None (with a hook-event warning). Never
+  raises.
+- ``ProposalOnlyError`` — raised when a guarded pass attempts to mutate
+  a pre-existing note during a proposal-only phase. Enforces the
+  convention that v1 LLM passes only WRITE proposal markers, never flip
+  end-state frontmatter on existing notes.
+- ``git_status_porcelain`` — pre-flight check; True if the wiki repo
+  has unmerged / conflict paths. C aborts on True to avoid writing into
+  a mid-merge working tree.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+class ProposalOnlyError(RuntimeError):
+    """Raised when a proposal-only pass attempts to mutate an existing note."""
+
+
+def validate_llm_response(
+    response: dict | None,
+    *,
+    required: dict[str, type | tuple[type, ...]],
+    ranges: dict[str, tuple[float, float]] | None = None,
+    lore_root: Path | None = None,
+    pass_name: str = "unknown",
+) -> dict | None:
+    """Validate an LLM tool-call response. Returns the dict or None.
+
+    ``required`` maps key → expected type (or tuple of types).
+    ``ranges`` maps numeric key → (min, max) inclusive.
+
+    On any violation (missing key, wrong type, out-of-range, None input,
+    non-dict input) returns None and emits a hook-event warning when
+    ``lore_root`` is provided. Never raises.
+    """
+    ranges = ranges or {}
+    if not isinstance(response, dict):
+        _warn(lore_root, pass_name, f"response is {type(response).__name__}, not dict")
+        return None
+
+    for key, expected_type in required.items():
+        if key not in response:
+            _warn(lore_root, pass_name, f"missing required key {key!r}")
+            return None
+        if not isinstance(response[key], expected_type):
+            _warn(
+                lore_root,
+                pass_name,
+                f"{key!r} has type {type(response[key]).__name__!r}; "
+                f"expected {expected_type}",
+            )
+            return None
+
+    for key, (lo, hi) in ranges.items():
+        val = response.get(key)
+        if val is None:
+            continue
+        try:
+            if not (lo <= val <= hi):
+                _warn(
+                    lore_root,
+                    pass_name,
+                    f"{key!r}={val!r} outside range [{lo}, {hi}]",
+                )
+                return None
+        except TypeError:
+            _warn(lore_root, pass_name, f"{key!r}={val!r} is not comparable")
+            return None
+
+    return response
+
+
+def _warn(lore_root: Path | None, pass_name: str, message: str) -> None:
+    if lore_root is None:
+        return
+    try:
+        from lore_core.hook_log import HookEventLogger
+        HookEventLogger(lore_root).emit(
+            event="curator-c",
+            outcome="llm-response-invalid",
+            error={"pass": pass_name, "message": message},
+        )
+    except Exception:
+        pass
+
+
+def git_status_porcelain(repo: Path) -> list[str]:
+    """Return non-empty lines from `git status --porcelain` or [] on error.
+
+    Used by the C integration skeleton as a pre-flight check — if the
+    wiki repo has uncommitted-conflict paths (UU, AA, DD), C aborts
+    before writing anything to avoid confusing the working tree.
+    """
+    try:
+        res = subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if res.returncode != 0:
+        return []
+    return [ln for ln in res.stdout.splitlines() if ln.strip()]
+
+
+def has_merge_conflicts(repo: Path) -> bool:
+    """True if the repo has unmerged paths (UU, AA, DD, UA, UD, DU, AU)."""
+    lines = git_status_porcelain(repo)
+    for ln in lines:
+        if len(ln) >= 2 and ln[0] in "UAD" and ln[1] in "UAD":
+            return True
+    return False

--- a/lib/lore_curator/curator_c.py
+++ b/lib/lore_curator/curator_c.py
@@ -878,6 +878,7 @@ app = typer.Typer(
 
 @app.callback(invoke_without_command=True)
 def curator(
+    ctx: typer.Context,
     wiki: str = typer.Option(None, "--wiki", help="Scope to one wiki."),
     apply: bool = typer.Option(
         False, "--apply", help="Actually write changes. Without this, runs dry."
@@ -897,6 +898,11 @@ def curator(
     ),
 ) -> None:
     """Run curator passes — flag stale, propagate implements, etc."""
+    # If a subcommand was invoked (e.g. `lore curator run --defrag`), let it
+    # handle the flow; the callback's hygiene-only path is for bare
+    # `lore curator` only.
+    if ctx.invoked_subcommand is not None:
+        return
     if migrate_open_items:
         run_open_items_migration(wiki_filter=wiki, dry_run=not apply)
         return
@@ -952,13 +958,53 @@ def run_command(
     scope: str = typer.Option(None, "--scope", help="Filter to one scope, e.g. 'mywiki:subproject'."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Classify but don't write notes or advance ledger."),
     abstract: bool = typer.Option(False, "--abstract", help="Also run the surface-extraction pass after filing session notes."),
-    wiki: str = typer.Option(None, "--wiki", help="Limit the surface-extraction pass to a single wiki (only meaningful with --abstract)."),
+    defrag: bool = typer.Option(False, "--defrag", help="Run Curator C weekly defragmentation (hygiene + LLM adjacent-merge / auto-supersede / orphan-repair / draft-promotion)."),
+    wiki: str = typer.Option(None, "--wiki", help="Limit the surface-extraction / defrag pass to a single wiki."),
     trace_llm: bool = typer.Option(False, "--trace-llm", help="Capture LLM prompts/responses to runs/<id>.trace.jsonl (equivalent to LORE_TRACE_LLM=1)."),
 ) -> None:
-    """Run the curator — classify pending transcripts and file session notes.
+    """Run the curator.
 
-    With --abstract, also runs the surface-extraction pass for the specified wiki(s).
+    Default: classify pending transcripts and file session notes.
+    --abstract also runs the surface-extraction pass.
+    --defrag runs the weekly whole-wiki defragmentation (hygiene passes
+    + LLM proposals for adjacent-concept merges, auto-supersession,
+    orphan wikilink repair, and draft promotions).
     """
+    import os as _os_check
+    if defrag:
+        # --defrag runs Curator C directly, not Curator A. Bypass the
+        # transcript classification path and go straight to the whole-wiki
+        # pipeline.
+        from pathlib import Path as _P
+        lore_root_str = _os_check.environ.get("LORE_ROOT", "")
+        if not lore_root_str:
+            console.print("[red]Error:[/red] LORE_ROOT environment variable not set.")
+            raise typer.Exit(1)
+
+        # LLM client resolution (same seam as Curator A).
+        from lore_curator.llm_client import LlmClientError, make_llm_client
+        err_console = Console(stderr=True)
+        api_key = _os_check.environ.get("ANTHROPIC_API_KEY", "") or None
+        try:
+            llm_client = make_llm_client(api_key=api_key)
+        except LlmClientError as exc:
+            err_console.print(f"[yellow]Warning:[/yellow] {exc}")
+            llm_client = None
+        if llm_client is None:
+            console.print(
+                "[yellow]Running --defrag without an LLM client — "
+                "LLM passes (adjacent-merge, auto-supersede, orphan-repair) "
+                "will be skipped.[/yellow]"
+            )
+
+        reports = run_curator_c(
+            wiki_filter=wiki,
+            dry_run=dry_run,
+            defrag=True,
+            anthropic_client=llm_client,
+        )
+        # Exit success — report already printed by run_curator_c.
+        return
     import os
     from datetime import UTC, datetime
     from pathlib import Path

--- a/lib/lore_curator/curator_c.py
+++ b/lib/lore_curator/curator_c.py
@@ -695,6 +695,31 @@ def run_curator_c(
     except Exception:
         lore_root = None
 
+    # Task 11: team-mode first-come-wins. Under defrag=True, re-read
+    # each wiki's last_curator_c at entry. If it matches the current ISO
+    # week we skip — another user already ran this cycle. Uses iso-week
+    # equivalence rather than timestamp comparison to survive clock skew
+    # across team members.
+    if defrag and lore_root is not None:
+        iso_now = now.isocalendar()[:2]
+        already_ran: set[str] = set()
+        for wiki_path in wikis:
+            entry = WikiLedger(lore_root, wiki_path.name).read()
+            last_c = entry.last_curator_c
+            if last_c is None:
+                continue
+            if last_c.tzinfo is None:
+                from datetime import UTC as _UTC
+                last_c = last_c.replace(tzinfo=_UTC)
+            if last_c.isocalendar()[:2] == iso_now:
+                already_ran.add(wiki_path.name)
+                console.print(
+                    f"[dim]Skipping wiki/{wiki_path.name}: already ran "
+                    f"this ISO week ({last_c.isoformat()}).[/dim]"
+                )
+        if already_ran:
+            wikis = [w for w in wikis if w.name not in already_ran]
+
     for wiki_path in wikis:
         if is_obsidian_holding(wiki_path) and not dry_run:
             console.print(

--- a/lib/lore_curator/curator_c.py
+++ b/lib/lore_curator/curator_c.py
@@ -571,14 +571,78 @@ def _apply_safely(action: CuratorAction) -> tuple[bool, str]:
     return (True, "applied")
 
 
+# Registry for LLM-driven Curator C defrag passes. Phase B of Plan 5
+# appends callables here; each callable has signature
+# ``(wiki_path, *, anthropic_client, dry_run) -> dict[str, int]`` (summary counts).
+_DEFRAG_PASSES: list = []
+
+
+def _run_defrag_passes(
+    wiki_path,
+    *,
+    anthropic_client,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Run every registered LLM pass for one wiki; return merged summary."""
+    summary: dict[str, int] = {}
+    for pass_fn in _DEFRAG_PASSES:
+        counts = pass_fn(
+            wiki_path, anthropic_client=anthropic_client, dry_run=dry_run
+        ) or {}
+        for k, v in counts.items():
+            summary[k] = summary.get(k, 0) + v
+    return summary
+
+
+def _snapshot_wiki(wiki_path) -> dict:
+    """Return {relative_path: content_str} for every .md file under wiki_path."""
+    out: dict = {}
+    if not wiki_path.exists():
+        return out
+    for p in sorted(wiki_path.rglob("*.md")):
+        if p.is_file():
+            try:
+                out[str(p.relative_to(wiki_path))] = p.read_text(errors="replace")
+            except OSError:
+                continue
+    return out
+
+
 def run_curator_c(
     wiki_filter: str | None = None,
     dry_run: bool = True,
     stale_threshold: int = STALENESS_DAYS,
+    *,
+    defrag: bool = False,
+    anthropic_client=None,
+    run_id: str | None = None,
 ) -> list[CuratorReport]:
+    """Run Curator C — hygiene by default; with ``defrag=True`` also runs
+    LLM passes (adjacent-merge, auto-supersede, orphan-repair) registered
+    in ``_DEFRAG_PASSES``.
+
+    When ``defrag=True``:
+      - pre-flight: abort if wiki repo has merge conflicts
+      - snapshot wiki before running passes
+      - run hygiene passes (pre-existing) + defrag passes
+      - write a diff-log entry
+      - prune old diff logs (90d retention)
+      - update ``WikiLedger.last_curator_c`` on success (atomic)
+    """
+    from datetime import UTC, datetime as _dt
+    from lore_core.config import get_lore_root
+    from lore_core.ledger import WikiLedger
+
     wikis = discover_wikis(wiki_filter)
     reports: list[CuratorReport] = []
     today = date.today()
+    now = _dt.now(UTC)
+    rid = run_id or now.strftime("%Y-%m-%dT%H-%M-%S")
+
+    try:
+        lore_root = get_lore_root()
+    except Exception:
+        lore_root = None
 
     for wiki_path in wikis:
         if is_obsidian_holding(wiki_path) and not dry_run:
@@ -587,6 +651,17 @@ def run_curator_c(
                 f"{wiki_path}. Proceeding — but if you have mid-edit "
                 "buffers, close them first."
             )
+
+        if defrag:
+            # Pre-flight: bail on mid-merge vault.
+            from lore_curator.c_passes import has_merge_conflicts
+            if has_merge_conflicts(wiki_path):
+                console.print(
+                    f"[yellow]Skipping wiki/{wiki_path.name}:[/yellow] "
+                    "merge conflicts detected. Resolve first."
+                )
+                continue
+
         report = CuratorReport(wiki=wiki_path.name)
         report.actions.extend(_pass_staleness(wiki_path, today, stale_threshold))
         report.actions.extend(_pass_supersession(wiki_path))
@@ -598,6 +673,13 @@ def run_curator_c(
     for report in reports:
         _print_report(report, dry_run)
 
+    defrag_summary_by_wiki: dict[str, dict[str, int]] = {}
+    wiki_snapshots_before: dict[str, dict] = {}
+
+    if defrag:
+        for wiki_path in wikis:
+            wiki_snapshots_before[wiki_path.name] = _snapshot_wiki(wiki_path)
+
     if not dry_run:
         for report in reports:
             for action in report.actions:
@@ -608,10 +690,50 @@ def run_curator_c(
                         f"  [red]skipped[/red] {action.path.name}: {reason}"
                     )
 
-    # Write a review summary file per wiki so next SessionStart can surface it
+    if defrag:
+        for wiki_path in wikis:
+            summary = _run_defrag_passes(
+                wiki_path, anthropic_client=anthropic_client, dry_run=dry_run
+            )
+            defrag_summary_by_wiki[wiki_path.name] = summary
+
     for report in reports:
         wiki_path = next(w for w in wikis if w.name == report.wiki)
         _write_review(wiki_path, report)
+
+    if defrag and lore_root is not None:
+        from lore_curator.curator_c_diff import (
+            prune_old_diff_logs,
+            write_diff_log_entry,
+        )
+        for wiki_path in wikis:
+            before = wiki_snapshots_before.get(wiki_path.name, {})
+            after = _snapshot_wiki(wiki_path)
+            summary = defrag_summary_by_wiki.get(wiki_path.name, {})
+            # Merge hygiene-pass action counts into the summary.
+            hygiene_report = next(
+                (r for r in reports if r.wiki == wiki_path.name), None
+            )
+            if hygiene_report:
+                for action in hygiene_report.actions:
+                    summary[action.kind] = summary.get(action.kind, 0) + 1
+            write_diff_log_entry(
+                lore_root,
+                run_id=rid,
+                snapshot_before=before,
+                snapshot_after=after,
+                dry_run=dry_run,
+                summary=summary,
+                now=now,
+            )
+        prune_old_diff_logs(lore_root)
+
+        # Atomic last_curator_c update — only reached on full-run success.
+        for wiki_path in wikis:
+            try:
+                WikiLedger(lore_root, wiki_path.name).update_last_curator("c", at=now)
+            except Exception:
+                pass
 
     return reports
 

--- a/lib/lore_curator/curator_c.py
+++ b/lib/lore_curator/curator_c.py
@@ -500,6 +500,57 @@ def _pass_implements(wiki_path: Path) -> list[CuratorAction]:
     return actions
 
 
+def _pass_draft_promotion(
+    wiki_path: Path, today: date, threshold_days: int = 14
+) -> list[CuratorAction]:
+    """Time-based proposal: mark long-standing drafts with
+    ``promotion_candidate: true``. NEVER flips ``draft: false``.
+
+    A note is a candidate when:
+      - ``draft: true`` AND
+      - ``created`` date is older than ``threshold_days`` days ago AND
+      - ``promotion_candidate`` is not already set
+    """
+    from datetime import date as _date_t, timedelta
+    actions: list[CuratorAction] = []
+    cutoff = today - timedelta(days=threshold_days)
+
+    for fpath in discover_notes(wiki_path):
+        try:
+            text = fpath.read_text(errors="replace")
+        except OSError:
+            continue
+        fm = parse_frontmatter(text)
+        if fm is None:
+            continue
+        if fm.get("draft") is not True:
+            continue
+        if fm.get("promotion_candidate") is True:
+            continue  # idempotent
+        created = fm.get("created")
+        if isinstance(created, str):
+            try:
+                created = _date_t.fromisoformat(created)
+            except ValueError:
+                continue
+        if not isinstance(created, _date_t):
+            continue
+        # Strictly older than cutoff — boundary exclusive.
+        if not (created < cutoff):
+            continue
+
+        # Patch: append promotion_candidate: true at end of frontmatter.
+        actions.append(
+            CuratorAction(
+                path=fpath,
+                kind="promote-draft",
+                reason=f"draft created {(today - created).days}d ago ({created.isoformat()})",
+                patch={"promotion_candidate": True},
+            )
+        )
+    return actions
+
+
 def _pass_team_mode_hint(wiki_path: Path) -> list[str]:
     """Check whether the wiki has outgrown solo mode.
 
@@ -667,6 +718,8 @@ def run_curator_c(
         report.actions.extend(_pass_supersession(wiki_path))
         report.actions.extend(_pass_implements(wiki_path))
         report.actions.extend(_pass_git_backfill(wiki_path))
+        if defrag:
+            report.actions.extend(_pass_draft_promotion(wiki_path, today))
         report.hints.extend(_pass_team_mode_hint(wiki_path))
         reports.append(report)
 

--- a/lib/lore_curator/curator_c.py
+++ b/lib/lore_curator/curator_c.py
@@ -628,6 +628,18 @@ def _apply_safely(action: CuratorAction) -> tuple[bool, str]:
 _DEFRAG_PASSES: list = []
 
 
+def _ensure_passes_registered() -> None:
+    """Lazy-import pass modules so their _register() side effects fire.
+
+    The pass modules each register themselves into _DEFRAG_PASSES on
+    import. Importing them eagerly from this module would circular-
+    import. Instead, we trigger them here the first time defrag runs.
+    """
+    import lore_curator.c_adjacent_merge  # noqa: F401
+    import lore_curator.c_auto_supersede  # noqa: F401
+    import lore_curator.c_orphan_links   # noqa: F401
+
+
 def _run_defrag_passes(
     wiki_path,
     *,
@@ -635,6 +647,7 @@ def _run_defrag_passes(
     dry_run: bool,
 ) -> dict[str, int]:
     """Run every registered LLM pass for one wiki; return merged summary."""
+    _ensure_passes_registered()
     summary: dict[str, int] = {}
     for pass_fn in _DEFRAG_PASSES:
         counts = pass_fn(

--- a/lib/lore_curator/curator_c_diff.py
+++ b/lib/lore_curator/curator_c_diff.py
@@ -1,0 +1,153 @@
+"""Pre/post-diff audit log for Curator C runs.
+
+One file per day at ``$LORE_ROOT/.lore/curator-c.diff.YYYY-MM-DD.log``.
+Each entry carries ``run_id`` so the diff can be cross-referenced with
+the structured ``runs/<id>.jsonl`` log. Zero-change runs compress to a
+single-line marker so the audit log stays grep-clean.
+
+Retention: 90 days (older files pruned on the next run).
+Rotation: 10 MB per log → rotates to ``.log.1``.
+Failures: permission denied → emits a ``curator-c/diff-log-write-failed``
+event to ``hook-events.jsonl`` (observable via CaptureState), never raises.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+_ROTATE_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+_RETENTION_DAYS_DEFAULT = 90
+
+
+def _log_path(lore_root: Path, ts: datetime | None = None) -> Path:
+    stamp = (ts or datetime.now(UTC)).strftime("%Y-%m-%d")
+    return lore_root / ".lore" / f"curator-c.diff.{stamp}.log"
+
+
+def _maybe_rotate(log: Path) -> None:
+    """If the log is ≥ 10 MB, move it to ``<log>.1`` (overwrites prior .1)."""
+    try:
+        size = log.stat().st_size
+    except OSError:
+        return
+    if size < _ROTATE_MAX_BYTES:
+        return
+    rotated = log.with_suffix(log.suffix + ".1")
+    try:
+        os.replace(log, rotated)
+    except OSError:
+        pass
+
+
+def _render_unified_diff(
+    before: dict[str, str], after: dict[str, str]
+) -> list[str]:
+    """Return unified-diff blocks (one per changed file) as strings."""
+    blocks: list[str] = []
+    all_files = sorted(set(before) | set(after))
+    for f in all_files:
+        b = before.get(f, "")
+        a = after.get(f, "")
+        if a == b:
+            continue
+        diff_lines = list(
+            difflib.unified_diff(
+                b.splitlines(keepends=True),
+                a.splitlines(keepends=True),
+                fromfile=f"a/{f}",
+                tofile=f"b/{f}",
+                lineterm="",
+            )
+        )
+        if diff_lines:
+            blocks.append("\n".join(diff_lines))
+    return blocks
+
+
+def _render_summary_table(summary: dict[str, int]) -> str:
+    if not summary:
+        return "(no summary counts)"
+    rows = [f"  {k}: {v}" for k, v in sorted(summary.items()) if v]
+    return "\n".join(rows) if rows else "(all counts zero)"
+
+
+def _emit_warning_event(lore_root: Path, outcome: str, message: str) -> None:
+    """Emit a curator-c warning event; never raise."""
+    try:
+        from lore_core.hook_log import HookEventLogger
+        HookEventLogger(lore_root).emit(
+            event="curator-c", outcome=outcome, error={"message": message}
+        )
+    except Exception:
+        pass
+
+
+def write_diff_log_entry(
+    lore_root: Path,
+    *,
+    run_id: str,
+    snapshot_before: dict[str, str],
+    snapshot_after: dict[str, str],
+    dry_run: bool,
+    summary: dict[str, int],
+    now: datetime | None = None,
+) -> None:
+    """Append one entry to today's log. Never raises on I/O failure.
+
+    Zero-change runs (snapshots equal + empty summary) write a single-line
+    marker and skip the full entry structure.
+    """
+    now = now or datetime.now(UTC)
+    log = _log_path(lore_root, now)
+    log.parent.mkdir(parents=True, exist_ok=True)
+
+    _maybe_rotate(log)
+
+    try:
+        diff_blocks = _render_unified_diff(snapshot_before, snapshot_after)
+        summary_has_data = any(v for v in summary.values())
+        is_noop = not diff_blocks and not summary_has_data
+
+        if is_noop:
+            line = f"{now.isoformat().replace('+00:00', 'Z')} run={run_id} status=no-op\n"
+            with log.open("a") as f:
+                f.write(line)
+            return
+
+        mode = "DRY-RUN" if dry_run else "apply"
+        header = (
+            f"═══ run={run_id} ts={now.isoformat().replace('+00:00', 'Z')} "
+            f"mode={mode} ═══"
+        )
+        parts = [header, "Summary:", _render_summary_table(summary), ""]
+        if diff_blocks:
+            parts.append("Diffs:")
+            parts.extend(diff_blocks)
+        parts.append("")  # trailing blank
+        with log.open("a") as f:
+            f.write("\n".join(parts) + "\n")
+    except OSError as exc:
+        _emit_warning_event(
+            lore_root, "diff-log-write-failed", f"{type(exc).__name__}: {exc}"
+        )
+
+
+def prune_old_diff_logs(
+    lore_root: Path, *, retention_days: int = _RETENTION_DAYS_DEFAULT
+) -> None:
+    """Delete diff logs older than ``retention_days`` days. Never raises."""
+    lore_dir = lore_root / ".lore"
+    if not lore_dir.exists():
+        return
+    threshold = time.time() - retention_days * 86400
+    for p in lore_dir.glob("curator-c.diff.*.log*"):
+        try:
+            if p.stat().st_mtime < threshold:
+                p.unlink()
+        except OSError:
+            continue

--- a/tests/test_c_adjacent_merge.py
+++ b/tests/test_c_adjacent_merge.py
@@ -1,0 +1,245 @@
+"""Task 6: adjacent-concept merge proposal pass."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FakeBlock:
+    def __init__(self, data: dict):
+        self.type = "tool_use"
+        self.input = data
+
+
+class _FakeResp:
+    def __init__(self, data: dict):
+        self.content = [_FakeBlock(data)]
+
+
+class FakeLlmClient:
+    """Minimal LlmClient returning a fixed tool-use block."""
+
+    def __init__(self, response_data: dict):
+        self._data = response_data
+
+        class _Messages:
+            def create(s, **kwargs):
+                return _FakeResp(self._data)
+
+        self.messages = _Messages()
+
+
+def _write_note(path: Path, *, type_: str, title: str, tags: list[str], body: str = "body") -> Path:
+    path.write_text(
+        "---\n"
+        f"type: {type_}\n"
+        f"title: {title}\n"
+        f"tags: [{', '.join(tags)}]\n"
+        "created: 2026-04-21\n"
+        "last_reviewed: 2026-04-21\n"
+        f"description: {title}\n"
+        "---\n\n"
+        f"{body}\n"
+    )
+    return path
+
+
+def _seed_vault(tmp_path: Path) -> Path:
+    lore_root = tmp_path / "vault"
+    (lore_root / ".lore").mkdir(parents=True)
+    wiki = lore_root / "wiki" / "testwiki"
+    (wiki / "sessions").mkdir(parents=True)
+    return lore_root
+
+
+# ---------------------------------------------------------------------------
+# Candidate generation (exercised independently)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_merge_candidates_filters_low_overlap(tmp_path: Path) -> None:
+    """Two notes without shared tags or fuzzy-title overlap → no candidate pair."""
+    from lore_curator.c_adjacent_merge import generate_merge_candidates
+
+    lore_root = _seed_vault(tmp_path)
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "a.md", type_="concept", title="Zarr Chunking", tags=["storage"])
+    _write_note(wiki / "sessions" / "b.md", type_="concept", title="MCP Adapter", tags=["adapters"])
+
+    pairs = generate_merge_candidates(wiki)
+    assert pairs == [], "no shared tags → no candidate pair"
+
+
+def test_generate_merge_candidates_pairs_shared_tag_fuzzy_title(tmp_path: Path) -> None:
+    from lore_curator.c_adjacent_merge import generate_merge_candidates
+
+    lore_root = _seed_vault(tmp_path)
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "zarr-chunking.md", type_="concept", title="Zarr Chunking", tags=["storage", "format"])
+    _write_note(wiki / "sessions" / "zarr-chunking-strategy.md", type_="concept", title="Zarr Chunking Strategy", tags=["storage"])
+
+    pairs = generate_merge_candidates(wiki)
+    assert len(pairs) == 1
+
+
+def test_candidates_skip_session_notes(tmp_path: Path) -> None:
+    from lore_curator.c_adjacent_merge import generate_merge_candidates
+
+    lore_root = _seed_vault(tmp_path)
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "s1.md", type_="session", title="Session One", tags=["z"])
+    _write_note(wiki / "sessions" / "s2.md", type_="session", title="Session Two", tags=["z"])
+
+    pairs = generate_merge_candidates(wiki)
+    assert pairs == [], "type=session never candidates for merge"
+
+
+# ---------------------------------------------------------------------------
+# Pass behaviour (with fake LLM)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_proposes_new_note_on_0_9_confidence(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_adjacent_merge import adjacent_merge_pass
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "zarr-chunking.md", type_="concept", title="Zarr Chunking", tags=["storage"])
+    _write_note(wiki / "sessions" / "zarr-chunking-strategy.md", type_="concept", title="Zarr Chunking Strategy", tags=["storage"])
+
+    client = FakeLlmClient(
+        {"should_merge": True, "confidence": 0.9, "reason": "same concept",
+         "merged_title": "Zarr Chunking", "merged_description": "merged"}
+    )
+
+    summary = adjacent_merge_pass(wiki, anthropic_client=client, dry_run=False)
+
+    assert summary.get("adjacent_merge_proposed") == 1
+    proposals = list((wiki / "sessions").glob("*-merge*.md"))
+    assert len(proposals) == 1
+    draft = proposals[0].read_text()
+    assert "draft: true" in draft
+    assert "merge_candidate_sources" in draft
+
+
+def test_merge_at_exact_0_8_is_included(tmp_path: Path, monkeypatch) -> None:
+    """Boundary: confidence == 0.8 → included (>= inclusive)."""
+    from lore_curator.c_adjacent_merge import adjacent_merge_pass
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "a.md", type_="concept", title="Cache", tags=["t"])
+    _write_note(wiki / "sessions" / "ab.md", type_="concept", title="Cached", tags=["t"])
+
+    client = FakeLlmClient(
+        {"should_merge": True, "confidence": 0.8, "reason": "at threshold"}
+    )
+    summary = adjacent_merge_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("adjacent_merge_proposed") == 1
+
+
+def test_merge_at_0_79_skips(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_adjacent_merge import adjacent_merge_pass
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "a.md", type_="concept", title="Cache", tags=["t"])
+    _write_note(wiki / "sessions" / "ab.md", type_="concept", title="Cached", tags=["t"])
+
+    client = FakeLlmClient(
+        {"should_merge": True, "confidence": 0.79, "reason": "just below"}
+    )
+    summary = adjacent_merge_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("adjacent_merge_proposed", 0) == 0
+    assert summary.get("adjacent_merge_skipped_low_confidence") == 1
+
+
+def test_merge_skips_malformed_llm_response(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_adjacent_merge import adjacent_merge_pass
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "a.md", type_="concept", title="Cache", tags=["t"])
+    _write_note(wiki / "sessions" / "ab.md", type_="concept", title="Cached", tags=["t"])
+
+    # Missing `reason` field.
+    client = FakeLlmClient({"should_merge": True, "confidence": 0.9})
+    summary = adjacent_merge_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("adjacent_merge_skipped_malformed") == 1
+    assert not list((wiki / "sessions").glob("*-merge*.md"))
+
+
+def test_merge_never_edits_originals(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_adjacent_merge import adjacent_merge_pass
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "testwiki"
+    a = _write_note(wiki / "sessions" / "a.md", type_="concept", title="Cache", tags=["t"])
+    b = _write_note(wiki / "sessions" / "ab.md", type_="concept", title="Cached", tags=["t"])
+    before_a = a.read_bytes()
+    before_b = b.read_bytes()
+
+    client = FakeLlmClient({"should_merge": True, "confidence": 0.9, "reason": "x"})
+    adjacent_merge_pass(wiki, anthropic_client=client, dry_run=False)
+
+    assert a.read_bytes() == before_a
+    assert b.read_bytes() == before_b
+
+
+def test_merge_idempotent_same_sources(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_adjacent_merge import adjacent_merge_pass
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "a.md", type_="concept", title="Cache", tags=["t"])
+    _write_note(wiki / "sessions" / "ab.md", type_="concept", title="Cached", tags=["t"])
+
+    client = FakeLlmClient({"should_merge": True, "confidence": 0.9, "reason": "x"})
+    adjacent_merge_pass(wiki, anthropic_client=client, dry_run=False)
+    first_drafts = sorted((wiki / "sessions").glob("*-merge*.md"))
+    adjacent_merge_pass(wiki, anthropic_client=client, dry_run=False)
+    second_drafts = sorted((wiki / "sessions").glob("*-merge*.md"))
+
+    assert first_drafts == second_drafts, "second run must not create duplicate drafts"
+
+
+def test_merge_dry_run_writes_no_notes(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_adjacent_merge import adjacent_merge_pass
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "a.md", type_="concept", title="Cache", tags=["t"])
+    _write_note(wiki / "sessions" / "ab.md", type_="concept", title="Cached", tags=["t"])
+
+    client = FakeLlmClient({"should_merge": True, "confidence": 0.9, "reason": "x"})
+    summary = adjacent_merge_pass(wiki, anthropic_client=client, dry_run=True)
+    assert summary.get("adjacent_merge_proposed") == 1  # counted
+    assert not list((wiki / "sessions").glob("*-merge*.md")), "dry-run writes no file"
+
+
+def test_merge_skipped_without_llm(tmp_path: Path) -> None:
+    from lore_curator.c_adjacent_merge import adjacent_merge_pass
+
+    lore_root = _seed_vault(tmp_path)
+    wiki = lore_root / "wiki" / "testwiki"
+    _write_note(wiki / "sessions" / "a.md", type_="concept", title="Cache", tags=["t"])
+    _write_note(wiki / "sessions" / "ab.md", type_="concept", title="Cached", tags=["t"])
+
+    summary = adjacent_merge_pass(wiki, anthropic_client=None, dry_run=False)
+    assert summary == {"adjacent_merge_skipped_no_llm": 1}
+
+
+def test_merge_pass_registered_in_defrag_passes() -> None:
+    """Confirms the pass is picked up by the integration skeleton."""
+    from lore_curator import c_adjacent_merge, curator_c  # noqa: F401
+    assert c_adjacent_merge.adjacent_merge_pass in curator_c._DEFRAG_PASSES

--- a/tests/test_c_auto_supersede.py
+++ b/tests/test_c_auto_supersede.py
@@ -1,0 +1,218 @@
+"""Task 7: auto-supersession proposal pass — marker only, never flips
+`superseded_by` directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _FakeBlock:
+    def __init__(self, data: dict):
+        self.type = "tool_use"
+        self.input = data
+
+
+class _FakeResp:
+    def __init__(self, data: dict):
+        self.content = [_FakeBlock(data)]
+
+
+class FakeLlmClient:
+    def __init__(self, response_data: dict):
+        self._data = response_data
+        class _M:
+            def create(s, **kw):
+                return _FakeResp(self._data)
+        self.messages = _M()
+
+
+def _write_decision(
+    path: Path, *, title: str, created: str, tags: list[str], canonical: bool = False
+) -> Path:
+    canon_line = "canonical: true\n" if canonical else ""
+    path.write_text(
+        "---\n"
+        "type: decision\n"
+        f"title: {title}\n"
+        f"tags: [{', '.join(tags)}]\n"
+        f"created: {created}\n"
+        f"last_reviewed: {created}\n"
+        f"description: {title}\n"
+        f"{canon_line}"
+        "---\n\n"
+        "body\n"
+    )
+    return path
+
+
+def _seed(tmp_path: Path) -> Path:
+    lore_root = tmp_path / "vault"
+    (lore_root / ".lore").mkdir(parents=True)
+    wiki = lore_root / "wiki" / "w"
+    (wiki / "sessions").mkdir(parents=True)
+    return lore_root
+
+
+# ---------------------------------------------------------------------------
+# Candidate generation
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_gen_requires_newer_created_date(tmp_path: Path) -> None:
+    from lore_curator.c_auto_supersede import generate_supersede_candidates
+
+    lore_root = _seed(tmp_path)
+    wiki = lore_root / "wiki" / "w"
+    _write_decision(wiki / "sessions" / "a.md", title="A", created="2026-04-20", tags=["x"])
+    _write_decision(wiki / "sessions" / "b.md", title="B", created="2026-04-21", tags=["x"])
+
+    pairs = generate_supersede_candidates(wiki)
+    assert len(pairs) == 1
+    older, newer = pairs[0]
+    assert older.stem == "a"
+    assert newer.stem == "b"
+
+
+def test_candidate_gen_requires_overlapping_scope(tmp_path: Path) -> None:
+    from lore_curator.c_auto_supersede import generate_supersede_candidates
+
+    lore_root = _seed(tmp_path)
+    wiki = lore_root / "wiki" / "w"
+    _write_decision(wiki / "sessions" / "a.md", title="A", created="2026-04-20", tags=["x"])
+    _write_decision(wiki / "sessions" / "b.md", title="B", created="2026-04-21", tags=["y"])
+
+    assert generate_supersede_candidates(wiki) == []
+
+
+def test_candidate_gen_ignores_non_decisions(tmp_path: Path) -> None:
+    from lore_curator.c_auto_supersede import generate_supersede_candidates
+    from tests.test_c_adjacent_merge import _write_note
+
+    lore_root = _seed(tmp_path)
+    wiki = lore_root / "wiki" / "w"
+    _write_note(wiki / "sessions" / "s1.md", type_="session", title="S1", tags=["x"])
+    _write_note(wiki / "sessions" / "s2.md", type_="session", title="S2", tags=["x"])
+
+    assert generate_supersede_candidates(wiki) == []
+
+
+# ---------------------------------------------------------------------------
+# Proposal writes (markers only)
+# ---------------------------------------------------------------------------
+
+
+def test_supersede_proposes_markers_on_0_9_confidence(tmp_path, monkeypatch) -> None:
+    from lore_curator.c_auto_supersede import auto_supersede_pass
+
+    lore_root = _seed(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    older = _write_decision(wiki / "sessions" / "a.md", title="A", created="2026-04-20", tags=["x"])
+    newer = _write_decision(wiki / "sessions" / "b.md", title="B", created="2026-04-21", tags=["x"])
+
+    client = FakeLlmClient({"contradicts": True, "confidence": 0.9, "reason": "flipped"})
+    summary = auto_supersede_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("auto_supersede_proposed") == 1
+
+    older_text = older.read_text()
+    newer_text = newer.read_text()
+    assert "supersede_candidate" in older_text
+    assert "[[b]]" in older_text
+    assert "supersede_candidate_of" in newer_text
+    assert "[[a]]" in newer_text
+    # CRITICAL: never writes the actual superseded_by field.
+    assert "superseded_by" not in older_text
+
+
+def test_supersede_at_exact_0_85(tmp_path, monkeypatch) -> None:
+    from lore_curator.c_auto_supersede import auto_supersede_pass
+
+    lore_root = _seed(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    _write_decision(wiki / "sessions" / "a.md", title="A", created="2026-04-20", tags=["x"])
+    _write_decision(wiki / "sessions" / "b.md", title="B", created="2026-04-21", tags=["x"])
+
+    client = FakeLlmClient({"contradicts": True, "confidence": 0.85, "reason": "boundary"})
+    summary = auto_supersede_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("auto_supersede_proposed") == 1
+
+
+def test_supersede_at_0_84_skips(tmp_path, monkeypatch) -> None:
+    from lore_curator.c_auto_supersede import auto_supersede_pass
+
+    lore_root = _seed(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    _write_decision(wiki / "sessions" / "a.md", title="A", created="2026-04-20", tags=["x"])
+    _write_decision(wiki / "sessions" / "b.md", title="B", created="2026-04-21", tags=["x"])
+
+    client = FakeLlmClient({"contradicts": True, "confidence": 0.84, "reason": "just below"})
+    summary = auto_supersede_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("auto_supersede_proposed", 0) == 0
+    assert summary.get("auto_supersede_skipped_low_confidence") == 1
+
+
+def test_supersede_respects_canonical_true(tmp_path, monkeypatch) -> None:
+    from lore_curator.c_auto_supersede import auto_supersede_pass
+
+    lore_root = _seed(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    _write_decision(wiki / "sessions" / "a.md", title="A", created="2026-04-20", tags=["x"], canonical=True)
+    _write_decision(wiki / "sessions" / "b.md", title="B", created="2026-04-21", tags=["x"])
+
+    client = FakeLlmClient({"contradicts": True, "confidence": 0.99, "reason": "x"})
+    summary = auto_supersede_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("auto_supersede_skipped_canonical") == 1
+    assert summary.get("auto_supersede_proposed", 0) == 0
+
+
+def test_supersede_idempotent(tmp_path, monkeypatch) -> None:
+    from lore_curator.c_auto_supersede import auto_supersede_pass
+
+    lore_root = _seed(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    _write_decision(wiki / "sessions" / "a.md", title="A", created="2026-04-20", tags=["x"])
+    _write_decision(wiki / "sessions" / "b.md", title="B", created="2026-04-21", tags=["x"])
+
+    client = FakeLlmClient({"contradicts": True, "confidence": 0.9, "reason": "x"})
+    auto_supersede_pass(wiki, anthropic_client=client, dry_run=False)
+    first_text = (wiki / "sessions" / "a.md").read_text()
+    auto_supersede_pass(wiki, anthropic_client=client, dry_run=False)
+    second_text = (wiki / "sessions" / "a.md").read_text()
+
+    # Marker should not be duplicated on second run.
+    assert first_text == second_text
+
+
+def test_supersede_skips_malformed(tmp_path, monkeypatch) -> None:
+    from lore_curator.c_auto_supersede import auto_supersede_pass
+
+    lore_root = _seed(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    _write_decision(wiki / "sessions" / "a.md", title="A", created="2026-04-20", tags=["x"])
+    _write_decision(wiki / "sessions" / "b.md", title="B", created="2026-04-21", tags=["x"])
+
+    client = FakeLlmClient({"contradicts": True})  # missing confidence + reason
+    summary = auto_supersede_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("auto_supersede_skipped_malformed") == 1
+
+
+def test_supersede_skipped_without_llm(tmp_path) -> None:
+    from lore_curator.c_auto_supersede import auto_supersede_pass
+
+    lore_root = _seed(tmp_path)
+    wiki = lore_root / "wiki" / "w"
+    summary = auto_supersede_pass(wiki, anthropic_client=None, dry_run=False)
+    assert summary == {"auto_supersede_skipped_no_llm": 1}
+
+
+def test_supersede_registered_in_defrag_passes() -> None:
+    from lore_curator import c_auto_supersede, curator_c  # noqa: F401
+    assert c_auto_supersede.auto_supersede_pass in curator_c._DEFRAG_PASSES

--- a/tests/test_c_coordination.py
+++ b/tests/test_c_coordination.py
@@ -1,0 +1,133 @@
+"""Task 11: Curator C first-come-wins coordination.
+
+- WikiLedger writes fsynced so concurrent readers see committed state
+- run_curator_c(defrag=True) re-reads last_curator_c at entry; skips
+  wikis whose last_curator_c matches the current ISO week (equivalence,
+  not timestamp > threshold — avoids clock-skew false positives)
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _seed_vault(tmp_path: Path) -> Path:
+    lore_root = tmp_path / "vault"
+    (lore_root / ".lore").mkdir(parents=True)
+    wiki = lore_root / "wiki" / "w"
+    (wiki / "sessions").mkdir(parents=True)
+    return lore_root
+
+
+def test_ledger_write_is_fsynced(tmp_path: Path, monkeypatch) -> None:
+    """atomic_write_text must fsync the tmp file before rename."""
+    fsync_calls = []
+    real_fsync = os.fsync
+
+    def tracking_fsync(fd):
+        fsync_calls.append(fd)
+        return real_fsync(fd)
+
+    monkeypatch.setattr("os.fsync", tracking_fsync)
+
+    from lore_core.io import atomic_write_text
+    atomic_write_text(tmp_path / "x.txt", "hello\n")
+
+    assert fsync_calls, "atomic_write_text must call fsync before rename"
+
+
+def test_second_user_skips_after_first_iso_week_match(tmp_path: Path, monkeypatch) -> None:
+    """Pre-populate last_curator_c as now → run_curator_c(defrag=True) skips."""
+    from lore_core.ledger import WikiLedger
+    from lore_curator.curator_c import run_curator_c
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    now = datetime.now(UTC)
+    # Fresh run this same ISO week.
+    WikiLedger(lore_root, "w").update_last_curator("c", at=now)
+
+    before_entry = WikiLedger(lore_root, "w").read()
+    before_ts = before_entry.last_curator_c
+
+    # Invoke. Since last_curator_c is in the current ISO week, the wiki
+    # is skipped; last_curator_c should NOT advance.
+    reports = run_curator_c(wiki_filter="w", dry_run=False, defrag=True)
+
+    after_entry = WikiLedger(lore_root, "w").read()
+    # Last-curator-c timestamp should be unchanged (or very close to it —
+    # the run didn't write a new one for the skipped wiki).
+    assert after_entry.last_curator_c is not None
+    # Within 2 seconds (allows for update_last_curator's own now() call).
+    delta = abs((after_entry.last_curator_c - before_ts).total_seconds())
+    assert delta < 2.0, (
+        f"skipped wiki must not advance last_curator_c materially; "
+        f"before={before_ts}, after={after_entry.last_curator_c}"
+    )
+
+
+def test_coordination_fresh_cycle_proceeds(tmp_path: Path, monkeypatch) -> None:
+    """last_curator_c from prior ISO week → run proceeds normally."""
+    from lore_core.ledger import WikiLedger
+    from lore_curator.curator_c import run_curator_c
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    prior_week = datetime.now(UTC) - timedelta(days=10)
+    WikiLedger(lore_root, "w").update_last_curator("c", at=prior_week)
+
+    run_curator_c(wiki_filter="w", dry_run=False, defrag=True)
+
+    after = WikiLedger(lore_root, "w").read()
+    # last_curator_c must have advanced to ~now (this cycle's run).
+    now = datetime.now(UTC)
+    assert after.last_curator_c is not None
+    assert (now - after.last_curator_c).total_seconds() < 60, (
+        "fresh cycle should advance last_curator_c to current run"
+    )
+
+
+def test_coordination_never_run_proceeds(tmp_path: Path, monkeypatch) -> None:
+    """No prior run (last_curator_c=None) → proceed; first run records."""
+    from lore_core.ledger import WikiLedger
+    from lore_curator.curator_c import run_curator_c
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+
+    assert WikiLedger(lore_root, "w").read().last_curator_c is None
+    run_curator_c(wiki_filter="w", dry_run=False, defrag=True)
+
+    after = WikiLedger(lore_root, "w").read()
+    assert after.last_curator_c is not None, "first run must record last_curator_c"
+
+
+def test_coordination_clock_skew_immune(tmp_path: Path, monkeypatch) -> None:
+    """Two users with clocks 5 min apart both in the same ISO week → the
+    second's `iso_now == iso_last` check correctly matches regardless of
+    which one wrote first. Skew doesn't cause a double-run.
+    """
+    from lore_core.ledger import WikiLedger
+    from lore_curator.curator_c import run_curator_c
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+
+    # User A writes last_curator_c 5 min in the future from user B's clock.
+    user_a_time = datetime.now(UTC) + timedelta(minutes=5)
+    WikiLedger(lore_root, "w").update_last_curator("c", at=user_a_time)
+
+    # User B (now) checks: iso_week(user_a_time) == iso_week(now_B) in
+    # nearly all cases except late Sunday. Assert same-week skip.
+    before = WikiLedger(lore_root, "w").read()
+
+    run_curator_c(wiki_filter="w", dry_run=False, defrag=True)
+
+    after = WikiLedger(lore_root, "w").read()
+    # Should be unchanged — skip path.
+    assert after.last_curator_c == before.last_curator_c

--- a/tests/test_c_draft_promotion.py
+++ b/tests/test_c_draft_promotion.py
@@ -1,0 +1,123 @@
+"""Task 9: draft-promotion proposal pass (time-based; proposes only)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+
+def _write_draft(
+    path: Path,
+    *,
+    created: date,
+    draft: bool = True,
+    promotion_candidate: bool | None = None,
+) -> Path:
+    lines = [
+        "---",
+        "type: concept",
+        f"created: {created.isoformat()}",
+        f"last_reviewed: {created.isoformat()}",
+        "description: draft note",
+        "tags: []",
+    ]
+    if draft:
+        lines.append("draft: true")
+    if promotion_candidate is not None:
+        lines.append(f"promotion_candidate: {str(promotion_candidate).lower()}")
+    lines += ["---", "", "body"]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _seed(tmp_path: Path) -> Path:
+    wiki = tmp_path / "wiki"
+    (wiki / "sessions").mkdir(parents=True)
+    return wiki
+
+
+# ---------------------------------------------------------------------------
+# _pass_draft_promotion unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_promotion_proposes_on_15d_old_draft(tmp_path: Path) -> None:
+    from lore_curator.curator_c import _pass_draft_promotion
+
+    wiki = _seed(tmp_path)
+    today = date(2026, 4, 21)
+    _write_draft(wiki / "sessions" / "a.md", created=today - timedelta(days=15))
+
+    actions = _pass_draft_promotion(wiki, today)
+    assert len(actions) == 1
+    assert actions[0].kind == "promote-draft"
+    assert actions[0].patch == {"promotion_candidate": True}
+
+
+def test_promotion_skips_at_exact_14d(tmp_path: Path) -> None:
+    """Boundary: created EXACTLY 14d ago → NOT a candidate (exclusive)."""
+    from lore_curator.curator_c import _pass_draft_promotion
+
+    wiki = _seed(tmp_path)
+    today = date(2026, 4, 21)
+    _write_draft(wiki / "sessions" / "a.md", created=today - timedelta(days=14))
+
+    actions = _pass_draft_promotion(wiki, today)
+    assert actions == [], "14d boundary exclusive — must NOT propose"
+
+
+def test_promotion_skips_recent_drafts(tmp_path: Path) -> None:
+    from lore_curator.curator_c import _pass_draft_promotion
+
+    wiki = _seed(tmp_path)
+    today = date(2026, 4, 21)
+    _write_draft(wiki / "sessions" / "a.md", created=today - timedelta(days=3))
+
+    assert _pass_draft_promotion(wiki, today) == []
+
+
+def test_promotion_never_flips_draft_false(tmp_path: Path) -> None:
+    """The action patch writes promotion_candidate only; draft stays true."""
+    from lore_curator.curator_c import _pass_draft_promotion, _apply_patch
+
+    wiki = _seed(tmp_path)
+    today = date(2026, 4, 21)
+    path = _write_draft(
+        wiki / "sessions" / "a.md", created=today - timedelta(days=30)
+    )
+
+    actions = _pass_draft_promotion(wiki, today)
+    assert len(actions) == 1
+    new_text = _apply_patch(path.read_text(), actions[0].patch)
+    # Patch must add promotion_candidate but leave draft: true intact.
+    assert "promotion_candidate: true" in new_text
+    assert "draft: true" in new_text
+
+
+def test_promotion_skips_non_drafts(tmp_path: Path) -> None:
+    from lore_curator.curator_c import _pass_draft_promotion
+
+    wiki = _seed(tmp_path)
+    today = date(2026, 4, 21)
+    _write_draft(
+        wiki / "sessions" / "a.md", created=today - timedelta(days=30), draft=False
+    )
+
+    assert _pass_draft_promotion(wiki, today) == []
+
+
+def test_promotion_idempotent(tmp_path: Path) -> None:
+    """Once promotion_candidate is set, don't propose again."""
+    from lore_curator.curator_c import _pass_draft_promotion
+
+    wiki = _seed(tmp_path)
+    today = date(2026, 4, 21)
+    _write_draft(
+        wiki / "sessions" / "a.md",
+        created=today - timedelta(days=30),
+        promotion_candidate=True,
+    )
+
+    assert _pass_draft_promotion(wiki, today) == []

--- a/tests/test_c_high_off_degradation.py
+++ b/tests/test_c_high_off_degradation.py
@@ -1,0 +1,99 @@
+"""Task 10: high-tier degradation when models.high == "off"."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _seed_vault(tmp_path: Path, *, models_high: str = "claude-opus-4-7") -> Path:
+    lore_root = tmp_path / "vault"
+    (lore_root / ".lore").mkdir(parents=True)
+    wiki = lore_root / "wiki" / "w"
+    (wiki / "sessions").mkdir(parents=True)
+    cfg = (
+        "curator:\n"
+        "  curator_c:\n"
+        "    enabled: true\n"
+        "models:\n"
+        "  simple: claude-haiku-4-5\n"
+        "  middle: claude-sonnet-4-6\n"
+        f"  high: {models_high}\n"
+    )
+    (wiki / ".lore-wiki.yml").write_text(cfg)
+    return lore_root
+
+
+def test_resolve_tier_returns_high_when_enabled(tmp_path: Path) -> None:
+    from lore_curator.c_passes import resolve_tier_for_pass
+
+    lore_root = _seed_vault(tmp_path, models_high="claude-opus-4-7")
+    wiki = lore_root / "wiki" / "w"
+    model = resolve_tier_for_pass(
+        wiki, pass_name="adjacent_merge", preferred_tier="high", lore_root=lore_root
+    )
+    assert model == "claude-opus-4-7"
+
+
+def test_resolve_tier_degrades_to_middle_when_high_off(tmp_path: Path) -> None:
+    from lore_curator.c_passes import resolve_tier_for_pass
+
+    lore_root = _seed_vault(tmp_path, models_high="off")
+    wiki = lore_root / "wiki" / "w"
+    model = resolve_tier_for_pass(
+        wiki, pass_name="adjacent_merge", preferred_tier="high", lore_root=lore_root
+    )
+    assert model == "claude-sonnet-4-6"
+
+
+def test_high_off_emits_warning_event_every_call(tmp_path: Path) -> None:
+    """Every resolution that degrades emits a warning — no sentinel, no
+    once-per-run suppression.
+    """
+    from lore_curator.c_passes import resolve_tier_for_pass
+
+    lore_root = _seed_vault(tmp_path, models_high="off")
+    wiki = lore_root / "wiki" / "w"
+    resolve_tier_for_pass(wiki, pass_name="adjacent_merge",
+                         preferred_tier="high", lore_root=lore_root)
+    resolve_tier_for_pass(wiki, pass_name="auto_supersede",
+                         preferred_tier="high", lore_root=lore_root)
+
+    events = lore_root / ".lore" / "hook-events.jsonl"
+    assert events.exists()
+    warnings = [
+        json.loads(l) for l in events.read_text().splitlines() if l.strip()
+    ]
+    high_off = [
+        e for e in warnings
+        if e.get("event") == "curator-c" and e.get("outcome") == "high-tier-off"
+    ]
+    assert len(high_off) == 2, f"every degradation must emit; got {len(high_off)}"
+    assert {e["error"]["pass"] for e in high_off} == {"adjacent_merge", "auto_supersede"}
+
+
+def test_resolve_middle_tier_unchanged_when_high_off(tmp_path: Path) -> None:
+    """Orphan + promotion passes use middle/simple and are unaffected by high:off."""
+    from lore_curator.c_passes import resolve_tier_for_pass
+
+    lore_root = _seed_vault(tmp_path, models_high="off")
+    wiki = lore_root / "wiki" / "w"
+    # Explicitly request middle — should always return middle, no warning.
+    model = resolve_tier_for_pass(
+        wiki, pass_name="orphan_links", preferred_tier="middle", lore_root=lore_root
+    )
+    assert model == "claude-sonnet-4-6"
+
+    events = lore_root / ".lore" / "hook-events.jsonl"
+    # Middle-tier requests never emit high-tier-off.
+    if events.exists():
+        warnings = [
+            json.loads(l) for l in events.read_text().splitlines() if l.strip()
+        ]
+        high_off = [
+            e for e in warnings
+            if e.get("event") == "curator-c" and e.get("outcome") == "high-tier-off"
+        ]
+        assert high_off == [], "middle-tier requests must not emit high-tier-off"

--- a/tests/test_c_integration_final.py
+++ b/tests/test_c_integration_final.py
@@ -1,0 +1,152 @@
+"""Task 12: final integration assertions — full Curator C run.
+
+Exercises the whole defrag pipeline end-to-end with a fake LLM,
+asserting:
+  - pass order: hygiene → adjacent-merge → auto-supersede → orphan → promotion
+  - diff log captures proposals + hygiene actions
+  - last_curator_c updates on success
+  - ships-dark gate still passes after all Phase B/C additions
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class _FakeBlock:
+    def __init__(self, data: dict):
+        self.type = "tool_use"
+        self.input = data
+
+
+class _FakeResp:
+    def __init__(self, data: dict):
+        self.content = [_FakeBlock(data)]
+
+
+class MultiToolFakeClient:
+    """Routes based on tool_choice.name — supports all four Plan 5 passes."""
+
+    def __init__(self, responses: dict[str, dict]):
+        self._responses = responses
+        class _M:
+            def create(s, **kwargs):
+                tc = kwargs.get("tool_choice") or {}
+                name = tc.get("name") if isinstance(tc, dict) else None
+                data = self._responses.get(
+                    name, {"should_merge": False, "confidence": 0.1, "reason": "default"}
+                )
+                return _FakeResp(data)
+        self.messages = _M()
+
+
+def _seed_vault(tmp_path: Path) -> Path:
+    lore_root = tmp_path / "vault"
+    (lore_root / ".lore").mkdir(parents=True)
+    wiki = lore_root / "wiki" / "w"
+    (wiki / "sessions").mkdir(parents=True)
+    (wiki / ".lore-wiki.yml").write_text(
+        "curator:\n"
+        "  curator_c:\n"
+        "    enabled: true\n"
+        "    defrag_body_writes: false\n"
+    )
+    return lore_root
+
+
+def _write_concept(path: Path, *, title: str, tags: list[str]) -> None:
+    path.write_text(
+        "---\n"
+        "type: concept\n"
+        f"title: {title}\n"
+        f"tags: [{', '.join(tags)}]\n"
+        "created: 2026-04-20\n"
+        "last_reviewed: 2026-04-20\n"
+        f"description: {title}\n"
+        "---\n\n"
+        "body\n"
+    )
+
+
+def test_full_defrag_run_writes_diff_log_and_advances_ledger(tmp_path, monkeypatch) -> None:
+    from lore_core.ledger import WikiLedger
+    from lore_curator.curator_c import run_curator_c
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+
+    _write_concept(wiki / "sessions" / "zarr-a.md", title="Zarr Chunking", tags=["z"])
+    _write_concept(wiki / "sessions" / "zarr-b.md", title="Zarr Chunking Plus", tags=["z"])
+
+    client = MultiToolFakeClient({
+        "propose_merge": {"should_merge": True, "confidence": 0.9, "reason": "similar"},
+        "judge_supersession": {"contradicts": False, "confidence": 0.1, "reason": "n/a"},
+        "confirm_rename": {"is_rename": False, "confidence": 0.1},
+    })
+
+    reports = run_curator_c(
+        wiki_filter="w", dry_run=False, defrag=True, anthropic_client=client
+    )
+
+    # Ledger advanced.
+    entry = WikiLedger(lore_root, "w").read()
+    assert entry.last_curator_c is not None
+
+    # Diff log exists.
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log = lore_root / ".lore" / f"curator-c.diff.{today}.log"
+    assert log.exists()
+    content = log.read_text()
+    # Summary captures the merge proposal.
+    assert "adjacent_merge_proposed" in content
+
+    # Proposal file exists in sessions.
+    merges = list((wiki / "sessions").glob("*-merge*.md"))
+    assert len(merges) == 1
+
+
+def test_defrag_run_does_not_crash_without_llm(tmp_path, monkeypatch) -> None:
+    """defrag=True with client=None → each LLM pass reports skipped_no_llm;
+    hygiene still runs; ledger still advances; diff log still written.
+    """
+    from lore_core.ledger import WikiLedger
+    from lore_curator.curator_c import run_curator_c
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    _write_concept(
+        lore_root / "wiki" / "w" / "sessions" / "a.md",
+        title="Concept A", tags=["t"],
+    )
+
+    reports = run_curator_c(
+        wiki_filter="w", dry_run=False, defrag=True, anthropic_client=None
+    )
+    # No crash.
+    entry = WikiLedger(lore_root, "w").read()
+    assert entry.last_curator_c is not None
+
+
+def test_hygiene_only_path_still_works(tmp_path, monkeypatch) -> None:
+    """Bare `lore curator` path (defrag=False) behaves as pre-Plan-5."""
+    from lore_core.ledger import WikiLedger
+    from lore_curator.curator_c import run_curator_c
+
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    _write_concept(
+        lore_root / "wiki" / "w" / "sessions" / "a.md",
+        title="Concept A", tags=["t"],
+    )
+
+    reports = run_curator_c(wiki_filter="w", dry_run=False, defrag=False)
+    # Without defrag: no last_curator_c update, no diff log.
+    entry = WikiLedger(lore_root, "w").read()
+    assert entry.last_curator_c is None
+    assert not list((lore_root / ".lore").glob("curator-c.diff.*.log"))

--- a/tests/test_c_integration_skeleton.py
+++ b/tests/test_c_integration_skeleton.py
@@ -1,0 +1,230 @@
+"""Task 5: Curator C integration skeleton + shared harness.
+
+Lands the skeleton BEFORE the LLM passes (architect must-fix): each
+pass in Phase B slots into a working pipeline. Tests here cover:
+
+- run_curator_c(defrag, anthropic_client) signature and wiring
+- Diff-log wrapping of the whole run
+- last_curator_c atomic-on-success update
+- Mid-merge vault pre-flight abort
+- Obsidian-holding guard (reuses existing hook)
+- Shared validate_llm_response helper
+- ProposalOnlyError guard
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lore_curator.c_passes import (
+    ProposalOnlyError,
+    has_merge_conflicts,
+    validate_llm_response,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_llm_response — parametrized malformed-response coverage
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_valid(tmp_path: Path) -> None:
+    resp = {"should_merge": True, "confidence": 0.9, "reason": "clear overlap"}
+    result = validate_llm_response(
+        resp,
+        required={"should_merge": bool, "confidence": (int, float), "reason": str},
+        ranges={"confidence": (0.0, 1.0)},
+        lore_root=tmp_path,
+        pass_name="adjacent_merge",
+    )
+    assert result == resp
+
+
+@pytest.mark.parametrize("response", [
+    None,
+    "not a dict",
+    [1, 2, 3],
+    42,
+])
+def test_validate_rejects_non_dict(response, tmp_path: Path) -> None:
+    (tmp_path / ".lore").mkdir()
+    result = validate_llm_response(
+        response,
+        required={"x": str},
+        lore_root=tmp_path,
+        pass_name="test",
+    )
+    assert result is None
+
+
+def test_validate_rejects_missing_field(tmp_path: Path) -> None:
+    (tmp_path / ".lore").mkdir()
+    result = validate_llm_response(
+        {"should_merge": True},
+        required={"should_merge": bool, "confidence": (int, float)},
+        lore_root=tmp_path,
+        pass_name="test",
+    )
+    assert result is None
+
+
+def test_validate_rejects_wrong_type(tmp_path: Path) -> None:
+    (tmp_path / ".lore").mkdir()
+    result = validate_llm_response(
+        {"confidence": "0.9"},  # string, not float
+        required={"confidence": (int, float)},
+        lore_root=tmp_path,
+        pass_name="test",
+    )
+    assert result is None
+
+
+def test_validate_rejects_out_of_range(tmp_path: Path) -> None:
+    (tmp_path / ".lore").mkdir()
+    result = validate_llm_response(
+        {"confidence": 1.5},
+        required={"confidence": (int, float)},
+        ranges={"confidence": (0.0, 1.0)},
+        lore_root=tmp_path,
+        pass_name="test",
+    )
+    assert result is None
+
+
+def test_validate_emits_warning_event_on_failure(tmp_path: Path) -> None:
+    (tmp_path / ".lore").mkdir()
+    validate_llm_response(
+        {"missing_required": True},
+        required={"needed": str},
+        lore_root=tmp_path,
+        pass_name="adjacent_merge",
+    )
+    events = tmp_path / ".lore" / "hook-events.jsonl"
+    assert events.exists()
+    lines = [json.loads(l) for l in events.read_text().splitlines() if l.strip()]
+    warnings = [
+        e for e in lines
+        if e.get("event") == "curator-c" and e.get("outcome") == "llm-response-invalid"
+    ]
+    assert warnings
+    assert warnings[0]["error"]["pass"] == "adjacent_merge"
+
+
+# ---------------------------------------------------------------------------
+# has_merge_conflicts — git pre-flight
+# ---------------------------------------------------------------------------
+
+
+def test_has_merge_conflicts_false_on_clean_repo(tmp_path: Path) -> None:
+    import subprocess
+    subprocess.run(["git", "init", str(tmp_path)], capture_output=True, check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "--allow-empty", "-m", "init"],
+        capture_output=True, env={**{"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+                                     "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}},
+        check=True,
+    )
+    assert not has_merge_conflicts(tmp_path)
+
+
+def test_has_merge_conflicts_false_on_non_git(tmp_path: Path) -> None:
+    """Non-git directory → no conflicts detected (graceful None return)."""
+    assert not has_merge_conflicts(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Integration skeleton: run_curator_c(defrag=True) with empty pass list
+# ---------------------------------------------------------------------------
+
+
+def _seed_minimal_vault(tmp_path: Path) -> Path:
+    lore_root = tmp_path / "vault"
+    (lore_root / ".lore").mkdir(parents=True)
+    (lore_root / "wiki" / "testwiki" / "sessions").mkdir(parents=True)
+    return lore_root
+
+
+def test_skeleton_runs_with_zero_passes(tmp_path: Path, monkeypatch) -> None:
+    """Fresh vault, defrag=True, no LLM passes registered → clean run,
+    writes a noop diff log entry, updates last_curator_c.
+    """
+    lore_root = _seed_minimal_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+
+    from lore_curator.curator_c import run_curator_c
+
+    reports = run_curator_c(
+        wiki_filter="testwiki",
+        dry_run=False,
+        defrag=True,
+        anthropic_client=None,
+    )
+
+    # last_curator_c updated.
+    from lore_core.ledger import WikiLedger
+    entry = WikiLedger(lore_root, "testwiki").read()
+    assert entry.last_curator_c is not None, "last_curator_c must update on success"
+
+    # Diff log exists (may be no-op marker).
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    diff_log = lore_root / ".lore" / f"curator-c.diff.{today}.log"
+    assert diff_log.exists(), "diff log must be written"
+
+
+def test_skeleton_defrag_false_does_not_update_ledger(tmp_path: Path, monkeypatch) -> None:
+    """Without --defrag, run_curator_c behaves pre-Plan-5: no ledger update
+    for last_curator_c, no diff log.
+    """
+    lore_root = _seed_minimal_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+
+    from lore_curator.curator_c import run_curator_c
+
+    run_curator_c(wiki_filter="testwiki", dry_run=False, defrag=False)
+
+    from lore_core.ledger import WikiLedger
+    entry = WikiLedger(lore_root, "testwiki").read()
+    assert entry.last_curator_c is None, "defrag=False must not touch last_curator_c"
+
+    diff_logs = list((lore_root / ".lore").glob("curator-c.diff.*.log"))
+    assert not diff_logs, "no diff log when defrag=False"
+
+
+def test_skeleton_atomic_on_failure(tmp_path: Path, monkeypatch) -> None:
+    """Mid-run exception → last_curator_c preserved (atomic-or-unchanged)."""
+    lore_root = _seed_minimal_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    from lore_core.ledger import WikiLedger
+    prior = datetime(2026, 4, 14, tzinfo=UTC)
+    WikiLedger(lore_root, "testwiki").update_last_curator("c", at=prior)
+
+    from lore_curator import curator_c as cc_mod
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("simulated mid-run failure")
+
+    # Hook the inner pass-list execution to raise.
+    monkeypatch.setattr(cc_mod, "_run_defrag_passes", boom)
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        cc_mod.run_curator_c(
+            wiki_filter="testwiki", dry_run=False, defrag=True, anthropic_client=None
+        )
+
+    entry = WikiLedger(lore_root, "testwiki").read()
+    assert entry.last_curator_c == prior, "last_curator_c must preserve prior on failure"
+
+
+# ---------------------------------------------------------------------------
+# ProposalOnlyError — enforcement is not convention
+# ---------------------------------------------------------------------------
+
+
+def test_proposal_only_error_is_raisable() -> None:
+    with pytest.raises(ProposalOnlyError):
+        raise ProposalOnlyError("test")

--- a/tests/test_c_orphan_links.py
+++ b/tests/test_c_orphan_links.py
@@ -1,0 +1,260 @@
+"""Task 8: orphan wikilink repair pass.
+
+Highest-blast-radius pass in Plan 5 — can rewrite link syntax in note
+bodies. Gated behind curator.curator_c.defrag_body_writes sub-flag
+(default false). Default: proposes via body-proposals log, no mutation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _FakeBlock:
+    def __init__(self, data: dict):
+        self.type = "tool_use"
+        self.input = data
+
+
+class _FakeResp:
+    def __init__(self, data: dict):
+        self.content = [_FakeBlock(data)]
+
+
+class FakeLlmClient:
+    def __init__(self, response_data: dict):
+        self._data = response_data
+        class _M:
+            def create(s, **kw):
+                return _FakeResp(self._data)
+        self.messages = _M()
+
+
+def _seed_vault(tmp_path: Path, *, defrag_body_writes: bool = False) -> Path:
+    lore_root = tmp_path / "vault"
+    (lore_root / ".lore").mkdir(parents=True)
+    wiki = lore_root / "wiki" / "w"
+    (wiki / "sessions").mkdir(parents=True)
+    # Write config enabling the sub-flag.
+    cfg = (
+        "curator:\n"
+        "  curator_c:\n"
+        "    enabled: true\n"
+        f"    defrag_body_writes: {str(defrag_body_writes).lower()}\n"
+    )
+    (wiki / ".lore-wiki.yml").write_text(cfg)
+    return lore_root
+
+
+def _write_note(path: Path, body: str) -> Path:
+    path.write_text(
+        "---\n"
+        "type: session\n"
+        "created: 2026-04-21\n"
+        "last_reviewed: 2026-04-21\n"
+        "description: test\n"
+        "tags: []\n"
+        "---\n\n"
+        f"{body}"
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Orphan detection
+# ---------------------------------------------------------------------------
+
+
+def test_find_orphan_links_detects_missing_targets(tmp_path: Path) -> None:
+    from lore_curator.c_orphan_links import find_orphan_links
+
+    lore_root = _seed_vault(tmp_path)
+    wiki = lore_root / "wiki" / "w"
+    _write_note(wiki / "sessions" / "a.md", "see [[missing-target]] and [[existing]]\n")
+    _write_note(wiki / "sessions" / "existing.md", "present\n")
+
+    orphans = find_orphan_links(wiki)
+    assert len(orphans) == 1
+    note, slug, _ = orphans[0]
+    assert slug == "missing-target"
+
+
+def test_find_orphan_links_detects_none_when_all_resolve(tmp_path: Path) -> None:
+    from lore_curator.c_orphan_links import find_orphan_links
+
+    lore_root = _seed_vault(tmp_path)
+    wiki = lore_root / "wiki" / "w"
+    _write_note(wiki / "sessions" / "a.md", "see [[b]]\n")
+    _write_note(wiki / "sessions" / "b.md", "exists\n")
+
+    assert find_orphan_links(wiki) == []
+
+
+# ---------------------------------------------------------------------------
+# Body-writes sub-flag OFF (default): no mutations, proposal log written
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_sub_flag_off_no_body_mutation(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_orphan_links import orphan_links_pass
+
+    lore_root = _seed_vault(tmp_path, defrag_body_writes=False)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    a = _write_note(wiki / "sessions" / "a.md", "see [[foo-bar-typoo]]\n")
+    _write_note(wiki / "sessions" / "foo-bar-typo.md", "present\n")
+
+    before = a.read_bytes()
+    client = FakeLlmClient({"is_rename": True, "confidence": 0.95})
+    summary = orphan_links_pass(wiki, anthropic_client=client, dry_run=False)
+
+    assert a.read_bytes() == before, "body must not mutate with sub-flag off"
+    assert summary.get("orphan_flagged", 0) >= 1
+
+    # Proposal log exists.
+    from datetime import UTC, datetime
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log = lore_root / ".lore" / f"curator-c.body-proposals.{today}.log"
+    assert log.exists()
+    content = log.read_text()
+    assert "foo-bar-typoo" in content
+    assert "proposed" in content
+
+
+# ---------------------------------------------------------------------------
+# Body-writes sub-flag ON: actual rewrite happens
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_sub_flag_on_rewrites_in_place(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_orphan_links import orphan_links_pass
+
+    lore_root = _seed_vault(tmp_path, defrag_body_writes=True)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    a = _write_note(wiki / "sessions" / "a.md", "see [[foo-bar-typoo]]\n")
+    _write_note(wiki / "sessions" / "foo-bar-typo.md", "present\n")
+
+    client = FakeLlmClient({"is_rename": True, "confidence": 0.95})
+    summary = orphan_links_pass(wiki, anthropic_client=client, dry_run=False)
+
+    text = a.read_text()
+    assert "[[foo-bar-typoo]]" not in text, "old link must be rewritten"
+    assert "[[foo-bar-typo]]" in text
+    assert summary.get("orphan_rewritten", 0) >= 1
+
+
+def test_orphan_preserves_display_text(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_orphan_links import orphan_links_pass
+
+    lore_root = _seed_vault(tmp_path, defrag_body_writes=True)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    a = _write_note(wiki / "sessions" / "a.md", "see [[foo-bar-typoo|the Thing]] for more\n")
+    _write_note(wiki / "sessions" / "foo-bar-typo.md", "present\n")
+
+    client = FakeLlmClient({"is_rename": True, "confidence": 0.95})
+    orphan_links_pass(wiki, anthropic_client=client, dry_run=False)
+
+    text = a.read_text()
+    assert "[[foo-bar-typo|the Thing]]" in text
+
+
+def test_orphan_preserves_crlf_and_trailing_newline(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_orphan_links import orphan_links_pass
+
+    lore_root = _seed_vault(tmp_path, defrag_body_writes=True)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+
+    # Write with CRLF line endings.
+    path = wiki / "sessions" / "a.md"
+    crlf_body = (
+        "---\r\n"
+        "type: session\r\n"
+        "created: 2026-04-21\r\n"
+        "last_reviewed: 2026-04-21\r\n"
+        "description: test\r\n"
+        "tags: []\r\n"
+        "---\r\n"
+        "\r\n"
+        "see [[foo-bar-typoo]] here\r\n"
+    )
+    path.write_bytes(crlf_body.encode("utf-8"))
+    _write_note(wiki / "sessions" / "foo-bar-typo.md", "present\n")
+
+    client = FakeLlmClient({"is_rename": True, "confidence": 0.95})
+    orphan_links_pass(wiki, anthropic_client=client, dry_run=False)
+
+    raw = path.read_bytes()
+    # CRLF preserved, trailing newline preserved.
+    assert b"\r\n" in raw
+    assert raw.endswith(b"\r\n")
+    assert b"[[foo-bar-typo]]" in raw
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous candidates → no rewrite even with sub-flag on
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_ambiguous_candidates_no_rewrite(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_orphan_links import orphan_links_pass
+
+    lore_root = _seed_vault(tmp_path, defrag_body_writes=True)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    a = _write_note(wiki / "sessions" / "a.md", "see [[zarr-chunking]]\n")
+    # Two closely-matching candidates above the 0.7 threshold.
+    _write_note(wiki / "sessions" / "zarr-chunking-one.md", "present\n")
+    _write_note(wiki / "sessions" / "zarr-chunking-two.md", "present\n")
+
+    before = a.read_bytes()
+    client = FakeLlmClient({"is_rename": True, "confidence": 0.95})
+    summary = orphan_links_pass(wiki, anthropic_client=client, dry_run=False)
+    assert a.read_bytes() == before, "ambiguous → no rewrite"
+    assert summary.get("orphan_ambiguous", 0) >= 1
+
+
+def test_orphan_truly_deleted_is_flagged(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_orphan_links import orphan_links_pass
+
+    lore_root = _seed_vault(tmp_path, defrag_body_writes=True)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    _write_note(wiki / "sessions" / "a.md", "see [[completely-unrelated-xyz]]\n")
+    _write_note(wiki / "sessions" / "something-else.md", "present\n")
+
+    client = FakeLlmClient({"is_rename": True, "confidence": 0.95})
+    summary = orphan_links_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("orphan_skipped_no_candidate", 0) >= 1
+
+
+def test_orphan_skips_malformed(tmp_path: Path, monkeypatch) -> None:
+    from lore_curator.c_orphan_links import orphan_links_pass
+
+    lore_root = _seed_vault(tmp_path, defrag_body_writes=True)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    wiki = lore_root / "wiki" / "w"
+    _write_note(wiki / "sessions" / "a.md", "see [[foo-bar-typoo]]\n")
+    _write_note(wiki / "sessions" / "foo-bar-typo.md", "present\n")
+
+    client = FakeLlmClient({"is_rename": True})  # missing confidence
+    summary = orphan_links_pass(wiki, anthropic_client=client, dry_run=False)
+    assert summary.get("orphan_skipped_malformed") == 1
+
+
+def test_orphan_skipped_without_llm(tmp_path: Path) -> None:
+    from lore_curator.c_orphan_links import orphan_links_pass
+
+    lore_root = _seed_vault(tmp_path)
+    wiki = lore_root / "wiki" / "w"
+    summary = orphan_links_pass(wiki, anthropic_client=None, dry_run=False)
+    assert summary == {"orphan_skipped_no_llm": 1}
+
+
+def test_orphan_registered_in_defrag_passes() -> None:
+    from lore_curator import c_orphan_links, curator_c  # noqa: F401
+    assert c_orphan_links.orphan_links_pass in curator_c._DEFRAG_PASSES

--- a/tests/test_c_ships_dark_gate.py
+++ b/tests/test_c_ships_dark_gate.py
@@ -1,0 +1,191 @@
+"""Task 2: the "ships-dark" merge gate.
+
+Proves that a fresh vault with NO explicit .lore-wiki.yml and NO
+Curator C config gets ZERO new behavior post-Plan-5. Any failure
+here blocks merge — Curator C MUST be invisible to existing users.
+
+This is the single atomic test for success criterion #6
+("zero impact on existing users"). Every other Plan 5 test verifies
+behavior WHEN the flag is on; this one verifies the flag-off path is
+truly inert.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from lore_cli.hooks import hook_app
+
+
+runner = CliRunner()
+
+
+LORE_BLOCK = """\
+# Project
+
+## Lore
+
+- wiki: testwiki
+- scope: testscope
+- backend: none
+"""
+
+
+def _make_fresh_vault(tmp_path: Path) -> Path:
+    """Vault with attached CLAUDE.md but NO .lore-wiki.yml — defaults apply."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "CLAUDE.md").write_text(LORE_BLOCK)
+    (project / "wiki" / "testwiki" / "sessions").mkdir(parents=True)
+    (project / ".lore").mkdir(parents=True, exist_ok=True)
+    # CRUCIAL: no .lore-wiki.yml is written — all config defaults.
+    return project
+
+
+def _snapshot_tree(path: Path, *, exclude_prefixes: tuple[str, ...] = ()) -> dict[str, bytes]:
+    """Return {relative_path: sha256_bytes} for every file under path."""
+    import hashlib
+
+    out: dict[str, bytes] = {}
+    if not path.exists():
+        return out
+    for p in sorted(path.rglob("*")):
+        if not p.is_file():
+            continue
+        rel = str(p.relative_to(path))
+        if any(rel.startswith(pref) for pref in exclude_prefixes):
+            continue
+        out[rel] = hashlib.sha256(p.read_bytes()).digest()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The five gate tests
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_vault_no_llm_calls(tmp_path: Path, monkeypatch) -> None:
+    """No .lore-wiki.yml → SessionStart triggers zero LLM instantiations."""
+    project = _make_fresh_vault(tmp_path)
+
+    def blow_up_on_llm(*_args, **_kwargs):
+        raise AssertionError(
+            "make_llm_client must NOT be called when curator_c.enabled is default-false"
+        )
+
+    monkeypatch.setattr("lore_curator.llm_client.make_llm_client", blow_up_on_llm)
+
+    # SessionStart hook — default-off config must not reach any LLM path.
+    result = runner.invoke(
+        hook_app,
+        ["session-start", "--cwd", str(project), "--plain"],
+        env={"LORE_ROOT": str(project)},
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_fresh_vault_no_spawns(tmp_path: Path) -> None:
+    """SessionStart in a default-config vault spawns ZERO detached curators."""
+    project = _make_fresh_vault(tmp_path)
+
+    c_calls: list = []
+    b_calls: list = []
+
+    def mock_spawn_c(*a, **kw):
+        c_calls.append(1)
+        return True
+
+    def mock_spawn_b(*a, **kw):
+        b_calls.append(1)
+        return True
+
+    with patch("lore_cli.hooks._spawn_detached_curator_c", side_effect=mock_spawn_c), \
+         patch("lore_cli.hooks._spawn_detached_curator_b", side_effect=mock_spawn_b):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(project)},
+            catch_exceptions=False,
+        )
+
+    assert c_calls == [], f"default-off vault must not spawn Curator C; got {c_calls}"
+    # Curator B is per-calendar-day. In a test run on an inactive vault with
+    # last_curator_b=None it *may* fire. We don't assert on B here — that
+    # scenario is a pre-Plan-5 behavior guaranteed by test_hooks_curator_b_trigger.
+
+
+def test_fresh_vault_no_frontmatter_mutations(tmp_path: Path) -> None:
+    """Byte-for-byte snapshot of wiki/ before and after a SessionStart loop."""
+    project = _make_fresh_vault(tmp_path)
+
+    # Seed one note to exercise the "would we mutate?" path.
+    note = project / "wiki" / "testwiki" / "sessions" / "2026-04-21-test.md"
+    note.write_text(
+        "---\n"
+        "type: session\n"
+        "created: 2026-04-21\n"
+        "last_reviewed: 2026-04-21\n"
+        "status: active\n"
+        "description: Test\n"
+        "tags: []\n"
+        "---\n\n"
+        "Body content.\n"
+    )
+
+    before = _snapshot_tree(project / "wiki")
+
+    # Run SessionStart + the bare curator commands that exist today.
+    runner.invoke(
+        hook_app,
+        ["session-start", "--cwd", str(project), "--plain"],
+        env={"LORE_ROOT": str(project)},
+        catch_exceptions=False,
+    )
+
+    after = _snapshot_tree(project / "wiki")
+    assert before == after, (
+        "default-config vault must not mutate wiki/ on SessionStart. Diff:\n"
+        f"  added:   {set(after) - set(before)}\n"
+        f"  removed: {set(before) - set(after)}\n"
+        f"  changed: {[k for k in before if k in after and before[k] != after[k]]}"
+    )
+
+
+def test_fresh_vault_no_diff_log(tmp_path: Path) -> None:
+    """No curator-c.diff.*.log is created in a default-config vault."""
+    project = _make_fresh_vault(tmp_path)
+
+    runner.invoke(
+        hook_app,
+        ["session-start", "--cwd", str(project), "--plain"],
+        env={"LORE_ROOT": str(project)},
+        catch_exceptions=False,
+    )
+
+    diff_logs = list((project / ".lore").glob("curator-c.diff.*.log"))
+    assert not diff_logs, f"default-config vault must not create diff logs; got {diff_logs}"
+
+
+def test_fresh_vault_no_new_config_files(tmp_path: Path) -> None:
+    """No .lore-wiki.yml materializes from a default-config SessionStart."""
+    project = _make_fresh_vault(tmp_path)
+    wiki_cfg = project / "wiki" / "testwiki" / ".lore-wiki.yml"
+    assert not wiki_cfg.exists(), "precondition: no config file"
+
+    runner.invoke(
+        hook_app,
+        ["session-start", "--cwd", str(project), "--plain"],
+        env={"LORE_ROOT": str(project)},
+        catch_exceptions=False,
+    )
+
+    assert not wiki_cfg.exists(), (
+        "default-config vault must not auto-create .lore-wiki.yml — that would "
+        "push opt-in config onto users without consent"
+    )

--- a/tests/test_curator_c_cli.py
+++ b/tests/test_curator_c_cli.py
@@ -1,0 +1,99 @@
+"""Task 4: `lore curator run --defrag [--dry-run]` CLI wiring."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from lore_curator.curator_c import app
+
+
+runner = CliRunner()
+
+
+def _seed_vault(tmp_path: Path) -> Path:
+    lore_root = tmp_path / "vault"
+    (lore_root / ".lore").mkdir(parents=True)
+    (lore_root / "wiki" / "testwiki" / "sessions").mkdir(parents=True)
+    return lore_root
+
+
+def test_defrag_flag_invokes_run_curator_c_with_defrag_true(tmp_path, monkeypatch) -> None:
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+
+    captured_kwargs = []
+
+    def mock_run(*args, **kwargs):
+        captured_kwargs.append(kwargs)
+        return []
+
+    with patch("lore_curator.curator_c.run_curator_c", side_effect=mock_run):
+        result = runner.invoke(app, ["run", "--defrag"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert captured_kwargs, "run_curator_c should have been called"
+    assert captured_kwargs[0].get("defrag") is True
+
+
+def test_defrag_dry_run_passes_through(tmp_path, monkeypatch) -> None:
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+
+    captured_kwargs = []
+    with patch(
+        "lore_curator.curator_c.run_curator_c",
+        side_effect=lambda *a, **kw: captured_kwargs.append(kw) or [],
+    ):
+        runner.invoke(app, ["run", "--defrag", "--dry-run"], catch_exceptions=False)
+    assert captured_kwargs[0].get("dry_run") is True
+    assert captured_kwargs[0].get("defrag") is True
+
+
+def test_no_defrag_flag_uses_curator_a_path(tmp_path, monkeypatch) -> None:
+    """Without --defrag, the command still runs Curator A (pre-Plan-5 behavior)."""
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+
+    defrag_called = []
+
+    def mock_c(*a, **kw):
+        defrag_called.append(kw)
+        return []
+
+    with patch("lore_curator.curator_c.run_curator_c", side_effect=mock_c):
+        # Without --defrag, run_curator_c should NOT be called via the --defrag
+        # short-circuit. The command proceeds to Curator A.
+        result = runner.invoke(app, ["run"], catch_exceptions=False)
+
+    # run_curator_c may be called WITHOUT defrag=True later in the pipeline,
+    # but the --defrag branch is the only place the short-circuit goes. Since
+    # there's no --defrag flag, the CLI goes through Curator A's path.
+    # Assert no --defrag-branch call.
+    defrag_calls = [kw for kw in defrag_called if kw.get("defrag") is True]
+    assert defrag_calls == [], "no --defrag → no defrag-branch call to run_curator_c"
+
+
+def test_defrag_without_lore_root_exits_error(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("LORE_ROOT", raising=False)
+    result = runner.invoke(app, ["run", "--defrag"], catch_exceptions=False)
+    assert result.exit_code == 1
+    assert "LORE_ROOT" in result.output
+
+
+def test_defrag_without_llm_client_warns_and_still_runs(tmp_path, monkeypatch) -> None:
+    """Missing LLM creds → run proceeds with clear warning; LLM passes skip."""
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    # Force make_llm_client to return None (no client available).
+    with patch("lore_curator.llm_client.make_llm_client", return_value=None):
+        result = runner.invoke(app, ["run", "--defrag"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    # Clear warning about skipped LLM passes.
+    assert "LLM" in result.output or "llm" in result.output

--- a/tests/test_curator_c_diff.py
+++ b/tests/test_curator_c_diff.py
@@ -1,0 +1,202 @@
+"""Task 3: Curator C pre/post-diff audit log.
+
+Every C run writes a date-stamped log entry with run_id, unified diff
+per modified note, and a summary table. Enables rollback auditing.
+
+Design points (per review):
+- Date-stamped file name: curator-c.diff.YYYY-MM-DD.log
+- Each entry carries run_id (cross-refs runs/<id>.jsonl)
+- 90-day retention (older files unlinked on next run)
+- 10 MB rotation (rotates to .1)
+- Zero-change runs → single-line marker, not full empty entry
+- Permission-denied → warning event, no crash
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from lore_curator.curator_c_diff import (
+    prune_old_diff_logs,
+    write_diff_log_entry,
+)
+
+
+def _lore_root(tmp_path: Path) -> Path:
+    (tmp_path / ".lore").mkdir()
+    return tmp_path
+
+
+def _read_log(path: Path) -> str:
+    return path.read_text()
+
+
+def _snapshot(files: dict[str, str]) -> dict[str, str]:
+    """{relative_path: content_str} — accepts empty for 'no file'."""
+    return dict(files)
+
+
+# ---------------------------------------------------------------------------
+# Basic capture
+# ---------------------------------------------------------------------------
+
+
+def test_diff_log_captures_frontmatter_changes(tmp_path: Path) -> None:
+    lore_root = _lore_root(tmp_path)
+
+    before = _snapshot({"note.md": "---\nstatus: active\n---\n\nBody\n"})
+    after = _snapshot({"note.md": "---\nstatus: stale\n---\n\nBody\n"})
+
+    write_diff_log_entry(
+        lore_root,
+        run_id="abc123",
+        snapshot_before=before,
+        snapshot_after=after,
+        dry_run=False,
+        summary={"staleness_flips": 1},
+    )
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log = lore_root / ".lore" / f"curator-c.diff.{today}.log"
+    assert log.exists()
+    content = _read_log(log)
+    assert "abc123" in content
+    assert "-status: active" in content
+    assert "+status: stale" in content
+
+
+def test_diff_log_dry_run_writes_entry(tmp_path: Path) -> None:
+    lore_root = _lore_root(tmp_path)
+    before = _snapshot({"a.md": "old\n"})
+    after = _snapshot({"a.md": "new\n"})
+
+    write_diff_log_entry(
+        lore_root, run_id="dry", snapshot_before=before, snapshot_after=after,
+        dry_run=True, summary={},
+    )
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log = lore_root / ".lore" / f"curator-c.diff.{today}.log"
+    content = _read_log(log)
+    assert "dry" in content
+    assert "dry-run" in content.lower() or "DRY-RUN" in content
+
+
+def test_diff_log_daily_append(tmp_path: Path) -> None:
+    """Two runs same day → two entries, distinct run_ids."""
+    lore_root = _lore_root(tmp_path)
+    before = _snapshot({"a.md": "x\n"})
+    after = _snapshot({"a.md": "y\n"})
+
+    write_diff_log_entry(lore_root, run_id="aaa", snapshot_before=before,
+                         snapshot_after=after, dry_run=False, summary={})
+    write_diff_log_entry(lore_root, run_id="bbb", snapshot_before=before,
+                         snapshot_after=after, dry_run=False, summary={})
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log = lore_root / ".lore" / f"curator-c.diff.{today}.log"
+    content = _read_log(log)
+    assert "aaa" in content
+    assert "bbb" in content
+    # Two run headers, delimited.
+    assert content.count("run=") >= 2
+
+
+def test_diff_log_no_op_writes_single_line_marker(tmp_path: Path) -> None:
+    """Zero-change run → single-line marker, not a full empty entry."""
+    lore_root = _lore_root(tmp_path)
+    # Identical snapshots — no changes.
+    snap = _snapshot({"note.md": "unchanged\n"})
+
+    write_diff_log_entry(lore_root, run_id="noop", snapshot_before=snap,
+                         snapshot_after=snap, dry_run=False, summary={})
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log = lore_root / ".lore" / f"curator-c.diff.{today}.log"
+    content = _read_log(log)
+    noop_lines = [l for l in content.splitlines() if "noop" in l and "no-op" in l]
+    assert noop_lines, f"expected a single-line no-op marker; got:\n{content}"
+
+
+# ---------------------------------------------------------------------------
+# Retention
+# ---------------------------------------------------------------------------
+
+
+def test_diff_log_90d_retention(tmp_path: Path) -> None:
+    """Logs older than 90 days are deleted by prune_old_diff_logs."""
+    import os as _os
+    lore_root = _lore_root(tmp_path)
+    log_dir = lore_root / ".lore"
+
+    # Create two log files: one 100d old, one 30d old.
+    old_log = log_dir / "curator-c.diff.2000-01-01.log"
+    old_log.write_text("ancient\n")
+    old_mtime = time.time() - 100 * 86400
+    _os.utime(old_log, (old_mtime, old_mtime))
+
+    new_log = log_dir / f"curator-c.diff.{datetime.now(UTC).strftime('%Y-%m-%d')}.log"
+    new_log.write_text("recent\n")
+
+    prune_old_diff_logs(lore_root, retention_days=90)
+
+    assert not old_log.exists(), "100d-old log should be pruned"
+    assert new_log.exists(), "recent log should survive"
+
+
+def test_diff_log_10mb_rotation(tmp_path: Path) -> None:
+    """Log ≥ 10 MB rotates to .1 before the new entry appends."""
+    lore_root = _lore_root(tmp_path)
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    log = lore_root / ".lore" / f"curator-c.diff.{today}.log"
+    # Pre-seed with 11 MB of dummy content.
+    log.write_text("x" * (11 * 1024 * 1024))
+
+    before = _snapshot({"a.md": "x\n"})
+    after = _snapshot({"a.md": "y\n"})
+    write_diff_log_entry(lore_root, run_id="fresh", snapshot_before=before,
+                         snapshot_after=after, dry_run=False, summary={})
+
+    rotated = lore_root / ".lore" / f"curator-c.diff.{today}.log.1"
+    assert rotated.exists(), "old log should rotate to .1"
+    assert rotated.stat().st_size >= 10 * 1024 * 1024
+    # Fresh log has only the new entry, not the rotated bulk.
+    assert log.stat().st_size < 10 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Permission denied → warning event
+# ---------------------------------------------------------------------------
+
+
+def test_diff_log_permission_denied_emits_warning_event(tmp_path: Path, monkeypatch) -> None:
+    lore_root = _lore_root(tmp_path)
+
+    # Simulate a write failure on the log file only (not the event log).
+    real_open = Path.open
+    def flaky_open(self, mode="r", *args, **kwargs):
+        if "curator-c.diff" in str(self) and any(m in mode for m in ("w", "a", "x")):
+            raise PermissionError(f"simulated denial on {self}")
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", flaky_open)
+
+    before = _snapshot({"a.md": "x\n"})
+    after = _snapshot({"a.md": "y\n"})
+    # Must NOT raise — failure is observable, not crash.
+    write_diff_log_entry(lore_root, run_id="perm", snapshot_before=before,
+                         snapshot_after=after, dry_run=False, summary={})
+
+    events = lore_root / ".lore" / "hook-events.jsonl"
+    assert events.exists()
+    lines = [json.loads(l) for l in events.read_text().splitlines() if l.strip()]
+    warnings = [
+        e for e in lines
+        if e.get("event") == "curator-c" and e.get("outcome") == "diff-log-write-failed"
+    ]
+    assert warnings, f"expected diff-log-write-failed event; got {lines}"

--- a/tests/test_curator_c_trigger.py
+++ b/tests/test_curator_c_trigger.py
@@ -1,0 +1,433 @@
+"""Task 1: Curator C weekly SessionStart trigger.
+
+- UTC-pinned ISO-week check
+- Per-user 48h jitter via SHA-256 of git user.email (hostname fallback)
+- Feature-flag gated (curator.curator_c.enabled, mode=local)
+- Reuses Plan A's try_acquire_spawn_lock("c")
+"""
+
+from __future__ import annotations
+
+import hashlib
+import multiprocessing as mp
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from lore_cli.hooks import hook_app
+from lore_core.ledger import WikiLedger, WikiLedgerEntry
+
+
+runner = CliRunner()
+
+
+LORE_BLOCK = """\
+# Project
+
+## Lore
+
+- wiki: testwiki
+- scope: testscope
+- backend: none
+"""
+
+
+def _make_attached_project(
+    root: Path, *, enabled: bool = True, mode: str = "local"
+) -> Path:
+    project = root / "project"
+    project.mkdir()
+    (project / "CLAUDE.md").write_text(LORE_BLOCK)
+    (project / "wiki" / "testwiki").mkdir(parents=True)
+    (project / ".lore").mkdir(parents=True, exist_ok=True)
+    # Per-wiki config enabling / configuring Curator C.
+    wiki_cfg = project / "wiki" / "testwiki" / ".lore-wiki.yml"
+    wiki_cfg.write_text(
+        "curator:\n"
+        f"  curator_c:\n"
+        f"    enabled: {str(enabled).lower()}\n"
+        f"    mode: {mode}\n"
+    )
+    return project
+
+
+def _iso_week_monday(ts: datetime) -> datetime:
+    """Monday 00:00Z of the ISO week containing ts."""
+    # isocalendar().weekday is 1 (Mon) .. 7 (Sun)
+    d = ts.date()
+    weekday = ts.isocalendar().weekday
+    monday = d - timedelta(days=weekday - 1)
+    return datetime(monday.year, monday.month, monday.day, tzinfo=UTC)
+
+
+def _expected_jitter_seconds(email: str) -> int:
+    return int(hashlib.sha256(email.encode()).hexdigest()[:8], 16) % 172800
+
+
+# ---------------------------------------------------------------------------
+# ISO-week rollover
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_fires_on_new_iso_week(tmp_path: Path) -> None:
+    """last_curator_c from prior ISO week → spawn."""
+    project = _make_attached_project(tmp_path, enabled=True)
+    lore_root = project
+
+    now = datetime(2026, 4, 21, 23, 0, 0, tzinfo=UTC)  # Tuesday of week 17
+    prior_week = now - timedelta(days=10)
+    wledger = WikiLedger(lore_root, "testwiki")
+    wledger.write(WikiLedgerEntry(wiki="testwiki", last_curator_c=prior_week))
+
+    spawns: list = []
+
+    def mock_spawn(lore_root_: Path, *a, **kw):
+        spawns.append(lore_root_)
+        return True
+
+    with patch("lore_cli.hooks._spawn_detached_curator_c", side_effect=mock_spawn), \
+         patch("lore_cli.hooks._now_utc", return_value=now), \
+         patch("lore_cli.hooks._curator_c_email", return_value="noop@test"):
+        result = runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert len(spawns) == 1, f"expected spawn on new ISO week; got {spawns}"
+
+
+def test_trigger_skips_same_iso_week(tmp_path: Path) -> None:
+    """last_curator_c from current ISO week → no spawn."""
+    project = _make_attached_project(tmp_path, enabled=True)
+    lore_root = project
+    now = datetime(2026, 4, 21, 23, 0, 0, tzinfo=UTC)
+    # Same ISO week as `now`.
+    this_week = now - timedelta(hours=12)
+
+    wledger = WikiLedger(lore_root, "testwiki")
+    wledger.write(WikiLedgerEntry(wiki="testwiki", last_curator_c=this_week))
+
+    spawns: list = []
+
+    with patch("lore_cli.hooks._spawn_detached_curator_c",
+               side_effect=lambda *a, **kw: spawns.append(1) or True), \
+         patch("lore_cli.hooks._now_utc", return_value=now), \
+         patch("lore_cli.hooks._curator_c_email", return_value="noop@test"):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+
+    assert spawns == [], f"expected no spawn same ISO week; got {spawns}"
+
+
+# ---------------------------------------------------------------------------
+# Jitter
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_respects_jitter_window(tmp_path: Path) -> None:
+    """Fixture email "fixture@test" has a specific computed offset.
+
+    hashlib.sha256("fixture@test".encode()).hexdigest()[:8] is a deterministic
+    value; the offset = int(.., 16) % 172800 is stable across machines.
+    Compute the expected value and use it to pin the before/after window.
+    """
+    email = "fixture@test"
+    offset = _expected_jitter_seconds(email)
+
+    project = _make_attached_project(tmp_path, enabled=True)
+    lore_root = project
+
+    # Last Monday's ISO-week we're about to fire for — pick a fresh one.
+    target_monday = datetime(2026, 4, 20, 0, 0, 0, tzinfo=UTC)  # Mon of wk 17
+
+    # last_curator_c from the previous week so the ISO-week condition is met.
+    wledger = WikiLedger(lore_root, "testwiki")
+    wledger.write(
+        WikiLedgerEntry(wiki="testwiki", last_curator_c=target_monday - timedelta(days=3))
+    )
+
+    # Time BEFORE jitter fires → no spawn.
+    before_fire = target_monday + timedelta(seconds=max(0, offset - 60))
+    spawns_before: list = []
+    with patch("lore_cli.hooks._spawn_detached_curator_c",
+               side_effect=lambda *a, **kw: spawns_before.append(1) or True), \
+         patch("lore_cli.hooks._now_utc", return_value=before_fire), \
+         patch("lore_cli.hooks._curator_c_email", return_value=email):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+
+    # Time AFTER jitter → spawn.
+    after_fire = target_monday + timedelta(seconds=offset + 60)
+    spawns_after: list = []
+    with patch("lore_cli.hooks._spawn_detached_curator_c",
+               side_effect=lambda *a, **kw: spawns_after.append(1) or True), \
+         patch("lore_cli.hooks._now_utc", return_value=after_fire), \
+         patch("lore_cli.hooks._curator_c_email", return_value=email):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+
+    assert spawns_before == [], f"before fire window, no spawn expected; got {spawns_before}"
+    assert spawns_after == [1], f"after fire window, spawn expected; got {spawns_after}"
+
+
+def test_trigger_jitter_fallback_when_git_email_unset(tmp_path: Path) -> None:
+    """Unset email falls back to hostname — still deterministic, still fires."""
+    import socket
+    project = _make_attached_project(tmp_path, enabled=True)
+    lore_root = project
+    target_monday = datetime(2026, 4, 20, 0, 0, 0, tzinfo=UTC)
+
+    wledger = WikiLedger(lore_root, "testwiki")
+    wledger.write(
+        WikiLedgerEntry(wiki="testwiki", last_curator_c=target_monday - timedelta(days=5))
+    )
+    hostname_offset = _expected_jitter_seconds(socket.gethostname())
+    after_fire = target_monday + timedelta(seconds=hostname_offset + 60)
+
+    spawns: list = []
+    with patch("lore_cli.hooks._spawn_detached_curator_c",
+               side_effect=lambda *a, **kw: spawns.append(1) or True), \
+         patch("lore_cli.hooks._now_utc", return_value=after_fire), \
+         patch("lore_cli.hooks._curator_c_email", return_value=""):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+    assert spawns == [1], "hostname fallback should still fire on same window"
+
+
+# ---------------------------------------------------------------------------
+# Feature-flag gates
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_disabled_by_default(tmp_path: Path) -> None:
+    """Default enabled=False → no spawn regardless of cadence."""
+    project = _make_attached_project(tmp_path, enabled=False)
+    lore_root = project
+    now = datetime(2026, 4, 21, 23, 0, 0, tzinfo=UTC)
+
+    wledger = WikiLedger(lore_root, "testwiki")
+    wledger.write(
+        WikiLedgerEntry(wiki="testwiki", last_curator_c=now - timedelta(days=30))
+    )
+
+    spawns: list = []
+    with patch("lore_cli.hooks._spawn_detached_curator_c",
+               side_effect=lambda *a, **kw: spawns.append(1) or True), \
+         patch("lore_cli.hooks._now_utc", return_value=now), \
+         patch("lore_cli.hooks._curator_c_email", return_value="noop@test"):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+    assert spawns == [], "disabled config must block spawn"
+
+
+def test_trigger_central_mode_fails_loudly(tmp_path: Path, capsys) -> None:
+    """mode=central → no spawn, emits a warning event, does NOT silently skip."""
+    project = _make_attached_project(tmp_path, enabled=True, mode="central")
+    lore_root = project
+    now = datetime(2026, 4, 21, 23, 0, 0, tzinfo=UTC)
+
+    wledger = WikiLedger(lore_root, "testwiki")
+    wledger.write(
+        WikiLedgerEntry(wiki="testwiki", last_curator_c=now - timedelta(days=30))
+    )
+
+    spawns: list = []
+    with patch("lore_cli.hooks._spawn_detached_curator_c",
+               side_effect=lambda *a, **kw: spawns.append(1) or True), \
+         patch("lore_cli.hooks._now_utc", return_value=now), \
+         patch("lore_cli.hooks._curator_c_email", return_value="noop@test"):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+
+    assert spawns == [], "central mode must not spawn locally"
+    # Warning event surfaced to hook-events.jsonl (observable, not silent).
+    import json as _json
+    events = project / ".lore" / "hook-events.jsonl"
+    if events.exists():
+        lines = [
+            _json.loads(l) for l in events.read_text().splitlines() if l.strip()
+        ]
+        central_warnings = [
+            e for e in lines
+            if e.get("event") == "curator-c" and e.get("outcome") == "central-mode-skipped"
+        ]
+        assert central_warnings, (
+            f"central mode should emit a hook-event warning; got {lines}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ISO-week boundary
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_fires_exactly_once_across_monday_boundary(tmp_path: Path) -> None:
+    """Sunday 23:59Z → no spawn; Monday 00:01Z + jitter → spawn."""
+    email = "boundary@test"
+    offset = _expected_jitter_seconds(email)
+
+    project = _make_attached_project(tmp_path, enabled=True)
+    lore_root = project
+
+    # Sunday of ISO week 17 (which ends Sun 2026-04-19, Mon 2026-04-20 starts wk 17 in ISO).
+    # Use 2026-04-19 23:59Z as Sunday; Monday 2026-04-20 begins new week.
+    sunday_late = datetime(2026, 4, 19, 23, 59, 0, tzinfo=UTC)
+    monday_target = datetime(2026, 4, 20, 0, 0, 0, tzinfo=UTC)
+
+    wledger = WikiLedger(lore_root, "testwiki")
+    wledger.write(
+        WikiLedgerEntry(wiki="testwiki", last_curator_c=monday_target - timedelta(days=7))
+    )
+
+    # Sunday → same ISO week as last_curator_c-week-13 (no rollover yet from a new-week perspective;
+    # actually: last_curator_c was wk 16. sunday_late is wk 16. So same ISO week.
+    # Actually this test verifies ISO-week detection pinned to UTC; fix: set last_curator_c to wk 15.
+    wledger.write(
+        WikiLedgerEntry(wiki="testwiki", last_curator_c=monday_target - timedelta(days=10))
+    )
+    # Now sunday_late is in wk 16, monday_target onward is in wk 17, last_curator_c wk 15.
+
+    spawns_sun: list = []
+    with patch("lore_cli.hooks._spawn_detached_curator_c",
+               side_effect=lambda *a, **kw: spawns_sun.append(1) or True), \
+         patch("lore_cli.hooks._now_utc", return_value=sunday_late), \
+         patch("lore_cli.hooks._curator_c_email", return_value=email):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+
+    # Post-jitter Monday.
+    fire_time = monday_target + timedelta(seconds=offset + 60)
+    spawns_mon: list = []
+    with patch("lore_cli.hooks._spawn_detached_curator_c",
+               side_effect=lambda *a, **kw: spawns_mon.append(1) or True), \
+         patch("lore_cli.hooks._now_utc", return_value=fire_time), \
+         patch("lore_cli.hooks._curator_c_email", return_value=email):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+
+    # Sunday-late may or may not fire depending on whether wk 16 > wk 15:
+    # last_curator_c is wk 15, sunday is wk 16 → rollover HAS happened.
+    # So sunday_late SHOULD fire too. The real boundary test: check that
+    # after firing on sunday, monday does not double-fire (same or newer week).
+    # Re-set: last_curator_c from far past (wk 14).
+    wledger.write(
+        WikiLedgerEntry(wiki="testwiki", last_curator_c=monday_target - timedelta(days=17))
+    )
+
+    # Pass 1: sunday_late should fire (wk 16 > wk 14)
+    spawns_sun_2: list = []
+    def sun_spawn(*a, **kw):
+        # Simulate the spawn updating last_curator_c to sunday_late.
+        wledger.update_last_curator("c", at=sunday_late)
+        spawns_sun_2.append(1)
+        return True
+
+    with patch("lore_cli.hooks._spawn_detached_curator_c", side_effect=sun_spawn), \
+         patch("lore_cli.hooks._now_utc", return_value=sunday_late), \
+         patch("lore_cli.hooks._curator_c_email", return_value=email):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+    assert spawns_sun_2 == [1], "Sunday with stale last_curator_c should fire"
+
+    # Pass 2: Monday of the NEW week — since last_curator_c is now sunday_late (wk 16),
+    # and monday_target is wk 17, it's a new ISO week — should fire again.
+    fire_time_new_week = monday_target + timedelta(seconds=offset + 60)
+    spawns_mon_new: list = []
+    with patch("lore_cli.hooks._spawn_detached_curator_c",
+               side_effect=lambda *a, **kw: spawns_mon_new.append(1) or True), \
+         patch("lore_cli.hooks._now_utc", return_value=fire_time_new_week), \
+         patch("lore_cli.hooks._curator_c_email", return_value=email):
+        runner.invoke(
+            hook_app,
+            ["session-start", "--cwd", str(project), "--plain"],
+            env={"LORE_ROOT": str(lore_root)},
+            catch_exceptions=False,
+        )
+    assert spawns_mon_new == [1], "Monday of new ISO week should fire again"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency (flock regression guard)
+# ---------------------------------------------------------------------------
+
+
+def _worker_c_spawn_attempt(lore_root_str: str, results_q, barrier) -> None:
+    """Child process attempting to acquire the Curator C spawn lock."""
+    from unittest.mock import patch
+    with patch("subprocess.Popen"):
+        from lore_cli.hooks import _spawn_detached_curator_a
+        # Reuse A's spawn semantics via try_acquire_spawn_lock for generic role.
+        # But Curator C uses role="c" — call the dedicated helper.
+        from lore_cli.hooks import _spawn_detached_curator_c
+        barrier.wait(timeout=10)
+        spawned = _spawn_detached_curator_c(Path(lore_root_str), cooldown_s=60)
+    results_q.put(spawned)
+
+
+def test_trigger_concurrent_sessions_coordinate(tmp_path: Path) -> None:
+    """Four concurrent processes attempting Curator C spawn → exactly one wins."""
+    lore_root = tmp_path / "root"
+    (lore_root / ".lore").mkdir(parents=True)
+
+    n = 4
+    ctx = mp.get_context("spawn")
+    barrier = ctx.Barrier(n)
+    results_q: mp.Queue = ctx.Queue()
+
+    procs = [
+        ctx.Process(target=_worker_c_spawn_attempt, args=(str(lore_root), results_q, barrier))
+        for _ in range(n)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+
+    results = []
+    while not results_q.empty():
+        results.append(results_q.get_nowait())
+    winners = [r for r in results if r]
+    assert len(winners) == 1, f"exactly one process must spawn; got {results}"


### PR DESCRIPTION
## Summary

Plan 5 of the passive-capture roadmap — Curator C, the weekly whole-wiki defragmentation pass that completes the A/B/C curator triad.

**Ships dark:** Gated behind `curator.curator_c.enabled: false` (default). Fresh vaults with no `.lore-wiki.yml` get zero new behavior — proven by Task 2's byte-for-byte snapshot gate.

### What landed

**Phase A — Infrastructure + shared harness (Tasks 1-5):**
- **Task 1** — weekly SessionStart trigger: UTC ISO-week check + per-user 48h jitter via `sha256(git user.email)`. Multi-process Barrier(4) regression test. Mode=central fails loudly to `hook-events.jsonl` (no silent skip). Email fallback chain: env var → git config → hostname → empty (offset=0).
- **Task 2** — "ships dark" merge gate: 5 assertions proving a fresh vault with no config gets zero new behavior (zero LLM calls, zero spawns, zero frontmatter mutations, zero diff logs, no auto-generated `.lore-wiki.yml`).
- **Task 3** — pre/post-diff audit log (`curator-c.diff.YYYY-MM-DD.log`): run_id per entry, 90-day retention, 10 MB rotation, no-op single-line marker, permission-denied warning via hook-events.
- **Task 4** — `lore curator run --defrag [--dry-run]` CLI. Also fixed a latent bug where the bare callback was calling `run_curator_c` unconditionally (missing `ctx.invoked_subcommand` gate).
- **Task 5** — integration skeleton + shared harness (`c_passes.py`): `validate_llm_response` (parametrized malformed-response coverage), `ProposalOnlyError` enforcement, `has_merge_conflicts` pre-flight. Empty `_DEFRAG_PASSES` registry — each Phase B task appends itself.

**Phase B — LLM passes (Tasks 6-9):**
- **Task 6** — `c_adjacent_merge.py`: fuzzy-title + shared-tag pre-filter, `propose_merge` tool, confidence >= 0.8 (inclusive, exact-boundary test). Writes new draft notes with `merge_candidate_sources`, never edits originals, idempotent same-day.
- **Task 7** — `c_auto_supersede.py`: **marker only** (architect must-fix — flipped from frontmatter-flip). Writes `supersede_candidate: ["[[newer]]"]` on older and `supersede_candidate_of: ["[[older]]"]` on newer. Never touches the real `superseded_by`. Conservative: `canonical: true` opt-out + 0.85 threshold + circular-chain guard.
- **Task 8** — `c_orphan_links.py`: highest blast radius, gated behind **sub-flag** `curator.curator_c.defrag_body_writes` (default false). Default: proposals-only log at `curator-c.body-proposals.YYYY-MM-DD.log`. Opt-in: in-place rewrite with CRLF + trailing-newline + display-text preservation.
- **Task 9** — `_pass_draft_promotion` folded into `curator_c.py` (merciless must-fix — ~30 lines, no standalone module). Time-based, no LLM. 14d threshold exclusive, idempotent.

**Phase C — Polish + coordination (Tasks 10-12):**
- **Task 10** — `models.high: off` degradation. `resolve_tier_for_pass` in `c_passes.py` returns actual model IDs from `WikiConfig.models`; degrades high→middle with a `curator-c/high-tier-off` event emitted **every run** (no once-per-sentinel — merciless cut). Also fixed a latent bug where passes hardcoded `model="high"` instead of resolving to a real model ID.
- **Task 11** — team-mode first-come-wins: `atomic_write_text` now fsyncs before rename, and `run_curator_c(defrag=True)` re-reads `last_curator_c` at entry and skips wikis whose stored timestamp matches the current ISO week (equivalence, not timestamp comparison — clock-skew-immune). Cross-clone git-push-lag race documented as accepted v1 cost (mode=central in v2 closes it).
- **Task 12** — final integration assertions + **lazy pass registration** fix: pass modules' `_register()` side effects only fire on import, so `run_curator_c(defrag=True)` wasn't picking them up. Added `_ensure_passes_registered()` inside the pipeline.

### Test delta

- Pre-Plan-5: 889 → 941 passing (+52 new tests, zero regressions)
- Critical regression guards:
  - `test_fresh_vault_*` (×5) — the ships-dark merge gate
  - `test_trigger_concurrent_sessions_coordinate` — multi-process Barrier(4) for flock
  - `test_ledger_write_is_fsynced` — team-mode coordination floor
  - `test_merge_never_edits_originals`, `test_supersede_only_proposes_never_flips_superseded_by` — proposal-only contract
  - `test_orphan_preserves_crlf_and_trailing_newline` — body-mutation safety
  - Shared malformed-LLM-response fixtures across passes 6/7/8

### Plan review

Drafted + architect + code-reviewer + merciless-dev passes (UX skipped — minimal user-facing surface). Must-fix items folded before execution:
- Phase reorder: Task 5 integration skeleton BEFORE LLM passes
- Task 7: proposal marker (not frontmatter flip)
- Task 8: sub-flag for body writes
- ISO-week UTC pinning + git-email fallback
- fsync on ledger writes
- Malformed-LLM-response shared coverage
- Task 9 folded into curator_c.py
- Central-mode fail-loud instead of silent branching
- High-tier-off emits every run (no sentinel)

### Design intent the user confirmed during drafting

- Heartbeat model: SessionStart + time + global flock; no cron.
- A/B/C triad is deliberate: A = per-session, B = per-day, C = per-week.
- User-facing copy stays role-named ("Curator") — A/B/C live in code only.

### After this merges

Plan 5 ships dark. Sole-dev adopters flip `curator.curator_c.enabled: true` in their `.lore-wiki.yml` and iterate on prompts. Plan 3 (Cursor adapter) and Plan 4 (Backfill + Onboarding) remain — neither blocked by anything in 5.

## Test plan

- [ ] `python -m pytest -q` — expect 941 passed
- [ ] `python -m pytest tests/test_c_ships_dark_gate.py -q` — merge gate
- [ ] `python -m pytest tests/test_curator_c_trigger.py::test_trigger_concurrent_sessions_coordinate -q` — flock regression
- [ ] Manual: opt in via `.lore-wiki.yml` (`curator.curator_c.enabled: true`), trigger `lore curator run --defrag --dry-run`, verify diff log writes to `.lore/curator-c.diff.<date>.log` without mutating the vault
- [ ] Manual: flip `defrag_body_writes: true` and re-run to validate orphan-link rewrite path (only if you have orphans to test against — my machine does not)