### PR TITLE
feat(#65): freshness verdicts — positive-evidence-only staleness end-to-end

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore",
   "description": "LLM-optimized knowledge graph for AI-coding teams — session notes, auto-extracted knowledge, pluggable briefings, magic context injection at session start.",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,38 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-### Added — Read-only freshness signal on retrieval (#65, slice 1)
+## [0.49.0] - 2026-05-08
 
-MCP retrieval surfaces (`lore_search`, `lore_read`, `lore_drill`) now
-attach a `freshness` block to every hit/result. Notes are classified
-as `confirmed` (default) or `stale-candidate` based on positive-
-evidence rules: authored frontmatter markers (`status: stale`,
-`superseded_by`, `supersede_candidate`, `supersede_candidate_of`).
-Age never flags. Subsequent slices wire the orphan signal, verdict
-writes, retrieval-time filter/downrank, and the in-passing nudge
-directive.
+### Added — Freshness verdicts: end-to-end (#65, slices 1–10)
+
+Positive-evidence-only staleness with read-time, in-passing user
+verdicts. Stack of ten vertical slices delivered together:
+
+- Slice 1: read-only `freshness` block on every `lore_search` /
+  `lore_read` / `lore_drill` MCP response.
+- Slice 2: legacy 90-day age rule retired — `_pass_staleness` is now
+  a no-op and the `--stale-threshold` CLI flag is removed.
+- Slice 3: retrieval-time filter — `confirmed` ranks above
+  `stale-candidate` at tied scores; SessionStart inject excludes
+  `status: stale` and downranks soft markers; audit log surfaced via
+  `/lore:context`.
+- Slice 4: orphan-link signal — `lore lint` caches the orphan set
+  in `_catalog.json`; freshness flags it with
+  `cause: orphan_broken`.
+- Slice 5: `lore_verdict` MCP tool with the stale + clear-stale
+  branches; `stale_marker_writer` writes the four-field schema
+  additively.
+- Slice 6: per-user `wiki/<name>/_verdicts/<handle>.json` sidecar
+  for personal confirms; soft-marker suppression with mtime gate +
+  14-day recency window.
+- Slice 7: in-passing nudge + dynamic-escalation directive added to
+  the lore-managed CLAUDE.md template.
+- Slice 8: SessionStart status-line `· N pending verdict[s]` chip
+  with soft cap (`9+`) and zero-state suppression.
+- Slice 9: team-mode disagreement detection — surfaces conflicts
+  between team-stale frontmatter and per-user sidecar confirms.
+- Slice 10: `/lore:verify` slash command for the explicit batch
+  resolver.
 
 ### Removed — `lore curator --stale-threshold` flag (#65, slice 2)
 
@@ -31,6 +53,16 @@ flag has been removed. Existing notes that already carry
 `status: stale` from prior runs are left untouched (additive-only
 edit policy, #37). Cron-driven `lore curator --stale-threshold N`
 invocations should drop the flag.
+
+### Added — `/lore:verify` slash command (#65, slice 10)
+
+Plugin skill registered as `lore:verify`; user-invocable batch
+picker over the freshness backlog. Bare `/lore:verify` lists notes
+flagged in the current session; `/lore:verify --all` lists every
+currently-stale-candidate note in the active wiki. Each entry
+prompts confirm / stale / skip; stale prompts for a one-line reason
+and calls `mcp__lore__lore_verdict` accordingly. Wraps the verdict
+MCP — no new write paths.
 
 ## [0.48.0] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added — Read-only freshness signal on retrieval (#65, slice 1)
+
+MCP retrieval surfaces (`lore_search`, `lore_read`, `lore_drill`) now
+attach a `freshness` block to every hit/result. Notes are classified
+as `confirmed` (default) or `stale-candidate` based on positive-
+evidence rules: authored frontmatter markers (`status: stale`,
+`superseded_by`, `supersede_candidate`, `supersede_candidate_of`).
+Age never flags. Subsequent slices wire the orphan signal, verdict
+writes, retrieval-time filter/downrank, and the in-passing nudge
+directive.
+
+### Removed — `lore curator --stale-threshold` flag (#65, slice 2)
+
+PRD #65 (positive-evidence-only staleness) replaces the 90-day age
+rule with read-time freshness signals derived from named causes only
+(authored markers, broken wikilinks). The corresponding curator-C
+pass `_pass_staleness` is now a no-op and the `--stale-threshold` CLI
+flag has been removed. Existing notes that already carry
+`status: stale` from prior runs are left untouched (additive-only
+edit policy, #37). Cron-driven `lore curator --stale-threshold N`
+invocations should drop the flag.
+
 ## [0.48.0] - 2026-05-08
 
 ### Changed — Plugin skill set reduced from 19 to 5 (#64)

--- a/lib/lore_cli/curator_cmd.py
+++ b/lib/lore_cli/curator_cmd.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Any
 
 import typer
-from lore_core.lint import STALENESS_DAYS
 from lore_core.run_render import pick_icon_set, render_flat_log, should_use_color
 from lore_curator.defrag_curator import (
     _resolve_backend,
@@ -45,11 +44,6 @@ def curator(
     apply: bool = typer.Option(
         False, "--apply", help="Actually write changes. Without this, runs dry."
     ),
-    stale_threshold: int = typer.Option(
-        STALENESS_DAYS,
-        "--stale-threshold",
-        help=f"Days after which active notes become stale (default {STALENESS_DAYS}).",
-    ),
     json_out: bool = typer.Option(
         False, "--json", help="Emit machine-readable summary."
     ),
@@ -72,7 +66,6 @@ def curator(
     reports = run_curator_c(
         wiki_filter=wiki,
         dry_run=not apply,
-        stale_threshold=stale_threshold,
     )
 
     if json_out:

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -507,6 +507,32 @@ def _last_session_hint_with_freshness(
     return results
 
 
+def _pending_verdict_chip(wiki: Path) -> str:
+    """Slice 8 of PRD #65 — `· N pending verdict` chip text or empty.
+
+    Reads the pending count from
+    :func:`lore_core.freshness.count_pending_verdicts` (catalog-based,
+    no fs walk per call). When the soft cap fires, renders ``"9+"``.
+    Zero-state suppressed entirely — most sessions should not see the
+    chip.
+
+    Cadence: refreshed at every SessionStart-like emit (this hook),
+    which is also the only time the status line changes for v1. No
+    live polling.
+    """
+    try:
+        from lore_core.freshness import count_pending_verdicts
+
+        count, capped = count_pending_verdicts(wiki)
+    except Exception:
+        return ""
+    if count <= 0:
+        return ""
+    label = "verdict" if count == 1 else "verdicts"
+    rendered = f"{count}+" if capped else str(count)
+    return f"{rendered} pending {label}"
+
+
 def _filter_session_hints(
     candidates: list[tuple[str, str, dict]], *, max_notes: int = 2
 ) -> tuple[list[tuple[str, str]], list[str]]:
@@ -833,6 +859,9 @@ def _session_start_from_lore(
         injected_bits.append(f"{len(issues)} issue{'s' if len(issues) != 1 else ''}")
     if prs:
         injected_bits.append(f"{len(prs)} PR{'s' if len(prs) != 1 else ''}")
+    pending_chip = _pending_verdict_chip(wiki)
+    if pending_chip:
+        injected_bits.append(pending_chip)
     status_line = f"lore {_lore_version()}: active" + (" · " + " · ".join(injected_bits) if injected_bits else "")
 
     out_parts: list[str] = [status_line, ""]
@@ -932,6 +961,9 @@ def _session_start(cwd: str | None) -> str:
     if session_hints:
         _, first_summary = session_hints[0]
         injected_bits.append(f"last: {first_summary}")
+    pending_chip = _pending_verdict_chip(wiki)
+    if pending_chip:
+        injected_bits.append(pending_chip)
     status_line = f"lore {_lore_version()}: active" + (" · " + " · ".join(injected_bits) if injected_bits else "")
 
     parts: list[str] = [status_line, ""]

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -463,6 +463,71 @@ def _session_note_date(path: Path) -> date | None:
     return None
 
 
+def _last_session_hint_with_freshness(
+    wiki: Path, max_notes: int = 2
+) -> list[tuple[str, str, dict]]:
+    """Like :func:`_last_session_hint` but also returns the freshness
+    block for each hit.
+
+    Used by the inject filter (slice 3 of PRD #65). The freshness block
+    is computed via :func:`lore_core.freshness.compute_freshness`
+    against the parsed frontmatter; orphan-set is empty in this slice
+    (the orphan cache wires in slice 4) and personal sidecars are out
+    of scope here (slice 6).
+    """
+    from lore_core.freshness import compute_freshness, signal_to_dict
+    from lore_core.schema import parse_frontmatter
+    from lore_core.session_writer import session_path_sort_key
+
+    sessions_dir = wiki / "sessions"
+    if not sessions_dir.is_dir():
+        return []
+
+    candidates = sorted(
+        (p for p in sessions_dir.rglob("*.md") if p.is_file() and not p.name.startswith("_")),
+        key=session_path_sort_key,
+        reverse=True,
+    )
+    results: list[tuple[str, str, dict]] = []
+    for path in candidates:
+        if len(results) >= max_notes:
+            break
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        fm = parse_frontmatter(text)
+        if fm.get("type") != "session":
+            continue
+        hint = fm.get("title") or fm.get("description") or fm.get("summary")
+        if not hint:
+            continue
+        signal = compute_freshness(fm, path, wiki, None, set())
+        results.append((path.stem, hint, signal_to_dict(signal)))
+    return results
+
+
+def _filter_session_hints(
+    candidates: list[tuple[str, str, dict]], *, max_notes: int = 2
+) -> tuple[list[tuple[str, str]], list[str]]:
+    """Apply the slice-3 freshness inject filter to session-hint candidates.
+
+    Hard-stale notes are excluded entirely; soft stale-candidates are
+    downranked (kept after confirmed peers). Returns the trimmed
+    ``(slug, hint)`` list and the audit-log lines for /lore:context.
+    """
+    from lore_core.freshness_filter import apply_inject_filter
+
+    result = apply_inject_filter(
+        candidates,
+        freshness_of=lambda c: c[2],
+        path_of=lambda c: c[0],
+        wiki_of=lambda _c: None,
+    )
+    kept = [(slug, hint) for slug, hint, _fr in result.kept[:max_notes]]
+    return kept, result.audit.render_lines()
+
+
 def _last_session_hint(wiki: Path, max_notes: int = 2) -> list[tuple[str, str]]:
     """Return (slug, status-line text) pairs for the most recent session notes.
 
@@ -751,7 +816,10 @@ def _session_start_from_lore(
         prs = results[1]
 
     project_entry = _project_note_for_repo(wiki, repo) if repo else None
-    session_hints = _last_session_hint(wiki)
+    session_hints_full = _last_session_hint_with_freshness(wiki, max_notes=4)
+    session_hints, freshness_audit_lines = _filter_session_hints(
+        session_hints_full, max_notes=2
+    )
 
     injected_bits: list[str] = []
     if scope:
@@ -781,6 +849,10 @@ def _session_start_from_lore(
     if session_hints:
         for slug, desc in session_hints[:2]:
             out_parts.append(f"Last: [[{slug}]] — {desc}")
+        out_parts.append("")
+
+    if freshness_audit_lines:
+        out_parts.extend(freshness_audit_lines)
         out_parts.append("")
 
     # Directive last: status + focus + open items show what Lore did for
@@ -849,7 +921,10 @@ def _session_start(cwd: str | None) -> str:
 
     # Project note focused on this repo, if any
     project_entry = _project_note_for_repo(wiki, repo) if repo else None
-    session_hints = _last_session_hint(wiki)
+    session_hints_full = _last_session_hint_with_freshness(wiki, max_notes=4)
+    session_hints, freshness_audit_lines = _filter_session_hints(
+        session_hints_full, max_notes=2
+    )
 
     injected_bits: list[str] = []
     if project_entry is not None:
@@ -874,6 +949,10 @@ def _session_start(cwd: str | None) -> str:
     if session_hints:
         for slug, desc in session_hints[:2]:
             parts.append(f"Last: [[{slug}]] — {desc}")
+        parts.append("")
+
+    if freshness_audit_lines:
+        parts.extend(freshness_audit_lines)
         parts.append("")
 
     # Directive last: see _session_start_from_lore for rationale.

--- a/lib/lore_core/disagreement.py
+++ b/lib/lore_core/disagreement.py
@@ -1,0 +1,96 @@
+"""Disagreement detection — slice 9 of PRD #65.
+
+A team-mode conflict surfaces when one user marked a note stale
+(team-wide frontmatter ``status: stale``) and a second user (or the
+same user later) personally confirmed it. The asymmetric storage
+means the two verdicts coexist silently; the disagreement detector
+spots the contradiction so the in-passing nudge can ask for an
+explicit resolution.
+
+Pure: no I/O. Inputs are the parsed frontmatter dict and the (already
+loaded) personal-sidecar confirm date.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date as _date
+
+
+@dataclass(frozen=True)
+class Disagreement:
+    """A team-stale verdict and a later personal confirm coexist.
+
+    Fields:
+        stale_by: Handle that authored the team-stale verdict.
+        stale_at: Date the team-stale verdict was written.
+        stale_reason: Reason text recorded with the stale verdict.
+        self_confirmed_at: The current user's personal confirm date.
+    """
+
+    stale_by: str
+    stale_at: _date
+    stale_reason: str
+    self_confirmed_at: _date
+
+
+def _coerce_date(value) -> _date | None:
+    if isinstance(value, _date):
+        return value
+    if isinstance(value, str):
+        try:
+            return _date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def detect_disagreement(
+    note_frontmatter: dict,
+    sidecar_confirmed_at: _date | None,
+) -> Disagreement | None:
+    """Return a :class:`Disagreement` when the two verdicts conflict.
+
+    A disagreement is produced when **all** of these hold:
+      * ``note_frontmatter`` contains ``status: stale`` (with
+        ``stale_by``, ``stale_at``, ``stale_reason``).
+      * ``sidecar_confirmed_at`` is non-null.
+      * ``sidecar_confirmed_at > stale_at``.
+
+    Same-user case is intentionally covered: the user may have
+    changed their own mind after a stale verdict and not cleared the
+    marker; that is still worth surfacing.
+
+    Returns ``None`` (not falsy) when:
+      * No personal confirm.
+      * No ``status: stale`` marker.
+      * The confirm precedes the stale verdict (stale wins).
+      * The frontmatter is missing ``stale_at`` (graceful skip — we
+        cannot order without a date).
+    """
+    fm = note_frontmatter or {}
+    if str(fm.get("status", "")).strip().lower() != "stale":
+        return None
+    if sidecar_confirmed_at is None:
+        return None
+    stale_at = _coerce_date(fm.get("stale_at"))
+    if stale_at is None:
+        return None
+    if sidecar_confirmed_at <= stale_at:
+        return None
+    return Disagreement(
+        stale_by=str(fm.get("stale_by") or ""),
+        stale_at=stale_at,
+        stale_reason=str(fm.get("stale_reason") or ""),
+        self_confirmed_at=sidecar_confirmed_at,
+    )
+
+
+def disagreement_to_dict(d: Disagreement) -> dict:
+    """JSON-friendly render for the MCP `freshness.disagreement` field."""
+    return {
+        "stale_by": d.stale_by,
+        "stale_at": d.stale_at.isoformat(),
+        "stale_reason": d.stale_reason,
+        "self_confirmed_at": d.self_confirmed_at.isoformat(),
+    }

--- a/lib/lore_core/freshness.py
+++ b/lib/lore_core/freshness.py
@@ -1,0 +1,207 @@
+"""Freshness signal — positive-evidence-only staleness classification.
+
+Pure, side-effect-free module used by retrieval surfaces (MCP server,
+SessionStart inject, /lore:context) to classify a note as ``confirmed``
+or ``stale-candidate`` based on **named causes** in its frontmatter or
+in derived signals (orphan-link cache, personal confirm sidecar).
+
+**Positive-evidence rule.** Age never flags. A missing
+``last_confirmed`` does not matter. A note becomes ``stale-candidate``
+*only* if at least one of the following is observed:
+
+1. Authored markers in frontmatter:
+   - ``status: stale``
+   - ``superseded_by: …``
+   - ``supersede_candidate: …``
+   - ``supersede_candidate_of: …``
+2. The note path is in the supplied orphan set (slice 4 wires the cache).
+
+Authored markers take precedence over the orphan signal — they carry
+richer reason text and the orphan signal is a fallback. A note with
+both reports ``cause: authored_marker``.
+
+Personal confirms (slice 6) can suppress flagging from *soft* markers
+(``supersede_candidate``, ``supersede_candidate_of``) but never
+override hard team-wide markers (``status: stale``, ``superseded_by``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Literal
+
+
+# Default recency window for personal confirms (slice 6). Hard-coded
+# until #51 lands the typed config knob; the constant is named so
+# audit/tests can target it.
+PERSONAL_CONFIRM_RECENCY_DAYS = 14
+
+
+_HARD_MARKER_KEYS = ("status", "superseded_by")
+_SOFT_MARKER_KEYS = ("supersede_candidate", "supersede_candidate_of")
+
+
+@dataclass(frozen=True)
+class FreshnessSignal:
+    """The classification of one note for one retrieval.
+
+    Fields:
+        status: ``confirmed`` (default) or ``stale-candidate``.
+        cause: Why a stale-candidate was raised. ``authored_marker`` for
+            frontmatter markers, ``orphan_broken`` for orphan-set
+            membership. ``"none"`` for confirmed notes (kept as a
+            literal rather than ``None`` so JSON consumers see a
+            consistent enum).
+        reason: Short human-readable explanation, used by the in-passing
+            nudge directive (slice 7).
+        confirmed_at: Personal sidecar confirm date when present
+            (slice 6). Always ``None`` in slice 1.
+    """
+
+    status: Literal["confirmed", "stale-candidate"]
+    cause: Literal["authored_marker", "orphan_broken", "none"] | None
+    reason: str | None
+    confirmed_at: date | None
+
+
+def _first_marker(fm: dict, keys: tuple[str, ...]) -> tuple[str, object] | None:
+    """Return the first ``(key, value)`` pair in ``keys`` that is set."""
+    for key in keys:
+        if key == "status":
+            if str(fm.get(key, "")).strip().lower() == "stale":
+                return key, fm.get(key)
+            continue
+        val = fm.get(key)
+        if val:
+            return key, val
+    return None
+
+
+def _format_marker_reason(key: str, value: object) -> str:
+    """Render a short human-readable reason for an authored marker."""
+    if key == "status":
+        return "marked stale"
+    if key == "superseded_by":
+        return f"superseded by {value}"
+    if key == "supersede_candidate":
+        return f"supersede candidate: {value}"
+    if key == "supersede_candidate_of":
+        return f"supersede candidate of {value}"
+    return f"{key}: {value}"
+
+
+def _has_authored_marker(fm: dict) -> tuple[str, object] | None:
+    """Return the first authored marker found, or None."""
+    hard = _first_marker(fm, _HARD_MARKER_KEYS)
+    if hard is not None:
+        return hard
+    return _first_marker(fm, _SOFT_MARKER_KEYS)
+
+
+def _is_soft_only(fm: dict) -> bool:
+    """True iff the only authored markers present are soft (suppressible)."""
+    if _first_marker(fm, _HARD_MARKER_KEYS) is not None:
+        return False
+    return _first_marker(fm, _SOFT_MARKER_KEYS) is not None
+
+
+def _file_mtime_date(note_path: Path) -> date | None:
+    try:
+        return date.fromtimestamp(note_path.stat().st_mtime)
+    except OSError:
+        return None
+
+
+def compute_freshness(
+    note_frontmatter: dict,
+    note_path: Path,
+    wiki_path: Path,
+    sidecar_confirmed_at: date | None = None,
+    orphan_set: set[Path] | None = None,
+    *,
+    today: date | None = None,
+    recency_days: int = PERSONAL_CONFIRM_RECENCY_DAYS,
+) -> FreshnessSignal:
+    """Classify ``note_path`` as confirmed or stale-candidate.
+
+    Pure: no I/O against the note body. The only filesystem touch is
+    the optional ``stat`` for mtime gating of personal confirms — the
+    caller can pass a pre-computed ``sidecar_confirmed_at`` and
+    ``orphan_set`` to keep the function fully decoupled.
+
+    Args:
+        note_frontmatter: Parsed YAML frontmatter dict (empty dict for
+            notes without frontmatter).
+        note_path: Absolute path to the note (used for orphan-set
+            membership and personal-confirm mtime gating only).
+        wiki_path: Absolute path to the wiki root (reserved for future
+            cross-note lookups; unused in slice 1).
+        sidecar_confirmed_at: The current user's most recent personal
+            confirm for this note, or ``None`` if no confirm exists.
+        orphan_set: Set of absolute note paths flagged as containing
+            broken wikilinks. Pass an empty set or ``None`` to skip the
+            orphan check.
+        today: Override "today's date" for recency-window math. Defaults
+            to ``date.today()``. Tests pass an explicit date.
+        recency_days: Override the personal-confirm recency window.
+            Defaults to ``PERSONAL_CONFIRM_RECENCY_DAYS``.
+
+    Returns:
+        A :class:`FreshnessSignal`.
+    """
+    fm = note_frontmatter or {}
+    today = today or date.today()
+    orphan_set = orphan_set or set()
+
+    authored = _has_authored_marker(fm)
+
+    # Personal confirm suppression: only suppresses *soft-only*
+    # authored markers. Hard markers (status:stale, superseded_by) and
+    # orphan-broken signals are NEVER suppressed by personal confirms.
+    if sidecar_confirmed_at is not None and _is_soft_only(fm):
+        mtime = _file_mtime_date(note_path)
+        within_window = (today - sidecar_confirmed_at) <= timedelta(days=recency_days)
+        not_yet_invalidated = mtime is None or sidecar_confirmed_at >= mtime
+        if within_window and not_yet_invalidated:
+            return FreshnessSignal(
+                status="confirmed",
+                cause="none",
+                reason=None,
+                confirmed_at=sidecar_confirmed_at,
+            )
+
+    if authored is not None:
+        key, value = authored
+        return FreshnessSignal(
+            status="stale-candidate",
+            cause="authored_marker",
+            reason=_format_marker_reason(key, value),
+            confirmed_at=sidecar_confirmed_at,
+        )
+
+    if note_path in orphan_set:
+        return FreshnessSignal(
+            status="stale-candidate",
+            cause="orphan_broken",
+            reason="contains a broken wikilink",
+            confirmed_at=sidecar_confirmed_at,
+        )
+
+    return FreshnessSignal(
+        status="confirmed",
+        cause="none",
+        reason=None,
+        confirmed_at=sidecar_confirmed_at,
+    )
+
+
+def signal_to_dict(signal: FreshnessSignal) -> dict:
+    """Render a FreshnessSignal as a JSON-friendly dict for MCP responses."""
+    return {
+        "status": signal.status,
+        "cause": signal.cause,
+        "reason": signal.reason,
+        "confirmed_at": signal.confirmed_at.isoformat() if signal.confirmed_at else None,
+    }

--- a/lib/lore_core/freshness.py
+++ b/lib/lore_core/freshness.py
@@ -205,3 +205,42 @@ def signal_to_dict(signal: FreshnessSignal) -> dict:
         "reason": signal.reason,
         "confirmed_at": signal.confirmed_at.isoformat() if signal.confirmed_at else None,
     }
+
+
+def load_orphan_set(wiki_path: Path) -> set[Path]:
+    """Load the cached orphan set for a wiki.
+
+    Slice 4 of PRD #65: ``lore lint`` writes a list of wiki-relative
+    paths under ``_catalog.json`` → ``orphan_set``. Computing orphans
+    on every retrieval would be too expensive (rglob over the wiki +
+    one frontmatter parse per note). The cache is refreshed on each
+    lint run; eventual-consistency is acceptable per the PRD — the
+    worst case is a brief window where a fresh-but-not-yet-linted
+    note is incorrectly flagged or unflagged.
+
+    Returns absolute paths so callers can use plain ``in`` membership
+    against the same paths they pass to :func:`compute_freshness`.
+
+    Cache miss (no catalog, no ``orphan_set`` key, malformed JSON)
+    degrades gracefully to an empty set — the freshness signal stays
+    ``confirmed`` for any note that would otherwise have been
+    orphan-flagged, with no error.
+    """
+    import json as _json
+
+    cat = wiki_path / "_catalog.json"
+    if not cat.exists():
+        return set()
+    try:
+        data = _json.loads(cat.read_text(errors="replace"))
+    except (OSError, _json.JSONDecodeError):
+        return set()
+    raw = data.get("orphan_set")
+    if not isinstance(raw, list):
+        return set()
+    out: set[Path] = set()
+    for rel in raw:
+        if not isinstance(rel, str) or not rel:
+            continue
+        out.add((wiki_path / rel).resolve())
+    return out

--- a/lib/lore_core/freshness.py
+++ b/lib/lore_core/freshness.py
@@ -207,6 +207,60 @@ def signal_to_dict(signal: FreshnessSignal) -> dict:
     }
 
 
+def count_pending_verdicts(
+    wiki_path: Path,
+    *,
+    soft_cap: int = 9,
+) -> tuple[int, bool]:
+    """Count notes in ``wiki_path`` that currently compute to
+    ``stale-candidate`` (slice 8 of PRD #65 — status-line chip).
+
+    Reads the cached ``_catalog.json`` so the per-call cost is one
+    JSON load, not a full wiki walk. Authored markers we can detect
+    from catalog metadata: ``status == 'stale'`` and ``superseded_by:``.
+    Soft markers (``supersede_candidate``) and personal-confirm
+    suppression are NOT considered here — the chip is intentionally
+    a coarse "is there work to do?" signal; the precise per-note
+    classification still flows through :func:`compute_freshness` at
+    retrieval time.
+
+    Returns ``(count, capped)`` where ``capped`` is True iff the soft
+    cap fired. The status-line render uses ``"9+"`` instead of the
+    raw count when ``capped`` is True.
+
+    Cache miss (no catalog) returns ``(0, False)`` — the chip
+    suppresses entirely until the next ``lore lint`` run.
+    """
+    import json as _json
+
+    cat = wiki_path / "_catalog.json"
+    if not cat.exists():
+        return 0, False
+    try:
+        data = _json.loads(cat.read_text(errors="replace"))
+    except (OSError, _json.JSONDecodeError):
+        return 0, False
+
+    orphan_paths = set(data.get("orphan_set") or [])
+    count = 0
+    for entries in (data.get("sections") or {}).values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            path = str(entry.get("path") or "")
+            if (
+                str(entry.get("status") or "").lower() == "stale"
+                or entry.get("superseded_by")
+                or path in orphan_paths
+            ):
+                count += 1
+                if count > soft_cap:
+                    return soft_cap, True
+    return count, False
+
+
 def load_orphan_set(wiki_path: Path) -> set[Path]:
     """Load the cached orphan set for a wiki.
 

--- a/lib/lore_core/freshness_filter.py
+++ b/lib/lore_core/freshness_filter.py
@@ -88,21 +88,25 @@ class FilterAudit:
 
 def _is_hard_stale(freshness: dict | None) -> bool:
     """Hard-stale = ``status == stale-candidate`` AND the cause is a hard
-    authored marker (``status: stale`` / ``superseded_by``).
+    authored marker (``status: stale`` / ``superseded_by``), OR the
+    block carries a slice-9 ``disagreement`` field — auto-inject must
+    defer to the team-stale signal until the user explicitly resolves
+    the conflict.
 
     The slice-3 inject filter excludes hard-stale notes entirely. Soft
-    markers (``supersede_candidate``) only downrank. Disagreement
-    (slice 9) layers on top by escalating to the hard-stale branch.
+    markers (``supersede_candidate``) only downrank.
     """
     if not freshness:
         return False
+    # Slice 9: any disagreement always counts as hard for inject
+    # purposes — even when the personal confirm has suppressed the
+    # status to "confirmed", we still want to keep it out of inject
+    # until the user resolves the conflict.
+    if freshness.get("disagreement"):
+        return True
     if freshness.get("status") != "stale-candidate":
         return False
     reason = (freshness.get("reason") or "").lower()
-    # The reason text comes from
-    # ``lore_core.freshness._format_marker_reason`` and is the cleanest
-    # disambiguator between hard and soft authored markers without
-    # re-parsing frontmatter on this side.
     if "marked stale" in reason:
         return True
     if reason.startswith("superseded by"):
@@ -221,15 +225,22 @@ def apply_inject_filter(
     for item in items:
         fr = freshness_of(item)
         status = _status_of(fr)
-        if status == "stale-candidate" and _is_hard_stale(fr):
+        # Slice 9: a disagreement always excludes — even if the status
+        # has been suppressed to "confirmed" by a personal sidecar.
+        # Auto-inject defers to team-stale until the user resolves.
+        if _is_hard_stale(fr):
             excluded.append(item)
+            cause = (fr or {}).get("cause")
+            reason = (fr or {}).get("reason")
+            if (fr or {}).get("disagreement") and not reason:
+                reason = "team-stale + personal confirm conflict"
             audit.entries.append(
                 FilterAuditEntry(
                     path=str(path_of(item)),
                     wiki=wiki_of(item),
                     action="excluded",
-                    cause=(fr or {}).get("cause"),
-                    reason=(fr or {}).get("reason"),
+                    cause=cause,
+                    reason=reason,
                 )
             )
             continue

--- a/lib/lore_core/freshness_filter.py
+++ b/lib/lore_core/freshness_filter.py
@@ -1,0 +1,254 @@
+"""Retrieval-time freshness filter — slice 3 of PRD #65.
+
+Consumes :class:`lore_core.freshness.FreshnessSignal` blocks attached
+in slice 1 and applies retrieval-time policy to result lists. Two
+public entry points:
+
+- :func:`apply_search_filter` — stable secondary-sort hits by status
+  so ``confirmed`` ranks above ``stale-candidate`` at *tied relevance
+  scores*. The relevance ordering itself is preserved — recall is
+  never sacrificed; a ``stale-candidate`` that is the only match for
+  a query still surfaces.
+
+- :func:`apply_inject_filter` — pre-classify session-hint candidates
+  (and any other inject-source list) into kept / downranked / excluded
+  tiers. ``status: stale`` (and equivalent hard markers like
+  ``superseded_by``) are excluded entirely from the SessionStart
+  ``additionalContext`` block. Soft-only ``stale-candidate`` notes
+  remain available but are appended after confirmed peers, so the
+  LLM still gets the breadcrumb without being primed by the body.
+
+Both functions return a structured ``audit`` log of the decisions
+they made; the caller stitches it into the ``/lore:context`` cache
+so users can see why a note was excluded or downranked.
+
+The module is pure data-structure manipulation — no I/O, no LLM
+calls, no fs walks beyond what the caller has already done. Latency
+budget at retrieval is therefore the cost of one stable sort.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Literal
+
+
+# Priority used by ``apply_search_filter`` as the *secondary* sort key
+# (relevance score remains primary). Lower = appears first.
+_STATUS_PRIORITY = {"confirmed": 0, "stale-candidate": 1}
+
+
+@dataclass(frozen=True)
+class FilterAuditEntry:
+    """One decision made by the filter.
+
+    Fields:
+        path: Note relative path within its wiki.
+        wiki: Wiki name.
+        action: ``downranked`` (kept but lower priority) or ``excluded``
+            (removed entirely from the inject set).
+        cause: Echoes the FreshnessSignal cause that drove the decision.
+        reason: Short human-readable explanation, suitable for direct
+            rendering in /lore:context.
+    """
+
+    path: str
+    wiki: str | None
+    action: Literal["downranked", "excluded"]
+    cause: str | None
+    reason: str | None
+
+
+@dataclass
+class FilterAudit:
+    """Aggregate audit log for one filter call."""
+
+    entries: list[FilterAuditEntry] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return bool(self.entries)
+
+    def render_lines(self) -> list[str]:
+        """Render entries as lines for the /lore:context cache.
+
+        Empty list when no decisions were made — caller suppresses the
+        whole subsection in that case.
+        """
+        if not self.entries:
+            return []
+        lines = ["### Filtered for staleness"]
+        for e in self.entries:
+            wiki = f"{e.wiki}/" if e.wiki else ""
+            note = f"[[{wiki}{e.path}]]" if e.path else "(unknown)"
+            verb = "excluded" if e.action == "excluded" else "downranked"
+            tail = e.reason or e.cause or ""
+            lines.append(f"- {note} — {verb}" + (f" — {tail}" if tail else ""))
+        return lines
+
+
+def _is_hard_stale(freshness: dict | None) -> bool:
+    """Hard-stale = ``status == stale-candidate`` AND the cause is a hard
+    authored marker (``status: stale`` / ``superseded_by``).
+
+    The slice-3 inject filter excludes hard-stale notes entirely. Soft
+    markers (``supersede_candidate``) only downrank. Disagreement
+    (slice 9) layers on top by escalating to the hard-stale branch.
+    """
+    if not freshness:
+        return False
+    if freshness.get("status") != "stale-candidate":
+        return False
+    reason = (freshness.get("reason") or "").lower()
+    # The reason text comes from
+    # ``lore_core.freshness._format_marker_reason`` and is the cleanest
+    # disambiguator between hard and soft authored markers without
+    # re-parsing frontmatter on this side.
+    if "marked stale" in reason:
+        return True
+    if reason.startswith("superseded by"):
+        return True
+    return False
+
+
+def _status_of(freshness: dict | None) -> str:
+    if not freshness:
+        return "confirmed"
+    return freshness.get("status") or "confirmed"
+
+
+def apply_search_filter(
+    hits: list[dict[str, Any]],
+    *,
+    score_key: str = "score",
+    freshness_key: str = "freshness",
+    path_key: str = "path",
+    wiki_key: str = "wiki",
+) -> tuple[list[dict[str, Any]], FilterAudit]:
+    """Stable-sort ``hits`` so confirmed precede stale-candidate at tied
+    scores. Relevance ordering is the primary sort key; freshness is
+    secondary.
+
+    Returns the (possibly reordered) hits and an audit log of
+    ``downranked`` entries — useful for the /lore:context render.
+
+    No exclusions: the search filter never silently hides a hit. The
+    recall property in PRD #65 is load-bearing for "did the system
+    forget about that note?".
+    """
+    audit = FilterAudit()
+    if not hits:
+        return hits, audit
+
+    # Build the sort key. ``-score`` so higher scores rank first;
+    # status priority second so confirmed wins ties; original index
+    # third so within a (score, status) tie we preserve the backend's
+    # ordering deterministically.
+    indexed = list(enumerate(hits))
+
+    def _sort_key(item):
+        idx, h = item
+        score = h.get(score_key, 0.0) or 0.0
+        status = _status_of(h.get(freshness_key))
+        prio = _STATUS_PRIORITY.get(status, 99)
+        return (-float(score), prio, idx)
+
+    sorted_hits = [h for _idx, h in sorted(indexed, key=_sort_key)]
+
+    for h in sorted_hits:
+        fr = h.get(freshness_key) or {}
+        if fr.get("status") == "stale-candidate":
+            audit.entries.append(
+                FilterAuditEntry(
+                    path=str(h.get(path_key, "")),
+                    wiki=h.get(wiki_key),
+                    action="downranked",
+                    cause=fr.get("cause"),
+                    reason=fr.get("reason"),
+                )
+            )
+
+    return sorted_hits, audit
+
+
+@dataclass
+class InjectFilterResult:
+    """Outcome of :func:`apply_inject_filter`.
+
+    Fields:
+        kept: Items to include in the injected context, in the order
+            they should appear (confirmed first, soft stale-candidate
+            after).
+        excluded: Items dropped entirely.
+        audit: Structured audit log for /lore:context.
+    """
+
+    kept: list[Any]
+    excluded: list[Any]
+    audit: FilterAudit
+
+
+def apply_inject_filter(
+    items: Iterable[Any],
+    freshness_of,
+    *,
+    path_of=lambda item: "",
+    wiki_of=lambda item: None,
+) -> InjectFilterResult:
+    """Partition ``items`` into kept / excluded / audit.
+
+    Args:
+        items: Inject candidates (e.g., session-hint tuples, project
+            note dicts). The shape is opaque to this filter; callers
+            supply accessors.
+        freshness_of: ``item -> dict | None`` — the freshness block
+            for the item, or None if unknown (treated as ``confirmed``).
+        path_of: ``item -> str`` accessor for the audit log.
+        wiki_of: ``item -> str | None`` accessor for the audit log.
+
+    Recall semantics:
+        * Hard-stale (status:stale, superseded_by) → excluded.
+        * Soft stale-candidate (supersede_candidate variants) → kept,
+          but appended after confirmed items in the result.
+        * Confirmed → kept in original order.
+
+    Stable: relative order within each tier is preserved.
+    """
+    confirmed: list[Any] = []
+    soft: list[Any] = []
+    excluded: list[Any] = []
+    audit = FilterAudit()
+
+    for item in items:
+        fr = freshness_of(item)
+        status = _status_of(fr)
+        if status == "stale-candidate" and _is_hard_stale(fr):
+            excluded.append(item)
+            audit.entries.append(
+                FilterAuditEntry(
+                    path=str(path_of(item)),
+                    wiki=wiki_of(item),
+                    action="excluded",
+                    cause=(fr or {}).get("cause"),
+                    reason=(fr or {}).get("reason"),
+                )
+            )
+            continue
+        if status == "stale-candidate":
+            soft.append(item)
+            audit.entries.append(
+                FilterAuditEntry(
+                    path=str(path_of(item)),
+                    wiki=wiki_of(item),
+                    action="downranked",
+                    cause=(fr or {}).get("cause"),
+                    reason=(fr or {}).get("reason"),
+                )
+            )
+            continue
+        confirmed.append(item)
+
+    return InjectFilterResult(
+        kept=confirmed + soft,
+        excluded=excluded,
+        audit=audit,
+    )

--- a/lib/lore_core/lint.py
+++ b/lib/lore_core/lint.py
@@ -959,6 +959,22 @@ def run_lint(
             notes = notes_by_wiki[wiki_name]
 
             catalog = build_catalog(wiki_name, notes, all_issues)
+            # Slice 4 of PRD #65: cache the orphan set so the read-time
+            # freshness check can do an O(1) membership test instead of
+            # walking the whole wiki on every retrieval. Stored as
+            # wiki-relative paths for portability.
+            try:
+                from lore_curator.c_orphan_links import find_orphan_links
+
+                orphan_paths = sorted({
+                    str(p.relative_to(wiki_path))
+                    for p, _slug, _off in find_orphan_links(wiki_path)
+                })
+            except Exception:
+                # Defensive: a broken curator import must not break lint.
+                orphan_paths = []
+            catalog["orphan_set"] = orphan_paths
+
             atomic_write_text(
                 wiki_path / "_catalog.json",
                 json.dumps(catalog, indent=2, default=str),

--- a/lib/lore_core/stale_marker_writer.py
+++ b/lib/lore_core/stale_marker_writer.py
@@ -1,0 +1,187 @@
+"""Stale-marker writer — slice 5 of PRD #65.
+
+Writes ``status: stale``, ``stale_reason``, ``stale_by``, ``stale_at``
+to a target note's frontmatter. Strictly **additive-only** per the
+vault-wide edit policy (#37): never deletes user-set fields, never
+overwrites pre-existing values without an explicit ``clear_stale``
+call.
+
+Body bytes are never touched. The writer reuses the safe-edit pattern
+from :mod:`lore_curator.c_auto_supersede`'s ``_append_marker``:
+operate on the YAML frontmatter block as text, leave the body alone,
+preserve trailing-newline.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date as _date
+from pathlib import Path
+
+
+_STALE_FIELDS = ("status", "stale_reason", "stale_by", "stale_at")
+_KEY_LINE_RE = re.compile(r"^(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*:")
+
+
+class StaleMarkerError(ValueError):
+    """Raised when a write would violate the additive-only contract."""
+
+
+def _split_frontmatter(text: str) -> tuple[str, str] | None:
+    """Return ``(fm_block, body)`` or ``None`` if no frontmatter.
+
+    ``fm_block`` is the inner YAML text *between* the fences (no
+    delimiters), ``body`` is everything after the closing ``---``.
+    """
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None
+    fm_inner = text[3:end + 1].lstrip("\n")
+    body = text[end + 4:]
+    if body.startswith("\n"):
+        body = body[1:]
+    return fm_inner, body
+
+
+def _scan_keys(fm_block: str) -> dict[str, int]:
+    """Return ``{top-level-key: line-index}`` for the FM block.
+
+    Lines that aren't ``key: value`` shape (continuations, comments)
+    are skipped. Indentation > 0 is treated as a continuation.
+    """
+    keys: dict[str, int] = {}
+    for i, line in enumerate(fm_block.splitlines()):
+        if not line or line[0] in " \t#-":
+            continue
+        m = _KEY_LINE_RE.match(line)
+        if m:
+            keys.setdefault(m.group("key"), i)
+    return keys
+
+
+def _format_value(key: str, value: object) -> str:
+    """Render ``value`` as a YAML scalar suitable for one-line append."""
+    if isinstance(value, _date):
+        return value.isoformat()
+    s = str(value)
+    if "\n" in s:
+        s = s.replace("\n", " ")
+    if any(ch in s for ch in [":", "#", "[", "]", "{", "}", ","]):
+        s = s.replace('"', '\\"')
+        return f'"{s}"'
+    return s
+
+
+def _additively_set(fm_block: str, key: str, value: object) -> str:
+    """Append ``key: value`` only if ``key`` is absent.
+
+    Raises :class:`StaleMarkerError` when the key already exists with
+    a different value (additive-only). Idempotent when the existing
+    line matches verbatim.
+    """
+    rendered = f"{key}: {_format_value(key, value)}"
+    keys = _scan_keys(fm_block)
+    if key in keys:
+        lines = fm_block.splitlines()
+        existing = lines[keys[key]].strip()
+        if existing == rendered:
+            return fm_block  # idempotent
+        # Re-check loose equality on the value side for status:stale
+        # variants like ``status: stale`` already present.
+        if existing.startswith(f"{key}:"):
+            cur = existing[len(key) + 1:].strip().strip('"').strip("'")
+            new = _format_value(key, value).strip('"').strip("'")
+            if cur == new:
+                return fm_block
+        raise StaleMarkerError(
+            f"refusing to overwrite existing field {key!r} "
+            f"(current={existing!r}, new={rendered!r}); call "
+            f"clear_stale() first."
+        )
+    if fm_block and not fm_block.endswith("\n"):
+        fm_block = fm_block + "\n"
+    return fm_block + rendered + "\n"
+
+
+def _drop_keys(fm_block: str, keys_to_drop: set[str]) -> str:
+    """Return ``fm_block`` with the given top-level keys removed.
+
+    Removes the ``key: value`` line *and* any indented continuation
+    lines (block-list items, multi-line scalars).
+    """
+    lines = fm_block.splitlines()
+    out: list[str] = []
+    skip = False
+    for line in lines:
+        if skip:
+            if line and (line[0] in " \t" or line.startswith("- ")):
+                continue
+            skip = False
+        m = _KEY_LINE_RE.match(line)
+        if m and m.group("key") in keys_to_drop:
+            skip = True
+            continue
+        out.append(line)
+    result = "\n".join(out)
+    if fm_block.endswith("\n") and not result.endswith("\n"):
+        result += "\n"
+    return result
+
+
+def mark_stale(
+    note_path: Path,
+    reason: str,
+    handle: str,
+    today: _date | None = None,
+) -> None:
+    """Write the four-field stale verdict additively.
+
+    ``status: stale``, ``stale_reason: <reason>``, ``stale_by: <handle>``,
+    ``stale_at: <today>``. Raises :class:`StaleMarkerError` if any of
+    the four fields already exists with a different value (use
+    :func:`clear_stale` first to remove a prior verdict — additive-
+    only contract).
+
+    Idempotent: writing the same verdict twice is a no-op.
+
+    Body bytes are never touched. ``last_reviewed``, ``description``,
+    ``tags`` and any user-authored fields are preserved verbatim.
+    """
+    if not isinstance(reason, str) or not reason.strip():
+        raise StaleMarkerError("reason is required and must be non-empty")
+    today = today or _date.today()
+    text = note_path.read_text(errors="replace")
+    split = _split_frontmatter(text)
+    if split is None:
+        raise StaleMarkerError(
+            f"note has no YAML frontmatter: {note_path}"
+        )
+    fm_block, body = split
+
+    fm_block = _additively_set(fm_block, "status", "stale")
+    fm_block = _additively_set(fm_block, "stale_reason", reason.strip())
+    fm_block = _additively_set(fm_block, "stale_by", handle)
+    fm_block = _additively_set(fm_block, "stale_at", today)
+
+    new_text = "---\n" + fm_block + "---\n" + body
+    note_path.write_text(new_text)
+
+
+def clear_stale(note_path: Path) -> None:
+    """Remove only the four stale fields. Other frontmatter is untouched.
+
+    No-op when none of the four fields are present (still safe to
+    call). Body bytes are never touched.
+    """
+    text = note_path.read_text(errors="replace")
+    split = _split_frontmatter(text)
+    if split is None:
+        return
+    fm_block, body = split
+    new_fm = _drop_keys(fm_block, set(_STALE_FIELDS))
+    if new_fm == fm_block:
+        return
+    new_text = "---\n" + new_fm + "---\n" + body
+    note_path.write_text(new_text)

--- a/lib/lore_core/templates/integration-rules/default.md
+++ b/lib/lore_core/templates/integration-rules/default.md
@@ -21,3 +21,11 @@ Do NOT escalate on:
 - Silence (the note doesn't mention X).
 - Topic mismatch (the note discusses an adjacent thing).
 - Vibe-level disagreement without two stated claims to compare.
+
+### Lore freshness — disagreement nudge
+
+When the freshness block carries `disagreement` (someone marked the note stale, someone else confirmed it after — including the same user changing their own mind), use the disagreement-flavored nudge instead of the regular one:
+
+`(› [[<note>]] marked stale by <stale_by> on <stale_at> (<reason>); you confirmed on <self_confirmed_at> — clarify?)`
+
+Never auto-resolve. The system never auto-clears a stale or auto-overrides a confirm; offer the user a fresh `lore_verdict` call once they decide which side wins.

--- a/lib/lore_core/templates/integration-rules/default.md
+++ b/lib/lore_core/templates/integration-rules/default.md
@@ -1,2 +1,23 @@
 ## Directives
 - **Vault first.** Unfamiliar project term, concept, decision, or wikilink? Call `lore_search` (MCP) before asking the user. Asking about a wikilinked term without searching first is a bug.
+
+### Lore freshness — in-passing nudge
+
+When you cite or rely on a note that Lore returned with `freshness.status: "stale-candidate"`, end your turn with a one-line check that quotes the specific claim you used:
+
+`(› [[<note>]] said "<claim>" — <reason>; still current?)`
+
+Rules:
+- Once per note per session. Track via session-local memory; do not retry.
+- Silence semantics: if the user types past the nudge without responding, do nothing. Never auto-write a verdict.
+- If the user replies with a verdict ("yes still good" / "no, stale because X" / "split it — first part is stale"), call the `lore_verdict` MCP tool with the appropriate arguments before continuing your substantive answer.
+- On a "split it" verdict, offer to edit the note: move the fresh content out, mark the rest stale via `lore_verdict`. The user confirms before any write.
+
+### Lore freshness — dynamic escalation
+
+If a retrieved note returns `freshness.status: "confirmed"` but you observe a *concrete claim-vs-claim contradiction* — claim A in this note vs claim B in another retrieved hit, or vs a fact the user just stated this session — treat the note as `stale-candidate` for this turn and emit the in-passing nudge.
+
+Do NOT escalate on:
+- Silence (the note doesn't mention X).
+- Topic mismatch (the note discusses an adjacent thing).
+- Vibe-level disagreement without two stated claims to compare.

--- a/lib/lore_core/verdicts_sidecar.py
+++ b/lib/lore_core/verdicts_sidecar.py
@@ -1,0 +1,113 @@
+"""Per-user personal-confirm sidecar — slice 6 of PRD #65.
+
+Records "I personally confirm this note is OK to use" verdicts in a
+per-user JSON file at ``wiki/<name>/_verdicts/<handle>.json``. The
+asymmetric storage (frontmatter for team-wide stale markers; sidecar
+for personal confirms) is load-bearing — see PRD #65: a confirm is a
+*personal* "I'm OK using this," it cannot vouch for the team-wide
+truth.
+
+Schema (canonical):
+
+.. code-block:: json
+
+    {
+      "confirmed": {
+        "<note-relative-path>": "YYYY-MM-DD"
+      }
+    }
+
+Atomic writes via the standard ``.tmp`` + ``os.replace`` pattern so
+an interrupted write never leaves a partial file. Multi-handle
+isolation is enforced by the path: writing one handle's sidecar
+never touches another handle's.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date as _date
+from pathlib import Path
+
+
+def _sanitize_handle(handle: str) -> str:
+    """Reject path-escape attempts in handle strings.
+
+    Handles are arbitrary user input from ``_users.yml`` — a hostile
+    handle like ``../../etc/passwd`` would otherwise resolve outside
+    the wiki. We reject any handle that contains a path separator.
+    """
+    h = handle.strip()
+    if not h:
+        raise ValueError("handle must be non-empty")
+    if "/" in h or "\\" in h or h.startswith(".") or "\x00" in h:
+        raise ValueError(f"invalid handle: {handle!r}")
+    return h
+
+
+def _sidecar_path(wiki_path: Path, handle: str) -> Path:
+    return wiki_path / "_verdicts" / f"{_sanitize_handle(handle)}.json"
+
+
+def _read(wiki_path: Path, handle: str) -> dict:
+    p = _sidecar_path(wiki_path, handle)
+    if not p.exists():
+        return {"confirmed": {}}
+    try:
+        data = json.loads(p.read_text(errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return {"confirmed": {}}
+    if not isinstance(data, dict):
+        return {"confirmed": {}}
+    if not isinstance(data.get("confirmed"), dict):
+        data["confirmed"] = {}
+    return data
+
+
+def _atomic_write(p: Path, data: dict) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True))
+    os.replace(tmp, p)
+
+
+def get_confirmed(
+    wiki_path: Path, handle: str, note_path: str
+) -> _date | None:
+    """Return the most recent personal confirm for ``note_path``.
+
+    Returns ``None`` if no confirm exists, or if the stored value is
+    unparseable. The note path is wiki-relative (e.g.
+    ``concepts/foo.md``).
+    """
+    data = _read(wiki_path, handle)
+    val = data.get("confirmed", {}).get(note_path)
+    if not isinstance(val, str):
+        return None
+    try:
+        return _date.fromisoformat(val)
+    except ValueError:
+        return None
+
+
+def set_confirmed(
+    wiki_path: Path, handle: str, note_path: str, when: _date | None = None
+) -> _date:
+    """Record a personal confirm for ``note_path`` and return the date written."""
+    when = when or _date.today()
+    data = _read(wiki_path, handle)
+    data.setdefault("confirmed", {})[note_path] = when.isoformat()
+    _atomic_write(_sidecar_path(wiki_path, handle), data)
+    return when
+
+
+def clear_confirmed(wiki_path: Path, handle: str, note_path: str) -> bool:
+    """Remove a personal confirm for ``note_path``. Returns whether one was removed."""
+    data = _read(wiki_path, handle)
+    confirmed = data.get("confirmed", {})
+    if note_path not in confirmed:
+        return False
+    del confirmed[note_path]
+    _atomic_write(_sidecar_path(wiki_path, handle), data)
+    return True

--- a/lib/lore_curator/defrag_curator.py
+++ b/lib/lore_curator/defrag_curator.py
@@ -7,12 +7,15 @@ auto-injection doesn't surface stale or superseded notes.
 
 What Curator C does (frontmatter-only edits — never touches note bodies):
 
-    1. Flag `status: active` + `last_reviewed > 90d` as `status: stale`.
-    2. Detect `supersedes [[X]]` in decision notes; mark X as superseded
+    1. Detect `supersedes [[X]]` in decision notes; mark X as superseded
        and backlink.
-    3. Backfill missing `last_reviewed` / `created` from `git log --follow`.
-    4. Propagate `implements:` status flips.
-    5. Write a `_review.md` summary the hook can surface next session.
+    2. Backfill missing `last_reviewed` / `created` from `git log --follow`.
+    3. Propagate `implements:` status flips.
+    4. Write a `_review.md` summary the hook can surface next session.
+
+(Pre-PRD-#65 the curator also flagged notes by `last_reviewed` age.
+That pass is now a no-op — staleness is read-time and positive-evidence-
+only; see :mod:`lore_core.freshness`.)
 
 Cadence: weekly. Triggered from SessionStart when `now - last_curator_c
 > 7d` and no global curator lock is held (see project_lore_heartbeat.md).
@@ -39,7 +42,7 @@ from lore_core.git import is_obsidian_holding
 from lore_core.identity import distinct_git_authors, team_mode_recommended
 from lore_core.io import atomic_write_text
 from lore_core.ledger import WikiLedger
-from lore_core.lint import STALENESS_DAYS, discover_notes, discover_wikis
+from lore_core.lint import discover_notes, discover_wikis
 from lore_core.run_log import RunLogger
 from lore_core.schema import compute_lifecycle, parse_frontmatter
 from rich.console import Console
@@ -326,39 +329,17 @@ def _apply_patch(text: str, patch: dict) -> str:
 
 
 def _pass_staleness(wiki_path: Path, today: date, threshold: int) -> list[CuratorAction]:
-    """Flag canonical notes whose `last_reviewed` exceeds `threshold` days.
+    """No-op since PRD #65 (positive-evidence-only staleness).
 
-    Review-only: the action carries an empty patch. The user resolves
-    each flagged note interactively (bump `last_reviewed`, add
-    `superseded_by:`, or delete). `_apply_safely` treats empty patches
-    as a no-op.
+    The legacy 90-day age rule is incompatible with the read-time
+    freshness model in :mod:`lore_core.freshness`. Age alone never
+    flags a note now — staleness requires a named cause (authored
+    marker or broken wikilink). The function survives as a hook for
+    future positive-evidence aggregation in Curator C (e.g., rolling
+    up orphan-flagged notes into the report). Arguments are accepted
+    but unused.
     """
-    actions: list[CuratorAction] = []
-    for fpath in discover_notes(wiki_path):
-        text = fpath.read_text(errors="replace")
-        fm = parse_frontmatter(text)
-        if fm.get("type") == "session":
-            continue
-        if compute_lifecycle(fm) != "canonical":
-            continue
-        lr = fm.get("last_reviewed")
-        if not lr:
-            continue
-        try:
-            lr_date = date.fromisoformat(str(lr))
-        except (ValueError, TypeError):
-            continue
-        days = (today - lr_date).days
-        if days > threshold:
-            actions.append(
-                CuratorAction(
-                    kind="review_stale",
-                    path=fpath,
-                    reason=f"last_reviewed {lr} ({days} days ago, > {threshold})",
-                    patch={},
-                )
-            )
-    return actions
+    return []
 
 
 def _pass_supersession(wiki_path: Path) -> list[CuratorAction]:
@@ -676,7 +657,6 @@ def _snapshot_wiki(wiki_path) -> dict:
 def run_curator_c(
     wiki_filter: str | None = None,
     dry_run: bool = True,
-    stale_threshold: int = STALENESS_DAYS,
     *,
     defrag: bool = False,
     llm_client=None,
@@ -717,7 +697,6 @@ def run_curator_c(
                 "wiki_filter": wiki_filter,
                 "defrag": defrag,
                 "dry_run": dry_run,
-                "stale_threshold": stale_threshold,
             },
             dry_run=dry_run,
             run_id=rid,
@@ -756,7 +735,7 @@ def run_curator_c(
                     continue
 
             report = CuratorReport(wiki=wiki_path.name)
-            report.actions.extend(_pass_staleness(wiki_path, today, stale_threshold))
+            report.actions.extend(_pass_staleness(wiki_path, today, 0))
             report.actions.extend(_pass_supersession(wiki_path))
             report.actions.extend(_pass_implements(wiki_path))
             report.actions.extend(_pass_git_backfill(wiki_path))

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -135,7 +135,18 @@ def _freshness_block_for(
         confirmed_at,
         orphan_set or set(),
     )
-    return signal_to_dict(sig)
+    block = signal_to_dict(sig)
+
+    # Slice 9: surface team-mode disagreements (someone marked stale,
+    # someone else confirmed after) so the in-passing nudge can ask
+    # for explicit resolution instead of silently overwriting.
+    from lore_core.disagreement import detect_disagreement, disagreement_to_dict
+
+    disagreement = detect_disagreement(fm, confirmed_at)
+    if disagreement is not None:
+        block["disagreement"] = disagreement_to_dict(disagreement)
+
+    return block
 
 
 # Time-based throttle for FTS reindexing in the long-lived MCP server.

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -65,20 +65,40 @@ def _resolve_wiki(wiki: str | None) -> Path | None:
     return wikis[0] if len(wikis) == 1 else None
 
 
+def _resolve_current_handle(wiki_path: Path) -> str:
+    """Best-effort current-user handle for personal-sidecar lookups.
+
+    Empty string in solo wikis without `_users.yml` and without a
+    configured git author is acceptable — callers treat ``""`` as
+    "no personal record" and skip the sidecar lookup.
+    """
+    from lore_core.git import git_user_email
+    from lore_core.identity import resolve_handle
+
+    email = git_user_email(None, env_override="GIT_AUTHOR_EMAIL")
+    return resolve_handle(wiki_path, email) if email else ""
+
+
 def _freshness_block_for(
     wiki_path: Path,
     rel_path: str,
     *,
     orphan_set: set[Path] | None = None,
     sidecar_confirmed_at=None,
+    handle: str | None = None,
 ) -> dict:
     """Compute the freshness block for a note hit.
 
     Centralised helper used by every retrieval surface so the wiring
     stays uniform. Returns a JSON-friendly dict with the four
-    :class:`lore_core.freshness.FreshnessSignal` fields. Slice 1 always
-    passes an empty orphan set and ``None`` sidecar — slice 4 wires the
-    cached orphan set, slice 6 wires the personal sidecar.
+    :class:`lore_core.freshness.FreshnessSignal` fields.
+
+    Sidecar lookup precedence:
+        1. ``sidecar_confirmed_at`` (caller already resolved it).
+        2. Otherwise read from
+           :func:`lore_core.verdicts_sidecar.get_confirmed` using
+           ``handle`` (or the best-effort current handle when
+           ``handle is None``).
 
     Best-effort: if the note can't be read (path-escape, missing file,
     etc.), returns a default ``confirmed`` block so callers never fail
@@ -96,11 +116,23 @@ def _freshness_block_for(
         fm = parse_frontmatter(target.read_text(errors="replace"))
     except OSError:
         pass
+
+    confirmed_at = sidecar_confirmed_at
+    if confirmed_at is None:
+        from lore_core.verdicts_sidecar import get_confirmed
+
+        eff_handle = handle if handle is not None else _resolve_current_handle(wiki_path)
+        if eff_handle:
+            try:
+                confirmed_at = get_confirmed(wiki_path, eff_handle, rel_path)
+            except (OSError, ValueError):
+                confirmed_at = None
+
     sig = compute_freshness(
         fm,
         target,
         wiki_path,
-        sidecar_confirmed_at,
+        confirmed_at,
         orphan_set or set(),
     )
     return signal_to_dict(sig)
@@ -894,12 +926,35 @@ def handle_verdict(
         return _mcp_error("path_not_found", f"not found: {rel_path}")
 
     if verdict == "confirm":
-        # Slice 6 wires the personal sidecar; slice 5 stub.
-        return _mcp_error(
-            "not_implemented",
-            "confirm verdict is not yet implemented",
-            next_="track in slice 6 (personal confirms — sidecar + confirm branch)",
+        from lore_core.verdicts_sidecar import set_confirmed
+
+        email = git_user_email(None, env_override="GIT_AUTHOR_EMAIL")
+        handle = resolve_handle(wiki_path, email) if email else ""
+        if not handle:
+            return _mcp_error(
+                "no_handle",
+                "could not resolve current handle for personal confirm",
+                next_="set GIT_AUTHOR_EMAIL or configure git user.email",
+            )
+        try:
+            written = set_confirmed(wiki_path, handle, rel_path)
+        except (OSError, ValueError) as e:
+            return _mcp_error("confirm_write_failed", str(e))
+        freshness = _freshness_block_for(
+            wiki_path,
+            rel_path,
+            orphan_set=load_orphan_set(wiki_path),
+            sidecar_confirmed_at=written,
+            handle=handle,
         )
+        return {
+            "schema": "lore.verdict/1",
+            "wiki": wiki_path.name,
+            "path": rel_path,
+            "verdict": "confirm",
+            "confirmed_at": written.isoformat(),
+            "freshness": freshness,
+        }
 
     if verdict == "stale":
         if not reason or not str(reason).strip():

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -35,6 +35,7 @@ from typing import Any
 
 from lore_core.config import get_wiki_root
 from lore_core.errors import mcp_error as _mcp_error
+from lore_core.freshness import compute_freshness, signal_to_dict
 from lore_core.schema import extract_wikilinks, parse_frontmatter
 from lore_search.fts import FtsBackend
 
@@ -61,6 +62,47 @@ def _resolve_wiki(wiki: str | None) -> Path | None:
     # Single-wiki users: return the only one
     wikis = [p for p in sorted(wiki_root.iterdir()) if p.resolve().is_dir()]
     return wikis[0] if len(wikis) == 1 else None
+
+
+def _freshness_block_for(
+    wiki_path: Path,
+    rel_path: str,
+    *,
+    orphan_set: set[Path] | None = None,
+    sidecar_confirmed_at=None,
+) -> dict:
+    """Compute the freshness block for a note hit.
+
+    Centralised helper used by every retrieval surface so the wiring
+    stays uniform. Returns a JSON-friendly dict with the four
+    :class:`lore_core.freshness.FreshnessSignal` fields. Slice 1 always
+    passes an empty orphan set and ``None`` sidecar — slice 4 wires the
+    cached orphan set, slice 6 wires the personal sidecar.
+
+    Best-effort: if the note can't be read (path-escape, missing file,
+    etc.), returns a default ``confirmed`` block so callers never fail
+    a retrieval over a freshness probe.
+    """
+    target = (wiki_path / rel_path).resolve()
+    try:
+        target.relative_to(wiki_path.resolve())
+    except ValueError:
+        return signal_to_dict(
+            compute_freshness({}, target, wiki_path, None, set())
+        )
+    fm: dict = {}
+    try:
+        fm = parse_frontmatter(target.read_text(errors="replace"))
+    except OSError:
+        pass
+    sig = compute_freshness(
+        fm,
+        target,
+        wiki_path,
+        sidecar_confirmed_at,
+        orphan_set or set(),
+    )
+    return signal_to_dict(sig)
 
 
 # Time-based throttle for FTS reindexing in the long-lived MCP server.
@@ -139,17 +181,33 @@ def handle_search(
     backend = FtsBackend()
     _maybe_reindex(backend, wiki)
     hits = backend.search(query, wiki=wiki, for_repo=for_repo, k=k)
-    return [
-        {
+    # Cache one wiki-path resolution per (wiki-name) to avoid re-walking
+    # ``$LORE_ROOT/wiki`` per hit.
+    wiki_path_cache: dict[str, Path | None] = {}
+
+    def _wp(name: str) -> Path | None:
+        if name not in wiki_path_cache:
+            wiki_path_cache[name] = _resolve_wiki(name)
+        return wiki_path_cache[name]
+
+    out: list[dict[str, Any]] = []
+    for h in hits:
+        wp = _wp(h.wiki)
+        freshness = (
+            _freshness_block_for(wp, h.path)
+            if wp is not None
+            else signal_to_dict(compute_freshness({}, Path(h.path), Path("/"), None, set()))
+        )
+        out.append({
             "path": h.path,
             "wiki": h.wiki,
             "filename": h.filename,
             "score": round(h.score, 3),
             "description": h.description,
             "tags": h.tags or [],
-        }
-        for h in hits
-    ]
+            "freshness": freshness,
+        })
+    return out
 
 
 def _resolve_slug(wiki_path: Path, slug: str) -> str | None:
@@ -221,6 +279,8 @@ def handle_read(
         return _mcp_error("path_not_found", f"not found: {path}")
     text = target.read_text(errors="replace")
 
+    freshness = _freshness_block_for(wiki_path, path)
+
     if section is not None:
         section_text, headings = _extract_section(text, section)
         if section_text is None:
@@ -240,12 +300,14 @@ def handle_read(
             "path": path,
             "content": section_text,
             "section": section,
+            "freshness": freshness,
         }
 
     return {
         "wiki": wiki_path.name,
         "path": path,
         "content": text,
+        "freshness": freshness,
     }
 
 

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -36,6 +36,7 @@ from typing import Any
 from lore_core.config import get_wiki_root
 from lore_core.errors import mcp_error as _mcp_error
 from lore_core.freshness import compute_freshness, signal_to_dict
+from lore_core.freshness_filter import apply_search_filter
 from lore_core.schema import extract_wikilinks, parse_frontmatter
 from lore_search.fts import FtsBackend
 
@@ -207,7 +208,8 @@ def handle_search(
             "tags": h.tags or [],
             "freshness": freshness,
         })
-    return out
+    sorted_out, _audit = apply_search_filter(out)
+    return sorted_out
 
 
 def _resolve_slug(wiki_path: Path, slug: str) -> str | None:

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -835,6 +835,110 @@ def handle_drill(
     return {"trace": trace, "result": {"notes": notes}}
 
 
+def handle_verdict(
+    wiki: str,
+    note: str,
+    verdict: str,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Slice 5 + 6: write a freshness verdict for a note.
+
+    Slice 5 wires the ``stale`` branch (frontmatter additive write of
+    the four ``status:stale`` fields). The ``confirm`` branch returns
+    a structured "not yet implemented in this slice" error pointing
+    at slice 6.
+
+    Returns the post-verdict :class:`FreshnessSignal` for the note so
+    the caller can confirm what changed.
+    """
+    from lore_core.identity import resolve_handle
+    from lore_core.git import git_user_email
+    from lore_core.stale_marker_writer import (
+        StaleMarkerError,
+        clear_stale,
+        mark_stale,
+    )
+
+    if verdict not in {"stale", "confirm", "clear-stale"}:
+        return _mcp_error(
+            "invalid_verdict",
+            f"verdict must be one of stale|confirm|clear-stale, got {verdict!r}",
+        )
+
+    wiki_path = _resolve_wiki(wiki)
+    if wiki_path is None:
+        return _mcp_error(
+            "wiki_not_found",
+            f"wiki not found: {wiki}",
+            next_="run `lore status` to list configured wikis",
+        )
+
+    # Resolve note path the same way handle_read does.
+    slug = None
+    if note.startswith("[[") and note.endswith("]]"):
+        slug = note[2:-2]
+    elif "/" not in note and not note.endswith(".md"):
+        slug = note
+    rel_path = note
+    if slug:
+        resolved = _resolve_slug(wiki_path, slug)
+        if resolved is None:
+            return _mcp_error("note_not_found", f"note not found: {slug}")
+        rel_path = resolved
+    target = (wiki_path / rel_path).resolve()
+    try:
+        target.relative_to(wiki_path.resolve())
+    except ValueError:
+        return _mcp_error("path_escape", "path escapes wiki root")
+    if not target.exists():
+        return _mcp_error("path_not_found", f"not found: {rel_path}")
+
+    if verdict == "confirm":
+        # Slice 6 wires the personal sidecar; slice 5 stub.
+        return _mcp_error(
+            "not_implemented",
+            "confirm verdict is not yet implemented",
+            next_="track in slice 6 (personal confirms — sidecar + confirm branch)",
+        )
+
+    if verdict == "stale":
+        if not reason or not str(reason).strip():
+            return _mcp_error(
+                "reason_required",
+                "verdict=stale requires a non-empty `reason`",
+                next_="describe in one short line why the note is stale",
+            )
+        email = git_user_email(None, env_override="GIT_AUTHOR_EMAIL")
+        handle = resolve_handle(wiki_path, email) if email else ""
+        try:
+            mark_stale(target, reason=str(reason), handle=handle)
+        except StaleMarkerError as e:
+            return _mcp_error("stale_write_refused", str(e))
+        freshness = _freshness_block_for(
+            wiki_path, rel_path, orphan_set=load_orphan_set(wiki_path)
+        )
+        return {
+            "schema": "lore.verdict/1",
+            "wiki": wiki_path.name,
+            "path": rel_path,
+            "verdict": "stale",
+            "freshness": freshness,
+        }
+
+    # verdict == "clear-stale"
+    clear_stale(target)
+    freshness = _freshness_block_for(
+        wiki_path, rel_path, orphan_set=load_orphan_set(wiki_path)
+    )
+    return {
+        "schema": "lore.verdict/1",
+        "wiki": wiki_path.name,
+        "path": rel_path,
+        "verdict": "clear-stale",
+        "freshness": freshness,
+    }
+
+
 def handle_wikilinks(note: str, wiki: str | None = None) -> dict[str, Any]:
     wiki_path = _resolve_wiki(wiki)
     if wiki_path is None:
@@ -1149,6 +1253,43 @@ def _tool_schema() -> list[dict]:
                 },
             },
         },
+        {
+            "name": "lore_verdict",
+            "description": (
+                "Record a freshness verdict for a note. Use when the "
+                "user replies to an in-passing freshness nudge with a "
+                "concrete answer: \"yes still good\" → "
+                "verdict=\"confirm\"; \"no, stale because X\" → "
+                "verdict=\"stale\" with a one-line `reason`. The "
+                "stale branch writes the four-field schema "
+                "(`status: stale`, `stale_reason`, `stale_by`, "
+                "`stale_at`) additively to the note's frontmatter; "
+                "never touches the body. The verdict is silent until "
+                "the user actually responds — if the user types past "
+                "the nudge without answering, do NOT call this tool. "
+                "(`clear-stale` removes a prior stale verdict; the "
+                "confirm branch lands in slice 6.)"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "wiki": {"type": "string"},
+                    "note": {
+                        "type": "string",
+                        "description": "Note path, [[wikilink]], or bare slug.",
+                    },
+                    "verdict": {
+                        "type": "string",
+                        "enum": ["confirm", "stale", "clear-stale"],
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Required when verdict=stale.",
+                    },
+                },
+                "required": ["wiki", "note", "verdict"],
+            },
+        },
     ]
 
 
@@ -1192,6 +1333,8 @@ def _dispatch(tool_name: str, args: dict) -> Any:
             return handle_journal_write(**args)
         case "lore_journal_read":
             return handle_journal_read(**args)
+        case "lore_verdict":
+            return handle_verdict(**args)
         case _:
             return _mcp_error("unknown_tool", f"unknown tool: {tool_name}")
 

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -35,7 +35,7 @@ from typing import Any
 
 from lore_core.config import get_wiki_root
 from lore_core.errors import mcp_error as _mcp_error
-from lore_core.freshness import compute_freshness, signal_to_dict
+from lore_core.freshness import compute_freshness, load_orphan_set, signal_to_dict
 from lore_core.freshness_filter import apply_search_filter
 from lore_core.schema import extract_wikilinks, parse_frontmatter
 from lore_search.fts import FtsBackend
@@ -182,23 +182,33 @@ def handle_search(
     backend = FtsBackend()
     _maybe_reindex(backend, wiki)
     hits = backend.search(query, wiki=wiki, for_repo=for_repo, k=k)
-    # Cache one wiki-path resolution per (wiki-name) to avoid re-walking
-    # ``$LORE_ROOT/wiki`` per hit.
+    # Cache one wiki-path resolution per (wiki-name) and one orphan-set
+    # load per wiki-path to avoid re-walking ``$LORE_ROOT/wiki`` and
+    # re-reading ``_catalog.json`` on every hit.
     wiki_path_cache: dict[str, Path | None] = {}
+    orphan_cache: dict[str, set[Path]] = {}
 
     def _wp(name: str) -> Path | None:
         if name not in wiki_path_cache:
             wiki_path_cache[name] = _resolve_wiki(name)
         return wiki_path_cache[name]
 
+    def _orphans(name: str, wp: Path) -> set[Path]:
+        if name not in orphan_cache:
+            orphan_cache[name] = load_orphan_set(wp)
+        return orphan_cache[name]
+
     out: list[dict[str, Any]] = []
     for h in hits:
         wp = _wp(h.wiki)
-        freshness = (
-            _freshness_block_for(wp, h.path)
-            if wp is not None
-            else signal_to_dict(compute_freshness({}, Path(h.path), Path("/"), None, set()))
-        )
+        if wp is not None:
+            freshness = _freshness_block_for(
+                wp, h.path, orphan_set=_orphans(h.wiki, wp)
+            )
+        else:
+            freshness = signal_to_dict(
+                compute_freshness({}, Path(h.path), Path("/"), None, set())
+            )
         out.append({
             "path": h.path,
             "wiki": h.wiki,
@@ -281,7 +291,9 @@ def handle_read(
         return _mcp_error("path_not_found", f"not found: {path}")
     text = target.read_text(errors="replace")
 
-    freshness = _freshness_block_for(wiki_path, path)
+    freshness = _freshness_block_for(
+        wiki_path, path, orphan_set=load_orphan_set(wiki_path)
+    )
 
     if section is not None:
         section_text, headings = _extract_section(text, section)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lore"
-version = "0.48.0"
+version = "0.49.0"
 description = "LLM-optimized knowledge graph for AI-coding teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lore:verify
+description: List pending freshness verdicts and let the user resolve
+  each one. The primary verdict path is the in-passing nudge emitted
+  during a session; this slash command is the explicit fallback that
+  makes the SessionStart pending-verdict chip actionable. Run with
+  "/lore:verify" for the current session's flagged notes,
+  "/lore:verify --all" for every currently-stale-candidate note in
+  the active wiki.
+user_invocable: true
+---
+
+# Pending freshness verdict resolver
+
+Walk the user through resolving the freshness backlog. Slice 10 of
+PRD #65 — secondary path; the primary verdict path is the LLM-emitted
+in-passing nudge.
+
+## Workflow
+
+1. **Resolve scope.**
+   - Bare `/lore:verify` — flagged notes touched in the current session
+     per Curator A's activity log.
+   - `/lore:verify --all` — every currently-stale-candidate note across
+     the active wiki.
+
+2. **Discover pending notes.** Read `_catalog.json` (a single fs read,
+   no walk) and filter for entries with `status: stale`,
+   `superseded_by`, or membership in the cached `orphan_set`. These are
+   the candidates. For the bare form, intersect with the activity log
+   from the most recent session note's `files_read` / `files_modified`
+   frontmatter.
+
+3. **For each candidate, build a picker entry:**
+   - Slug, cause (`authored_marker` / `orphan_broken`), short reason
+     from the note's frontmatter.
+   - Most recent personal `confirmed_at` from
+     `wiki/<name>/_verdicts/<handle>.json` if any.
+   - When the freshness block carries `disagreement`, render the
+     stale-by / stale-at / self-confirmed-at fields verbatim.
+
+4. **Show one picker at a time** (use AskUserQuestion). Options:
+   - `confirm` → call `mcp__lore__lore_verdict` with
+     `{verdict: "confirm", wiki, note}`. No reason required.
+   - `stale` → prompt the user for a one-line reason (required by the
+     stale verdict contract, slice 5), then call `mcp__lore__lore_verdict`
+     with `{verdict: "stale", wiki, note, reason}`.
+   - `skip` → make no write at all. Silence semantics preserved at
+     this surface too.
+
+5. **After every verdict, echo the new freshness block** so the user
+   sees exactly what changed.
+
+6. **At the end of the loop**, summarize: how many confirmed, how many
+   stale, how many skipped. Mention that the SessionStart status-line
+   chip will reflect the new count on the next refresh (slice 8).
+
+## Hard rules
+
+- One MCP call per verdict — do not batch (each verdict is a separate
+  user choice and the per-write audit trail matters).
+- Never auto-resolve a `disagreement` — always ask.
+- `skip` means *make no write*; do not even open the sidecar.
+- Never modify the note body. The verdict contract is frontmatter-only
+  (slice 5) plus the per-user sidecar (slice 6); both are additive.
+- If the user has zero pending verdicts in scope, say so and stop —
+  do not invent work.

--- a/tests/test_directive_template.py
+++ b/tests/test_directive_template.py
@@ -65,6 +65,26 @@ EXPECTED_DIRECTIVE_LINES = [
     "- Topic mismatch (the note discusses an adjacent thing).",
     "- Vibe-level disagreement without two stated claims to compare.",
     "",
+    "### Lore freshness — disagreement nudge",
+    "",
+    (
+        "When the freshness block carries `disagreement` (someone marked "
+        "the note stale, someone else confirmed it after — including the "
+        "same user changing their own mind), use the disagreement-flavored "
+        "nudge instead of the regular one:"
+    ),
+    "",
+    (
+        "`(› [[<note>]] marked stale by <stale_by> on <stale_at> "
+        "(<reason>); you confirmed on <self_confirmed_at> — clarify?)`"
+    ),
+    "",
+    (
+        "Never auto-resolve. The system never auto-clears a stale or "
+        "auto-overrides a confirm; offer the user a fresh `lore_verdict` "
+        "call once they decide which side wins."
+    ),
+    "",
 ]
 
 

--- a/tests/test_directive_template.py
+++ b/tests/test_directive_template.py
@@ -21,6 +21,50 @@ EXPECTED_DIRECTIVE_LINES = [
         "Asking about a wikilinked term without searching first is a bug."
     ),
     "",
+    "### Lore freshness — in-passing nudge",
+    "",
+    (
+        "When you cite or rely on a note that Lore returned with "
+        "`freshness.status: \"stale-candidate\"`, end your turn with a "
+        "one-line check that quotes the specific claim you used:"
+    ),
+    "",
+    "`(› [[<note>]] said \"<claim>\" — <reason>; still current?)`",
+    "",
+    "Rules:",
+    "- Once per note per session. Track via session-local memory; do not retry.",
+    (
+        "- Silence semantics: if the user types past the nudge without "
+        "responding, do nothing. Never auto-write a verdict."
+    ),
+    (
+        "- If the user replies with a verdict (\"yes still good\" / "
+        "\"no, stale because X\" / \"split it — first part is stale\"), "
+        "call the `lore_verdict` MCP tool with the appropriate arguments "
+        "before continuing your substantive answer."
+    ),
+    (
+        "- On a \"split it\" verdict, offer to edit the note: move the "
+        "fresh content out, mark the rest stale via `lore_verdict`. The "
+        "user confirms before any write."
+    ),
+    "",
+    "### Lore freshness — dynamic escalation",
+    "",
+    (
+        "If a retrieved note returns `freshness.status: \"confirmed\"` "
+        "but you observe a *concrete claim-vs-claim contradiction* — "
+        "claim A in this note vs claim B in another retrieved hit, or "
+        "vs a fact the user just stated this session — treat the note "
+        "as `stale-candidate` for this turn and emit the in-passing "
+        "nudge."
+    ),
+    "",
+    "Do NOT escalate on:",
+    "- Silence (the note doesn't mention X).",
+    "- Topic mismatch (the note discusses an adjacent thing).",
+    "- Vibe-level disagreement without two stated claims to compare.",
+    "",
 ]
 
 

--- a/tests/test_disagreement.py
+++ b/tests/test_disagreement.py
@@ -1,0 +1,104 @@
+"""Tests for ``lore_core.disagreement`` — slice 9 of PRD #65."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from lore_core.disagreement import (
+    Disagreement,
+    detect_disagreement,
+    disagreement_to_dict,
+)
+
+
+def _stale_fm(stale_at, by="alice", reason="X"):
+    return {
+        "status": "stale",
+        "stale_by": by,
+        "stale_at": stale_at,
+        "stale_reason": reason,
+    }
+
+
+def test_detect_when_confirm_after_stale() -> None:
+    fm = _stale_fm(date(2026, 5, 1))
+    out = detect_disagreement(fm, sidecar_confirmed_at=date(2026, 5, 5))
+    assert isinstance(out, Disagreement)
+    assert out.stale_by == "alice"
+    assert out.stale_at == date(2026, 5, 1)
+    assert out.self_confirmed_at == date(2026, 5, 5)
+    assert out.stale_reason == "X"
+
+
+def test_detect_when_confirm_before_stale_returns_none() -> None:
+    fm = _stale_fm(date(2026, 5, 5))
+    out = detect_disagreement(fm, sidecar_confirmed_at=date(2026, 5, 1))
+    assert out is None
+
+
+def test_detect_returns_none_without_status_stale() -> None:
+    out = detect_disagreement(
+        {"status": "active"}, sidecar_confirmed_at=date(2026, 5, 5)
+    )
+    assert out is None
+
+
+def test_detect_returns_none_without_personal_confirm() -> None:
+    fm = _stale_fm(date(2026, 5, 1))
+    assert detect_disagreement(fm, None) is None
+
+
+def test_detect_graceful_when_stale_at_missing() -> None:
+    fm = {"status": "stale", "stale_by": "alice", "stale_reason": "X"}
+    assert detect_disagreement(fm, date(2026, 5, 5)) is None
+
+
+def test_detect_handles_iso_string_dates() -> None:
+    fm = _stale_fm("2026-05-01")
+    out = detect_disagreement(fm, date(2026, 5, 5))
+    assert out is not None
+    assert out.stale_at == date(2026, 5, 1)
+
+
+def test_detect_handles_naive_date_object() -> None:
+    fm = _stale_fm(date(2026, 5, 1))
+    out = detect_disagreement(fm, date(2026, 5, 5))
+    assert out is not None
+
+
+def test_detect_same_user_changing_mind() -> None:
+    """Solo-user vault: marked stale weeks ago, forgot, confirmed today."""
+    fm = _stale_fm(date(2026, 4, 1))
+    out = detect_disagreement(fm, date(2026, 5, 5))
+    assert out is not None
+
+
+def test_detect_equal_dates_not_disagreement() -> None:
+    fm = _stale_fm(date(2026, 5, 5))
+    assert detect_disagreement(fm, date(2026, 5, 5)) is None
+
+
+def test_to_dict_shape() -> None:
+    fm = _stale_fm(date(2026, 5, 1))
+    out = detect_disagreement(fm, date(2026, 5, 5))
+    assert out is not None
+    d = disagreement_to_dict(out)
+    assert d == {
+        "stale_by": "alice",
+        "stale_at": "2026-05-01",
+        "stale_reason": "X",
+        "self_confirmed_at": "2026-05-05",
+    }
+
+
+def test_detect_unparseable_stale_at_string() -> None:
+    fm = {"status": "stale", "stale_at": "not-a-date"}
+    assert detect_disagreement(fm, date(2026, 5, 5)) is None
+
+
+def test_detect_status_stale_case_insensitive() -> None:
+    fm = {"status": "Stale", "stale_at": date(2026, 5, 1)}
+    out = detect_disagreement(fm, date(2026, 5, 5))
+    assert out is not None

--- a/tests/test_freshness_filter.py
+++ b/tests/test_freshness_filter.py
@@ -1,0 +1,176 @@
+"""Tests for ``lore_core.freshness_filter`` — slice 3 of PRD #65."""
+
+from __future__ import annotations
+
+from lore_core.freshness_filter import (
+    FilterAudit,
+    FilterAuditEntry,
+    apply_inject_filter,
+    apply_search_filter,
+)
+
+
+# ---------------------------------------------------------------------------
+# apply_search_filter
+# ---------------------------------------------------------------------------
+
+
+def _hit(path: str, score: float, status: str, reason: str | None = None) -> dict:
+    return {
+        "path": path,
+        "wiki": "demo",
+        "score": score,
+        "freshness": {"status": status, "cause": "authored_marker", "reason": reason},
+    }
+
+
+def test_search_filter_at_tied_scores_confirmed_wins() -> None:
+    hits = [
+        _hit("a.md", 0.9, "stale-candidate", "marked stale"),
+        _hit("b.md", 0.9, "confirmed"),
+        _hit("c.md", 0.5, "confirmed"),
+    ]
+    out, audit = apply_search_filter(hits)
+    paths = [h["path"] for h in out]
+    # Tied at 0.9: confirmed b before stale-candidate a.
+    assert paths == ["b.md", "a.md", "c.md"]
+    # Audit notes the downrank.
+    assert any(e.path == "a.md" and e.action == "downranked" for e in audit.entries)
+
+
+def test_search_filter_higher_score_stale_still_first() -> None:
+    """Recall property — stale-candidate with a higher score still leads."""
+    hits = [
+        _hit("a.md", 0.95, "stale-candidate", "marked stale"),
+        _hit("b.md", 0.5, "confirmed"),
+    ]
+    out, _audit = apply_search_filter(hits)
+    assert [h["path"] for h in out] == ["a.md", "b.md"]
+
+
+def test_search_filter_only_match_stale_still_surfaces() -> None:
+    """A stale-candidate that is the only match must surface."""
+    hits = [_hit("only.md", 0.7, "stale-candidate", "marked stale")]
+    out, audit = apply_search_filter(hits)
+    assert [h["path"] for h in out] == ["only.md"]
+    # It IS downranked in the audit (recorded), but still in the result.
+    assert audit.entries[0].path == "only.md"
+    assert audit.entries[0].action == "downranked"
+
+
+def test_search_filter_empty_input() -> None:
+    out, audit = apply_search_filter([])
+    assert out == []
+    assert not audit
+
+
+def test_search_filter_preserves_within_tier_order_at_same_score() -> None:
+    """When several confirmed hits are tied, the input order survives."""
+    hits = [
+        _hit("a.md", 0.5, "confirmed"),
+        _hit("b.md", 0.5, "confirmed"),
+        _hit("c.md", 0.5, "confirmed"),
+    ]
+    out, _ = apply_search_filter(hits)
+    assert [h["path"] for h in out] == ["a.md", "b.md", "c.md"]
+
+
+def test_search_filter_no_freshness_block_treated_as_confirmed() -> None:
+    hits = [
+        {"path": "a.md", "wiki": "w", "score": 0.5},
+        {"path": "b.md", "wiki": "w", "score": 0.5,
+         "freshness": {"status": "stale-candidate", "cause": "authored_marker", "reason": "marked stale"}},
+    ]
+    out, _ = apply_search_filter(hits)
+    assert [h["path"] for h in out] == ["a.md", "b.md"]
+
+
+# ---------------------------------------------------------------------------
+# apply_inject_filter
+# ---------------------------------------------------------------------------
+
+
+def _item(slug: str, status: str, reason: str | None = None) -> dict:
+    return {
+        "slug": slug,
+        "freshness": {"status": status, "cause": "authored_marker", "reason": reason},
+    }
+
+
+def _f(item):
+    return item.get("freshness")
+
+
+def _p(item):
+    return item.get("slug", "")
+
+
+def _w(_item):
+    return "demo"
+
+
+def test_inject_filter_excludes_hard_stale() -> None:
+    items = [
+        _item("a", "confirmed"),
+        _item("b", "stale-candidate", "marked stale"),  # hard
+        _item("c", "stale-candidate", "supersede candidate: [[x]]"),  # soft
+    ]
+    result = apply_inject_filter(items, _f, path_of=_p, wiki_of=_w)
+    kept_slugs = [i["slug"] for i in result.kept]
+    assert "b" not in kept_slugs  # hard stale excluded
+    assert "a" in kept_slugs and "c" in kept_slugs
+    assert [i["slug"] for i in result.excluded] == ["b"]
+
+
+def test_inject_filter_downranks_soft_stale_after_confirmed() -> None:
+    items = [
+        _item("soft1", "stale-candidate", "supersede candidate: [[x]]"),
+        _item("ok1", "confirmed"),
+        _item("soft2", "stale-candidate", "supersede candidate of [[y]]"),
+        _item("ok2", "confirmed"),
+    ]
+    result = apply_inject_filter(items, _f, path_of=_p, wiki_of=_w)
+    assert [i["slug"] for i in result.kept] == ["ok1", "ok2", "soft1", "soft2"]
+
+
+def test_inject_filter_excludes_superseded_by_as_hard() -> None:
+    items = [
+        _item("a", "stale-candidate", "superseded by [[newer]]"),
+    ]
+    result = apply_inject_filter(items, _f, path_of=_p, wiki_of=_w)
+    assert result.excluded == items
+    assert result.kept == []
+
+
+def test_inject_filter_audit_log_shape() -> None:
+    items = [
+        _item("a", "confirmed"),
+        _item("b", "stale-candidate", "marked stale"),
+        _item("c", "stale-candidate", "supersede candidate: [[x]]"),
+    ]
+    result = apply_inject_filter(items, _f, path_of=_p, wiki_of=_w)
+    actions = {(e.path, e.action) for e in result.audit.entries}
+    assert ("b", "excluded") in actions
+    assert ("c", "downranked") in actions
+    assert ("a", "downranked") not in actions and ("a", "excluded") not in actions
+
+
+def test_inject_filter_render_lines_includes_section_heading() -> None:
+    items = [_item("b", "stale-candidate", "marked stale")]
+    result = apply_inject_filter(items, _f, path_of=_p, wiki_of=_w)
+    lines = result.audit.render_lines()
+    assert lines[0] == "### Filtered for staleness"
+    assert any("excluded" in line for line in lines[1:])
+
+
+def test_inject_filter_empty_audit_renders_nothing() -> None:
+    items = [_item("a", "confirmed")]
+    result = apply_inject_filter(items, _f, path_of=_p, wiki_of=_w)
+    assert result.audit.render_lines() == []
+
+
+def test_inject_filter_treats_missing_freshness_as_confirmed() -> None:
+    items = [{"slug": "a"}, {"slug": "b", "freshness": None}]
+    result = apply_inject_filter(items, _f, path_of=_p, wiki_of=_w)
+    assert [i["slug"] for i in result.kept] == ["a", "b"]
+    assert result.excluded == []

--- a/tests/test_freshness_orphan_signal.py
+++ b/tests/test_freshness_orphan_signal.py
@@ -1,0 +1,189 @@
+"""Tests for the orphan-link signal wired into freshness — slice 4 of PRD #65."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from lore_core.freshness import compute_freshness, load_orphan_set
+from lore_mcp.server import handle_read, handle_search
+
+
+# ---------------------------------------------------------------------------
+# load_orphan_set — cache loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_orphan_set_missing_catalog_returns_empty(tmp_path):
+    assert load_orphan_set(tmp_path) == set()
+
+
+def test_load_orphan_set_missing_orphan_key_returns_empty(tmp_path):
+    cat = tmp_path / "_catalog.json"
+    cat.write_text(json.dumps({"wiki": "demo"}))
+    assert load_orphan_set(tmp_path) == set()
+
+
+def test_load_orphan_set_malformed_returns_empty(tmp_path):
+    (tmp_path / "_catalog.json").write_text("{not json")
+    assert load_orphan_set(tmp_path) == set()
+
+
+def test_load_orphan_set_returns_resolved_paths(tmp_path):
+    rel = "concepts/n.md"
+    (tmp_path / "concepts").mkdir()
+    (tmp_path / "concepts" / "n.md").write_text("body")
+    (tmp_path / "_catalog.json").write_text(
+        json.dumps({"wiki": "demo", "orphan_set": [rel]})
+    )
+    out = load_orphan_set(tmp_path)
+    assert (tmp_path / rel).resolve() in out
+
+
+def test_load_orphan_set_skips_non_string_entries(tmp_path):
+    (tmp_path / "_catalog.json").write_text(
+        json.dumps({"wiki": "demo", "orphan_set": ["a.md", 42, None, ""]})
+    )
+    out = load_orphan_set(tmp_path)
+    assert len(out) == 1
+    assert (tmp_path / "a.md").resolve() in out
+
+
+# ---------------------------------------------------------------------------
+# compute_freshness — orphan branch
+# ---------------------------------------------------------------------------
+
+
+def test_compute_freshness_orphan_membership(tmp_path):
+    note = tmp_path / "n.md"
+    note.write_text("body")
+    sig = compute_freshness({}, note, tmp_path, None, {note.resolve()})
+    assert sig.status == "stale-candidate"
+    assert sig.cause == "orphan_broken"
+
+
+def test_compute_freshness_orphan_authored_marker_wins(tmp_path):
+    note = tmp_path / "n.md"
+    note.write_text("body")
+    sig = compute_freshness(
+        {"status": "stale"}, note, tmp_path, None, {note.resolve()}
+    )
+    # Authored markers always take precedence over orphan signal.
+    assert sig.cause == "authored_marker"
+
+
+# ---------------------------------------------------------------------------
+# lint integration — orphan_set is written into _catalog.json
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_wiki(tmp_path: Path, monkeypatch, files: dict[str, str]) -> Path:
+    wiki = tmp_path / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    for name, body in files.items():
+        (wiki / "concepts" / name).write_text(body)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    return wiki
+
+
+def test_lint_writes_orphan_set_into_catalog(tmp_path, monkeypatch):
+    files = {
+        "good.md": dedent("""\
+            ---
+            type: concept
+            description: ok
+            tags: [x]
+            ---
+            references [[good]]
+            """),
+        "broken.md": dedent("""\
+            ---
+            type: concept
+            description: broken
+            tags: [x]
+            ---
+            references [[never-existed]]
+            """),
+    }
+    wiki = _bootstrap_wiki(tmp_path, monkeypatch, files)
+    from lore_core.lint import run_lint
+
+    run_lint()
+    catalog = json.loads((wiki / "_catalog.json").read_text())
+    assert "orphan_set" in catalog
+    assert "concepts/broken.md" in catalog["orphan_set"]
+    assert "concepts/good.md" not in catalog["orphan_set"]
+
+
+def test_handle_search_flags_orphan_after_lint(tmp_path, monkeypatch):
+    files = {
+        "broken.md": dedent("""\
+            ---
+            type: concept
+            description: broken alpha
+            tags: [alpha]
+            ---
+            content with broken [[nonexistent-target]]
+            """),
+        "ok.md": dedent("""\
+            ---
+            type: concept
+            description: ok alpha
+            tags: [alpha]
+            ---
+            no broken refs alpha
+            """),
+    }
+    _bootstrap_wiki(tmp_path, monkeypatch, files)
+    from lore_core.lint import run_lint
+
+    run_lint()
+
+    hits = handle_search("alpha", wiki="demo", k=5)
+    by_path = {h["path"]: h for h in hits}
+    if "concepts/broken.md" in by_path:
+        h = by_path["concepts/broken.md"]
+        assert h["freshness"]["status"] == "stale-candidate"
+        assert h["freshness"]["cause"] == "orphan_broken"
+    if "concepts/ok.md" in by_path:
+        assert by_path["concepts/ok.md"]["freshness"]["status"] == "confirmed"
+
+
+def test_handle_read_flags_orphan_after_lint(tmp_path, monkeypatch):
+    files = {
+        "broken.md": dedent("""\
+            ---
+            type: concept
+            description: broken
+            ---
+            content with broken [[nonexistent]]
+            """),
+    }
+    _bootstrap_wiki(tmp_path, monkeypatch, files)
+    from lore_core.lint import run_lint
+
+    run_lint()
+
+    result = handle_read("concepts/broken.md", wiki="demo")
+    assert result["freshness"]["status"] == "stale-candidate"
+    assert result["freshness"]["cause"] == "orphan_broken"
+
+
+def test_handle_read_no_lint_run_degrades_gracefully(tmp_path, monkeypatch):
+    """Cache miss (no _catalog.json yet) → orphan check no-ops; not an error."""
+    wiki = tmp_path / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    (wiki / "concepts" / "broken.md").write_text(
+        dedent("""\
+            ---
+            type: concept
+            ---
+            content with broken [[nonexistent]]
+            """)
+    )
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    # Skip lint — no catalog cache.
+    result = handle_read("concepts/broken.md", wiki="demo")
+    # Without the cache, orphans are invisible — confirmed is the safe default.
+    assert result["freshness"]["status"] == "confirmed"

--- a/tests/test_freshness_signal.py
+++ b/tests/test_freshness_signal.py
@@ -1,0 +1,295 @@
+"""Tests for ``lore_core.freshness`` — slice 1 of PRD #65.
+
+These cover the pure classification logic. Personal-confirm suppression
+behavior is exercised here too because the parameter shape is part of
+slice 1's signature, even though slice 1 always passes
+``sidecar_confirmed_at=None`` from the retrieval surfaces. The full
+behaviour is wired in slice 6 — these tests pin the contract early so
+slice 6's wiring is the only change needed.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from lore_core.freshness import (
+    PERSONAL_CONFIRM_RECENCY_DAYS,
+    FreshnessSignal,
+    compute_freshness,
+    signal_to_dict,
+)
+
+
+def _write_note(path: Path, body: str = "body") -> None:
+    path.write_text(body)
+
+
+def _set_mtime(path: Path, target: date) -> None:
+    """Set the mtime of ``path`` to noon on ``target``."""
+    import os
+    import time
+
+    ts = time.mktime((target.year, target.month, target.day, 12, 0, 0, 0, 0, -1))
+    os.utime(path, (ts, ts))
+
+
+# ---------------------------------------------------------------------------
+# Authored-marker variants — each in isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fm, expected_reason_substr",
+    [
+        ({"status": "stale"}, "marked stale"),
+        ({"superseded_by": "[[newer]]"}, "superseded by"),
+        ({"supersede_candidate": "[[newer]]"}, "supersede candidate:"),
+        ({"supersede_candidate_of": "[[older]]"}, "supersede candidate of"),
+    ],
+)
+def test_each_authored_marker_flags_stale_candidate(
+    tmp_path: Path, fm: dict, expected_reason_substr: str
+) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness(fm, note, tmp_path, None, set())
+    assert sig.status == "stale-candidate"
+    assert sig.cause == "authored_marker"
+    assert sig.reason is not None
+    assert expected_reason_substr in sig.reason
+
+
+def test_no_markers_returns_confirmed(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness({}, note, tmp_path, None, set())
+    assert sig == FreshnessSignal(
+        status="confirmed", cause="none", reason=None, confirmed_at=None
+    )
+
+
+def test_only_unrelated_fields_stay_confirmed(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness(
+        {"type": "concept", "tags": ["x"], "created": "2026-01-01"},
+        note,
+        tmp_path,
+        None,
+        set(),
+    )
+    assert sig.status == "confirmed"
+
+
+def test_status_active_does_not_flag(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness({"status": "active"}, note, tmp_path, None, set())
+    assert sig.status == "confirmed"
+
+
+# ---------------------------------------------------------------------------
+# Multiple markers + precedence
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_markers_picks_first_hard(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    fm = {"status": "stale", "supersede_candidate": "[[other]]"}
+    sig = compute_freshness(fm, note, tmp_path, None, set())
+    # Hard marker (status) wins over soft.
+    assert sig.cause == "authored_marker"
+    assert "marked stale" in (sig.reason or "")
+
+
+def test_authored_marker_wins_over_orphan(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    fm = {"status": "stale"}
+    sig = compute_freshness(fm, note, tmp_path, None, {note})
+    assert sig.cause == "authored_marker"  # docstring contract
+
+
+def test_orphan_only_yields_orphan_broken(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness({}, note, tmp_path, None, {note})
+    assert sig.status == "stale-candidate"
+    assert sig.cause == "orphan_broken"
+    assert sig.reason is not None
+
+
+def test_path_outside_orphan_set_stays_confirmed(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    other = tmp_path / "other.md"
+    _write_note(note)
+    _write_note(other)
+    sig = compute_freshness({}, note, tmp_path, None, {other})
+    assert sig.status == "confirmed"
+
+
+# ---------------------------------------------------------------------------
+# Age never flags
+# ---------------------------------------------------------------------------
+
+
+def test_age_alone_never_flags(tmp_path: Path) -> None:
+    """A note can be ancient — no markers, no orphan → confirmed."""
+    note = tmp_path / "n.md"
+    _write_note(note)
+    fm = {"last_reviewed": "2010-01-01", "created": "2010-01-01"}
+    sig = compute_freshness(fm, note, tmp_path, None, set())
+    assert sig.status == "confirmed"
+
+
+def test_missing_last_confirmed_does_not_flag(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness({"type": "concept"}, note, tmp_path, None, set())
+    assert sig.status == "confirmed"
+
+
+# ---------------------------------------------------------------------------
+# Personal confirm suppression (slice 6 contract pinned in slice 1)
+# ---------------------------------------------------------------------------
+
+
+def test_personal_confirm_suppresses_soft_marker(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    today = date(2026, 5, 8)
+    # Note was last edited a week ago; confirmed two days ago — confirm
+    # is newer than mtime, so the soft marker is suppressed.
+    _set_mtime(note, today - timedelta(days=7))
+    fm = {"supersede_candidate": "[[other]]"}
+    confirmed_at = today - timedelta(days=2)
+    sig = compute_freshness(
+        fm, note, tmp_path, confirmed_at, set(), today=today
+    )
+    assert sig.status == "confirmed"
+    assert sig.confirmed_at == confirmed_at
+
+
+def test_personal_confirm_does_not_suppress_status_stale(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    fm = {"status": "stale"}
+    today = date(2026, 5, 8)
+    confirmed_at = today - timedelta(days=2)
+    sig = compute_freshness(
+        fm, note, tmp_path, confirmed_at, set(), today=today
+    )
+    # Hard marker wins — confirm cannot vouch for team-wide truth.
+    assert sig.status == "stale-candidate"
+    assert sig.cause == "authored_marker"
+
+
+def test_personal_confirm_does_not_suppress_superseded_by(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    fm = {"superseded_by": "[[newer]]"}
+    today = date(2026, 5, 8)
+    confirmed_at = today - timedelta(days=2)
+    sig = compute_freshness(
+        fm, note, tmp_path, confirmed_at, set(), today=today
+    )
+    assert sig.status == "stale-candidate"
+
+
+def test_personal_confirm_outside_recency_window_does_not_suppress(
+    tmp_path: Path,
+) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    today = date(2026, 5, 8)
+    # Note edited long ago, but the confirm is also older than the window.
+    confirmed_at = today - timedelta(days=PERSONAL_CONFIRM_RECENCY_DAYS + 5)
+    _set_mtime(note, confirmed_at - timedelta(days=2))
+    fm = {"supersede_candidate": "[[other]]"}
+    sig = compute_freshness(
+        fm, note, tmp_path, confirmed_at, set(), today=today
+    )
+    assert sig.status == "stale-candidate"
+
+
+def test_personal_confirm_after_edit_does_not_suppress(tmp_path: Path) -> None:
+    """Edit-then-confirm-stale: mtime-after-confirm invalidates suppression."""
+    note = tmp_path / "n.md"
+    _write_note(note)
+    today = date(2026, 5, 8)
+    # Confirm last week, but the note was edited today (after the confirm).
+    confirmed_at = today - timedelta(days=7)
+    # Bump mtime to today (later than confirmed_at).
+    import os
+    import time
+
+    target_ts = time.mktime((today.year, today.month, today.day, 12, 0, 0, 0, 0, -1))
+    os.utime(note, (target_ts, target_ts))
+
+    fm = {"supersede_candidate": "[[other]]"}
+    sig = compute_freshness(
+        fm, note, tmp_path, confirmed_at, set(), today=today
+    )
+    assert sig.status == "stale-candidate"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_frontmatter_dict(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness({}, note, tmp_path, None, set())
+    assert sig.status == "confirmed"
+
+
+def test_none_frontmatter_treated_as_empty(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness(None, note, tmp_path, None, set())  # type: ignore[arg-type]
+    assert sig.status == "confirmed"
+
+
+def test_orphan_set_none_treated_as_empty(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness({}, note, tmp_path, None, None)
+    assert sig.status == "confirmed"
+
+
+def test_signal_to_dict_shape(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    sig = compute_freshness({"status": "stale"}, note, tmp_path, None, set())
+    d = signal_to_dict(sig)
+    assert d == {
+        "status": "stale-candidate",
+        "cause": "authored_marker",
+        "reason": "marked stale",
+        "confirmed_at": None,
+    }
+
+
+def test_signal_to_dict_with_confirmed_at(tmp_path: Path) -> None:
+    note = tmp_path / "n.md"
+    _write_note(note)
+    today = date(2026, 5, 8)
+    confirmed = today - timedelta(days=1)
+    _set_mtime(note, today - timedelta(days=5))
+    sig = compute_freshness(
+        {"supersede_candidate": "[[x]]"},
+        note,
+        tmp_path,
+        confirmed,
+        set(),
+        today=today,
+    )
+    d = signal_to_dict(sig)
+    assert d["status"] == "confirmed"
+    assert d["confirmed_at"] == confirmed.isoformat()

--- a/tests/test_hooks_freshness_inject.py
+++ b/tests/test_hooks_freshness_inject.py
@@ -1,0 +1,137 @@
+"""SessionStart inject filter tests — slice 3 of PRD #65."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from lore_cli.hooks import (
+    _filter_session_hints,
+    _last_session_hint_with_freshness,
+)
+
+
+def _make_session(
+    wiki: Path, name: str, body: str, mtime: float | None = None
+) -> Path:
+    sess = wiki / "sessions" / "2026" / "05"
+    sess.mkdir(parents=True, exist_ok=True)
+    p = sess / name
+    p.write_text(body)
+    if mtime is not None:
+        import os
+
+        os.utime(p, (mtime, mtime))
+    return p
+
+
+def test_session_hints_with_freshness_carries_block(tmp_path):
+    wiki = tmp_path / "wiki" / "demo"
+    wiki.mkdir(parents=True)
+    body = dedent("""\
+        ---
+        type: session
+        title: confirmed session
+        ---
+        body
+        """)
+    _make_session(wiki, "08-1500-confirmed.md", body)
+
+    hits = _last_session_hint_with_freshness(wiki)
+    assert hits
+    assert hits[0][2]["status"] == "confirmed"
+
+
+def test_filter_excludes_status_stale_session(tmp_path):
+    wiki = tmp_path / "wiki" / "demo"
+    wiki.mkdir(parents=True)
+    body_ok = dedent("""\
+        ---
+        type: session
+        title: ok session
+        ---
+        body
+        """)
+    body_stale = dedent("""\
+        ---
+        type: session
+        title: stale session
+        status: stale
+        ---
+        body
+        """)
+    # Order in time: stale is newest, ok is older — newest-first sort puts
+    # stale first; the filter must drop it.
+    _make_session(wiki, "07-0900-ok.md", body_ok)
+    _make_session(wiki, "08-1500-stale.md", body_stale)
+
+    candidates = _last_session_hint_with_freshness(wiki, max_notes=4)
+    kept, audit_lines = _filter_session_hints(candidates, max_notes=2)
+    kept_slugs = [s for s, _ in kept]
+    assert "08-1500-stale" not in kept_slugs
+    assert "07-0900-ok" in kept_slugs
+    assert any("excluded" in line for line in audit_lines)
+
+
+def test_filter_downranks_soft_stale_after_confirmed(tmp_path):
+    wiki = tmp_path / "wiki" / "demo"
+    wiki.mkdir(parents=True)
+    body_soft = dedent("""\
+        ---
+        type: session
+        title: soft stale
+        supersede_candidate: "[[newer]]"
+        ---
+        body
+        """)
+    body_ok = dedent("""\
+        ---
+        type: session
+        title: ok session
+        ---
+        body
+        """)
+    # Soft is newest, OK is older. After downrank, ok comes first.
+    _make_session(wiki, "07-0900-ok.md", body_ok)
+    _make_session(wiki, "08-1500-soft.md", body_soft)
+
+    candidates = _last_session_hint_with_freshness(wiki, max_notes=4)
+    kept, audit_lines = _filter_session_hints(candidates, max_notes=4)
+    kept_slugs = [s for s, _ in kept]
+    # Confirmed comes before soft after the filter, even though soft was newer.
+    assert kept_slugs.index("07-0900-ok") < kept_slugs.index("08-1500-soft")
+    # Audit logged the downrank.
+    assert any("downranked" in line for line in audit_lines)
+
+
+def test_filter_no_audit_when_all_confirmed(tmp_path):
+    wiki = tmp_path / "wiki" / "demo"
+    wiki.mkdir(parents=True)
+    body = dedent("""\
+        ---
+        type: session
+        title: ok
+        ---
+        body
+        """)
+    _make_session(wiki, "08-1500-ok.md", body)
+    candidates = _last_session_hint_with_freshness(wiki, max_notes=4)
+    _kept, audit_lines = _filter_session_hints(candidates)
+    assert audit_lines == []
+
+
+def test_max_notes_caps_after_filter(tmp_path):
+    wiki = tmp_path / "wiki" / "demo"
+    wiki.mkdir(parents=True)
+    body = dedent("""\
+        ---
+        type: session
+        title: ok-{i}
+        ---
+        body
+        """)
+    for i in range(5):
+        _make_session(wiki, f"0{i+1}-1500-ok-{i}.md", body)
+    candidates = _last_session_hint_with_freshness(wiki, max_notes=4)
+    kept, _ = _filter_session_hints(candidates, max_notes=2)
+    assert len(kept) == 2

--- a/tests/test_lore_verify_skill.py
+++ b/tests/test_lore_verify_skill.py
@@ -1,0 +1,73 @@
+"""Smoke test for the `/lore:verify` plugin skill — slice 10 of PRD #65."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import yaml
+
+
+SKILL_PATH = Path(__file__).resolve().parent.parent / "skills" / "verify" / "SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text()
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    return yaml.safe_load(text[4:end]) or {}
+
+
+def test_skill_file_exists():
+    assert SKILL_PATH.is_file(), f"missing {SKILL_PATH}"
+
+
+def test_skill_name_is_lore_colon_verify():
+    """Plugin namespace caveat: SKILL.md `name:` is used verbatim
+    per the existing memory note — must include the `lore:` prefix."""
+    fm = _frontmatter(SKILL_PATH)
+    assert fm.get("name") == "lore:verify"
+
+
+def test_skill_user_invocable_flag_set():
+    fm = _frontmatter(SKILL_PATH)
+    assert fm.get("user_invocable") is True
+
+
+def test_skill_description_present_and_short():
+    fm = _frontmatter(SKILL_PATH)
+    desc = fm.get("description") or ""
+    # Must mention what the command does to be discoverable.
+    assert "verdict" in desc.lower() or "stale" in desc.lower()
+    # Run-with hint required for plugin discoverability.
+    assert "/lore:verify" in desc
+
+
+def test_skill_body_documents_three_picker_options():
+    """confirm / stale / skip must all be referenced in the body."""
+    text = SKILL_PATH.read_text().lower()
+    assert "confirm" in text
+    assert "stale" in text
+    assert "skip" in text
+
+
+def test_skill_calls_lore_verdict_mcp():
+    """No new write paths — must wrap the existing MCP tool."""
+    text = SKILL_PATH.read_text()
+    assert "lore_verdict" in text
+
+
+def test_plugin_version_bumped_for_skill_addition():
+    """Per the lore-plugin-cache-stale memory: any plugin.json change
+    needs a version bump or installed caches never re-fetch."""
+    import json
+
+    plugin = json.loads(
+        (SKILL_PATH.parent.parent.parent / ".claude-plugin" / "plugin.json").read_text()
+    )
+    # The new skill ships in 0.49.0 (slice 10 of #65) — pin the bump.
+    assert plugin["version"] == "0.49.0"

--- a/tests/test_mcp_disagreement.py
+++ b/tests/test_mcp_disagreement.py
@@ -1,0 +1,141 @@
+"""Integration tests for disagreement on retrieval surfaces — slice 9."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+from textwrap import dedent
+
+from lore_cli.hooks import _filter_session_hints
+from lore_core.verdicts_sidecar import set_confirmed
+from lore_mcp.server import handle_read, handle_search
+
+
+def _setup(tmp_path: Path, monkeypatch, body: str, name: str = "n.md") -> Path:
+    wiki = tmp_path / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    (wiki / "concepts" / name).write_text(body)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "alice@example.com")
+    return wiki
+
+
+def test_handle_read_carries_disagreement_field(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        status: stale
+        stale_by: alice
+        stale_at: 2026-05-01
+        stale_reason: superseded
+        ---
+        body
+        """)
+    wiki = _setup(tmp_path, monkeypatch, body)
+    set_confirmed(wiki, "alice", "concepts/n.md", date(2026, 5, 5))
+
+    result = handle_read("concepts/n.md", wiki="demo")
+    assert "disagreement" in result["freshness"]
+    d = result["freshness"]["disagreement"]
+    assert d["stale_by"] == "alice"
+    assert d["stale_at"] == "2026-05-01"
+    assert d["self_confirmed_at"] == "2026-05-05"
+
+
+def test_no_disagreement_field_when_no_conflict(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        ---
+        body
+        """)
+    _setup(tmp_path, monkeypatch, body)
+    result = handle_read("concepts/n.md", wiki="demo")
+    assert "disagreement" not in result["freshness"]
+
+
+def test_disagreement_excluded_from_inject_filter(tmp_path):
+    """Slice 3 + 9: a hit with disagreement is hard-excluded from inject."""
+    candidates = [
+        (
+            "stale-then-confirmed",
+            "title",
+            {
+                "status": "stale-candidate",
+                "cause": "authored_marker",
+                "reason": "marked stale",
+                "confirmed_at": "2026-05-05",
+                "disagreement": {
+                    "stale_by": "alice",
+                    "stale_at": "2026-05-01",
+                    "stale_reason": "X",
+                    "self_confirmed_at": "2026-05-05",
+                },
+            },
+        ),
+    ]
+    kept, audit_lines = _filter_session_hints(candidates, max_notes=2)
+    assert kept == []
+    assert any("excluded" in line for line in audit_lines)
+
+
+def test_disagreement_excluded_even_when_status_confirmed(tmp_path):
+    """When personal confirm suppresses to confirmed but disagreement
+    is set (because slice-9 detector saw the conflict), inject still
+    excludes — defer to team-stale until user resolves."""
+    candidates = [
+        (
+            "x",
+            "t",
+            {
+                "status": "confirmed",
+                "cause": "none",
+                "reason": None,
+                "confirmed_at": "2026-05-05",
+                "disagreement": {
+                    "stale_by": "alice",
+                    "stale_at": "2026-05-01",
+                    "stale_reason": "X",
+                    "self_confirmed_at": "2026-05-05",
+                },
+            },
+        ),
+    ]
+    kept, _ = _filter_session_hints(candidates, max_notes=2)
+    assert kept == []
+
+
+def test_handle_search_disagreement_surfaces_with_downrank(tmp_path, monkeypatch):
+    body_dis = dedent("""\
+        ---
+        type: concept
+        description: alpha disagreed
+        tags: [alpha]
+        status: stale
+        stale_by: alice
+        stale_at: 2026-05-01
+        stale_reason: superseded
+        ---
+        alpha quick brown fox
+        """)
+    body_ok = dedent("""\
+        ---
+        type: concept
+        description: alpha plain
+        tags: [alpha]
+        ---
+        alpha plain content
+        """)
+    wiki = _setup(tmp_path, monkeypatch, body_dis, name="dis.md")
+    (wiki / "concepts" / "ok.md").write_text(body_ok)
+    set_confirmed(wiki, "alice", "concepts/dis.md", date(2026, 5, 5))
+
+    from lore_core.lint import run_lint
+
+    run_lint()
+
+    hits = handle_search("alpha", wiki="demo", k=5)
+    by_path = {h["path"]: h for h in hits}
+    if "concepts/dis.md" in by_path:
+        # Surfaces in search (recall property), and carries the disagreement.
+        assert "disagreement" in by_path["concepts/dis.md"]["freshness"]

--- a/tests/test_mcp_freshness.py
+++ b/tests/test_mcp_freshness.py
@@ -1,0 +1,178 @@
+"""Tests for freshness wiring on MCP retrieval surfaces (slice 1).
+
+Covers ``handle_read`` and ``handle_search`` (which `handle_drill`
+composes; drill therefore inherits freshness automatically — verified
+by a smoke test).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from lore_mcp.server import handle_read, handle_search
+
+
+def _setup_wiki(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    body: str,
+    name: str = "note.md",
+    folder: str = "concepts",
+) -> Path:
+    wiki = tmp_path / "wiki" / "demo"
+    (wiki / folder).mkdir(parents=True)
+    (wiki / folder / name).write_text(body)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    return wiki
+
+
+# ---------------------------------------------------------------------------
+# handle_read
+# ---------------------------------------------------------------------------
+
+
+def test_handle_read_attaches_freshness_default_confirmed(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        ---
+        body
+        """)
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read("concepts/note.md", wiki="demo")
+    assert "freshness" in result
+    assert result["freshness"]["status"] == "confirmed"
+    assert result["freshness"]["cause"] == "none"
+
+
+def test_handle_read_status_stale_marks_candidate(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        status: stale
+        ---
+        body
+        """)
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read("concepts/note.md", wiki="demo")
+    assert result["freshness"]["status"] == "stale-candidate"
+    assert result["freshness"]["cause"] == "authored_marker"
+
+
+def test_handle_read_supersede_candidate_marks_candidate(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        supersede_candidate: "[[newer]]"
+        ---
+        body
+        """)
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read("concepts/note.md", wiki="demo")
+    assert result["freshness"]["status"] == "stale-candidate"
+    assert result["freshness"]["cause"] == "authored_marker"
+
+
+def test_handle_read_supersede_candidate_of_marks_candidate(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        supersede_candidate_of: "[[older]]"
+        ---
+        body
+        """)
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read("concepts/note.md", wiki="demo")
+    assert result["freshness"]["status"] == "stale-candidate"
+    assert result["freshness"]["cause"] == "authored_marker"
+
+
+def test_handle_read_section_response_carries_freshness(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        status: stale
+        ---
+        # T
+
+        ## Alpha
+        body
+        """)
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read("concepts/note.md", wiki="demo", section="alpha")
+    assert result.get("section") == "alpha"
+    assert result["freshness"]["status"] == "stale-candidate"
+
+
+# ---------------------------------------------------------------------------
+# handle_search
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_searchable_wiki(
+    tmp_path: Path, monkeypatch, files: dict[str, str]
+) -> Path:
+    """Create a wiki with the given files and run lint to populate indexes."""
+    wiki = tmp_path / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    for name, body in files.items():
+        (wiki / "concepts" / name).write_text(body)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    # Populate _catalog.json so reindex/search has metadata.
+    from lore_core.lint import run_lint
+
+    run_lint()
+    return wiki
+
+
+def test_handle_search_each_hit_carries_freshness(tmp_path, monkeypatch):
+    files = {
+        "fresh.md": dedent("""\
+            ---
+            type: concept
+            description: alpha thing
+            tags: [alpha]
+            ---
+            alpha quick brown fox
+            """),
+        "stale.md": dedent("""\
+            ---
+            type: concept
+            description: alpha legacy
+            tags: [alpha]
+            status: stale
+            ---
+            alpha legacy fox content
+            """),
+    }
+    _bootstrap_searchable_wiki(tmp_path, monkeypatch, files)
+    hits = handle_search("alpha fox", wiki="demo", k=5)
+    assert len(hits) >= 1
+    for h in hits:
+        assert "freshness" in h
+        assert h["freshness"]["status"] in {"confirmed", "stale-candidate"}
+    # The stale one should be flagged.
+    by_path = {h["path"]: h for h in hits}
+    if "concepts/stale.md" in by_path:
+        assert by_path["concepts/stale.md"]["freshness"]["status"] == "stale-candidate"
+    if "concepts/fresh.md" in by_path:
+        assert by_path["concepts/fresh.md"]["freshness"]["status"] == "confirmed"
+
+
+def test_handle_search_default_is_confirmed(tmp_path, monkeypatch):
+    files = {
+        "n.md": dedent("""\
+            ---
+            type: concept
+            description: alpha thing
+            tags: [alpha]
+            ---
+            alpha quick brown fox
+            """),
+    }
+    _bootstrap_searchable_wiki(tmp_path, monkeypatch, files)
+    hits = handle_search("alpha", wiki="demo", k=5)
+    if hits:
+        assert hits[0]["freshness"]["status"] == "confirmed"
+        assert hits[0]["freshness"]["cause"] == "none"

--- a/tests/test_mcp_lore_verdict.py
+++ b/tests/test_mcp_lore_verdict.py
@@ -1,0 +1,148 @@
+"""Tests for the ``lore_verdict`` MCP tool — slice 5 of PRD #65."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from lore_core.schema import parse_frontmatter
+from lore_mcp.server import handle_read, handle_verdict
+
+
+def _setup(tmp_path: Path, monkeypatch, body: str) -> Path:
+    wiki = tmp_path / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    (wiki / "concepts" / "n.md").write_text(body)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "alice@example.com")
+    return wiki
+
+
+def test_verdict_stale_writes_four_fields_and_returns_signal(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        description: thing
+        ---
+        body
+        """)
+    wiki = _setup(tmp_path, monkeypatch, body)
+    result = handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="stale", reason="superseded"
+    )
+    assert result.get("verdict") == "stale"
+    assert result["freshness"]["status"] == "stale-candidate"
+    assert result["freshness"]["cause"] == "authored_marker"
+    fm = parse_frontmatter((wiki / "concepts" / "n.md").read_text())
+    assert fm["status"] == "stale"
+    assert fm["stale_reason"] == "superseded"
+    assert fm["stale_by"] == "alice"
+    assert "stale_at" in fm
+
+
+def test_verdict_stale_without_reason_returns_error(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        ---
+        body
+        """)
+    _setup(tmp_path, monkeypatch, body)
+    result = handle_verdict(wiki="demo", note="concepts/n.md", verdict="stale")
+    assert "error" in result
+    assert result["error"]["code"] == "reason_required"
+
+
+def test_verdict_confirm_returns_not_implemented(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        ---
+        body
+        """)
+    _setup(tmp_path, monkeypatch, body)
+    result = handle_verdict(wiki="demo", note="concepts/n.md", verdict="confirm")
+    assert "error" in result
+    assert result["error"]["code"] == "not_implemented"
+
+
+def test_verdict_unknown_value_returns_error(tmp_path, monkeypatch):
+    body = "---\ntype: concept\n---\nbody\n"
+    _setup(tmp_path, monkeypatch, body)
+    result = handle_verdict(wiki="demo", note="concepts/n.md", verdict="bogus")
+    assert "error" in result
+    assert result["error"]["code"] == "invalid_verdict"
+
+
+def test_verdict_unknown_wiki_returns_error(tmp_path, monkeypatch):
+    body = "---\ntype: concept\n---\nbody\n"
+    _setup(tmp_path, monkeypatch, body)
+    result = handle_verdict(wiki="other", note="x", verdict="stale", reason="x")
+    assert "error" in result
+    assert result["error"]["code"] == "wiki_not_found"
+
+
+def test_verdict_unknown_note_returns_error(tmp_path, monkeypatch):
+    body = "---\ntype: concept\n---\nbody\n"
+    _setup(tmp_path, monkeypatch, body)
+    result = handle_verdict(
+        wiki="demo", note="missing-slug", verdict="stale", reason="x"
+    )
+    assert "error" in result
+
+
+def test_verdict_after_stale_search_response_reflects_stale(tmp_path, monkeypatch):
+    body = "---\ntype: concept\ndescription: t\n---\nbody\n"
+    _setup(tmp_path, monkeypatch, body)
+    handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="stale", reason="X"
+    )
+    after = handle_read("concepts/n.md", wiki="demo")
+    assert after["freshness"]["status"] == "stale-candidate"
+    assert after["freshness"]["cause"] == "authored_marker"
+
+
+def test_verdict_clear_stale_reverses_stale(tmp_path, monkeypatch):
+    body = "---\ntype: concept\ndescription: t\n---\nbody\n"
+    wiki = _setup(tmp_path, monkeypatch, body)
+    handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="stale", reason="X"
+    )
+    fm_after = parse_frontmatter((wiki / "concepts" / "n.md").read_text())
+    assert fm_after["status"] == "stale"
+
+    result = handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="clear-stale"
+    )
+    assert result.get("verdict") == "clear-stale"
+    assert result["freshness"]["status"] == "confirmed"
+    fm_after = parse_frontmatter((wiki / "concepts" / "n.md").read_text())
+    assert "status" not in fm_after
+    assert "stale_reason" not in fm_after
+
+
+def test_verdict_stale_idempotent(tmp_path, monkeypatch):
+    body = "---\ntype: concept\n---\nbody\n"
+    _setup(tmp_path, monkeypatch, body)
+    r1 = handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="stale", reason="X"
+    )
+    assert "error" not in r1
+    r2 = handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="stale", reason="X"
+    )
+    # Second identical call is idempotent (same handle, same reason, same date).
+    assert "error" not in r2
+
+
+def test_verdict_stale_refuses_to_overwrite_different_reason(tmp_path, monkeypatch):
+    body = "---\ntype: concept\n---\nbody\n"
+    _setup(tmp_path, monkeypatch, body)
+    handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="stale", reason="reason A"
+    )
+    result = handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="stale", reason="reason B"
+    )
+    assert "error" in result
+    assert result["error"]["code"] == "stale_write_refused"

--- a/tests/test_mcp_lore_verdict.py
+++ b/tests/test_mcp_lore_verdict.py
@@ -53,17 +53,26 @@ def test_verdict_stale_without_reason_returns_error(tmp_path, monkeypatch):
     assert result["error"]["code"] == "reason_required"
 
 
-def test_verdict_confirm_returns_not_implemented(tmp_path, monkeypatch):
+def test_verdict_confirm_writes_personal_sidecar(tmp_path, monkeypatch):
+    """Slice 6 replaced slice 5's `confirm` stub with the sidecar write."""
     body = dedent("""\
         ---
         type: concept
+        supersede_candidate: "[[newer]]"
         ---
         body
         """)
     _setup(tmp_path, monkeypatch, body)
-    result = handle_verdict(wiki="demo", note="concepts/n.md", verdict="confirm")
-    assert "error" in result
-    assert result["error"]["code"] == "not_implemented"
+    result = handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="confirm"
+    )
+    assert "error" not in result
+    assert result.get("verdict") == "confirm"
+    assert "confirmed_at" in result
+    # Sidecar suppression of soft markers fires immediately (mtime is "now",
+    # but the mtime guard in compute_freshness compares mtime <= today's
+    # confirmed_at — both are today, so the >= check passes).
+    assert result["freshness"]["status"] == "confirmed"
 
 
 def test_verdict_unknown_value_returns_error(tmp_path, monkeypatch):

--- a/tests/test_mcp_personal_confirms.py
+++ b/tests/test_mcp_personal_confirms.py
@@ -1,0 +1,130 @@
+"""End-to-end tests for personal-confirm sidecar wiring — slice 6 of PRD #65."""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import date, timedelta
+from pathlib import Path
+from textwrap import dedent
+
+from lore_core.verdicts_sidecar import set_confirmed
+from lore_mcp.server import handle_read, handle_verdict
+
+
+def _setup(tmp_path: Path, monkeypatch, body: str, name: str = "n.md") -> Path:
+    wiki = tmp_path / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    p = wiki / "concepts" / name
+    p.write_text(body)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "alice@example.com")
+    return wiki
+
+
+def _set_mtime(path: Path, target: date) -> None:
+    ts = time.mktime((target.year, target.month, target.day, 12, 0, 0, 0, 0, -1))
+    os.utime(path, (ts, ts))
+
+
+def test_confirm_suppresses_soft_marker_on_subsequent_read(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        supersede_candidate: "[[newer]]"
+        ---
+        body
+        """)
+    wiki = _setup(tmp_path, monkeypatch, body)
+    # Make the note older than today so the mtime gate passes after confirm.
+    _set_mtime(wiki / "concepts" / "n.md", date.today() - timedelta(days=3))
+
+    handle_verdict(wiki="demo", note="concepts/n.md", verdict="confirm")
+    after = handle_read("concepts/n.md", wiki="demo")
+    assert after["freshness"]["status"] == "confirmed"
+    assert after["freshness"]["confirmed_at"] is not None
+
+
+def test_confirm_does_not_suppress_status_stale(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        status: stale
+        ---
+        body
+        """)
+    wiki = _setup(tmp_path, monkeypatch, body)
+    _set_mtime(wiki / "concepts" / "n.md", date.today() - timedelta(days=3))
+
+    handle_verdict(wiki="demo", note="concepts/n.md", verdict="confirm")
+    after = handle_read("concepts/n.md", wiki="demo")
+    # Hard team-wide marker survives — confirm cannot vouch for team truth.
+    assert after["freshness"]["status"] == "stale-candidate"
+    assert after["freshness"]["cause"] == "authored_marker"
+
+
+def test_confirm_does_not_suppress_superseded_by(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        superseded_by: "[[newer]]"
+        ---
+        body
+        """)
+    wiki = _setup(tmp_path, monkeypatch, body)
+    _set_mtime(wiki / "concepts" / "n.md", date.today() - timedelta(days=3))
+
+    handle_verdict(wiki="demo", note="concepts/n.md", verdict="confirm")
+    after = handle_read("concepts/n.md", wiki="demo")
+    assert after["freshness"]["status"] == "stale-candidate"
+
+
+def test_confirm_after_edit_no_longer_suppresses(tmp_path, monkeypatch):
+    """Edit-then-confirm: bumping mtime after a confirm invalidates suppression."""
+    body = dedent("""\
+        ---
+        type: concept
+        supersede_candidate: "[[newer]]"
+        ---
+        body
+        """)
+    wiki = _setup(tmp_path, monkeypatch, body)
+    note_path = wiki / "concepts" / "n.md"
+    # Note was old when confirmed.
+    seven_days_ago = date.today() - timedelta(days=7)
+    _set_mtime(note_path, seven_days_ago)
+    set_confirmed(wiki, "alice", "concepts/n.md", seven_days_ago + timedelta(days=1))
+    # Now simulate editing the note: bump mtime to today.
+    _set_mtime(note_path, date.today())
+
+    after = handle_read("concepts/n.md", wiki="demo")
+    assert after["freshness"]["status"] == "stale-candidate"
+
+
+def test_confirm_outside_recency_window_no_longer_suppresses(tmp_path, monkeypatch):
+    body = dedent("""\
+        ---
+        type: concept
+        supersede_candidate: "[[newer]]"
+        ---
+        body
+        """)
+    wiki = _setup(tmp_path, monkeypatch, body)
+    note_path = wiki / "concepts" / "n.md"
+    long_ago = date.today() - timedelta(days=90)
+    _set_mtime(note_path, long_ago)
+    set_confirmed(wiki, "alice", "concepts/n.md", long_ago + timedelta(days=1))
+
+    after = handle_read("concepts/n.md", wiki="demo")
+    # Confirm older than the 14-day window — soft marker re-flags.
+    assert after["freshness"]["status"] == "stale-candidate"
+
+
+def test_confirm_response_carries_confirmed_at(tmp_path, monkeypatch):
+    body = "---\ntype: concept\n---\nbody\n"
+    _setup(tmp_path, monkeypatch, body)
+    result = handle_verdict(
+        wiki="demo", note="concepts/n.md", verdict="confirm"
+    )
+    assert result["confirmed_at"] == date.today().isoformat()
+    assert result["freshness"]["confirmed_at"] is not None

--- a/tests/test_minimal_status.py
+++ b/tests/test_minimal_status.py
@@ -205,7 +205,11 @@ def test_index_renders_lifecycle_badges(wiki_root: Path):
 # ---------- curator: staleness + supersession ----------
 
 
-def test_curator_staleness_is_review_only(tmp_path: Path, monkeypatch):
+def test_curator_staleness_pass_is_now_a_noop(tmp_path: Path, monkeypatch):
+    """PRD #65: age never flags. The legacy 90-day pass is a no-op now;
+    staleness is positive-evidence-only at read time. Even an ancient
+    `last_reviewed` produces zero actions.
+    """
     root = tmp_path / "vault"
     wiki = root / "wiki" / "w"
     (wiki / "concepts").mkdir(parents=True)
@@ -226,10 +230,7 @@ body
 """
     )
     actions = _pass_staleness(wiki, date.today(), threshold=180)
-    assert len(actions) == 1
-    a = actions[0]
-    assert a.kind == "review_stale"
-    assert a.patch == {}  # review-only, no frontmatter write
+    assert actions == []
 
 
 def test_curator_supersession_writes_only_superseded_by(tmp_path: Path, monkeypatch):

--- a/tests/test_pending_verdict_chip.py
+++ b/tests/test_pending_verdict_chip.py
@@ -1,0 +1,114 @@
+"""Tests for the pending-verdict chip — slice 8 of PRD #65."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lore_cli.hooks import _pending_verdict_chip
+from lore_core.freshness import count_pending_verdicts
+
+
+def _write_catalog(wiki: Path, sections: dict, orphan_set: list[str] | None = None) -> None:
+    payload = {
+        "wiki": wiki.name,
+        "sections": sections,
+        "orphan_set": orphan_set or [],
+    }
+    (wiki / "_catalog.json").write_text(json.dumps(payload))
+
+
+def test_count_zero_when_no_catalog(tmp_path):
+    assert count_pending_verdicts(tmp_path) == (0, False)
+
+
+def test_count_zero_when_all_confirmed(tmp_path):
+    _write_catalog(
+        tmp_path,
+        sections={
+            "concepts": [{"path": "concepts/a.md", "name": "a", "status": "active"}]
+        },
+    )
+    assert count_pending_verdicts(tmp_path) == (0, False)
+
+
+def test_count_status_stale_is_pending(tmp_path):
+    _write_catalog(
+        tmp_path,
+        sections={
+            "concepts": [{"path": "concepts/a.md", "name": "a", "status": "stale"}]
+        },
+    )
+    assert count_pending_verdicts(tmp_path) == (1, False)
+
+
+def test_count_superseded_by_is_pending(tmp_path):
+    _write_catalog(
+        tmp_path,
+        sections={
+            "concepts": [
+                {"path": "concepts/a.md", "name": "a", "superseded_by": "[[b]]"}
+            ]
+        },
+    )
+    assert count_pending_verdicts(tmp_path) == (1, False)
+
+
+def test_count_orphan_is_pending(tmp_path):
+    _write_catalog(
+        tmp_path,
+        sections={"concepts": [{"path": "concepts/a.md", "name": "a"}]},
+        orphan_set=["concepts/a.md"],
+    )
+    assert count_pending_verdicts(tmp_path) == (1, False)
+
+
+def test_soft_cap_returns_capped_flag(tmp_path):
+    entries = [
+        {"path": f"concepts/{i}.md", "name": str(i), "status": "stale"}
+        for i in range(20)
+    ]
+    _write_catalog(tmp_path, sections={"concepts": entries})
+    count, capped = count_pending_verdicts(tmp_path, soft_cap=9)
+    assert count == 9
+    assert capped is True
+
+
+def test_chip_zero_state_suppressed(tmp_path):
+    _write_catalog(
+        tmp_path,
+        sections={"concepts": [{"path": "a.md", "name": "a"}]},
+    )
+    assert _pending_verdict_chip(tmp_path) == ""
+
+
+def test_chip_renders_count(tmp_path):
+    _write_catalog(
+        tmp_path,
+        sections={
+            "concepts": [
+                {"path": "a.md", "name": "a", "status": "stale"},
+                {"path": "b.md", "name": "b", "status": "stale"},
+            ]
+        },
+    )
+    assert _pending_verdict_chip(tmp_path) == "2 pending verdicts"
+
+
+def test_chip_singular_form_for_one(tmp_path):
+    _write_catalog(
+        tmp_path,
+        sections={"concepts": [{"path": "a.md", "name": "a", "status": "stale"}]},
+    )
+    assert _pending_verdict_chip(tmp_path) == "1 pending verdict"
+
+
+def test_chip_renders_capped_number(tmp_path):
+    entries = [
+        {"path": f"concepts/{i}.md", "name": str(i), "status": "stale"}
+        for i in range(20)
+    ]
+    _write_catalog(tmp_path, sections={"concepts": entries})
+    chip = _pending_verdict_chip(tmp_path)
+    assert chip.startswith("9+")
+    assert "verdict" in chip

--- a/tests/test_stale_marker_writer.py
+++ b/tests/test_stale_marker_writer.py
@@ -1,0 +1,144 @@
+"""Tests for ``lore_core.stale_marker_writer`` — slice 5 of PRD #65."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from lore_core.schema import parse_frontmatter
+from lore_core.stale_marker_writer import (
+    StaleMarkerError,
+    clear_stale,
+    mark_stale,
+)
+
+
+def _make_note(path: Path, fm: str = "type: concept\n", body: str = "body\n") -> Path:
+    path.write_text(f"---\n{fm}---\n{body}")
+    return path
+
+
+def test_mark_stale_writes_four_fields(tmp_path):
+    p = _make_note(tmp_path / "n.md", fm="type: concept\ndescription: thing\n")
+    mark_stale(p, reason="superseded by new approach", handle="alice", today=date(2026, 5, 8))
+    fm = parse_frontmatter(p.read_text())
+    assert fm["status"] == "stale"
+    assert fm["stale_reason"] == "superseded by new approach"
+    assert fm["stale_by"] == "alice"
+    assert str(fm["stale_at"]) == "2026-05-08"
+
+
+def test_mark_stale_preserves_existing_fields(tmp_path):
+    p = _make_note(
+        tmp_path / "n.md",
+        fm="type: concept\ndescription: thing\ntags: [x]\nlast_reviewed: 2026-04-01\n",
+    )
+    mark_stale(p, reason="X", handle="alice", today=date(2026, 5, 8))
+    fm = parse_frontmatter(p.read_text())
+    assert fm["type"] == "concept"
+    assert fm["description"] == "thing"
+    assert fm["tags"] == ["x"]
+    assert str(fm["last_reviewed"]) == "2026-04-01"
+
+
+def test_mark_stale_preserves_body(tmp_path):
+    p = _make_note(tmp_path / "n.md", body="# Title\n\nimportant body content\n")
+    mark_stale(p, reason="X", handle="alice", today=date(2026, 5, 8))
+    text = p.read_text()
+    assert "# Title" in text
+    assert "important body content" in text
+
+
+def test_mark_stale_idempotent(tmp_path):
+    p = _make_note(tmp_path / "n.md")
+    mark_stale(p, reason="X", handle="alice", today=date(2026, 5, 8))
+    first = p.read_text()
+    mark_stale(p, reason="X", handle="alice", today=date(2026, 5, 8))
+    second = p.read_text()
+    assert first == second
+
+
+def test_mark_stale_refuses_to_overwrite_existing_status(tmp_path):
+    p = _make_note(tmp_path / "n.md", fm="type: concept\nstatus: active\n")
+    with pytest.raises(StaleMarkerError):
+        mark_stale(p, reason="X", handle="alice", today=date(2026, 5, 8))
+
+
+def test_mark_stale_refuses_to_overwrite_existing_stale_reason(tmp_path):
+    p = _make_note(
+        tmp_path / "n.md",
+        fm="type: concept\nstatus: stale\nstale_reason: prior reason\nstale_by: bob\nstale_at: 2026-04-01\n",
+    )
+    with pytest.raises(StaleMarkerError):
+        mark_stale(p, reason="new reason", handle="alice", today=date(2026, 5, 8))
+
+
+def test_mark_stale_requires_non_empty_reason(tmp_path):
+    p = _make_note(tmp_path / "n.md")
+    with pytest.raises(StaleMarkerError):
+        mark_stale(p, reason="", handle="alice")
+    with pytest.raises(StaleMarkerError):
+        mark_stale(p, reason="   ", handle="alice")
+
+
+def test_mark_stale_no_frontmatter_raises(tmp_path):
+    p = tmp_path / "n.md"
+    p.write_text("just body, no frontmatter\n")
+    with pytest.raises(StaleMarkerError):
+        mark_stale(p, reason="X", handle="alice")
+
+
+def test_clear_stale_removes_only_four_fields(tmp_path):
+    p = _make_note(
+        tmp_path / "n.md",
+        fm="type: concept\ndescription: thing\nstatus: stale\nstale_reason: X\nstale_by: alice\nstale_at: 2026-05-08\n",
+        body="body\n",
+    )
+    clear_stale(p)
+    fm = parse_frontmatter(p.read_text())
+    assert fm["type"] == "concept"
+    assert fm["description"] == "thing"
+    assert "status" not in fm
+    assert "stale_reason" not in fm
+    assert "stale_by" not in fm
+    assert "stale_at" not in fm
+    assert "body" in p.read_text()
+
+
+def test_clear_stale_no_op_when_no_markers(tmp_path):
+    p = _make_note(tmp_path / "n.md", fm="type: concept\ndescription: thing\n")
+    before = p.read_text()
+    clear_stale(p)
+    assert p.read_text() == before
+
+
+def test_round_trip_mark_then_clear(tmp_path):
+    """Reversibility: mark + clear returns to original confirmed state."""
+    p = _make_note(tmp_path / "n.md", fm="type: concept\ndescription: thing\n")
+    before = p.read_text()
+    mark_stale(p, reason="test", handle="alice", today=date(2026, 5, 8))
+    clear_stale(p)
+    after = p.read_text()
+    # FM key order may differ marginally but parse equivalence holds.
+    fm_before = parse_frontmatter(before)
+    fm_after = parse_frontmatter(after)
+    assert fm_before == fm_after
+
+
+def test_no_body_or_field_deletion_compliance(tmp_path):
+    """Vault-wide edit policy: no body modifications, no field deletions
+    outside the explicit clear_stale exit."""
+    p = _make_note(
+        tmp_path / "n.md",
+        fm="type: concept\ndescription: keep me\ntags: [a, b]\n",
+        body="# Title\n\nparagraph\n",
+    )
+    body_before = p.read_text().split("---\n", 2)[2]
+    mark_stale(p, reason="X", handle="alice", today=date(2026, 5, 8))
+    body_after = p.read_text().split("---\n", 2)[2]
+    assert body_before == body_after
+    fm = parse_frontmatter(p.read_text())
+    assert fm["description"] == "keep me"
+    assert fm["tags"] == ["a", "b"]

--- a/tests/test_verdicts_sidecar.py
+++ b/tests/test_verdicts_sidecar.py
@@ -1,0 +1,113 @@
+"""Tests for ``lore_core.verdicts_sidecar`` — slice 6 of PRD #65."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lore_core.verdicts_sidecar import (
+    _sidecar_path,
+    clear_confirmed,
+    get_confirmed,
+    set_confirmed,
+)
+
+
+def test_get_confirmed_missing_returns_none(tmp_path):
+    assert get_confirmed(tmp_path, "alice", "concepts/n.md") is None
+
+
+def test_set_then_get(tmp_path):
+    when = date(2026, 5, 8)
+    set_confirmed(tmp_path, "alice", "concepts/n.md", when)
+    assert get_confirmed(tmp_path, "alice", "concepts/n.md") == when
+
+
+def test_set_default_today(tmp_path):
+    written = set_confirmed(tmp_path, "alice", "n.md")
+    assert written == date.today()
+
+
+def test_round_trip_persisted_to_disk(tmp_path):
+    set_confirmed(tmp_path, "alice", "concepts/n.md", date(2026, 5, 8))
+    p = _sidecar_path(tmp_path, "alice")
+    assert p.exists()
+    data = json.loads(p.read_text())
+    assert data["confirmed"]["concepts/n.md"] == "2026-05-08"
+
+
+def test_clear_confirmed_removes_entry(tmp_path):
+    set_confirmed(tmp_path, "alice", "concepts/n.md", date(2026, 5, 8))
+    assert clear_confirmed(tmp_path, "alice", "concepts/n.md") is True
+    assert get_confirmed(tmp_path, "alice", "concepts/n.md") is None
+
+
+def test_clear_confirmed_missing_returns_false(tmp_path):
+    assert clear_confirmed(tmp_path, "alice", "concepts/missing.md") is False
+
+
+def test_handle_isolation(tmp_path):
+    set_confirmed(tmp_path, "alice", "n.md", date(2026, 5, 8))
+    set_confirmed(tmp_path, "bob", "n.md", date(2026, 5, 1))
+    assert get_confirmed(tmp_path, "alice", "n.md") == date(2026, 5, 8)
+    assert get_confirmed(tmp_path, "bob", "n.md") == date(2026, 5, 1)
+    # Bob's sidecar untouched by Alice's writes.
+    bob_path = _sidecar_path(tmp_path, "bob")
+    raw = json.loads(bob_path.read_text())
+    assert "confirmed" in raw
+    assert "n.md" in raw["confirmed"]
+
+
+def test_invalid_handle_rejected(tmp_path):
+    with pytest.raises(ValueError):
+        set_confirmed(tmp_path, "../etc/passwd", "n.md")
+    with pytest.raises(ValueError):
+        get_confirmed(tmp_path, "", "n.md")
+    with pytest.raises(ValueError):
+        set_confirmed(tmp_path, "a/b", "n.md")
+
+
+def test_atomic_write_no_partial_file(tmp_path, monkeypatch):
+    """Simulate an interrupted write: replace fails between tmp + commit.
+
+    A partial-file leaves either the prior file intact or no file at
+    all — never half-written JSON the next read would choke on.
+    """
+    set_confirmed(tmp_path, "alice", "n.md", date(2026, 5, 1))
+    original = json.loads(_sidecar_path(tmp_path, "alice").read_text())
+
+    real_replace = os.replace
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated crash mid-replace")
+
+    with patch("lore_core.verdicts_sidecar.os.replace", side_effect=boom):
+        with pytest.raises(OSError):
+            set_confirmed(tmp_path, "alice", "n.md", date(2026, 5, 8))
+
+    # Old contents survive verbatim — the replace was the failing step
+    # so the prior file was never touched.
+    after = json.loads(_sidecar_path(tmp_path, "alice").read_text())
+    assert after == original
+
+
+def test_malformed_sidecar_treated_as_empty(tmp_path):
+    p = _sidecar_path(tmp_path, "alice")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("not json{")
+    assert get_confirmed(tmp_path, "alice", "n.md") is None
+    # Setting after a malformed file recovers cleanly.
+    set_confirmed(tmp_path, "alice", "n.md", date(2026, 5, 8))
+    assert get_confirmed(tmp_path, "alice", "n.md") == date(2026, 5, 8)
+
+
+def test_unparseable_date_treated_as_none(tmp_path):
+    p = _sidecar_path(tmp_path, "alice")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"confirmed": {"n.md": "not-a-date"}}))
+    assert get_confirmed(tmp_path, "alice", "n.md") is None


### PR DESCRIPTION
## Summary

PRD #65 — positive-evidence-only freshness with read-time, in-passing user verdicts. Ten vertical slices delivered as ten commits on this branch.

- **Slice 01** — pure `compute_freshness` + `FreshnessSignal`; wired into `handle_search` / `handle_read` / `handle_drill` MCP responses.
- **Slice 02** — legacy 90-day `_pass_staleness` rule retired; `--stale-threshold` flag removed.
- **Slice 03** — retrieval-time filter: confirmed > stale-candidate at tied scores, hard-stale excluded from SessionStart inject, audit log surfaced via `/lore:context`.
- **Slice 04** — `lore lint` caches the orphan set in `_catalog.json`; freshness flags `cause: orphan_broken`.
- **Slice 05** — `stale_marker_writer` (additive-only) + `lore_verdict` MCP tool with stale + clear-stale branches.
- **Slice 06** — per-user `wiki/<name>/_verdicts/<handle>.json` sidecar; soft-marker suppression with mtime + 14-day recency window.
- **Slice 07** — in-passing nudge + dynamic-escalation directive added to the lore-managed integration-rules template (HITL: wording approved).
- **Slice 08** — SessionStart `· N pending verdict[s]` chip with soft cap (`9+`) and zero-state suppression.
- **Slice 09** — pure `disagreement_detector`; freshness block carries the `disagreement` field; inject filter excludes disagreement-flagged hits even when status is suppressed-confirmed.
- **Slice 10** — `/lore:verify` user-invocable skill wraps `lore_verdict`; plugin/package version bumped to 0.49.0.

Out of scope per PRD #65: claim-level extraction, code-state grounding, reference-graph decay, cross-note semantic clustering, aggregated team UI, auto-confirm on bot retrieval, migration of pre-existing `status: stale` notes.

## Test plan

- [x] `python -m pytest tests/ --ignore=tests/test_openai_backend.py` — 2619 passed, 7 skipped.
- [x] Per-slice tests live alongside each slice (`tests/test_freshness_*.py`, `tests/test_stale_marker_writer.py`, `tests/test_verdicts_sidecar.py`, `tests/test_disagreement.py`, `tests/test_pending_verdict_chip.py`, `tests/test_lore_verify_skill.py`, `tests/test_mcp_*.py`).
- [x] HITL: directive wording (slice 7) approved as-is.
- [ ] Smoke: open a session against a wiki with a `status: stale` note → verify the chip appears + `/lore:verify` enumerates it.
- [ ] Smoke: `lore_verdict {verdict: "stale", reason: "X"}` writes the four-field schema additively + a follow-up `clear-stale` reverses it.
- [ ] Smoke: `lore_verdict {verdict: "confirm"}` writes `_verdicts/<handle>.json` and suppresses the next read of a soft-marker note.

Refs PRD #65.