### PR TITLE
feat(#71): release 0.48.0 — version bump + CHANGELOG migration table

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore",
   "description": "LLM-optimized knowledge graph for AI-coding teams — session notes, auto-extracted knowledge, pluggable briefings, magic context injection at session start.",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,55 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-05-08
+
+### Changed — Plugin skill set reduced from 19 to 5 (#64)
+
+The lore plugin now ships only 5 skills instead of 19. Every skill's
+name and description is paid into the always-on available-skills
+system reminder on every session start; the previous 19-skill list was
+mostly thin CLI wrappers, deprecated aliases, and one-time admin
+tools. The reduction is **subtractive only** — every removed skill's
+function remains reachable through CLI, MCP, or natural-language ask.
+
+**Surviving skills (judgment-required):** `inbox`, `surface`,
+`resume`, `curator`, `context`. SKILL.md bodies were also trimmed
+(541 → 266 lines total, -50.8%).
+
+**Migration table:**
+
+| Removed | Replacement |
+|---|---|
+| `/lore:loud` | `lore on citations` |
+| `/lore:quiet` | `lore off citations` |
+| `/lore:journal` | `lore journal write [--ai] "<text>"` (or ask Claude); `lore_journal_write` MCP for AI-side |
+| `/lore:init` | `lore init` |
+| `/lore:new-wiki` | `lore new-wiki <name>` |
+| `/lore:import` | symlink the vault under `$LORE_ROOT/wiki/<name>` and run `lore lint`; ask Claude to enrich frontmatter if desired |
+| `/lore:attach` | `lore attach` |
+| `/lore:detach` | `lore detach` |
+| `/lore:briefing` | `lore briefing --wiki <name>` |
+| `/lore:lint` | `lore lint` |
+| `/lore:on` | `lore on` |
+| `/lore:off` | `lore off` |
+| `/lore:search` | `/lore:resume <query>` (keyword mode); raw paths via `lore search <query>` shell or `lore_search` MCP |
+| `/lore:surface-init` | `/lore:surface <wiki>` (answer "redesign" at the dispatch prompt) |
+| `/lore:surface-add` | `/lore:surface <wiki>` (answer "add") |
+
+**Why hard cut and not a deprecation cycle:** the cut surfaces are
+infrequent (init / import / attach are one-time-per-machine; on / off /
+loud / quiet are rare debug verbs; lint / briefing / search are
+CLI-shaped already). A CHANGELOG entry plus clear "command not found"
+errors covers the user impact.
+
+**Plugin version bump is mandatory** for installed caches to invalidate
+and pick up the new manifest. `claude plugin update lore@lore` after
+upgrading.
+
+Tracked in PRD #64; implemented across #67 (delete 12 skills), #68
+(merge surface-init + surface-add), #69 (fold search into resume),
+#70 (body-trim survivors), #71 (this release).
+
 ## [0.47.0] - 2026-05-07
 
 ### Fixed — Curator A: one note per `(transcript_id, local_date)` (#52)

--- a/README.md
+++ b/README.md
@@ -191,10 +191,11 @@ capture path knows which wiki / scope to file notes under:
 cd /path/to/your/repo
 ```
 
-Then in a Claude Code session in that repo:
+Then in a Claude Code session in that repo, ask Claude to run
+`lore attach` (or run it from a shell):
 
 ```
-/lore:attach
+lore attach
 ```
 
 Interactive — asks for wiki + scope, writes the managed block to
@@ -213,24 +214,20 @@ lore new-wiki product --surfaces design      # + artefact + critique
 lore new-wiki scratch --surfaces custom      # skeleton you fill yourself
 ```
 
-`SURFACES.md` is human-editable markdown with embedded YAML. Three ways
+`SURFACES.md` is human-editable markdown with embedded YAML. Two ways
 to author and maintain it:
 
-- **Design a wiki's vocabulary (interactive, LLM-guided):**
-  `lore surface init --wiki <name>` drops into the `/lore:surface-init`
-  skill in Claude Code. Guided holistic design — one open question,
-  full synthesis, per-surface refinement, hybrid commit.
-- **Add one new surface (interactive, LLM-guided):**
-  `lore surface add --wiki <name>` drops into `/lore:surface-add`.
-  Proposes a full draft from one open question with semantic-overlap
-  detection against existing surfaces.
-- **Scripted / automation / no-LLM:** write a `draft.json`
-  (schema: `lore.surface.draft/1`) and run
-  `lore surface commit <path>`. This is also how the skill paths write
-  under the hood. `lore new-wiki <name> --surfaces <template>` (above)
-  remains the fastest way to seed a wiki headlessly.
+- **Interactive, LLM-guided:** `/lore:surface <wiki>` opens with one
+  dispatch question — *add* a new surface or *redesign* the full set —
+  and routes to either flow. Both commit through
+  `lore surface commit <path>`.
+- **Scripted / automation / no-LLM:** write a `draft.json` (schema:
+  `lore.surface.draft/1`) and run `lore surface commit <path>`. This
+  is also how the skill writes under the hood.
+  `lore new-wiki <name> --surfaces <template>` (above) remains the
+  fastest way to seed a wiki headlessly.
 
-Both interactive flows require `claude` on PATH. The `commit` primitive
+The interactive flow requires `claude` on PATH. The `commit` primitive
 does not. Run `lore surface lint` anytime to validate the file.
 
 See `docs/superpowers/specs/2026-04-20-surface-authoring-design.md` for
@@ -363,7 +360,7 @@ ln -s ~/git/research/knowledge research
 # personal wiki lives inline at ~/lore/wiki/personal/
 ```
 
-Then `/lore:init` to write the root CLAUDE.md and you're set.
+Then run `lore init` to write the root CLAUDE.md and you're set.
 
 ### 2. Single-wiki — one team's knowledge only
 

--- a/docs/how-to/matrix-bot.md
+++ b/docs/how-to/matrix-bot.md
@@ -1,8 +1,8 @@
 # How to publish briefings to Matrix
 
-End-to-end recipe for a wiki briefing landing in a Matrix room. Works
-from the `/lore:briefing` skill or directly from `lore briefing
-publish` on the CLI.
+End-to-end recipe for a wiki briefing landing in a Matrix room. Run
+via `lore briefing --wiki <wiki>` (the CLI does gather + render +
+publish + ledger update in one shot).
 
 ---
 
@@ -80,14 +80,13 @@ them. Commit the file like any other wiki note.
 
 ## Step 3 — publish
 
-### From the `/lore:briefing` skill
+### From the CLI
 
-```
-/lore:briefing <wiki>
+```bash
+lore briefing --wiki <wiki>
 ```
 
-The skill calls `lore_briefing_gather`, composes the prose, then
-shells out to:
+Or, for the publish step alone:
 
 ```bash
 lore briefing publish --sink matrix --wiki <wiki>
@@ -166,6 +165,6 @@ homeserver doesn't currently auto-refresh tokens.
 
 - `docs/architecture/config.md` — full precedence table for every
   Lore config source.
-- `skills/briefing/SKILL.md` — the `/lore:briefing` skill workflow.
+- `lore briefing --help` — CLI reference for the gather + publish flow.
 - `lib/lore_core/briefing/sinks/matrix.py` — the sink itself; module
   docstring reiterates the resolution order.


### PR DESCRIPTION
Closes #71. Final release roll-up for PRD #64 (also closes #64 — confirms #67/#68/#69/#70 reach users).

## Summary

- Bump `.claude-plugin/plugin.json` from 0.47.0 → 0.48.0 (matches `pyproject.toml`). Mandatory for installed plugin caches to invalidate.
- Add CHANGELOG entry for 0.48.0 with the full 14-row migration table.
- Update README references to removed slash commands → CLI verbs.
- Update `docs/how-to/matrix-bot.md` to reference `lore briefing` directly.

## Migration table (in CHANGELOG)

Covers all 14 removals across deprecated aliases, journal, one-time admin verbs, thin wrappers, and merge-collapses (search → resume, surface-init/add → surface).

## Test plan

- [x] `pyproject.toml` and `.claude-plugin/plugin.json` agree on `0.48.0`
- [x] `CHANGELOG.md` has a `## [0.48.0] — 2026-05-08` section under `## [Unreleased]`
- [x] `tests/test_version_sync.py` now passes (was failing on main with version drift between pyproject and plugin manifest)
- [x] Full test suite green (2524 passing; pre-existing optional-dep test for `openai` deselected)
- [x] No reference to a removed slash command remains in README or `docs/how-to/`
- [ ] After merge: `claude plugin update lore@lore` and confirm fresh available-skills reminder shows only the 5 survivors