### PR TITLE
fix(#81): drain banner names the wiki on multi-event tallies

### DIFF
--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -2840,16 +2840,36 @@ def _format_drain_summary(counts: dict[str, int], events) -> str:
         if wikilink and n_filed == 1:
             parts.append(f"new note {wikilink}")
         else:
-            parts.append(f"{n_filed} new notes")
+            parts.append(f"{n_filed} new notes{_wiki_suffix(events, 'note-filed')}")
     if n_appended:
         wikilink = _latest_wikilink(events, "note-appended")
         if wikilink and n_appended == 1:
             parts.append(f"added to {wikilink}")
         else:
-            parts.append(f"{n_appended} added")
+            parts.append(f"{n_appended} added{_wiki_suffix(events, 'note-appended')}")
     if n_surface:
-        parts.append(f"{n_surface} surface proposed")
+        parts.append(f"{n_surface} surface proposed{_wiki_suffix(events, 'surface-proposed')}")
     return " · ".join(parts)
+
+
+def _wiki_suffix(events, event_name: str) -> str:
+    """Build ' in <wiki>' or ' (2 in a, 1 in b)' for multi-event tallies.
+
+    Returns "" when any matching event lacks a wiki tag, to avoid
+    misleading partial breakdowns on legacy/migration data.
+    """
+    from collections import Counter
+    matching = [e for e in events if e.event == event_name]
+    if not matching or any(not e.wiki for e in matching):
+        return ""
+    tally = Counter(e.wiki for e in matching)
+    if len(tally) == 1:
+        wiki, _ = next(iter(tally.items()))
+        return f" in {wiki}"
+    # Highest count first, alphabetical tiebreak — stable across runs.
+    items = sorted(tally.items(), key=lambda kv: (-kv[1], kv[0]))
+    bits = ", ".join(f"{n} in {w}" for w, n in items)
+    return f" ({bits})"
 
 
 def _spawn_detached_transcript_sync(

--- a/tests/test_hooks_drain_banner.py
+++ b/tests/test_hooks_drain_banner.py
@@ -121,7 +121,47 @@ def test_render_pluralizes_multiple_new_notes(tmp_path, pid_session):
     for i in range(3):
         session_store.emit("note-filed", wiki="a", wikilink=f"[[n{i}]]")
     lines = _render_drain_lines(tmp_path, tmp_path)
-    assert "3 new notes" in lines[0]
+    assert "3 new notes in a" in lines[0]
+
+
+def test_render_multi_wiki_new_notes_breakdown(tmp_path, pid_session):
+    """2+ notes spanning multiple wikis render a per-wiki tally in parens."""
+    session_store = DrainStore(tmp_path, pid_session)
+    session_store.emit("note-filed", wiki="a", wikilink="[[n1]]")
+    session_store.emit("note-filed", wiki="a", wikilink="[[n2]]")
+    session_store.emit("note-filed", wiki="b", wikilink="[[n3]]")
+    lines = _render_drain_lines(tmp_path, tmp_path)
+    # Highest count first, alphabetical tiebreak.
+    assert "3 new notes (2 in a, 1 in b)" in lines[0]
+
+
+def test_render_multi_appended_named_with_wiki(tmp_path, pid_session):
+    """2+ appends collapse to a wiki-tagged count."""
+    session_store = DrainStore(tmp_path, pid_session)
+    session_store.emit("note-appended", wiki="a", wikilink="[[t1]]")
+    session_store.emit("note-appended", wiki="a", wikilink="[[t2]]")
+    lines = _render_drain_lines(tmp_path, tmp_path)
+    assert "2 added in a" in lines[0]
+
+
+def test_render_surface_proposed_named_with_wiki(tmp_path, pid_session):
+    """surface-proposed gets the same wiki context treatment."""
+    _seed_system_cursor_in_past(tmp_path)
+    _write_legacy_system_row(tmp_path, event="surface-proposed", wiki="ccat")
+    _write_legacy_system_row(tmp_path, event="surface-proposed", wiki="ccat")
+    lines = _render_drain_lines(tmp_path, tmp_path)
+    assert "2 surface proposed in ccat" in lines[0]
+
+
+def test_render_falls_back_when_wiki_missing(tmp_path, pid_session):
+    """Legacy events without a wiki tag fall back to the bare count."""
+    _seed_system_cursor_in_past(tmp_path)
+    # Both rows have no wiki — guard against partial tallies.
+    _write_legacy_system_row(tmp_path, event="note-filed", wiki=None, wikilink="[[x]]")
+    _write_legacy_system_row(tmp_path, event="note-filed", wiki=None, wikilink="[[y]]")
+    lines = _render_drain_lines(tmp_path, tmp_path)
+    assert "2 new notes" in lines[0]
+    assert " in " not in lines[0].split("Since you left")[-1]
 
 
 def test_render_advances_cursor_so_second_call_is_silent(tmp_path, pid_session):


### PR DESCRIPTION
Closes #81.

## Summary
- `_format_drain_summary` now appends wiki context when 2+ events are tallied.
- Single wiki: `3 new notes in private`.
- Multi-wiki: `3 new notes (2 in private, 1 in ccat)` — count-desc, alpha tiebreak.
- Same treatment for the `note-appended` and `surface-proposed` branches.
- Single-event branch (`new note [[foo]]` / `added to [[foo]]`) is unchanged.
- Falls back to today's bare count when any matching event lacks a wiki tag, so legacy/migration rows don't yield misleading partial breakdowns.

## Test plan
- [x] `tests/test_hooks_drain_banner.py` — 4 new cases (single-wiki suffix, multi-wiki breakdown, appended suffix, surface-proposed suffix, missing-wiki fallback) + tightened existing pluralization test.
- [x] Full drain/heartbeat sweep green (`test_hooks_drain_banner` + `test_hooks_heartbeat` + `test_heartbeat_session_drain` + `test_drain_prune` + `test_capture_state`).