### PR TITLE
feat(#70): body-trim 5 surviving skills toward soft cap

### DIFF
--- a/skills/context/SKILL.md
+++ b/skills/context/SKILL.md
@@ -7,55 +7,24 @@ user_invocable: true
 
 # Context — show what Lore injected this session
 
-Prints the context log: a timestamped timeline of everything Lore
-injected into this session — the initial SessionStart block plus
-any mid-session heartbeat updates.
+One Bash call, then one text message:
 
-## Implementation
+1. Run `lore hook context-log` with `dangerouslyDisableSandbox: true`
+   (it walks `/proc` for the Claude Code ancestor PID; sandboxed
+   seccomp blocks that on the first try).
+2. Output the captured stdout **verbatim** inside a fenced code block.
+   No preamble, no commentary — Bash output is collapsed in the UI by
+   default, so echoing it as text is what makes the timeline visible.
 
-One Bash call, then one text message. Two requirements:
-
-1. Run `lore hook context-log` with `dangerouslyDisableSandbox: true`.
-   The command walks `/proc` to find the Claude Code ancestor PID,
-   which the default sandbox blocks with a seccomp error on the first
-   try. Disabling upfront avoids a wasted retry.
-2. After the Bash call returns, output the captured stdout **verbatim
-   as your text reply** — inside a fenced code block so whitespace and
-   the `──` separators render cleanly. This is essential: Bash tool
-   output is collapsed in the UI by default, so echoing it as text is
-   what makes the timeline visible inline.
-
-**Do not add a summary, restate the content, or interpret it** — the
-user can read it themselves. No preamble, no trailing commentary.
-Just the fenced block.
-
-The output is a timeline:
-
-```
-── SessionStart HH:MM ──
-lore: active · [[project]] · 2 sessions · 3 issues
-[full context body]
-
-── HH:MM ──
-new note [[2026-04-23-some-slug]]
-  → injected: [[2026-04-23-some-slug]]
-```
-
-SessionStart overwrites the log; heartbeat appends. The file is
-PID-scoped so concurrent Claude sessions don't cross-talk.
-
-## When the cache is empty
-
-If no context log exists, the command prints a message explaining
-that SessionStart hasn't fired. `lore doctor` is the right next
-step for diagnosing why — mention it only if the user asks.
+If the log is empty, the command prints a message; relay it as-is.
+Mention `lore doctor` only if the user asks why.
 
 ## Do not
 
 - Re-narrate the output.
-- Invoke `lore hook session-start` to re-generate. Use
-  `/lore:resume` for a fresh gather.
-- Read wiki notes, grep the catalog, call MCP tools.
+- Invoke `lore hook session-start` to re-generate — use `/lore:resume`
+  for a fresh gather.
+- Read wiki notes, grep the catalog, or call MCP tools.
 
 ## Related
 

--- a/skills/curator/SKILL.md
+++ b/skills/curator/SKILL.md
@@ -13,65 +13,32 @@ user_invocable: true
 Keeps the vault's metadata trustworthy so SessionStart's auto-injection
 surfaces only current, active knowledge.
 
-## What it does
+Four passes per wiki, all frontmatter-only — bodies are never touched
+without user approval:
 
-Four passes per wiki (all frontmatter-only — bodies are never touched
-without user approval):
-
-1. **Staleness** — notes with `status: active` + `last_reviewed > 90
-   days` ago become `status: stale`.
-2. **Supersession** — when note A says "supersedes [[B]]", B becomes
+1. **Staleness** — `status: active` + `last_reviewed > 90 days` ago →
+   `status: stale`.
+2. **Supersession** — note A says "supersedes [[B]]" → B becomes
    `status: superseded` with `superseded_by: [[A]]`.
-3. **Git backfill** — notes missing `created` / `last_reviewed` get
-   them from `git log --follow`.
+3. **Git backfill** — missing `created` / `last_reviewed` filled from
+   `git log --follow`.
 4. **Review summary** — writes `wiki/<name>/_review.md` listing every
-   action taken; SessionStart surfaces the count as part of its
-   one-liner.
-
-## Safety
-
-- **Mtime guard**: read mtime before patch, re-read and abort if it
-  changed mid-patch (Obsidian edit race).
-- **Obsidian-open warning**: detects `.obsidian/` in the vault tree;
-  proceeds but warns the user.
-- **Dry-run by default**: `--apply` required to write. `/lore:curator
-  <wiki>` without `--apply` shows the diff.
-- **No body edits**: staleness, supersession, and backfill are all
-  frontmatter-only.
+   action; SessionStart surfaces the count in its one-liner.
 
 ## Workflow
 
 ```bash
-# 0. Git pull
 git -C $LORE_ROOT/wiki/<wiki> pull --ff-only
-
-# 1. Dry run — review what would change
-lore curator --wiki <wiki>
-
-# 2. Apply
-lore curator --wiki <wiki> --apply
-
-# 3. Commit
-git -C $LORE_ROOT/wiki/<wiki> add -A
-git -C $LORE_ROOT/wiki/<wiki> commit -m "lore: curator pass YYYY-MM-DD"
+lore curator --wiki <wiki>            # dry run; review the diff
+lore curator --wiki <wiki> --apply    # write
+git -C $LORE_ROOT/wiki/<wiki> commit -am "lore: curator pass YYYY-MM-DD"
 ```
+
+Dry-run is the default; `--apply` is required to write. Mtime guards
+detect concurrent Obsidian edits and abort the patch.
 
 ## Scheduling
 
-No default cadence — pick your trade-off (see README):
-
-- `/schedule /lore:curator <wiki>` — laptop-local, free
-- `cron` + `claude -p "/lore:curator <wiki> --apply"` — headless, free
-- GitHub Actions on push to the wiki repo — always-on, API cost
-- Home server + cron — always-on, free
-
-Examples in the plugin's `examples/` directory.
-
-## Output surfaced to future sessions
-
-Next SessionStart reads `_review.md` (or its absence means "all clear")
-and folds the count into the one-liner status:
-
-```
-lore: loaded <wiki> (N notes, M open items, 3 stale flagged) · /lore:context
-```
+No default cadence. See README for trade-offs across `/schedule`,
+`cron + claude -p`, GitHub Actions, and home-server cron. Examples in
+`examples/`.

--- a/skills/inbox/SKILL.md
+++ b/skills/inbox/SKILL.md
@@ -9,108 +9,44 @@ user_invocable: true
 
 # Knowledge Inbox Processor
 
-Processes files dropped into any inbox and creates structured notes
-in the appropriate wiki. The walk + classification is one MCP call;
-the LLM only reads the files (judgment is required for note
-composition) and composes the resulting notes.
-
-## Inbox locations
-
-| Inbox | Purpose | Auto-routes to |
-|-------|---------|----------------|
-| `$LORE_ROOT/inbox/` | Root triage — unsorted drops | Determine by content, ask if unsure |
-| `$LORE_ROOT/wiki/<name>/inbox/` | Per-wiki drops | `wiki/<name>/` |
-
-Per-wiki inboxes are pre-routed; root inbox needs triage.
+Process files dropped into any inbox and create structured notes in
+the appropriate wiki. The walk + classification is one MCP call; the
+LLM reads files, composes notes, and archives originals.
 
 ## Workflow
 
-### 1. MCP classify (silent, fast)
+1. **Classify** — call `mcp__lore__lore_inbox_classify` (no args).
+   Returns per-file `path`, `type`, `target_wiki`, `needs_triage`. If
+   `total == 0`, report and stop. Do not Glob substitute.
 
-Call `mcp__lore__lore_inbox_classify` with no args. Returns:
+2. **Per file: route + analyze** — pre-routed files (`target_wiki`
+   set) go to that wiki; root-inbox files (`needs_triage: true`) need
+   content-driven routing (ask if ambiguous).
 
-```
-{
-  "files": [
-    {
-      "path": "<absolute>",
-      "filename": "<basename>",
-      "extension": ".md",
-      "type": "markdown" | "pdf" | "image" | "notebook" | "code" | "config" | "rst" | "text" | "unknown",
-      "size_bytes": 1234,
-      "target_wiki": "ccat" | null,
-      "needs_triage": false | true
-    },
-    ...
-  ],
-  "by_inbox": {"(root)": [...], "ccat": [...], ...},
-  "by_type": {"markdown": 3, "pdf": 1, ...},
-  "total": 4
-}
-```
+3. **Compose the note** — pick type
+   (project / concept / decision / paper / reference), subfolder,
+   and slug. Call `mcp__lore__lore_search` once with the topic to
+   find related notes; `[[wikilink]]` the top hits.
 
-If `total == 0`, report "No inbox files to process" and stop. **Do
-not** Glob the inbox dirs yourself.
+4. **Contradiction check** — if the new content contradicts a top
+   search hit's description, set `contradicts: [[note]]` in
+   frontmatter and surface it in the final report. Don't auto-merge.
 
-### 2. For each file, read + analyze (LLM judgment)
+5. **Write + commit** — write the note via the Write tool following
+   the wiki's CLAUDE.md conventions (`schema_version: 2`,
+   `provenance: extracted` + `source:` for non-text). Commit with
+   `lore session commit <path>`.
 
