### PR TITLE
feat(#85): collapse /lore:verify discovery into one MCP call (v0.50.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore",
   "description": "LLM-optimized knowledge graph for AI-coding teams — session notes, auto-extracted knowledge, pluggable briefings, magic context injection at session start.",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-05-12
+
+### Added — `lore_pending_verdicts` MCP tool, `/lore:verify` rewrite
+
+The `/lore:verify` slash command no longer does ad-hoc bash discovery
+to find pending freshness verdicts. One MCP call now returns the full,
+picker-ready, pre-sorted list.
+
+- New `lore_pending_verdicts` MCP tool — wiki-wide enumeration of
+  notes currently flagged as stale-candidate. Returns the
+  `lore.pending_verdicts/1` envelope with per-entry slug, cause
+  (`authored_marker` / `orphan_broken`), reason text, personal
+  `confirmed_at`, and the disagreement block when present.
+- Entries arrive pre-sorted: disagreements first, then
+  `authored_marker`, then `orphan_broken`; within each bucket, most
+  recently marked stale first.
+- `wiki` arg is optional — auto-resolves from the active cwd
+  attachment in multi-wiki vaults.
+- Slash command rewritten to call the tool once, then loop a picker
+  per entry. Zero bash; the catalog + frontmatter + sidecar reads all
+  live behind the MCP boundary.
+
+### Changed
+
+- `lore_core.freshness`: extracted `_is_pending_from_catalog_entry`
+  shared predicate; `count_pending_verdicts` (the status-line chip)
+  and the new `list_pending_verdicts` (the picker) both gate on it,
+  so the chip count and the picker can no longer drift on what
+  counts as pending.
+
+### Why
+
+The chip says "1 pending verdict" but bare `/lore:verify` previously
+returned zero because it filtered by session-touched activity log —
+which is empty at SessionStart. The slash command is the chip's
+actionable surface, so it now matches the chip's scope exactly
+(wiki-wide). The session-scoped narrowing was redundant with the
+in-passing nudge (which already fires per-note, in-flow, per
+session).
+
 ## [0.49.0] - 2026-05-08
 
 ### Added — Freshness verdicts: end-to-end (#65, slices 1–10)

--- a/lib/lore_core/freshness.py
+++ b/lib/lore_core/freshness.py
@@ -207,6 +207,58 @@ def signal_to_dict(signal: FreshnessSignal) -> dict:
     }
 
 
