### PR TITLE
feat(#80): PR 2 — install quintuplet collapse via verb registry

### DIFF
--- a/lib/lore_cli/__main__.py
+++ b/lib/lore_cli/__main__.py
@@ -146,29 +146,13 @@ def _build_app() -> typer.Typer:
     app.add_typer(scopes_cmd.app, name="scopes", rich_help_panel=_ADV)
     app.add_typer(transcripts_cmd.app, name="transcripts", rich_help_panel=_ADV)
 
-    @app.command(
+    app.command(
         "uninstall",
         help="Symmetric semantic remove (alias for `install uninstall`).",
-    )
-    def cmd_uninstall_alias(
-        integration: str = install_cmd._INTEGRATION,
-        yes: bool = install_cmd._YES,
-        quiet: bool = install_cmd._QUIET,
-        json_out: bool = install_cmd._JSON,
-        force: bool = install_cmd._FORCE,
-        lore_repo: str = install_cmd._LORE_REPO,
-    ) -> None:
-        """Top-level `lore uninstall` — same flags as `lore install uninstall`."""
-        args = install_cmd._make_args(
-            "uninstall",
-            integration=integration,
-            yes=yes,
-            quiet=quiet,
-            json_out=json_out,
-            force=force,
-            lore_repo=lore_repo,
-        )
-        install_cmd._exit_with(install_cmd._cmd_install(args, mode="uninstall"))
+    )(install_cmd.build_install_command(
+        "uninstall",
+        "Top-level `lore uninstall` — same flags as `lore install uninstall`.",
+    ))
 
     return app
 

--- a/lib/lore_cli/install_cmd.py
+++ b/lib/lore_cli/install_cmd.py
@@ -31,6 +31,8 @@ import json
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -366,11 +368,11 @@ def _print_integration_summary(integration_name: str, fail_count: int, mode: str
 # ---------------------------------------------------------------------------
 
 
-def _build_ctx(args: SimpleNamespace) -> InstallContext:
+def _build_ctx(args: SimpleNamespace, *, mode: str) -> InstallContext:
     return InstallContext(
         lore_repo=Path(args.lore_repo).expanduser() if args.lore_repo else None,
         force=args.force,
-        dry_run=args.cmd == "check",
+        dry_run=mode == "check",
     )
 
 
@@ -611,11 +613,12 @@ def _refresh_claude_plugin_cache(*, quiet: bool) -> None:
         )
 
 
-def _cmd_install(args: SimpleNamespace, mode: str = "install") -> int:
-    """Shared install / upgrade / uninstall driver. `mode` selects:
+def _cmd_install(args: SimpleNamespace, mode: str) -> int:
+    """Shared install / upgrade / check / uninstall driver. `mode` selects:
         install   → integration.plan(ctx)
         upgrade   → integration.plan(ctx) (same; the dispatcher reports no-op
                     when all actions are no-op kind=check)
+        check     → integration.plan(ctx) (dry-run; never writes)
         uninstall → integration.uninstall_plan(ctx)
     """
     if args.force and args.yes:
@@ -635,7 +638,7 @@ def _cmd_install(args: SimpleNamespace, mode: str = "install") -> int:
     if not integrations:
         console.print("  [yellow]No integrations selected.[/yellow]", markup=True)
         return 0
-    ctx = _build_ctx(args)
+    ctx = _build_ctx(args, mode=mode)
 
     # Legacy artifact detection — only for install / upgrade (and only
     # gates writing modes; `check` shows everything and exits 0).
@@ -650,7 +653,7 @@ def _cmd_install(args: SimpleNamespace, mode: str = "install") -> int:
             if not args.json:
                 _print_legacy_warning(legacy_artifacts)
             # Check mode: print plan too, then exit 0
-            if args.cmd != "check" and not args.force:
+            if mode != "check" and not args.force:
                 if args.json:
                     _emit_json(
                         {
@@ -672,7 +675,7 @@ def _cmd_install(args: SimpleNamespace, mode: str = "install") -> int:
         plans.append((integration_name, actions))
 
     # JSON output mode — emit the plan envelope and exit
-    if args.json or args.cmd == "check":
+    if args.json or mode == "check":
         envelope = {
             "mode": mode,
             "legacy_artifacts": [a.__dict__ for a in legacy_artifacts],
@@ -734,16 +737,7 @@ def _cmd_install(args: SimpleNamespace, mode: str = "install") -> int:
     return 0 if overall_failures == 0 else 1
 
 
-app = typer.Typer(
-    add_completion=False,
-    help=__doc__,
-    no_args_is_help=False,
-    rich_markup_mode="rich",
-)
-
-
 def _make_args(
-    cmd: str,
     *,
     integration: str | None,
     yes: bool,
@@ -752,9 +746,8 @@ def _make_args(
     force: bool,
     lore_repo: str | None,
 ) -> SimpleNamespace:
-    """Adapt typer kwargs into the argparse-Namespace shape `_cmd_install` reads."""
+    """Adapt typer kwargs into the namespace shape `_cmd_install` reads."""
     return SimpleNamespace(
-        cmd=cmd,
         integration=integration,
         yes=yes,
         quiet=quiet,
@@ -769,9 +762,10 @@ def _exit_with(rc: int) -> None:
         raise typer.Exit(code=rc)
 
 
-# Common flag set repeated across subcommands. Typer doesn't share
+# Common flag set shared across the install verbs. Typer doesn't share
 # options between root + subcommands cleanly (Click constraint), so
-# we declare them on each function. ~6 lines × 4 commands.
+# every command takes the same six options via these module-level
+# defaults.
 
 _INTEGRATION = typer.Option(
     None,
@@ -807,6 +801,91 @@ _UPGRADE = typer.Option(
 )
 
 
+def build_install_command(
+    modes: str | tuple[str, ...], docstring: str
+) -> Callable[..., None]:
+    """Build a typer-compatible function that runs `_cmd_install` for one
+    or more sequential modes.
+
+    Single-mode entries (``"check"``, ``"upgrade"``, ``"uninstall"``)
+    drive `_cmd_install` once; the chained form ``("uninstall",
+    "install")`` powers the ``reinstall`` verb. Reused by the top-level
+    ``lore uninstall`` alias in `lore_cli.__main__`.
+    """
+    seq = (modes,) if isinstance(modes, str) else modes
+
+    def _cmd(
+        integration: str = _INTEGRATION,
+        yes: bool = _YES,
+        quiet: bool = _QUIET,
+        json_out: bool = _JSON,
+        force: bool = _FORCE,
+        lore_repo: str = _LORE_REPO,
+    ) -> None:
+        for i, mode in enumerate(seq):
+            args = _make_args(
+                integration=integration,
+                yes=yes,
+                quiet=quiet,
+                json_out=json_out,
+                force=force,
+                lore_repo=lore_repo,
+            )
+            rc = _cmd_install(args, mode=mode)
+            # Abort a chained run (reinstall) on the first failing step.
+            if rc != 0 or i == len(seq) - 1:
+                _exit_with(rc)
+                return
+
+    _cmd.__doc__ = docstring
+    return _cmd
+
+
+@dataclass(frozen=True)
+class _Verb:
+    """One row in the install-verb registry."""
+
+    name: str
+    modes: str | tuple[str, ...]
+    docstring: str
+
+
+_INSTALL_VERBS: tuple[_Verb, ...] = (
+    _Verb("check", "check", "Plan-only — never writes."),
+    _Verb(
+        "upgrade",
+        "upgrade",
+        "Re-install — no-op if managed schema is current.",
+    ),
+    _Verb("uninstall", "uninstall", "Symmetric semantic remove."),
+    _Verb(
+        "reinstall",
+        ("uninstall", "install"),
+        (
+            "Uninstall then install — useful after upgrading the Lore package.\n"
+            "\n"
+            "Equivalent to:\n"
+            "\n"
+            "    lore install uninstall && lore install\n"
+            "\n"
+            "The install pass automatically runs ``claude plugin update lore@lore``\n"
+            "when the Claude integration is part of the run, so the plugin manifest\n"
+            "cache stays in sync. The ``.claude-plugin/plugin.json`` version still\n"
+            "has to be bumped in the source for Claude's update to do anything —\n"
+            "see CHANGELOG.md."
+        ),
+    ),
+)
+
+
+app = typer.Typer(
+    add_completion=False,
+    help=__doc__,
+    no_args_is_help=False,
+    rich_markup_mode="rich",
+)
+
+
 @app.callback(invoke_without_command=True)
 def root(
     ctx: typer.Context,
@@ -828,7 +907,6 @@ def root(
         _exit_with(_run_self_upgrade(quiet=quiet))
         return
     args = _make_args(
-        "install",
         integration=integration,
         yes=yes,
         quiet=quiet,
@@ -839,117 +917,8 @@ def root(
     _exit_with(_cmd_install(args, mode="install"))
 
 
-@app.command("check")
-def cmd_check(
-    integration: str = _INTEGRATION,
-    yes: bool = _YES,
-    quiet: bool = _QUIET,
-    json_out: bool = _JSON,
-    force: bool = _FORCE,
-    lore_repo: str = _LORE_REPO,
-) -> None:
-    """Plan-only — never writes."""
-    args = _make_args(
-        "check",
-        integration=integration,
-        yes=yes,
-        quiet=quiet,
-        json_out=json_out,
-        force=force,
-        lore_repo=lore_repo,
-    )
-    _exit_with(_cmd_install(args, mode="install"))
-
-
-@app.command("upgrade")
-def cmd_upgrade(
-    integration: str = _INTEGRATION,
-    yes: bool = _YES,
-    quiet: bool = _QUIET,
-    json_out: bool = _JSON,
-    force: bool = _FORCE,
-    lore_repo: str = _LORE_REPO,
-) -> None:
-    """Re-install — no-op if managed schema is current."""
-    args = _make_args(
-        "upgrade",
-        integration=integration,
-        yes=yes,
-        quiet=quiet,
-        json_out=json_out,
-        force=force,
-        lore_repo=lore_repo,
-    )
-    _exit_with(_cmd_install(args, mode="upgrade"))
-
-
-@app.command("uninstall")
-def cmd_uninstall(
-    integration: str = _INTEGRATION,
-    yes: bool = _YES,
-    quiet: bool = _QUIET,
-    json_out: bool = _JSON,
-    force: bool = _FORCE,
-    lore_repo: str = _LORE_REPO,
-) -> None:
-    """Symmetric semantic remove."""
-    args = _make_args(
-        "uninstall",
-        integration=integration,
-        yes=yes,
-        quiet=quiet,
-        json_out=json_out,
-        force=force,
-        lore_repo=lore_repo,
-    )
-    _exit_with(_cmd_install(args, mode="uninstall"))
-
-
-@app.command("reinstall")
-def cmd_reinstall(
-    integration: str = _INTEGRATION,
-    yes: bool = _YES,
-    quiet: bool = _QUIET,
-    json_out: bool = _JSON,
-    force: bool = _FORCE,
-    lore_repo: str = _LORE_REPO,
-) -> None:
-    """Uninstall then install — useful after upgrading the Lore package.
-
-    Equivalent to:
-
-        lore install uninstall && lore install
-
-    The install pass automatically runs ``claude plugin update lore@lore``
-    when the Claude integration is part of the run, so the plugin manifest
-    cache stays in sync. The ``.claude-plugin/plugin.json`` version still
-    has to be bumped in the source for Claude's update to do anything —
-    see CHANGELOG.md.
-    """
-    uninstall_args = _make_args(
-        "reinstall",
-        integration=integration,
-        yes=yes,
-        quiet=quiet,
-        json_out=json_out,
-        force=force,
-        lore_repo=lore_repo,
-    )
-    rc = _cmd_install(uninstall_args, mode="uninstall")
-    if rc != 0:
-        _exit_with(rc)
-
-    install_args = _make_args(
-        "reinstall",
-        integration=integration,
-        yes=yes,
-        quiet=quiet,
-        json_out=json_out,
-        force=force,
-        lore_repo=lore_repo,
-    )
-    rc = _cmd_install(install_args, mode="install")
-    _exit_with(rc)
+for _verb in _INSTALL_VERBS:
+    app.command(_verb.name)(build_install_command(_verb.modes, _verb.docstring))
 
 
 main = argv_main(app)

--- a/tests/test_install_dispatcher.py
+++ b/tests/test_install_dispatcher.py
@@ -52,7 +52,10 @@ def test_json_envelope_for_check_mode(clean_home, capsys):
     install_cmd.main(["check", "--integration", "cursor", "--json"])
     out = capsys.readouterr().out
     envelope = json.loads(out)
-    assert envelope["mode"] == "install"  # check delegates to install plan
+    # `check` is now first-class in the dispatcher (it builds an install
+    # plan but reports its own mode label); previously the envelope said
+    # "install" because the verb was passed through as install + dry_run.
+    assert envelope["mode"] == "check"
     assert any(h["integration"] == "cursor" for h in envelope["integrations"])
 
 


### PR DESCRIPTION
## Summary

Second PR in the [#80 streamlining track](https://github.com/buchbend/lore/issues/80). Replaces the four near-identical `cmd_check` / `cmd_upgrade` / `cmd_uninstall` / `cmd_reinstall` Typer command bodies in `lib/lore_cli/install_cmd.py` with one `build_install_command(modes, docstring)` factory driven by a tiny `_INSTALL_VERBS` registry. Adding a new install verb is now one row in the registry, not a 20-line copy-paste.

Also fixes the `cmd_check` mode/docstring inconsistency the PRD called out:

- Before: docstring said *Plan-only — never writes*, but the dispatcher was called with `mode=\"install\"` and the dry-run was gated on a separate `args.cmd == \"check\"` mirror field.
- After: `cmd_check` passes `mode=\"check\"` through to `_cmd_install`. `_cmd_install`'s docstring lists `check` as a first-class mode; `_build_ctx` reads `dry_run = mode == \"check\"`; the JSON envelope's `mode` field now reports `\"check\"` to match the verb the user typed; the `args.cmd` mirror field is gone entirely.

The top-level `lore uninstall` alias in `lib/lore_cli/__main__.py` becomes a one-liner over the same factory (PRD ratifies keeping it as an alias).

**Net delta:** **-44 LOC** across three files (`install_cmd.py` shrinks by 73, `__main__.py` by 19, test gains 3 lines for the comment + assertion flip). Under the PRD's ~120 estimate because `_make_args` lost its `cmd` parameter and the alias collapse in `__main__.py` shaved more than the registry adds back.

## Test plan

- [x] Existing `tests/test_install_dispatcher.py` (10 tests) — all pass; `test_check_does_not_write` still green so the dry-run gate on `mode == \"check\"` works.
- [x] `test_json_envelope_for_check_mode` updated to assert `envelope[\"mode\"] == \"check\"` (was `\"install\"`); the comment is rewritten to explain the new semantics.
- [x] `tests/test_install_helpers.py` (legacy artifact detection), `test_install_version_drift.py`, and `test_directive_template.py` all pass — total 49 install-suite tests green.
- [x] Smoke-tested CLI surface byte-stability: `lore install --help`, `lore install check --help`, `lore install upgrade --help`, `lore install uninstall --help`, `lore install reinstall --help`, `lore uninstall --help` all render with the right docstrings, flags, and help text.
- [x] Full pytest sweep: **2599 passed, 7 skipped**, two pre-existing failures on `main` ignored (`test_openai_backend.py` — missing `openai` optional dep; `test_resume.py` — fixture date drift, both noted in the PR-1 ship comment on #80).

Refs #80.