-For pre-routed files (`target_wiki` set), the wiki is decided. For
-root-inbox files (`needs_triage: true`), pick the best wiki by
-content; ask the user when ambiguous.
+6. **Archive** — `lore inbox archive <path>` moves the source to
+   `.processed/<YYYY-MM-DD>_<filename>`. Never delete.
 
-Per file, decide:
-- **Note type**: project / concept / decision / paper / reference
-- **Subfolder** (if hierarchical wiki conventions warrant)
-- **Slug** (kebab-case)
-- **Wikilink candidates**: call `mcp__lore__lore_search` once with
-  the file's topic to find existing related notes — `[[wikilink]]`
-  the top hits
-
-### 3. Contradiction check
-
-Before writing, scan the top search hits' descriptions. If the new
-content contradicts an existing note, set
-`contradicts: [[existing-note-name]]` in frontmatter and surface
-the conflict in your final report. Don't auto-merge.
-
-### 4. Write the vault note
-
-Write the new note directly with the Write tool, following the
-target wiki's CLAUDE.md conventions:
-
-- `schema_version: 2`
-- `provenance: extracted` and `source: "<original-filename>"` for
-  non-text sources (PDF, image, notebook)
-- `[[wikilinks]]` to related existing notes
-- Atomic per topic — split multi-topic documents
-
-Then commit with `lore session commit <new-note-path>` (the commit
-subcommand works for any path inside a wiki).
-
-### 5. Archive the original via Bash
-
-```bash
-lore inbox archive <path-from-classify>
-```
-
-The CLI moves the source to `.processed/<YYYY-MM-DD>_<filename>` in
-the same inbox. Never delete inbox files — always archive.
-
-### 6. Report
-
-Summarize: files processed (by type and inbox), where each was filed,
-links created, files needing user review (ambiguous routing, large
-PDFs that needed chunking, contradictions).
+7. **Report** — by type and inbox: filed paths, links created, items
+   needing user review (ambiguous routing, large PDFs, contradictions).
 
 ## Hard rules
 