+def _is_pending_from_catalog_entry(
+    entry: dict, orphan_paths: set[str]
+) -> bool:
+    """Shared coarse predicate: does this catalog entry currently flag
+    as ``stale-candidate`` from catalog metadata alone?
+
+    Catalog-only signals (``status: stale``, ``superseded_by``,
+    ``orphan_set`` membership) are what both the status-line chip
+    (:func:`count_pending_verdicts`) and the picker
+    (:func:`list_pending_verdicts`) gate on. Centralising the rule
+    keeps the two surfaces from drifting — a key UX bug we want to
+    make unrepresentable.
+
+    Soft markers (``supersede_candidate``) and personal-confirm
+    suppression are NOT considered here — both the chip and the
+    picker are intentionally coarse "is there work to do?" signals;
+    the precise per-note classification still flows through
+    :func:`compute_freshness` at retrieval time.
+    """
+    if not isinstance(entry, dict):
+        return False
+    path = str(entry.get("path") or "")
+    return bool(
+        str(entry.get("status") or "").lower() == "stale"
+        or entry.get("superseded_by")
+        or (path and path in orphan_paths)
+    )
+
+
+def _iter_catalog_entries(catalog_data: dict):
+    """Yield every dict entry across all ``sections`` of the catalog."""
+    for entries in (catalog_data.get("sections") or {}).values():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict):
+                yield entry
+
+
+def _load_catalog(wiki_path: Path) -> dict | None:
+    """Return the parsed ``_catalog.json`` for a wiki, or None on miss."""
+    import json as _json
+
+    cat = wiki_path / "_catalog.json"
+    if not cat.exists():
+        return None
+    try:
+        return _json.loads(cat.read_text(errors="replace"))
+    except (OSError, _json.JSONDecodeError):
+        return None
+
+
 def count_pending_verdicts(
     wiki_path: Path,
     *,
@@ -216,13 +268,9 @@ def count_pending_verdicts(
     ``stale-candidate`` (slice 8 of PRD #65 — status-line chip).
 
     Reads the cached ``_catalog.json`` so the per-call cost is one
-    JSON load, not a full wiki walk. Authored markers we can detect
-    from catalog metadata: ``status == 'stale'`` and ``superseded_by:``.
-    Soft markers (``supersede_candidate``) and personal-confirm
-    suppression are NOT considered here — the chip is intentionally
-    a coarse "is there work to do?" signal; the precise per-note
-    classification still flows through :func:`compute_freshness` at
-    retrieval time.
+    JSON load, not a full wiki walk. Delegates to
+    :func:`_is_pending_from_catalog_entry` so the chip and the
+    picker can never drift on what counts as "pending."
 
     Returns ``(count, capped)`` where ``capped`` is True iff the soft
     cap fired. The status-line render uses ``"9+"`` instead of the
@@ -231,34 +279,190 @@ def count_pending_verdicts(
     Cache miss (no catalog) returns ``(0, False)`` — the chip
     suppresses entirely until the next ``lore lint`` run.
     """
-    import json as _json
-
-    cat = wiki_path / "_catalog.json"
-    if not cat.exists():
-        return 0, False
-    try:
-        data = _json.loads(cat.read_text(errors="replace"))
-    except (OSError, _json.JSONDecodeError):
+    data = _load_catalog(wiki_path)
+    if data is None:
         return 0, False
 
     orphan_paths = set(data.get("orphan_set") or [])
     count = 0
-    for entries in (data.get("sections") or {}).values():
-        if not isinstance(entries, list):
+    for entry in _iter_catalog_entries(data):
+        if not _is_pending_from_catalog_entry(entry, orphan_paths):
             continue
-        for entry in entries:
-            if not isinstance(entry, dict):
-                continue
-            path = str(entry.get("path") or "")
-            if (
-                str(entry.get("status") or "").lower() == "stale"
-                or entry.get("superseded_by")
-                or path in orphan_paths
-            ):
-                count += 1
-                if count > soft_cap:
-                    return soft_cap, True
+        count += 1
+        if count > soft_cap:
+            return soft_cap, True
     return count, False
+
+
+@dataclass(frozen=True)
+class PendingEntry:
+    """One picker-ready row for the ``/lore:verify`` resolver.
+
+    Built by :func:`list_pending_verdicts` from the catalog walk plus a
+    per-note frontmatter read + per-user sidecar lookup. Carries every
+    field the picker needs so the skill never has to do additional I/O.
+    """
+
+    path: str  # wiki-relative
+    slug: str
+    cause: Literal["authored_marker", "orphan_broken"]
+    reason: str
+    confirmed_at: date | None
+    disagreement: "Disagreement | None"  # forward ref; imported lazily
+    stale_at: date | None  # for sort tiebreaking; None if not set
+    mtime: date | None  # final fallback for sort
+
+
+def _sort_key(entry: "PendingEntry") -> tuple:
+    """Sort: disagreements first → authored_marker → orphan_broken;
+    within bucket, most-recently-marked-stale first (then file mtime).
+
+    Tuple ordering reverses dates (negate via ``date.toordinal``)
+    so the natural ascending sort of tuples puts "more recent" first.
+    """
+    has_disagreement = entry.disagreement is not None
+    cause_rank = 0 if entry.cause == "authored_marker" else 1
+    stale_ord = -entry.stale_at.toordinal() if entry.stale_at else 0
+    mtime_ord = -entry.mtime.toordinal() if entry.mtime else 0
+    return (
+        0 if has_disagreement else 1,
+        cause_rank,
+        stale_ord,
+        mtime_ord,
+        entry.path,
+    )
+
+
+def list_pending_verdicts(
+    wiki_path: Path,
+    handle: str | None = None,
+) -> list[PendingEntry]:
+    """Enumerate wiki-wide pending verdicts as picker-ready rows.
+
+    The chip's coarse predicate (:func:`_is_pending_from_catalog_entry`)
+    selects the set; per-note frontmatter reads then enrich each entry
+    with the reason text + four-field stale schema (when present), and
+    the per-user sidecar resolves the personal ``confirmed_at``.
+
+    The returned list is sorted per the picker UX contract:
+
+    * Disagreements first (someone marked stale, this user confirmed
+      after — needs explicit resolution).
+    * Then ``authored_marker`` (richer reason text from the note's
+      own frontmatter) before ``orphan_broken`` (derived signal).
+    * Within each bucket, most-recently-marked-stale first; falls back
+      to file mtime; final tiebreak by path for stability.
+
+    Args:
+        wiki_path: Absolute path to the wiki root.
+        handle: Current user's handle for personal-sidecar lookup.
+            ``None`` or empty string means no sidecar read — every
+            entry's ``confirmed_at`` will be ``None``. Solo vaults
+            without ``_users.yml`` typically pass ``""``.
+
+    Returns:
+        List of :class:`PendingEntry`, possibly empty. Cache miss
+        (missing/unreadable catalog) yields ``[]``.
+    """
+    from lore_core.disagreement import detect_disagreement
+    from lore_core.schema import parse_frontmatter
+    from lore_core.verdicts_sidecar import get_confirmed
+
+    data = _load_catalog(wiki_path)
+    if data is None:
+        return []
+
+    orphan_paths_str = set(data.get("orphan_set") or [])
+
+    out: list[PendingEntry] = []
+    for entry in _iter_catalog_entries(data):
+        if not _is_pending_from_catalog_entry(entry, orphan_paths_str):
+            continue
+
+        rel_path = str(entry.get("path") or "")
+        if not rel_path:
+            continue
+        target = wiki_path / rel_path
+        try:
+            target.resolve().relative_to(wiki_path.resolve())
+        except ValueError:
+            continue
+
+        fm: dict = {}
+        try:
+            fm = parse_frontmatter(target.read_text(errors="replace"))
+        except OSError:
+            fm = {}
+
+        # Determine cause: authored markers take precedence over orphan.
+        authored = _has_authored_marker(fm)
+        if authored is not None:
+            key, value = authored
+            cause: Literal["authored_marker", "orphan_broken"] = "authored_marker"
+            reason = _format_marker_reason(key, value)
+        elif rel_path in orphan_paths_str:
+            cause = "orphan_broken"
+            reason = "contains a broken wikilink"
+        else:
+            # Catalog flagged it but neither signal survived per-note
+            # parsing (e.g. note's frontmatter was sanitised since
+            # last lint). Skip rather than emit a no-cause entry.
+            continue
+
+        confirmed_at: date | None = None
+        if handle:
+            try:
+                confirmed_at = get_confirmed(wiki_path, handle, rel_path)
+            except (OSError, ValueError):
+                confirmed_at = None
+
+        disagreement = detect_disagreement(fm, confirmed_at)
+
+        stale_at: date | None = None
+        raw_stale_at = fm.get("stale_at")
+        if isinstance(raw_stale_at, date):
+            stale_at = raw_stale_at
+        elif isinstance(raw_stale_at, str):
+            try:
+                stale_at = date.fromisoformat(raw_stale_at)
+            except ValueError:
+                stale_at = None
+
+        mtime = _file_mtime_date(target)
+
+        slug = Path(rel_path).stem
+
+        out.append(
+            PendingEntry(
+                path=rel_path,
+                slug=slug,
+                cause=cause,
+                reason=reason,
+                confirmed_at=confirmed_at,
+                disagreement=disagreement,
+                stale_at=stale_at,
+                mtime=mtime,
+            )
+        )
+
+    out.sort(key=_sort_key)
+    return out
+
+
+def pending_entry_to_dict(entry: PendingEntry) -> dict:
+    """JSON-friendly render for the MCP ``pending`` array."""
+    from lore_core.disagreement import disagreement_to_dict
+
+    return {
+        "path": entry.path,
+        "slug": entry.slug,
+        "cause": entry.cause,
+        "reason": entry.reason,
+        "confirmed_at": entry.confirmed_at.isoformat() if entry.confirmed_at else None,
+        "disagreement": (
+            disagreement_to_dict(entry.disagreement) if entry.disagreement else None
+        ),
+    }
 
 
 def load_orphan_set(wiki_path: Path) -> set[Path]:

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -35,7 +35,13 @@ from typing import Any
 
 from lore_core.config import get_wiki_root
 from lore_core.errors import mcp_error as _mcp_error
-from lore_core.freshness import compute_freshness, load_orphan_set, signal_to_dict
+from lore_core.freshness import (
+    compute_freshness,
+    list_pending_verdicts,
+    load_orphan_set,
+    pending_entry_to_dict,
+    signal_to_dict,
+)
 from lore_core.freshness_filter import apply_search_filter
 from lore_core.schema import extract_wikilinks, parse_frontmatter
 from lore_search.fts import FtsBackend
@@ -1005,6 +1011,84 @@ def handle_verdict(
     }
 
 
+def _resolve_wiki_with_active_scope_fallback(wiki: str | None) -> Path | None:
+    """Like :func:`_resolve_wiki` but auto-resolves from the active
+    cwd attachment when ``wiki`` is omitted and there's no single-wiki
+    fallback to lean on.
+
+    Order:
+      1. Explicit ``wiki`` argument → :func:`_resolve_wiki`.
+      2. No argument, single-wiki vault → :func:`_resolve_wiki(None)`.
+      3. No argument, multi-wiki vault → :func:`resolve_scope(cwd)` →
+         the wiki named by the active attachment.
+    """
+    if wiki:
+        return _resolve_wiki(wiki)
+    direct = _resolve_wiki(None)
+    if direct is not None:
+        return direct
+    from lore_core.scope_resolver import resolve_scope
+
+    scope = resolve_scope(Path.cwd())
+    if scope is None or not scope.wiki:
+        return None
+    return _resolve_wiki(scope.wiki)
+
+
+def handle_pending_verdicts(wiki: str | None = None) -> dict[str, Any]:
+    """Enumerate wiki-wide pending freshness verdicts as picker-ready rows.
+
+    Backs the ``/lore:verify`` slash command. The skill calls this once
+    to get the full list (sorted: disagreements → authored_marker →
+    orphan_broken), then loops one ``AskUserQuestion`` per row, calling
+    :func:`handle_verdict` for each ``stale``/``confirm`` choice.
+
+    Returns the ``lore.pending_verdicts/1`` envelope:
+
+    .. code-block:: json
+
+        {
+          "schema": "lore.pending_verdicts/1",
+          "wiki": "<wiki-name>",
+          "pending": [
+            {
+              "path": "<wiki-relative path>",
+              "slug": "<slug>",
+              "cause": "authored_marker|orphan_broken",
+              "reason": "<short human reason>",
+              "confirmed_at": "<ISO date or null>",
+              "disagreement": {<...>} | null
+            },
+            ...
+          ],
+          "count": <int>,
+          "capped": false
+        }
+    """
+    wiki_path = _resolve_wiki_with_active_scope_fallback(wiki)
+    if wiki_path is None:
+        return _mcp_error(
+            "wiki_not_found",
+            (
+                f"wiki not found: {wiki}" if wiki else
+                "could not resolve active wiki (no explicit `wiki`, no "
+                "single-wiki fallback, no cwd attachment)"
+            ),
+            next_="pass `wiki` explicitly or attach the cwd to a wiki",
+        )
+
+    handle = _resolve_current_handle(wiki_path)
+    entries = list_pending_verdicts(wiki_path, handle or None)
+
+    return {
+        "schema": "lore.pending_verdicts/1",
+        "wiki": wiki_path.name,
+        "pending": [pending_entry_to_dict(e) for e in entries],
+        "count": len(entries),
+        "capped": False,
+    }
+
+
 def handle_wikilinks(note: str, wiki: str | None = None) -> dict[str, Any]:
     wiki_path = _resolve_wiki(wiki)
     if wiki_path is None:
@@ -1320,6 +1404,34 @@ def _tool_schema() -> list[dict]:
             },
         },
         {
+            "name": "lore_pending_verdicts",
+            "description": (
+                "Enumerate wiki-wide pending freshness verdicts as "
+                "picker-ready rows. Backs the `/lore:verify` slash "
+                "command: one call returns the full sorted list "
+                "(disagreements first, then authored markers, then "
+                "orphan-link signals), each row carrying everything "
+                "the picker needs (slug, cause, reason, personal "
+                "confirmed_at, optional disagreement block). The "
+                "skill then loops one `AskUserQuestion` per row and "
+                "calls `lore_verdict` for each user choice. `wiki` "
+                "is optional — auto-resolves from the active cwd "
+                "attachment when omitted."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "wiki": {
+                        "type": "string",
+                        "description": (
+                            "Wiki name. Optional; auto-resolves from "
+                            "the active attachment when omitted."
+                        ),
+                    },
+                },
+            },
+        },
+        {
             "name": "lore_verdict",
             "description": (
                 "Record a freshness verdict for a note. Use when the "
@@ -1401,6 +1513,8 @@ def _dispatch(tool_name: str, args: dict) -> Any:
             return handle_journal_read(**args)
         case "lore_verdict":
             return handle_verdict(**args)
+        case "lore_pending_verdicts":
+            return handle_pending_verdicts(**args)
         case _:
             return _mcp_error("unknown_tool", f"unknown tool: {tool_name}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lore"
-version = "0.49.0"
+version = "0.50.0"
 description = "LLM-optimized knowledge graph for AI-coding teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -4,64 +4,74 @@ description: List pending freshness verdicts and let the user resolve
   each one. The primary verdict path is the in-passing nudge emitted
   during a session; this slash command is the explicit fallback that
   makes the SessionStart pending-verdict chip actionable. Run with
-  "/lore:verify" for the current session's flagged notes,
-  "/lore:verify --all" for every currently-stale-candidate note in
-  the active wiki.
+  "/lore:verify" — wiki-scoped to match the chip count.
 user_invocable: true
 ---
 
 # Pending freshness verdict resolver
 
-Walk the user through resolving the freshness backlog. Slice 10 of
-PRD #65 — secondary path; the primary verdict path is the LLM-emitted
-in-passing nudge.
+Walk the user through the wiki-wide freshness backlog one entry at a
+time. Wiki-scoped to match the SessionStart status-line chip: when the
+chip says "N pending verdict", running this command surfaces exactly
+those N notes.
+
+The primary verdict path is the LLM-emitted in-passing nudge that
+fires when the agent actively cites a stale-candidate note in flow.
+This slash command is the explicit fallback for the user who wants to
+clear the backlog on their own schedule.
 
 ## Workflow
 
-1. **Resolve scope.**
-   - Bare `/lore:verify` — flagged notes touched in the current session
-     per Curator A's activity log.
-   - `/lore:verify --all` — every currently-stale-candidate note across
-     the active wiki.
+1. **Discover.** Call `mcp__lore__lore_pending_verdicts` (no args —
+   the tool auto-resolves the active wiki from the cwd attachment).
+   The response carries every picker field per entry; no further reads
+   are needed.
 
-2. **Discover pending notes.** Read `_catalog.json` (a single fs read,
-   no walk) and filter for entries with `status: stale`,
-   `superseded_by`, or membership in the cached `orphan_set`. These are
-   the candidates. For the bare form, intersect with the activity log
-   from the most recent session note's `files_read` / `files_modified`
-   frontmatter.
+2. **Handle empty.** If `count == 0`, say "no pending verdicts in this
+   wiki" and stop. Do not invent work.
 
-3. **For each candidate, build a picker entry:**
-   - Slug, cause (`authored_marker` / `orphan_broken`), short reason
-     from the note's frontmatter.
-   - Most recent personal `confirmed_at` from
-     `wiki/<name>/_verdicts/<handle>.json` if any.
-   - When the freshness block carries `disagreement`, render the
-     stale-by / stale-at / self-confirmed-at fields verbatim.
+3. **Loop one picker per entry.** Entries arrive pre-sorted:
+   disagreements first, then `authored_marker`, then `orphan_broken`.
+   For each, show one `AskUserQuestion` with three options:
+   `stale` / `confirm` / `skip`.
 
-4. **Show one picker at a time** (use AskUserQuestion). Options:
-   - `confirm` → call `mcp__lore__lore_verdict` with
-     `{verdict: "confirm", wiki, note}`. No reason required.
-   - `stale` → prompt the user for a one-line reason (required by the
-     stale verdict contract, slice 5), then call `mcp__lore__lore_verdict`
-     with `{verdict: "stale", wiki, note, reason}`.
-   - `skip` → make no write at all. Silence semantics preserved at
-     this surface too.
+   **Header wording.**
 
-5. **After every verdict, echo the new freshness block** so the user
-   sees exactly what changed.
+   - *Disagreement* (entry has `disagreement` block):
+     `[[<slug>]] — stale by <disagreement.stale_by> <disagreement.stale_at>, you confirmed <disagreement.self_confirmed_at>`
+   - *Plain*:
+     `[[<slug>]] — <reason>`
 
-6. **At the end of the loop**, summarize: how many confirmed, how many
-   stale, how many skipped. Mention that the SessionStart status-line
-   chip will reflect the new count on the next refresh (slice 8).
+   In the option `description` fields, surface the cause and any prior
+   personal confirm so the user has context without re-reading the
+   note.
+
+4. **On `stale`.** Show a second `AskUserQuestion` for the one-line
+   reason. Offer three context-aware canned options derived from the
+   entry's `reason` field (the picker UI will also expose "Other" for
+   free-form entry). Then call `mcp__lore__lore_verdict` with
+   `{wiki: <response.wiki>, note: entry.path, verdict: "stale",
+   reason: <chosen>}`. Echo the returned freshness block so the user
+   sees what landed.
+
+5. **On `confirm`.** Call `mcp__lore__lore_verdict` with
+   `{wiki: <response.wiki>, note: entry.path, verdict: "confirm"}`.
+   Echo the returned freshness block.
+
+6. **On `skip`.** No MCP call. Move to the next entry.
+
+7. **Summarize.** End-of-loop: how many confirmed, how many stale,
+   how many skipped. Mention that the SessionStart status-line chip
+   will reflect the new count on the next refresh.
 
 ## Hard rules
 
+- **Zero bash.** Everything you need is in `lore_pending_verdicts`'s
+  response + per-entry `lore_verdict` calls. Do not read the catalog,
+  walk the wiki, or open notes directly.
 - One MCP call per verdict — do not batch (each verdict is a separate
   user choice and the per-write audit trail matters).
 - Never auto-resolve a `disagreement` — always ask.
 - `skip` means *make no write*; do not even open the sidecar.
 - Never modify the note body. The verdict contract is frontmatter-only
-  (slice 5) plus the per-user sidecar (slice 6); both are additive.
-- If the user has zero pending verdicts in scope, say so and stop —
-  do not invent work.
+  plus the per-user sidecar; both are additive.

--- a/tests/test_lore_verify_skill.py
+++ b/tests/test_lore_verify_skill.py
@@ -69,5 +69,6 @@ def test_plugin_version_bumped_for_skill_addition():
     plugin = json.loads(
         (SKILL_PATH.parent.parent.parent / ".claude-plugin" / "plugin.json").read_text()
     )
-    # The new skill ships in 0.49.0 (slice 10 of #65) — pin the bump.
-    assert plugin["version"] == "0.49.0"
+    # 0.50.0 bump: `/lore:verify` rewritten to use the new
+    # `lore_pending_verdicts` MCP tool — zero bash.
+    assert plugin["version"] == "0.50.0"

--- a/tests/test_mcp_pending_verdicts.py
+++ b/tests/test_mcp_pending_verdicts.py
@@ -1,0 +1,205 @@
+"""Tests for the ``lore_pending_verdicts`` MCP handler.
+
+End-to-end coverage of the picker-side surface: catalog walk plus
+per-note frontmatter read plus sidecar resolution, returned in the
+``lore.pending_verdicts/1`` envelope.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from lore_mcp.server import handle_pending_verdicts
+
+
+def _setup_wiki(tmp_path: Path, monkeypatch, wiki_name: str = "demo") -> Path:
+    wiki = tmp_path / "wiki" / wiki_name
+    wiki.mkdir(parents=True)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "alice@example.com")
+    return wiki
+
+
+def _write_note(wiki: Path, rel: str, frontmatter: dict) -> None:
+    p = wiki / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["---"]
+    for k, v in frontmatter.items():
+        if isinstance(v, str):
+            lines.append(f"{k}: '{v}'")
+        else:
+            lines.append(f"{k}: {v}")
+    lines.append("---")
+    lines.append("body")
+    p.write_text("\n".join(lines))
+
+
+def _write_catalog(wiki: Path, entries: list[dict], orphan_set: list[str] | None = None) -> None:
+    data: dict = {"sections": {"notes": entries}}
+    if orphan_set is not None:
+        data["orphan_set"] = orphan_set
+    (wiki / "_catalog.json").write_text(json.dumps(data))
+
+
+# ---------------------------------------------------------------------------
+# Empty + happy-path
+# ---------------------------------------------------------------------------
+
+
+def test_no_pending_returns_empty_envelope(tmp_path, monkeypatch):
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    _write_note(wiki, "n.md", {"type": "concept"})
+    _write_catalog(wiki, [{"path": "n.md"}])
+
+    result = handle_pending_verdicts(wiki="demo")
+    assert result == {
+        "schema": "lore.pending_verdicts/1",
+        "wiki": "demo",
+        "pending": [],
+        "count": 0,
+        "capped": False,
+    }
+
+
+def test_one_authored_marker_entry(tmp_path, monkeypatch):
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    _write_note(
+        wiki,
+        "concepts/old.md",
+        {
+            "status": "stale",
+            "stale_by": "alice",
+            "stale_at": "2026-05-01",
+            "stale_reason": "rewritten",
+        },
+    )
+    _write_catalog(wiki, [{"path": "concepts/old.md", "status": "stale"}])
+
+    result = handle_pending_verdicts(wiki="demo")
+    assert result["count"] == 1
+    entry = result["pending"][0]
+    assert entry["path"] == "concepts/old.md"
+    assert entry["slug"] == "old"
+    assert entry["cause"] == "authored_marker"
+    assert entry["reason"] == "marked stale"
+    assert entry["disagreement"] is None
+
+
+# ---------------------------------------------------------------------------
+# Disagreement wires through into the response
+# ---------------------------------------------------------------------------
+
+
+def test_disagreement_block_surfaces_in_response(tmp_path, monkeypatch):
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    _write_note(
+        wiki,
+        "n.md",
+        {
+            "status": "stale",
+            "stale_by": "bob",
+            "stale_at": "2026-05-01",
+            "stale_reason": "wrong",
+        },
+    )
+    # `alice` is the current user (via GIT_AUTHOR_EMAIL); record her
+    # personal confirm AFTER the stale verdict.
+    sidecar_dir = wiki / "_verdicts"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "alice.json").write_text(
+        json.dumps({"confirmed": {"n.md": "2026-05-05"}})
+    )
+    _write_catalog(wiki, [{"path": "n.md", "status": "stale"}])
+
+    result = handle_pending_verdicts(wiki="demo")
+    assert result["count"] == 1
+    entry = result["pending"][0]
+    assert entry["confirmed_at"] == "2026-05-05"
+    assert entry["disagreement"] == {
+        "stale_by": "bob",
+        "stale_at": "2026-05-01",
+        "stale_reason": "wrong",
+        "self_confirmed_at": "2026-05-05",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Wiki auto-resolution
+# ---------------------------------------------------------------------------
+
+
+def test_auto_resolve_single_wiki_when_arg_omitted(tmp_path, monkeypatch):
+    wiki = _setup_wiki(tmp_path, monkeypatch, wiki_name="only")
+    _write_note(wiki, "n.md", {"superseded_by": "[[x]]"})
+    _write_catalog(wiki, [{"path": "n.md", "superseded_by": "[[x]]"}])
+
+    result = handle_pending_verdicts()
+    assert result["wiki"] == "only"
+    assert result["count"] == 1
+
+
+def test_explicit_wiki_arg_wins_over_auto(tmp_path, monkeypatch):
+    # Two wikis — auto would be ambiguous, but explicit arg resolves it.
+    _setup_wiki(tmp_path, monkeypatch, wiki_name="a")
+    wiki_b = _setup_wiki(tmp_path, monkeypatch, wiki_name="b")
+    _write_note(wiki_b, "n.md", {"status": "stale", "stale_at": "2026-05-01", "stale_by": "alice", "stale_reason": "x"})
+    _write_catalog(wiki_b, [{"path": "n.md", "status": "stale"}])
+    # `a` has no catalog → empty
+    result = handle_pending_verdicts(wiki="b")
+    assert result["wiki"] == "b"
+    assert result["count"] == 1
+
+
+def test_unknown_wiki_returns_error(tmp_path, monkeypatch):
+    _setup_wiki(tmp_path, monkeypatch)
+    result = handle_pending_verdicts(wiki="nonexistent")
+    assert "error" in result
+    assert result["error"]["code"] == "wiki_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Sort ordering preserved through the handler
+# ---------------------------------------------------------------------------
+
+
+def test_sort_order_disagreement_authored_orphan(tmp_path, monkeypatch):
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    # Disagreement entry
+    _write_note(
+        wiki,
+        "z-disagree.md",
+        {
+            "status": "stale",
+            "stale_by": "bob",
+            "stale_at": "2026-04-01",
+            "stale_reason": "x",
+        },
+    )
+    sidecar_dir = wiki / "_verdicts"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "alice.json").write_text(
+        json.dumps({"confirmed": {"z-disagree.md": "2026-05-01"}})
+    )
+    # Plain authored
+    _write_note(
+        wiki,
+        "m-authored.md",
+        {"status": "stale", "stale_at": "2026-05-10", "stale_by": "alice", "stale_reason": "x"},
+    )
+    # Orphan-only
+    _write_note(wiki, "a-orphan.md", {})
+    _write_catalog(
+        wiki,
+        [
+            {"path": "z-disagree.md", "status": "stale"},
+            {"path": "m-authored.md", "status": "stale"},
+            {"path": "a-orphan.md"},
+        ],
+        orphan_set=["a-orphan.md"],
+    )
+
+    result = handle_pending_verdicts(wiki="demo")
+    paths = [e["path"] for e in result["pending"]]
+    assert paths == ["z-disagree.md", "m-authored.md", "a-orphan.md"]

--- a/tests/test_pending_verdicts_list.py
+++ b/tests/test_pending_verdicts_list.py
@@ -1,0 +1,435 @@
+"""Tests for ``lore_core.freshness.list_pending_verdicts`` and the
+shared ``_is_pending_from_catalog_entry`` predicate.
+
+These cover the picker-ready data the new ``lore_pending_verdicts``
+MCP tool returns. The same predicate gates ``count_pending_verdicts``
+(the status-line chip) and ``list_pending_verdicts`` (the picker), so
+the regression bar is "if the chip says N, the picker shows N rows
+with the same flagged-ness."
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from lore_core.freshness import (
+    PendingEntry,
+    _is_pending_from_catalog_entry,
+    count_pending_verdicts,
+    list_pending_verdicts,
+    pending_entry_to_dict,
+)
+
+
+# ---------------------------------------------------------------------------
+# Catalog fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_catalog(
+    wiki: Path, sections: dict[str, list[dict]], orphan_set: list[str] | None = None
+) -> None:
+    data = {"sections": sections}
+    if orphan_set is not None:
+        data["orphan_set"] = orphan_set
+    (wiki / "_catalog.json").write_text(json.dumps(data))
+
+
+def _write_note(wiki: Path, rel: str, frontmatter: dict, body: str = "body") -> Path:
+    p = wiki / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["---"]
+    for k, v in frontmatter.items():
+        if isinstance(v, str):
+            lines.append(f"{k}: '{v}'")
+        else:
+            lines.append(f"{k}: {v}")
+    lines.append("---")
+    lines.append(body)
+    p.write_text("\n".join(lines))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Shared predicate — the contract both the chip and the picker depend on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entry, orphans, expected",
+    [
+        ({"path": "a.md", "status": "stale"}, set(), True),
+        ({"path": "a.md", "status": "STALE"}, set(), True),  # case-insensitive
+        ({"path": "a.md", "superseded_by": "[[b]]"}, set(), True),
+        ({"path": "a.md"}, {"a.md"}, True),
+        ({"path": "a.md"}, set(), False),
+        ({"path": "a.md", "status": "draft"}, set(), False),
+        ({"path": "", "status": "stale"}, set(), True),  # status alone wins
+        ({"path": "", "superseded_by": ""}, set(), False),  # empty string falsy
+        ({"path": "", "superseded_by": None}, set(), False),
+        ({}, {"a.md"}, False),  # empty path → orphan check skipped
+        ("not-a-dict", set(), False),  # type guard
+    ],
+)
+def test_is_pending_from_catalog_entry(entry, orphans, expected) -> None:
+    assert _is_pending_from_catalog_entry(entry, orphans) is expected
+
+
+def test_count_and_list_agree_on_flagged_set(tmp_path: Path) -> None:
+    """The chip predicate and the picker predicate must never drift.
+
+    Same catalog → same count from both surfaces.
+    """
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(wiki, "a.md", {"status": "stale", "stale_by": "u", "stale_at": "2026-05-01", "stale_reason": "x"})
+    _write_note(wiki, "b.md", {"superseded_by": "[[c]]"})
+    _write_note(wiki, "c.md", {})  # plain, no markers — but in orphan set
+    _write_note(wiki, "d.md", {})  # not flagged anywhere
+    _write_catalog(
+        wiki,
+        {
+            "notes": [
+                {"path": "a.md", "status": "stale"},
+                {"path": "b.md", "superseded_by": "[[c]]"},
+                {"path": "c.md"},
+                {"path": "d.md"},
+            ]
+        },
+        orphan_set=["c.md"],
+    )
+
+    count, capped = count_pending_verdicts(wiki)
+    entries = list_pending_verdicts(wiki, handle="")
+
+    assert capped is False
+    assert count == len(entries) == 3
+
+
+# ---------------------------------------------------------------------------
+# list_pending_verdicts — empty / cache miss
+# ---------------------------------------------------------------------------
+
+
+def test_list_empty_when_no_catalog(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    assert list_pending_verdicts(wiki, handle="") == []
+
+
+def test_list_empty_when_no_flagged_entries(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(wiki, "a.md", {})
+    _write_catalog(wiki, {"notes": [{"path": "a.md"}]})
+    assert list_pending_verdicts(wiki, handle="") == []
+
+
+def test_list_empty_when_catalog_malformed(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    (wiki / "_catalog.json").write_text("not json {{{")
+    assert list_pending_verdicts(wiki, handle="") == []
+
+
+# ---------------------------------------------------------------------------
+# Cause + reason wiring
+# ---------------------------------------------------------------------------
+
+
+def test_authored_marker_cause_with_status_stale(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(
+        wiki,
+        "concepts/old.md",
+        {
+            "status": "stale",
+            "stale_by": "alice",
+            "stale_at": "2026-05-01",
+            "stale_reason": "rewritten",
+        },
+    )
+    _write_catalog(wiki, {"notes": [{"path": "concepts/old.md", "status": "stale"}]})
+
+    entries = list_pending_verdicts(wiki, handle="")
+
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.cause == "authored_marker"
+    assert e.reason == "marked stale"
+    assert e.slug == "old"
+    assert e.path == "concepts/old.md"
+    assert e.disagreement is None
+    assert e.confirmed_at is None
+
+
+def test_authored_marker_cause_with_superseded_by(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(wiki, "a.md", {"superseded_by": "[[newer]]"})
+    _write_catalog(wiki, {"notes": [{"path": "a.md", "superseded_by": "[[newer]]"}]})
+
+    entries = list_pending_verdicts(wiki, handle="")
+    assert len(entries) == 1
+    assert entries[0].cause == "authored_marker"
+    assert "superseded by" in entries[0].reason
+
+
+def test_orphan_broken_cause(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(wiki, "linky.md", {})  # no authored markers
+    _write_catalog(
+        wiki,
+        {"notes": [{"path": "linky.md"}]},
+        orphan_set=["linky.md"],
+    )
+
+    entries = list_pending_verdicts(wiki, handle="")
+    assert len(entries) == 1
+    assert entries[0].cause == "orphan_broken"
+    assert entries[0].reason == "contains a broken wikilink"
+
+
+def test_authored_takes_precedence_over_orphan(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(wiki, "n.md", {"status": "stale"})
+    _write_catalog(
+        wiki,
+        {"notes": [{"path": "n.md", "status": "stale"}]},
+        orphan_set=["n.md"],
+    )
+
+    entries = list_pending_verdicts(wiki, handle="")
+    assert len(entries) == 1
+    assert entries[0].cause == "authored_marker"
+
+
+def test_catalog_flagged_but_no_per_note_signal_skipped(tmp_path: Path) -> None:
+    """Catalog says flagged, but the note's frontmatter no longer
+    matches and it's not in the orphan set. Sanitised mid-flight.
+    The picker silently drops the entry rather than emit a no-cause row.
+    """
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(wiki, "n.md", {})  # frontmatter has no markers anymore
+    # Catalog still has stale state — picker should reconcile.
+    _write_catalog(wiki, {"notes": [{"path": "n.md", "status": "stale"}]})
+
+    assert list_pending_verdicts(wiki, handle="") == []
+
+
+# ---------------------------------------------------------------------------
+# Disagreement detection wires through
+# ---------------------------------------------------------------------------
+
+
+def test_disagreement_surfaced_when_personal_confirm_after_stale(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(
+        wiki,
+        "n.md",
+        {
+            "status": "stale",
+            "stale_by": "alice",
+            "stale_at": "2026-05-01",
+            "stale_reason": "ohno",
+        },
+    )
+    # Personal sidecar — current user confirmed AFTER the stale verdict
+    sidecar_dir = wiki / "_verdicts"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "bob.json").write_text(
+        json.dumps({"confirmed": {"n.md": "2026-05-05"}})
+    )
+    _write_catalog(wiki, {"notes": [{"path": "n.md", "status": "stale"}]})
+
+    entries = list_pending_verdicts(wiki, handle="bob")
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.disagreement is not None
+    assert e.disagreement.stale_by == "alice"
+    assert e.disagreement.stale_reason == "ohno"
+    assert e.confirmed_at == date(2026, 5, 5)
+
+
+def test_no_disagreement_when_confirm_precedes_stale(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(
+        wiki,
+        "n.md",
+        {
+            "status": "stale",
+            "stale_by": "alice",
+            "stale_at": "2026-05-10",
+            "stale_reason": "x",
+        },
+    )
+    sidecar_dir = wiki / "_verdicts"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "bob.json").write_text(
+        json.dumps({"confirmed": {"n.md": "2026-05-01"}})  # before
+    )
+    _write_catalog(wiki, {"notes": [{"path": "n.md", "status": "stale"}]})
+
+    entries = list_pending_verdicts(wiki, handle="bob")
+    assert entries[0].disagreement is None
+
+
+def test_no_handle_means_no_sidecar_read(tmp_path: Path) -> None:
+    """Empty handle → confirmed_at always None regardless of sidecar contents."""
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(wiki, "n.md", {"status": "stale", "stale_at": "2026-05-01", "stale_by": "alice", "stale_reason": "x"})
+    sidecar_dir = wiki / "_verdicts"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "bob.json").write_text(
+        json.dumps({"confirmed": {"n.md": "2026-05-05"}})
+    )
+    _write_catalog(wiki, {"notes": [{"path": "n.md", "status": "stale"}]})
+
+    entries = list_pending_verdicts(wiki, handle="")
+    assert entries[0].confirmed_at is None
+    assert entries[0].disagreement is None
+
+
+# ---------------------------------------------------------------------------
+# Sort order: disagreements → authored_marker → orphan_broken
+# ---------------------------------------------------------------------------
+
+
+def test_sort_disagreements_first(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    # Two stale entries — one with disagreement, one without.
+    _write_note(
+        wiki,
+        "a-plain.md",
+        {"status": "stale", "stale_at": "2026-05-10", "stale_by": "u", "stale_reason": "x"},
+    )
+    _write_note(
+        wiki,
+        "b-disagreement.md",
+        {"status": "stale", "stale_at": "2026-05-01", "stale_by": "alice", "stale_reason": "x"},
+    )
+    sidecar_dir = wiki / "_verdicts"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "bob.json").write_text(
+        json.dumps({"confirmed": {"b-disagreement.md": "2026-05-05"}})
+    )
+    _write_catalog(
+        wiki,
+        {"notes": [
+            {"path": "a-plain.md", "status": "stale"},
+            {"path": "b-disagreement.md", "status": "stale"},
+        ]},
+    )
+
+    entries = list_pending_verdicts(wiki, handle="bob")
+    assert [e.path for e in entries] == ["b-disagreement.md", "a-plain.md"]
+
+
+def test_sort_authored_marker_before_orphan_broken(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(wiki, "x-orphan.md", {})
+    _write_note(wiki, "y-authored.md", {"status": "stale", "stale_at": "2026-05-01", "stale_by": "u", "stale_reason": "x"})
+    _write_catalog(
+        wiki,
+        {"notes": [
+            {"path": "x-orphan.md"},
+            {"path": "y-authored.md", "status": "stale"},
+        ]},
+        orphan_set=["x-orphan.md"],
+    )
+
+    entries = list_pending_verdicts(wiki, handle="")
+    assert [e.cause for e in entries] == ["authored_marker", "orphan_broken"]
+
+
+def test_sort_most_recent_stale_first_within_bucket(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(
+        wiki,
+        "older.md",
+        {"status": "stale", "stale_at": "2026-04-01", "stale_by": "u", "stale_reason": "x"},
+    )
+    _write_note(
+        wiki,
+        "newer.md",
+        {"status": "stale", "stale_at": "2026-05-10", "stale_by": "u", "stale_reason": "x"},
+    )
+    _write_catalog(
+        wiki,
+        {"notes": [
+            {"path": "older.md", "status": "stale"},
+            {"path": "newer.md", "status": "stale"},
+        ]},
+    )
+
+    entries = list_pending_verdicts(wiki, handle="")
+    assert [e.path for e in entries] == ["newer.md", "older.md"]
+
+
+# ---------------------------------------------------------------------------
+# JSON serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_pending_entry_to_dict_shape(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(
+        wiki,
+        "n.md",
+        {
+            "status": "stale",
+            "stale_by": "alice",
+            "stale_at": "2026-05-01",
+            "stale_reason": "rewritten",
+        },
+    )
+    sidecar_dir = wiki / "_verdicts"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "bob.json").write_text(
+        json.dumps({"confirmed": {"n.md": "2026-05-05"}})
+    )
+    _write_catalog(wiki, {"notes": [{"path": "n.md", "status": "stale"}]})
+
+    entries = list_pending_verdicts(wiki, handle="bob")
+    d = pending_entry_to_dict(entries[0])
+    assert d == {
+        "path": "n.md",
+        "slug": "n",
+        "cause": "authored_marker",
+        "reason": "marked stale",
+        "confirmed_at": "2026-05-05",
+        "disagreement": {
+            "stale_by": "alice",
+            "stale_at": "2026-05-01",
+            "stale_reason": "rewritten",
+            "self_confirmed_at": "2026-05-05",
+        },
+    }
+
+
+def test_pending_entry_to_dict_minimal(tmp_path: Path) -> None:
+    wiki = tmp_path / "w"
+    wiki.mkdir()
+    _write_note(wiki, "n.md", {"superseded_by": "[[other]]"})
+    _write_catalog(wiki, {"notes": [{"path": "n.md", "superseded_by": "[[other]]"}]})
+
+    entries = list_pending_verdicts(wiki, handle="")
+    d = pending_entry_to_dict(entries[0])
+    assert d["confirmed_at"] is None
+    assert d["disagreement"] is None
+    assert d["cause"] == "authored_marker"


### PR DESCRIPTION
Closes #85.

## Summary

- New `lore_pending_verdicts` MCP tool — wiki-wide, picker-ready, pre-sorted list of stale-candidate notes. Returns `lore.pending_verdicts/1` envelope with per-entry slug, cause, reason, personal `confirmed_at`, and disagreement block.
- `/lore:verify` rewritten to one MCP call + loop. Zero bash. Scope arg dropped (wiki-wide always — matches the SessionStart chip).
- Shared `_is_pending_from_catalog_entry` predicate extracted; the chip and the picker can no longer drift on what counts as pending.
- Version bump to 0.50.0 (pyproject + plugin.json).

## Design

Walked through `/grill-me` 2026-05-12. Key calls:

| # | Decision |
|---|---|
| Scope | Dropped — wiki-wide always (matches chip) |
| Payload source | Per-request frontmatter reads + sidecar |
| Sort | Disagreements → authored_marker → orphan_broken; most-recently-stale first within bucket |
| Tool signature | `lore_pending_verdicts(wiki?: str)` — optional, auto-resolves from cwd attachment |
| Refactor | Share predicate with `count_pending_verdicts` |

## Test plan

- [x] 28 unit tests in `tests/test_pending_verdicts_list.py` (predicate, cause wiring, disagreement, sort, JSON shape, empty/malformed catalog).
- [x] 7 MCP integration tests in `tests/test_mcp_pending_verdicts.py` (envelope shape, disagreement, auto-resolve, error path, sort).
- [x] Verify-skill metadata tests updated (version pin → 0.50.0).
- [x] 114 freshness/verdict tests pass; 2641 full-suite pass; 2 pre-existing failures (missing `openai` dep, date-window flake in `test_resume`) reproduce on `main`.
- [x] Live-fired against real `private` wiki → returns the expected single pending entry.