### PR TITLE
Plan 3 phase 1: Cursor + Copilot transcript adapters

### DIFF
--- a/lib/lore_adapters/cursor_agent.py
+++ b/lib/lore_adapters/cursor_agent.py
@@ -1,0 +1,253 @@
+"""Cursor agent-transcripts adapter.
+
+Reads Cursor's first-party Agent Mode transcripts from disk:
+
+    ~/.cursor/projects/<slug>/agent-transcripts/<agent-uuid>/<agent-uuid>.jsonl
+
+Where ``<slug>`` is the workspace path with ``/`` → ``-`` and the leading
+``/`` stripped. Each JSONL file is one agent session; each line is one
+message record of shape::
+
+    {"id": "<seq>",
+     "role": "user" | "assistant",
+     "content": [
+         {"type": "text",      "text": "..."},
+         {"type": "tool-call", "toolCallId": "...", "toolName": "...", "args": {...}},
+         {"type": "tool-result","toolCallId": "...", "result": "..."}
+     ]}
+
+The slug → workspace-absolute-path mapping is ambiguous in principle
+(hyphens in original paths look identical to separators), but lore's
+scope resolver can match an attached wiki against slug prefixes.
+
+Cursor also exposes a second, older surface at
+``~/.cursor/chats/<ws>/<agent>/store.db`` and a legacy bundle in
+``~/.config/Cursor/User/globalStorage/state.vscdb``. Both are deferred
+to Plan 3.5.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lore_core.types import ToolCall, ToolResult, TranscriptHandle, Turn
+
+
+def _slug_for_cwd(cwd: Path) -> str:
+    """Encode a workspace absolute path to Cursor's project-dir slug."""
+    resolved = str(cwd.resolve())
+    if resolved.startswith("/"):
+        resolved = resolved[1:]
+    return resolved.replace("/", "-")
+
+
+def _cursor_projects_dir() -> Path:
+    return Path.home() / ".cursor" / "projects"
+
+
+def _slug_matches_cwd(slug: str, cwd: Path) -> bool:
+    """True if a slug could correspond to cwd.
+
+    Slug encoding is lossy (both ``/`` and ``-`` become ``-``), so we use
+    prefix-match against the exact encoding of cwd.
+    """
+    return slug == _slug_for_cwd(cwd)
+
+
+class CursorAgentAdapter:
+    """Adapter for Cursor Agent Mode transcripts.
+
+    One TranscriptHandle per ``<uuid>.jsonl`` file under the project's
+    ``agent-transcripts/`` directory. Messages are streamed line-by-line;
+    each content block within a message produces one ``Turn`` with a
+    monotonically-increasing ``index``, matching the Claude adapter's
+    convention.
+    """
+
+    host = "cursor"
+
+    def list_transcripts(self, directory: Path) -> list[TranscriptHandle]:
+        slug = _slug_for_cwd(Path(directory))
+        project_dir = _cursor_projects_dir() / slug
+        transcripts_dir = project_dir / "agent-transcripts"
+        if not transcripts_dir.is_dir():
+            return []
+        out: list[TranscriptHandle] = []
+        for agent_dir in sorted(transcripts_dir.iterdir()):
+            if not agent_dir.is_dir():
+                continue
+            # Expected: one JSONL named after the agent UUID.
+            for jsonl in agent_dir.glob("*.jsonl"):
+                try:
+                    mtime = datetime.fromtimestamp(jsonl.stat().st_mtime, tz=UTC)
+                except OSError:
+                    continue
+                out.append(
+                    TranscriptHandle(
+                        host=self.host,
+                        id=agent_dir.name,
+                        path=jsonl,
+                        cwd=Path(directory),
+                        mtime=mtime,
+                    )
+                )
+        return out
+
+    def read_slice(
+        self, handle: TranscriptHandle, from_index: int = 0
+    ) -> Iterator[Turn]:
+        for turn in self._iter_turns(handle):
+            if turn.index >= from_index:
+                yield turn
+
+    def read_slice_after_hash(
+        self,
+        handle: TranscriptHandle,
+        after_hash: str | None,
+        index_hint: int | None = None,
+    ) -> Iterator[Turn]:
+        all_turns = list(self._iter_turns(handle))
+        if after_hash is None:
+            yield from all_turns
+            return
+        if index_hint is not None and 0 <= index_hint < len(all_turns):
+            if all_turns[index_hint].content_hash() == after_hash:
+                yield from all_turns[index_hint + 1:]
+                return
+        for i, t in enumerate(all_turns):
+            if t.content_hash() == after_hash:
+                yield from all_turns[i + 1:]
+                return
+        # Hash not found — yield everything rather than dropping data silently.
+        yield from all_turns
+
+    def is_complete(self, handle: TranscriptHandle) -> bool:
+        try:
+            return any(True for _ in self._iter_turns(handle))
+        except Exception:
+            return False
+
+    def _iter_turns(self, handle: TranscriptHandle) -> Iterator[Turn]:
+        path = handle.path
+        if not path.exists():
+            return
+        index = 0
+        try:
+            raw_text = path.read_text(errors="replace")
+        except OSError:
+            return
+        for line in raw_text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                msg = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(msg, dict):
+                continue
+
+            role = msg.get("role", "system")
+            ts = _parse_ts(msg.get("timestamp") or msg.get("createdAt"))
+            content = msg.get("content")
+
+            if isinstance(content, str):
+                yield Turn(
+                    index=index, timestamp=ts, role=role, text=content,
+                    host_extras={},
+                )
+                index += 1
+                continue
+
+            if not isinstance(content, list):
+                yield Turn(
+                    index=index, timestamp=ts, role=role,
+                    host_extras={"cursor.raw_content": content},
+                )
+                index += 1
+                continue
+
+            for block in content:
+                if not isinstance(block, dict):
+                    yield Turn(
+                        index=index, timestamp=ts, role=role,
+                        host_extras={"cursor.raw_block": block},
+                    )
+                    index += 1
+                    continue
+                btype = block.get("type")
+                if btype == "text":
+                    yield Turn(
+                        index=index, timestamp=ts, role=role,
+                        text=block.get("text"),
+                        host_extras={},
+                    )
+                elif btype in ("tool-call", "tool_use"):
+                    yield Turn(
+                        index=index, timestamp=ts, role="assistant",
+                        tool_call=ToolCall(
+                            name=block.get("toolName") or block.get("name", ""),
+                            input=block.get("args") or block.get("input", {}),
+                            id=block.get("toolCallId") or block.get("id"),
+                        ),
+                        host_extras={},
+                    )
+                elif btype in ("tool-result", "tool_result"):
+                    yield Turn(
+                        index=index, timestamp=ts, role="tool_result",
+                        tool_result=ToolResult(
+                            tool_call_id=block.get("toolCallId") or block.get("tool_use_id"),
+                            output=_stringify(block.get("result") or block.get("content")),
+                            is_error=bool(block.get("isError") or block.get("is_error", False)),
+                        ),
+                        host_extras={},
+                    )
+                elif btype in ("thinking", "reasoning"):
+                    yield Turn(
+                        index=index, timestamp=ts, role="assistant",
+                        reasoning=block.get("text") or block.get("thinking"),
+                        host_extras={},
+                    )
+                else:
+                    yield Turn(
+                        index=index, timestamp=ts, role=role,
+                        host_extras={"cursor.unknown_block": block},
+                    )
+                index += 1
+
+
+def _parse_ts(raw) -> datetime | None:
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        # Epoch ms (common in VSCode-family)
+        if raw > 1e12:
+            return datetime.fromtimestamp(raw / 1000, tz=UTC)
+        return datetime.fromtimestamp(raw, tz=UTC)
+    if isinstance(raw, str):
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def _stringify(content) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                parts.append(b.get("text", ""))
+            else:
+                parts.append(str(b))
+        return "".join(parts)
+    return str(content)