-- **One MCP call for the walk.** Glob/Read substitutes are a
-  regression.
-- **Per-wiki inboxes are pre-routed.** Don't second-guess
-  `target_wiki`.
-- **Root inbox needs triage.** Analyze content; ask when unsure.
-- **Always archive, never delete.** `.processed/` is the audit trail.
-- **Respect each wiki's CLAUDE.md.** Tag taxonomies and frontmatter
-  conventions vary per wiki.
-- **Atomic notes.** One topic per note; split multi-topic documents.
-- **Flag contradictions, never silently override.**
+- One MCP call for the walk (Glob substitutes are a regression).
+- Per-wiki inboxes are pre-routed — don't second-guess `target_wiki`.
+- Always archive, never delete.
+- Atomic notes — one topic per note; split multi-topic documents.
+- Flag contradictions, never silently override.

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -9,98 +9,47 @@ user_invocable: true
 
 # Resume — load context via the `lore_resume` MCP tool
 
-Reconstructs working context by calling the `lore_resume` MCP tool
-exactly once. The tool covers four modes; the skill picks the right
-mode from the user's input and renders the result.
+One MCP call, then render. The tool dispatches four modes; the skill
+parses the user's input and renders the result. No Glob, no Read, no
+Grep — the gather work lives in the CLI / MCP, free of permission
+churn.
 
-**Do not** Glob, Read, or Grep the vault from this skill — the gather
-work is the CLI's job (and via MCP, free of permission prompts and
-iterative tool churn).
+## Parse + dispatch
 
-## Modes (the MCP tool dispatches in this priority order)
+| User input | MCP arguments | Mode |
+|---|---|---|
+| `/lore:resume` | `{}` | recent (3d) |
+| `/lore:resume ccat` | `{"wiki": "ccat"}` | wiki |
+| `/lore:resume ccat:data-center` | `{"scope": "ccat:data-center"}` | scope |
+| `/lore:resume numa` | `{"keyword": "numa"}` | keyword |
+| `/lore:resume ccat numa` | `{"keyword": "numa", "wiki": "ccat"}` | keyword |
+| `/lore:resume last week` | `{"days": 7}` | recent |
 
-1. **scope** — argument contains a `:` (e.g. `ccat:data-center`).
-   Aggregates `gh issue list` + `gh pr list` per repo in the subtree
-   plus matching session notes.
-2. **keyword** — single word or phrase that does not look like a wiki
-   name or a scope. Ranked FTS5 search across the vault.
-3. **wiki** — argument matches a wiki directory name (`ccat`,
-   `private`, `science`, etc.). Recent sessions in that wiki.
-4. **recent (default)** — no arguments. Recent sessions across all
-   wikis (last 3 days by default).
+Heuristics: `:` → scope; known wiki name → wiki; "last N days/week/
+month" → recent with days; otherwise keyword. Two tokens with first a
+wiki name → keyword scoped to that wiki.
 
-## Workflow
+## Render
 