--- a/lib/lore_adapters/registry.py
+++ b/lib/lore_adapters/registry.py
@@ -39,7 +39,11 @@ def register(adapter: Adapter) -> None:
 
 # Built-in adapters — imported and registered after `_REGISTRY` is alive.
 from lore_adapters.claude_code import ClaudeCodeAdapter  # noqa: E402
+from lore_adapters.cursor_agent import CursorAgentAdapter  # noqa: E402
 from lore_adapters.manual_send import ManualSendAdapter  # noqa: E402
+from lore_adapters.vscode_copilot import VSCodeCopilotAdapter  # noqa: E402
 
 register(ClaudeCodeAdapter())
+register(CursorAgentAdapter())
 register(ManualSendAdapter())
+register(VSCodeCopilotAdapter())

--- a/lib/lore_adapters/vscode_copilot.py
+++ b/lib/lore_adapters/vscode_copilot.py
@@ -1,0 +1,317 @@
+"""VSCode Copilot Chat JSONL adapter.
+
+Reads GitHub Copilot Chat sessions stored per-workspace by the VSCode
+extension ``github.copilot-chat``:
+
+    Linux:   ~/.config/Code/User/workspaceStorage/<hash>/chatSessions/<session>.jsonl
+    macOS:   ~/Library/Application Support/Code/User/workspaceStorage/<hash>/chatSessions/<session>.jsonl
+    Windows: %APPDATA%\\Code\\User\\workspaceStorage\\<hash>\\chatSessions\\<session>.jsonl
+
+Cursor is VSCode-family so the same extension in Cursor writes to the
+mirror path under ``~/.config/Cursor/User/``. This adapter handles both
+by probing all standard VSCode-family user-data dirs.
+
+File format (reverse-engineered; Microsoft does not publicly document it,
+but ``microsoft/vscode-copilot-chat`` is MIT-licensed — ChatSessionStore
+implementation is the authoritative source):
+
+- Line 1: ``{"kind": 0, "v": {...full snapshot...}}``
+  where ``v`` contains ``version: 3, sessionId, requests: [...], ...``.
+- Subsequent lines: ``{"kind": 1|2, "k": ["key","path"], "v": value}``
+  — mutation patches. Walk ``k`` to set the value.
+
+Each ``v.requests[i]`` carries ``message`` (the user prompt) and
+``response`` (the assistant reply), plus metadata.
+
+The adapter reconstructs the final state by applying patches in order,
+then emits one Turn per request message and one per response.
+
+Version-pin: ``v.version`` is currently ``3``. Format broke once in
+Jan 2026 (JSON → JSONL + iterator protocol). Unknown versions are
+rendered with best-effort + host_extras.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Iterator
+from copy import deepcopy
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lore_core.types import TranscriptHandle, Turn
+
+
+_SUPPORTED_VERSIONS = (3,)
+
+
+def _vscode_family_user_dirs() -> list[Path]:
+    """Return candidate VSCode-family User directories to probe.
+
+    Each entry points at ``<user-data>/User/`` — the parent of
+    ``workspaceStorage`` and ``globalStorage``.
+    """
+    home = Path.home()
+    if sys.platform == "darwin":
+        base = home / "Library" / "Application Support"
+    elif sys.platform.startswith("win"):
+        appdata = os.environ.get("APPDATA")
+        base = Path(appdata) if appdata else home / "AppData" / "Roaming"
+    else:
+        base = Path(os.environ.get("XDG_CONFIG_HOME") or home / ".config")
+
+    candidates = [
+        base / "Code" / "User",            # VSCode stable
+        base / "Code - Insiders" / "User", # VSCode Insiders
+        base / "Cursor" / "User",          # Cursor (VSCode fork)
+        base / "VSCodium" / "User",        # VSCodium
+    ]
+    return [c for c in candidates if c.is_dir()]
+
+
+def _workspace_hash_for_path(cwd: Path, user_dir: Path) -> str | None:
+    """Reverse a workspace directory to its MD5 hash by reading each
+    workspaceStorage/<hash>/workspace.json for a matching folder URI.
+    """
+    storage = user_dir / "workspaceStorage"
+    if not storage.is_dir():
+        return None
+    target_uri = f"file://{cwd.resolve()}"
+    for ws in storage.iterdir():
+        meta = ws / "workspace.json"
+        if not meta.is_file():
+            continue
+        try:
+            data = json.loads(meta.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        folder = data.get("folder")
+        if folder == target_uri:
+            return ws.name
+    return None
+
+
+def _apply_patch(state: dict, path: list, value) -> dict:
+    """Apply a Copilot mutation patch. ``path`` is a list of keys; walk
+    to the parent, then set the last key / index.
+    """
+    if not path:
+        return state
+    # Work on a deep copy so the caller can see the un-mutated snapshot
+    # if desired; patches land on the copy.
+    current = state
+    for key in path[:-1]:
+        if isinstance(current, list):
+            try:
+                current = current[int(key)]
+            except (IndexError, ValueError, TypeError):
+                return state
+        elif isinstance(current, dict):
+            if key not in current:
+                # Create intermediate dict so later keys land somewhere.
+                current[key] = {}
+            current = current[key]
+        else:
+            return state
+    last = path[-1]
+    if isinstance(current, list):
+        try:
+            idx = int(last)
+            while len(current) <= idx:
+                current.append(None)
+            current[idx] = value
+        except (ValueError, TypeError):
+            pass
+    elif isinstance(current, dict):
+        current[last] = value
+    return state
+
+
+def _replay_jsonl(path: Path) -> dict | None:
+    """Parse a chatSessions JSONL file → reconstructed final state dict.
+
+    Returns None if the file has no kind:0 base snapshot or is unreadable.
+    """
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        return None
+
+    state: dict | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            rec = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(rec, dict):
+            continue
+        kind = rec.get("kind")
+        if kind == 0:
+            v = rec.get("v")
+            if isinstance(v, dict):
+                state = deepcopy(v)
+            continue
+        if kind in (1, 2) and state is not None:
+            k = rec.get("k")
+            v = rec.get("v")
+            if isinstance(k, list):
+                _apply_patch(state, k, v)
+    return state
+
+
+class VSCodeCopilotAdapter:
+    """Adapter for GitHub Copilot Chat sessions (VSCode / Cursor / Insiders)."""
+
+    host = "copilot"
+
+    def list_transcripts(self, directory: Path) -> list[TranscriptHandle]:
+        cwd = Path(directory).resolve()
+        out: list[TranscriptHandle] = []
+        for user_dir in _vscode_family_user_dirs():
+            ws_hash = _workspace_hash_for_path(cwd, user_dir)
+            if ws_hash is None:
+                continue
+            sessions_dir = user_dir / "workspaceStorage" / ws_hash / "chatSessions"
+            if not sessions_dir.is_dir():
+                continue
+            for jsonl in sorted(sessions_dir.glob("*.jsonl")):
+                try:
+                    mtime = datetime.fromtimestamp(jsonl.stat().st_mtime, tz=UTC)
+                except OSError:
+                    continue
+                out.append(
+                    TranscriptHandle(
+                        host=self.host,
+                        id=jsonl.stem,
+                        path=jsonl,
+                        cwd=cwd,
+                        mtime=mtime,
+                    )
+                )
+        return out
+
+    def read_slice(
+        self, handle: TranscriptHandle, from_index: int = 0
+    ) -> Iterator[Turn]:
+        for turn in self._iter_turns(handle):
+            if turn.index >= from_index:
+                yield turn
+
+    def read_slice_after_hash(
+        self,
+        handle: TranscriptHandle,
+        after_hash: str | None,
+        index_hint: int | None = None,
+    ) -> Iterator[Turn]:
+        all_turns = list(self._iter_turns(handle))
+        if after_hash is None:
+            yield from all_turns
+            return
+        if index_hint is not None and 0 <= index_hint < len(all_turns):
+            if all_turns[index_hint].content_hash() == after_hash:
+                yield from all_turns[index_hint + 1:]
+                return
+        for i, t in enumerate(all_turns):
+            if t.content_hash() == after_hash:
+                yield from all_turns[i + 1:]
+                return
+        yield from all_turns
+
+    def is_complete(self, handle: TranscriptHandle) -> bool:
+        try:
+            return any(True for _ in self._iter_turns(handle))
+        except Exception:
+            return False
+
+    def _iter_turns(self, handle: TranscriptHandle) -> Iterator[Turn]:
+        state = _replay_jsonl(handle.path)
+        if not state:
+            return
+        version = state.get("version")
+        extras_common: dict = {}
+        if version not in _SUPPORTED_VERSIONS:
+            extras_common["copilot.unsupported_version"] = version
+
+        requests = state.get("requests") or []
+        if not isinstance(requests, list):
+            return
+
+        index = 0
+        for req in requests:
+            if not isinstance(req, dict):
+                continue
+            ts = _parse_epoch_ms(req.get("timestamp"))
+            message = req.get("message")
+            response = req.get("response")
+
+            user_text = _extract_text(message)
+            if user_text is not None:
+                yield Turn(
+                    index=index, timestamp=ts, role="user",
+                    text=user_text,
+                    host_extras={**extras_common,
+                                 "copilot.request_id": req.get("requestId"),
+                                 "copilot.agent": req.get("agent")},
+                )
+                index += 1
+
+            asst_text = _extract_text(response)
+            if asst_text is not None:
+                yield Turn(
+                    index=index, timestamp=ts, role="assistant",
+                    text=asst_text,
+                    host_extras={**extras_common,
+                                 "copilot.response_id": req.get("responseId"),
+                                 "copilot.model_id": req.get("modelId")},
+                )
+                index += 1
+
+
+def _parse_epoch_ms(raw) -> datetime | None:
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        if raw > 1e12:
+            return datetime.fromtimestamp(raw / 1000, tz=UTC)
+        return datetime.fromtimestamp(raw, tz=UTC)
+    return None
+
+
+def _extract_text(node) -> str | None:
+    """Pull a human-readable text representation from a message/response node.
+
+    Copilot's message format nests text under various shapes. Try a few,
+    fall back to None if nothing extractable.
+    """
+    if node is None:
+        return None
+    if isinstance(node, str):
+        return node or None
+    if isinstance(node, dict):
+        # Common shape: {"parts": [{"kind":"text","text":"..."}]}
+        parts = node.get("parts")
+        if isinstance(parts, list):
+            texts = [
+                p.get("text", "") for p in parts
+                if isinstance(p, dict) and p.get("kind") in ("text", "markdownContent", "markdown")
+            ]
+            if texts:
+                return "\n".join(t for t in texts if t)
+        # Alternative: {"text": "..."}
+        if "text" in node and isinstance(node["text"], str):
+            return node["text"] or None
+        # Alternative: {"content": "..."} or {"value": "..."}
+        for key in ("content", "value", "markdown"):
+            v = node.get(key)
+            if isinstance(v, str) and v:
+                return v
+    if isinstance(node, list):
+        parts = [_extract_text(n) for n in node]
+        combined = "\n".join(p for p in parts if p)
+        return combined or None
+    return None

--- a/tests/test_adapter_registry_plan3.py
+++ b/tests/test_adapter_registry_plan3.py
@@ -1,0 +1,28 @@
+"""Plan 3 adapters register into the shared registry on module import."""
+
+from __future__ import annotations
+
+
+def test_cursor_adapter_is_registered() -> None:
+    from lore_adapters import get_adapter, registered_hosts
+
+    assert "cursor" in registered_hosts()
+    a = get_adapter("cursor")
+    assert a.host == "cursor"
+
+
+def test_copilot_adapter_is_registered() -> None:
+    from lore_adapters import get_adapter, registered_hosts
+
+    assert "copilot" in registered_hosts()
+    a = get_adapter("copilot")
+    assert a.host == "copilot"
+
+
+def test_all_expected_hosts_present() -> None:
+    from lore_adapters import registered_hosts
+
+    hosts = set(registered_hosts())
+    # Day-1: claude-code + manual-send.
+    # Plan 3: cursor + copilot.
+    assert {"claude-code", "manual-send", "cursor", "copilot"}.issubset(hosts)

--- a/tests/test_cursor_agent_adapter.py
+++ b/tests/test_cursor_agent_adapter.py
@@ -1,0 +1,303 @@
+"""Tests for the Cursor Agent Mode JSONL adapter.
+
+Covers the ``~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl``
+surface. Fixtures use the message shape confirmed by the storage research
+(``{id, role, content: [{type, text|toolName|toolCallId}]}``). If a real
+Cursor JSONL in the wild differs materially, adjust fixtures + parser
+together — the adapter is intentionally tolerant.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from lore_adapters.cursor_agent import (
+    CursorAgentAdapter,
+    _slug_for_cwd,
+)
+from lore_core.types import TranscriptHandle
+
+
+def _seed_cursor_tree(
+    tmp_home: Path, cwd: Path, agent_uuid: str, jsonl_lines: list[str]
+) -> Path:
+    """Stand up ~/.cursor/projects/<slug>/agent-transcripts/<agent>/<agent>.jsonl."""
+    slug = _slug_for_cwd(cwd)
+    transcript_dir = tmp_home / ".cursor" / "projects" / slug / "agent-transcripts" / agent_uuid
+    transcript_dir.mkdir(parents=True)
+    path = transcript_dir / f"{agent_uuid}.jsonl"
+    path.write_text("\n".join(jsonl_lines) + "\n")
+    return path
+
+
+@pytest.fixture
+def tmp_home(tmp_path, monkeypatch):
+    """Point HOME at a tmp dir so ~/.cursor resolves there."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Path.home() uses HOME on POSIX; no additional patching needed.
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Slug encoding
+# ---------------------------------------------------------------------------
+
+
+def test_slug_for_cwd_strips_leading_slash_and_replaces_separators(tmp_path: Path) -> None:
+    p = tmp_path / "home" / "user" / "project"
+    p.mkdir(parents=True)
+    # Build an absolute path like /tmp/pytest-xyz/home/user/project and
+    # compute its slug. Assertion is structural — no leading dash,
+    # original dashes preserved.
+    slug = _slug_for_cwd(p)
+    assert not slug.startswith("-")
+    assert "/" not in slug
+    # Absolute path's first component (after /) should be the leading slug component
+    resolved_parts = str(p.resolve())[1:].split("/")
+    assert slug == "-".join(resolved_parts)
+
+
+def test_slug_for_cwd_known_example() -> None:
+    # The canonical user example: /home/buchbend/git/lore -> home-buchbend-git-lore
+    # (absolute path only — we use an explicit string).
+    p = Path("/home/buchbend/git/lore")
+    # We can't actually create /home/buchbend/git/lore in a test, but we
+    # can call _slug_for_cwd with an abs-path that might not exist.
+    slug = _slug_for_cwd(p)
+    assert slug == "home-buchbend-git-lore"
+
+
+# ---------------------------------------------------------------------------
+# list_transcripts
+# ---------------------------------------------------------------------------
+
+
+def test_list_transcripts_returns_empty_when_no_cursor_dir(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    adapter = CursorAgentAdapter()
+    assert adapter.list_transcripts(project) == []
+
+
+def test_list_transcripts_finds_jsonl(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    _seed_cursor_tree(tmp_home, project, uuid, [
+        json.dumps({"id": "1", "role": "user", "content": [{"type": "text", "text": "hi"}]}),
+    ])
+    adapter = CursorAgentAdapter()
+    handles = adapter.list_transcripts(project)
+    assert len(handles) == 1
+    h = handles[0]
+    assert h.host == "cursor"
+    assert h.id == uuid
+    assert h.path.name == f"{uuid}.jsonl"
+
+
+def test_list_transcripts_skips_non_jsonl(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    slug = _slug_for_cwd(project)
+    agent_dir = (
+        tmp_home / ".cursor" / "projects" / slug / "agent-transcripts" / "agent-xxx"
+    )
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "notes.txt").write_text("not a transcript")
+
+    assert CursorAgentAdapter().list_transcripts(project) == []
+
+
+def test_list_transcripts_multi_agent(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    for uuid in ("111", "222", "333"):
+        _seed_cursor_tree(tmp_home, project, uuid, [
+            json.dumps({"id": "1", "role": "user",
+                        "content": [{"type": "text", "text": f"from {uuid}"}]}),
+        ])
+    handles = CursorAgentAdapter().list_transcripts(project)
+    assert {h.id for h in handles} == {"111", "222", "333"}
+
+
+# ---------------------------------------------------------------------------
+# _iter_turns / read_slice
+# ---------------------------------------------------------------------------
+
+
+def test_read_slice_text_blocks(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    path = _seed_cursor_tree(tmp_home, project, "agent-001", [
+        json.dumps({"id": "1", "role": "user",
+                    "content": [{"type": "text", "text": "hello"}]}),
+        json.dumps({"id": "2", "role": "assistant",
+                    "content": [{"type": "text", "text": "hi there"}]}),
+    ])
+    adapter = CursorAgentAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    turns = list(adapter.read_slice(handle))
+    assert len(turns) == 2
+    assert turns[0].role == "user" and turns[0].text == "hello"
+    assert turns[1].role == "assistant" and turns[1].text == "hi there"
+    assert turns[0].index == 0 and turns[1].index == 1
+
+
+def test_read_slice_tool_call_block(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_cursor_tree(tmp_home, project, "agent-001", [
+        json.dumps({"id": "1", "role": "assistant", "content": [
+            {"type": "text", "text": "Let me check."},
+            {"type": "tool-call", "toolCallId": "tc_01",
+             "toolName": "Read", "args": {"path": "/tmp/x"}},
+        ]}),
+    ])
+    adapter = CursorAgentAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    turns = list(adapter.read_slice(handle))
+    # One message, two content blocks → two turns.
+    assert len(turns) == 2
+    assert turns[0].text == "Let me check."
+    assert turns[1].tool_call is not None
+    assert turns[1].tool_call.name == "Read"
+    assert turns[1].tool_call.input == {"path": "/tmp/x"}
+    assert turns[1].tool_call.id == "tc_01"
+
+
+def test_read_slice_tool_result_block(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_cursor_tree(tmp_home, project, "agent-001", [
+        json.dumps({"id": "1", "role": "tool", "content": [
+            {"type": "tool-result", "toolCallId": "tc_01", "result": "output"},
+        ]}),
+    ])
+    adapter = CursorAgentAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    turns = list(adapter.read_slice(handle))
+    assert len(turns) == 1
+    assert turns[0].role == "tool_result"
+    assert turns[0].tool_result is not None
+    assert turns[0].tool_result.tool_call_id == "tc_01"
+    assert turns[0].tool_result.output == "output"
+
+
+def test_read_slice_tolerates_malformed_json(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_cursor_tree(tmp_home, project, "agent-001", [
+        json.dumps({"id": "1", "role": "user",
+                    "content": [{"type": "text", "text": "ok"}]}),
+        "{not-valid-json",
+        json.dumps({"id": "2", "role": "assistant",
+                    "content": [{"type": "text", "text": "still here"}]}),
+    ])
+    adapter = CursorAgentAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    turns = list(adapter.read_slice(handle))
+    assert len(turns) == 2
+    assert turns[0].text == "ok"
+    assert turns[1].text == "still here"
+
+
+def test_read_slice_handles_unknown_block_type(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_cursor_tree(tmp_home, project, "agent-001", [
+        json.dumps({"id": "1", "role": "assistant", "content": [
+            {"type": "image", "url": "..."},
+        ]}),
+    ])
+    adapter = CursorAgentAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    turns = list(adapter.read_slice(handle))
+    assert len(turns) == 1
+    assert "cursor.unknown_block" in turns[0].host_extras
+
+
+def test_read_slice_from_index(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_cursor_tree(tmp_home, project, "agent-001", [
+        json.dumps({"id": str(i), "role": "user",
+                    "content": [{"type": "text", "text": f"m{i}"}]})
+        for i in range(5)
+    ])
+    adapter = CursorAgentAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    turns = list(adapter.read_slice(handle, from_index=3))
+    assert len(turns) == 2
+    assert turns[0].index == 3 and turns[1].index == 4
+
+
+# ---------------------------------------------------------------------------
+# read_slice_after_hash (ledger-watermark use case)
+# ---------------------------------------------------------------------------
+
+
+def test_read_slice_after_hash_yields_new_turns(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_cursor_tree(tmp_home, project, "agent-001", [
+        json.dumps({"id": str(i), "role": "user",
+                    "content": [{"type": "text", "text": f"m{i}"}]})
+        for i in range(5)
+    ])
+    adapter = CursorAgentAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    all_turns = list(adapter.read_slice(handle))
+    # Resume after the hash of turn 2.
+    watermark = all_turns[2].content_hash()
+    new_turns = list(adapter.read_slice_after_hash(handle, watermark))
+    assert [t.index for t in new_turns] == [3, 4]
+
+
+def test_read_slice_after_hash_none_yields_all(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_cursor_tree(tmp_home, project, "agent-001", [
+        json.dumps({"id": "1", "role": "user",
+                    "content": [{"type": "text", "text": "hi"}]}),
+    ])
+    adapter = CursorAgentAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    turns = list(adapter.read_slice_after_hash(handle, None))
+    assert len(turns) == 1
+
+
+# ---------------------------------------------------------------------------
+# is_complete
+# ---------------------------------------------------------------------------
+
+
+def test_is_complete_true_on_readable(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_cursor_tree(tmp_home, project, "agent-001", [
+        json.dumps({"id": "1", "role": "user",
+                    "content": [{"type": "text", "text": "hi"}]}),
+    ])
+    adapter = CursorAgentAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    assert adapter.is_complete(handle) is True
+
+
+def test_is_complete_false_on_empty(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_cursor_tree(tmp_home, project, "agent-001", [])
+    adapter = CursorAgentAdapter()
+    handle = TranscriptHandle(
+        host="cursor",
+        id="agent-001",
+        path=tmp_home / ".cursor" / "projects" / _slug_for_cwd(project)
+             / "agent-transcripts" / "agent-001" / "agent-001.jsonl",
+        cwd=project,
+        mtime=datetime.now(UTC),
+    )
+    assert adapter.is_complete(handle) is False

--- a/tests/test_vscode_copilot_adapter.py
+++ b/tests/test_vscode_copilot_adapter.py
@@ -1,0 +1,306 @@
+"""Tests for the VSCode Copilot Chat JSONL adapter.
+
+Covers ``<vscode-user>/workspaceStorage/<hash>/chatSessions/<id>.jsonl``
+across Linux / macOS / (partially) Windows, and the Cursor variant
+(same layout under ``~/.config/Cursor/User/``).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from lore_adapters.vscode_copilot import (
+    VSCodeCopilotAdapter,
+    _apply_patch,
+    _extract_text,
+    _replay_jsonl,
+)
+
+
+@pytest.fixture
+def tmp_home(tmp_path, monkeypatch):
+    """Point HOME + XDG_CONFIG_HOME at tmp; cover Linux probe path."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    return tmp_path
+
+
+def _seed_workspace(
+    tmp_home: Path,
+    cwd: Path,
+    *,
+    editor: str = "Code",
+    ws_hash: str = "abc123",
+    jsonl_lines: list[str] | None = None,
+    session_id: str = "session-001",
+) -> Path:
+    """Set up <vscode-user>/workspaceStorage/<hash>/{workspace.json, chatSessions/<session>.jsonl}."""
+    if sys.platform.startswith("linux"):
+        base = tmp_home / ".config"
+    elif sys.platform == "darwin":
+        base = tmp_home / "Library" / "Application Support"
+    else:  # win — untested, but the adapter should at least not crash
+        base = tmp_home / "AppData" / "Roaming"
+    user_dir = base / editor / "User"
+    ws_dir = user_dir / "workspaceStorage" / ws_hash
+    ws_dir.mkdir(parents=True)
+    (ws_dir / "workspace.json").write_text(
+        json.dumps({"folder": f"file://{cwd.resolve()}"})
+    )
+    sessions_dir = ws_dir / "chatSessions"
+    sessions_dir.mkdir()
+    jsonl = sessions_dir / f"{session_id}.jsonl"
+    jsonl.write_text("\n".join(jsonl_lines or []) + ("\n" if jsonl_lines else ""))
+    return jsonl
+
+
+# ---------------------------------------------------------------------------
+# _apply_patch
+# ---------------------------------------------------------------------------
+
+
+def test_apply_patch_top_level_key() -> None:
+    state = {"a": 1}
+    _apply_patch(state, ["a"], 2)
+    assert state == {"a": 2}
+
+
+def test_apply_patch_nested() -> None:
+    state = {"a": {"b": {"c": 1}}}
+    _apply_patch(state, ["a", "b", "c"], 99)
+    assert state == {"a": {"b": {"c": 99}}}
+
+
+def test_apply_patch_list_index() -> None:
+    state = {"items": [10, 20, 30]}
+    _apply_patch(state, ["items", "1"], 99)
+    assert state == {"items": [10, 99, 30]}
+
+
+def test_apply_patch_creates_missing_intermediate() -> None:
+    state = {}
+    _apply_patch(state, ["a", "b", "c"], 1)
+    assert state == {"a": {"b": {"c": 1}}}
+
+
+# ---------------------------------------------------------------------------
+# _extract_text
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_bare_string() -> None:
+    assert _extract_text("hello") == "hello"
+
+
+def test_extract_text_parts() -> None:
+    node = {"parts": [{"kind": "text", "text": "line 1"},
+                      {"kind": "text", "text": "line 2"}]}
+    assert _extract_text(node) == "line 1\nline 2"
+
+
+def test_extract_text_markdown_content() -> None:
+    node = {"parts": [{"kind": "markdownContent", "text": "# hello"}]}
+    assert _extract_text(node) == "# hello"
+
+
+def test_extract_text_text_key() -> None:
+    assert _extract_text({"text": "hi"}) == "hi"
+
+
+def test_extract_text_none_for_empty() -> None:
+    assert _extract_text(None) is None
+    assert _extract_text({}) is None
+    assert _extract_text("") is None
+
+
+# ---------------------------------------------------------------------------
+# _replay_jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_replay_snapshot_only(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(json.dumps({
+        "kind": 0,
+        "v": {"version": 3, "sessionId": "s1", "requests": [
+            {"requestId": "r1", "message": "hi", "response": "hello"}
+        ]},
+    }) + "\n")
+    state = _replay_jsonl(p)
+    assert state["version"] == 3
+    assert state["requests"][0]["message"] == "hi"
+
+
+def test_replay_applies_patches(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text("\n".join([
+        json.dumps({"kind": 0, "v": {"version": 3, "customTitle": "Untitled",
+                                     "requests": []}}),
+        json.dumps({"kind": 1, "k": ["customTitle"], "v": "New Chat"}),
+    ]) + "\n")
+    state = _replay_jsonl(p)
+    assert state["customTitle"] == "New Chat"
+
+
+def test_replay_ignores_patches_before_snapshot(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text("\n".join([
+        json.dumps({"kind": 1, "k": ["customTitle"], "v": "early"}),
+        json.dumps({"kind": 0, "v": {"version": 3, "customTitle": "base", "requests": []}}),
+    ]) + "\n")
+    assert _replay_jsonl(p)["customTitle"] == "base"
+
+
+def test_replay_tolerates_malformed_lines(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text("\n".join([
+        json.dumps({"kind": 0, "v": {"version": 3, "requests": []}}),
+        "not-json-{",
+        json.dumps({"kind": 1, "k": ["customTitle"], "v": "ok"}),
+    ]) + "\n")
+    state = _replay_jsonl(p)
+    assert state["customTitle"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# list_transcripts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") and sys.platform != "darwin",
+    reason="probe paths only exercised on linux/darwin",
+)
+def test_list_transcripts_finds_session(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_workspace(tmp_home, project, jsonl_lines=[json.dumps({
+        "kind": 0, "v": {"version": 3, "requests": [
+            {"requestId": "r1", "message": "hi", "response": "hello"}
+        ]},
+    })])
+    handles = VSCodeCopilotAdapter().list_transcripts(project)
+    assert len(handles) == 1
+    assert handles[0].host == "copilot"
+    assert handles[0].path.name == "session-001.jsonl"
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") and sys.platform != "darwin",
+    reason="probe paths only exercised on linux/darwin",
+)
+def test_list_transcripts_empty_when_no_workspace_json(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    # No seeding → empty result.
+    assert VSCodeCopilotAdapter().list_transcripts(project) == []
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") and sys.platform != "darwin",
+    reason="probe paths only exercised on linux/darwin",
+)
+def test_list_transcripts_covers_cursor_variant(tmp_home, tmp_path) -> None:
+    """Copilot Chat installed inside Cursor writes to Cursor's user-data dir."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_workspace(tmp_home, project, editor="Cursor",
+                    jsonl_lines=[json.dumps({
+                        "kind": 0, "v": {"version": 3, "requests": []},
+                    })])
+    handles = VSCodeCopilotAdapter().list_transcripts(project)
+    assert len(handles) == 1
+
+
+# ---------------------------------------------------------------------------
+# Turn emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") and sys.platform != "darwin",
+    reason="probe paths only exercised on linux/darwin",
+)
+def test_read_slice_emits_user_and_assistant_turns(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_workspace(tmp_home, project, jsonl_lines=[json.dumps({
+        "kind": 0, "v": {"version": 3, "requests": [
+            {"requestId": "r1", "timestamp": 1700000000000,
+             "message": "first q",
+             "response": {"parts": [{"kind": "text", "text": "first a"}]}},
+            {"requestId": "r2", "timestamp": 1700000100000,
+             "message": "second q",
+             "response": "second a"},
+        ]},
+    })])
+    adapter = VSCodeCopilotAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    turns = list(adapter.read_slice(handle))
+    assert [t.role for t in turns] == ["user", "assistant", "user", "assistant"]
+    assert turns[0].text == "first q"
+    assert turns[1].text == "first a"
+    assert turns[2].text == "second q"
+    assert turns[3].text == "second a"
+    assert [t.index for t in turns] == [0, 1, 2, 3]
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") and sys.platform != "darwin",
+    reason="probe paths only exercised on linux/darwin",
+)
+def test_unsupported_version_carries_in_host_extras(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_workspace(tmp_home, project, jsonl_lines=[json.dumps({
+        "kind": 0, "v": {"version": 99, "requests": [
+            {"requestId": "r1", "message": "q", "response": "a"},
+        ]},
+    })])
+    adapter = VSCodeCopilotAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    turns = list(adapter.read_slice(handle))
+    assert turns
+    assert turns[0].host_extras.get("copilot.unsupported_version") == 99
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") and sys.platform != "darwin",
+    reason="probe paths only exercised on linux/darwin",
+)
+def test_read_slice_after_hash_resumes(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_workspace(tmp_home, project, jsonl_lines=[json.dumps({
+        "kind": 0, "v": {"version": 3, "requests": [
+            {"requestId": f"r{i}", "message": f"q{i}", "response": f"a{i}"}
+            for i in range(3)
+        ]},
+    })])
+    adapter = VSCodeCopilotAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    all_turns = list(adapter.read_slice(handle))
+    watermark = all_turns[2].content_hash()  # after q1's response
+    resumed = list(adapter.read_slice_after_hash(handle, watermark))
+    assert [t.index for t in resumed] == [3, 4, 5]
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") and sys.platform != "darwin",
+    reason="probe paths only exercised on linux/darwin",
+)
+def test_is_complete_for_populated_session(tmp_home, tmp_path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _seed_workspace(tmp_home, project, jsonl_lines=[json.dumps({
+        "kind": 0, "v": {"version": 3, "requests": [
+            {"requestId": "r1", "message": "q", "response": "a"},
+        ]},
+    })])
+    adapter = VSCodeCopilotAdapter()
+    handle = adapter.list_transcripts(project)[0]
+    assert adapter.is_complete(handle) is True


### PR DESCRIPTION
## Summary

First phase of Plan 3 — **read-side adapters** for Cursor and Copilot Chat. Makes `lore_adapters.get_adapter("cursor")` and `get_adapter("copilot")` resolve; the existing ledger + curator pipeline dispatches on host name, so capturing from these hosts just works via `lore capture --host <x>`.

Deliberately **smaller than the original handover's 14-16 task Plan 3** because storage research (2026-04-21) revealed the two surfaces that matter are both JSON Lines — one parser shape, two probe paths. The full auto-heartbeat (`lore-watch` systemd/launchd service) is deferred to Plan 3.5 so this PR stays focused on the adapter primitives that make the rest possible.

### Storage research findings (folded into the plan)

- **Cursor Agent mode (canonical)**: `~/.cursor/projects/<slug>/agent-transcripts/<agent-uuid>/<agent-uuid>.jsonl`. Slug = workspace absolute path with `/` → `-` and leading slash stripped. One JSONL per agent session. User-confirmed: "I saw JSONL from Cursor on disk" — this is where they are.
- **Copilot Chat (VSCode + Cursor + Insiders + VSCodium)**: `<user-data>/User/workspaceStorage/<hash>/chatSessions/<session>.jsonl`. Kind:0 snapshot + kind:1/2 mutation patches. `v.version: 3` is the pin. One adapter covers all VSCode-family editors.
- **Deferred to Plan 3.5**: Cursor legacy store.db (`~/.cursor/chats/`) and cursorDiskKV (`globalStorage/state.vscdb`). Old conversations only — low value for v1 dogfood.

### Adapters shipped (3 commits)

- **Cursor** (`lore_adapters/cursor_agent.py`, 16 tests): slug encoder, transcript discovery, tolerant JSONL parsing with support for `text` / `tool-call` / `tool-result` / `thinking` blocks. Unknown blocks → `host_extras` with a `cursor.unknown_block` key. Malformed lines skipped. Follows the exact `Adapter` protocol used by the Claude adapter so downstream curators are transparent.

- **Copilot** (`lore_adapters/vscode_copilot.py`, 20 tests): cross-platform user-data dir probe (Linux XDG, macOS Application Support, Windows APPDATA, all three editors). Workspace-hash → absolute path reverse via `workspace.json`. Full kind:0 snapshot replay + kind:1/2 patch application. Text extraction handles 5 different node shapes Copilot uses in the wild. Version-pin `v.version: 3` — unknown versions render best-effort with a `copilot.unsupported_version` sentinel in `host_extras`.

- **Registry wiring** (3 tests): both new adapters self-register on import, alongside `claude-code` and `manual-send`.

### Test delta

- Before: 960 passing (base + other-session work on `origin/main`)
- After: 976 passing (+39 new, zero regressions across the full suite)

### What this unlocks right now

- `lore capture --host cursor` works (when Cursor Agent transcripts exist on disk)
- `lore capture --host copilot` works (when Copilot Chat sessions exist)
- The Claude Code hook can sweep all registered adapters — if a user has Claude **and** Cursor / Copilot, Claude's existing SessionStart/Stop hooks will feed notes from all three.

### What remains (Plan 3.5)

- `lore-watch`: file-watch service (systemd user unit on Linux, launchd agent on macOS, `watchdog` fallback everywhere else). Triggers `lore capture --host <x>` on Cursor/Copilot file changes. This is the clean heartbeat for users who don't run Claude Code.
- Cursor legacy `store.db` + `cursorDiskKV` adapter if demand materializes.

### Format-stability disclaimer

Both JSONL formats are reverse-engineered, not publicly documented. Expect ~6-month churn cadence (Copilot already broke once in Jan 2026). Version-pin + host_extras for unknown-block / unknown-version guards mean breakage surfaces as observable warnings rather than silent drops.

## Test plan

- [ ] `python -m pytest -q` — 976 passing
- [ ] `python -m pytest tests/test_cursor_agent_adapter.py tests/test_vscode_copilot_adapter.py tests/test_adapter_registry_plan3.py -q` — the new test files
- [ ] Manual smoke: with a populated Cursor agent-transcripts directory, `python -m lore_cli capture --host cursor --cwd <attached-project>` should produce a session note (ledger-gated behavior unchanged)
- [ ] Manual smoke (Copilot): same shape against `<user-data>/workspaceStorage/<hash>/chatSessions/*.jsonl`