-### 1. Parse the argument
+The tool returns a structured dict with a `mode` discriminator. Use
+these section headers (matching the CLI's `format_markdown`):
 
-The user may type any of:
-
-```
-/lore:resume                         → mode=recent
-/lore:resume ccat                    → mode=wiki, wiki="ccat"
-/lore:resume ccat:data-center        → mode=scope, scope="ccat:data-center"
-/lore:resume "ffts numa debugging"   → mode=keyword, keyword=...
-/lore:resume ccat numa               → mode=keyword, keyword="numa", wiki="ccat"
-/lore:resume last week               → mode=recent, days=7
-```
-
-Heuristics:
-- Argument contains `:` → `scope`
-- Argument is a known wiki name (single token, no space) → `wiki`
-- Argument is "last N days" or "last week"/"last month" → `recent`
-  with days set
-- Otherwise → `keyword`
-- If two tokens and first is a wiki name → `keyword` scoped to that
-  wiki
-
-### 2. Call the MCP tool — exactly one call
-
-Use the `mcp__lore__lore_resume` tool with the parsed arguments. Only
-pass non-default values. Examples:
-
-| User input | MCP arguments |
-|---|---|
-| `/lore:resume` | `{}` |
-| `/lore:resume ccat` | `{"wiki": "ccat"}` |
-| `/lore:resume ccat:data-center` | `{"scope": "ccat:data-center"}` |
-| `/lore:resume numa` | `{"keyword": "numa"}` |
-| `/lore:resume ccat numa` | `{"keyword": "numa", "wiki": "ccat"}` |
-| `/lore:resume last week` | `{"days": 7}` |
-
-### 3. Render the result
-
-The MCP tool returns a structured dict with a `mode` discriminator and
-mode-specific fields. Render it as markdown — the shape is already
-clean. For consistency with the CLI's `format_markdown`, use these
-section headers:
-
-- `mode == "recent"` → `## Resume: <wiki|all wikis> (last Nd)` then
-  `### Recent sessions` and `### Open items`.
-- `mode == "keyword"` → `## Resume: <keyword>` then `### Top matches`.
-- `mode == "scope"` → `## /lore:resume <scope>` then `### Open issues`,
+- `recent` → `## Resume: <wiki|all wikis> (last Nd)` then `### Recent
+  sessions` and `### Open items`.
+- `keyword` → `## Resume: <keyword>` then `### Top matches`.
+- `scope` → `## /lore:resume <scope>` then `### Open issues`,
   `### Open PRs`, `### Recent session notes`.
 
 If the result has an `error` field, surface it verbatim.
 
-## Why this is short
+## Rules
 
-In the CLI-first design, every gather operation lives in
-`lore_core/resume.py` and is exposed through both the CLI
-(`lore resume`) and the MCP tool (`lore_resume`). The skill is just
-the keyboard shortcut and the renderer. Token-economy by construction.
-
-## Important rules
-
-- **One MCP call.** No Glob, no Read, no Grep, no fallback to
-  iterative file walks. If the MCP call fails, surface the error —
-  do not retry by hand.
-- **Read-only.** This skill never writes files.
-- **No re-format if the user asked for JSON.** If the user explicitly
-  wants raw JSON, suggest `lore resume --json` from a shell instead.
+- One MCP call. No retry-by-hand fallbacks.
+- Read-only.
+- For raw JSON, suggest `lore resume --json` from a shell.
 
 ## Related
 
-- `/lore:context` — show what SessionStart already cached (no fresh
-  gather)
-- For raw ranked paths without the resume framing, use `lore search
-  <query>` in the shell or the `lore_search` MCP tool directly.
+- `/lore:context` — show what SessionStart already cached.
+- For raw ranked paths without resume framing, use `lore search
+  <query>` (shell) or `lore_search` MCP.

--- a/skills/surface/SKILL.md
+++ b/skills/surface/SKILL.md
@@ -9,171 +9,75 @@ user_invocable: true
 
 # Surface Authoring
 
-Guide the user through editing `$LORE_ROOT/wiki/<wiki>/SURFACES.md`.
-The skill always opens with one dispatch question — *add* one surface
-or *redesign* the full set — regardless of whether SURFACES.md is
-empty or populated. No auto-detect, no silent mode switch.
+Edit `$LORE_ROOT/wiki/<wiki>/SURFACES.md` via an interview. Always
+opens with one dispatch question — *add* one surface or *redesign* the
+full set — regardless of whether SURFACES.md is empty or populated.
 
-## Arguments
-
-`/lore:surface <wiki>` — the positional is the wiki name (e.g.
-`science`). If the wiki name is missing, ask the user once before
-starting.
+If the wiki name is missing, ask once before starting.
 
 ## Step 1 — Gather context (silent)
 
-Call `lore_surface_context(wiki=<wiki>)`. You will get:
-
-- `current_surfaces` — already-declared surfaces (empty if none)
-- `surfaces_md_exists` — boolean
-- `claude_md_attach` — the wiki's CLAUDE.md `## Lore` block
-- `note_samples` — wikilinks to ~3 recent notes per existing type
-- `shipped_templates` — `standard`, `science`, `design` template text
-
-Read all of it. Do not show it to the user directly.
+Call `lore_surface_context(wiki=<wiki>)`. Read `current_surfaces`,
+`surfaces_md_exists`, `claude_md_attach`, `note_samples`,
+`shipped_templates`. Don't show the pack to the user.
 
 ## Step 2 — Dispatch question
 
-Ask **one** question:
+> "Add a new surface, or redesign the full set?"
 
-> "Add a new surface, or redesign the full set?
-> (`add` extends the existing vocabulary; `redesign` proposes a complete
-> new SURFACES.md and replaces the current one with `--force` on commit.)"
+If `redesign` and `surfaces_md_exists`, confirm: replacing SURFACES.md
+needs `--force`. Stop on `no`.
 
-If `surfaces_md_exists` is `false`, mention that — but still ask. The
-user may want to design just one surface first and grow the set.
+## Add flow
 
-If the answer is `redesign` and `surfaces_md_exists` is `true`, confirm:
-*"This will replace SURFACES.md at `<path>` (with `--force`). Continue?"*
-Stop on `no`.
+Ask: *"Describe the new surface in your own words — what does it
+capture, and when should Curator extract one?"* (User-facing term is
+"Curator", never "Curator B".) Synthesize a complete surface spec:
 
-Branch on the answer.
+- `name` (lowercase ASCII, `^[a-z][a-z0-9_]*$`), one-sentence
+  `description`, `required` (always starts with `type, created,
+  description, tags` unless reasoned otherwise), `optional` (usually
+  `draft`), `extract_when` hint.
+- `plural` / `slug_format` / `extract_prompt` only when needed.
 
----
+Run a semantic-overlap check vs `current_surfaces`; if the new surface
+sounds like an existing one, propose extending instead.
 
-## Add flow (one new surface)
+Build a draft with `"operation": "append"` and a single `surface`
+block. Validate via `lore_surface_validate`; revise silently (max 2
+retries; report codes if still failing).
 
-### Step A1 — Open the conversation
+## Redesign flow
 
-Ask:
+Ask: *"What's this wiki for, and what kinds of things do you want to
+capture?"* Synthesize 3–6 surfaces, internally consistent: no semantic
+overlap; one naming register; `type, created, description, tags` in
+`required` for every surface; always include `session`. Use
+`shipped_templates` for inspiration but don't pick wholesale.
 
-> "Describe the new surface in your own words — what does it capture,
-> and when should Curator extract one?"
+Build a draft with `"operation": "init"` and a `surfaces: [...]`
+array. Validate as above.
 
-User-facing term is "Curator" — never "Curator B".
+## Step 3 — Present + branch
 
-If the user asks for a semantic scan first, call `lore_search` with
-their description as the query, present the top 5 hits, and ask if any
-cluster looks like it would fit this surface.
+Show the rendered markdown + a one-line-per-surface summary + any
+overlap notes. Ask: *"Commit, deepen/refine, or save as draft?"*
 
-### Step A2 — Synthesize a full draft
+- **Commit** — write draft to `$TMPDIR/lore-surface-<ts>.json`, run
+  `lore surface commit <path>` (`--force` for redesign-replacing-
+  existing). Report receipt + new wikilinks.
+- **Deepen** (add) — pick a field, ask focused question, update,
+  re-validate, return to Present.
+- **Refine** (redesign) — pick a surface, run a mini add-flow on it,
+  preserve the rest, return to Present.
+- **Save** — write to `$LORE_ROOT/drafts/surfaces/<wiki>-<name>.json`
+  (or `<wiki>-init.json`); print the commit command; stop.
 
-From the user's answer + the context pack, produce a complete surface
-spec:
-
-- `name` — lowercase ASCII, `^[a-z][a-z0-9_]*$`
-- `description` — one sentence
-- `required` — list; always starts with `type, created, description,
-  tags` unless there's a reason to drop
-- `optional` — list (`draft` is usually present)
-- `extract_when` — short prose hint for Curator
-- `plural` — only if `<name>s` would be wrong (`study` → `studies`)
-- `slug_format` — only if the default `{date}-{slug}` wouldn't suit
-- `extract_prompt` — only if needed beyond `description`
-
-Run a semantic-overlap check against `current_surfaces`. If the new
-surface sounds like an existing one, say so explicitly and propose
-extending the existing surface instead. Let the user decide.
-
-Build a draft-spec JSON with `"operation": "append"` and a single
-`"surface": { ... }` block. Call `lore_surface_validate`. Revise
-silently on issues (max 2 retries; if still broken, surface the codes
-honestly).
-
-### Step A3 — Present
-
-Show the rendered `## <name>` section, a compact diff summary, and any
-overlap notes. Ask:
-
-> "Commit this, deepen a specific field, or save as draft?"
-
-Branch as in **Commit / Deepen / Save** below.
-
----
-
-## Redesign flow (full SURFACES.md set)
-
-### Step R1 — Open the conversation
-
-Ask:
-
-> "What's this wiki for, and what kinds of things do you want to
-> capture? A rough list or free-text description — either works."
-
-### Step R2 — Synthesize the full set
-
-Produce a complete SURFACES.md draft: 3–6 surfaces, internally
-consistent:
-
-- No semantic overlap between surfaces (`decision` and `choice` don't
-  both exist).
-- Consistent naming register (all imperative-nouns, or all agent-role
-  nouns — pick a lane).
-- `type, created, description, tags` in `required` for every surface
-  unless there's a reason to drop.
-- Always include a `session` surface (Curator writes session notes; the
-  wiki needs a slot for them).
-- Use `plural`, `slug_format`, `extract_prompt` only where they add
-  real value.
-
-Consult `shipped_templates` for inspiration — do **not** pick one
-wholesale; build a set tailored to the user's description.
-
-Build a draft-spec JSON with `"operation": "init"` and a `surfaces:
-[...]` array. Call `lore_surface_validate`. Revise silently.
-
-### Step R3 — Present
-
-Show the rendered SURFACES.md and a one-line-per-surface summary
-("`concept` — ideas that recur across sessions", etc.). Ask:
-
-> "Commit this, refine one surface, or save as draft?"
-
-Branch as in **Commit / Refine / Save** below.
-
----
-
-## Commit / Deepen-or-Refine / Save (shared)
-
-**Commit:**
-1. Write draft to `$TMPDIR/lore-surface-<timestamp>.json`.
-2. Run `lore surface commit <path>` (add `--force` for redesign if
-   SURFACES.md already existed).
-3. Report the receipt JSON path + the new surface's wikilink.
-
-**Deepen** (add flow) — ask which field to tune; ask a focused
-question; update the draft; re-validate; return to **Present**.
-
-**Refine** (redesign flow) — ask which surface; run a mini add-flow
-loop for that one surface only; preserve all other surfaces; return to
-**Present**.
-
-**Save as draft:**
-1. Write to `$LORE_ROOT/drafts/surfaces/<wiki>-<name>.json` (add
-   flow) or `<wiki>-init.json` (redesign flow).
-2. Print: *"Saved. Commit later with `lore surface commit <path>`."*
-3. Stop.
-
-## Error handling, rules
+## Hard rules
 
 - Never edit SURFACES.md directly — `lore surface commit` is the only
   write path.
-- Never say "Curator B"; say "Curator".
-- If MCP is unreachable, stop honestly; do not fake a context pack.
-- If validation keeps failing after 2 retries, surface the issue codes
-  verbatim and ask the user how to adjust.
-- Commit exits non-zero → show stderr and stop; do not retry
-  automatically.
-- Do not invent surface fields the user didn't ask for.
-- Do not offer to rename or remove existing surfaces — that's a
-  separate (future) flow.
+- MCP unreachable → stop honestly. Validation failing twice → surface
+  the codes verbatim. Commit non-zero → show stderr and stop.
+- Don't invent fields the user didn't ask for; don't rename or remove
+  existing surfaces (separate future flow).


### PR DESCRIPTION
Closes #70

## Summary

- Trim all 5 surviving skill bodies. Total goes from 541 → 266 lines (-50.8%).
- No MCP tool or CLI changes — pure skill-text edits.

## Per-skill counts

| Skill | Before | After | Δ |
|---|---|---|---|
| context | 63 | 32 | -49% |
| curator | 77 | 44 | -43% |
| inbox | 116 | 52 | -55% |
| resume | 106 | 55 | -48% |
| surface | 179 | 83 | -54% |

## Note on the soft cap

`surface` lands at 83 (above the ~50 line soft cap). The dispatch question + two distinct flows (add / redesign) + shared commit/save block don't compress further without moving the interview script into MCP responses — and that's a code change parked for a future iteration. Slice 5 was scoped to skill-text trim with the soft-cap-as-target policy chosen in PRD #64.

## Test plan

- [x] Each survivor's body materially smaller
- [x] Total under the ~250 line target
- [ ] Manual smoke: `/lore:context`, `/lore:resume`, `/lore:curator`, `/lore:inbox`, `/lore:surface` all still produce equivalent behavior

## Out of this slice

- README slash-command list update → #71 (release)
- Plugin version bump → #71 (release)