### PR TITLE
feat(#80): PR 3 — spawn module extraction + role registry

### DIFF
--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -1294,6 +1294,28 @@ from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry, WikiLedger
 from lore_core.scope_resolver import resolve_scope  # noqa: E402
 from lore_cli._argv_compat import argv_main  # noqa: E402
 
+# Re-export the spawn machinery so hooks-internal heartbeat code and any
+# external test that patches ``lore_cli.hooks.<name>`` keep working without
+# tracking the move to ``lore_cli.spawn``.
+from lore_cli.spawn import (  # noqa: E402, F401
+    _migrate_legacy_spawn_stamp,
+    _open_proc_log,
+    _prior_spawn_runaway,
+    _process_is_ours,
+    _rotate_meta_sidecar,
+    _spawn_detached,
+    _spawn_detached_curator_a,
+    _spawn_detached_curator_b,
+    _spawn_detached_curator_c,
+    _spawn_detached_transcript_sync,
+    _stamp_within_cooldown,
+    _write_stamp,
+    _curator_c_email,
+    _curator_c_jitter_seconds,
+    _iso_week_monday_utc,
+    spawn,
+)
+
 hook_app = typer.Typer(
     add_completion=False,
     help="Internal hook dispatcher — invoked by Claude Code at SessionStart, PreCompact, etc.",
@@ -2232,266 +2254,6 @@ def _load_wiki_cfg_for_wiki(lore_root: Path, wiki_name: str):
     return load_wiki_config(lore_root / "wiki" / wiki_name)
 
 
-def _stamp_within_cooldown(stamp: Path, cooldown_s: int) -> bool:
-    """True if stamp exists and is younger than cooldown_s seconds."""
-    import time as _time
-    try:
-        last = float(stamp.read_text().strip())
-    except (OSError, ValueError):
-        return False
-    return (_time.time() - last) < cooldown_s
-
-
-def _write_stamp(stamp: Path) -> None:
-    """Atomic write of current unix timestamp into stamp. Best-effort."""
-    import time as _time
-    stamp.parent.mkdir(parents=True, exist_ok=True)
-    tmp = stamp.with_suffix(stamp.suffix + ".tmp")
-    tmp.write_text(f"{_time.time():.6f}")
-    os.replace(tmp, stamp)
-
-
-def _migrate_legacy_spawn_stamp(lore_root: Path, role: str) -> None:
-    """Unlink the pre-flock stamp file if present; log to hook-events on failure."""
-    old = lore_root / ".lore" / f"last-curator-{role}-spawn"
-    try:
-        old.unlink()
-    except FileNotFoundError:
-        return
-    except OSError as exc:
-        try:
-            HookEventLogger(lore_root).emit(
-                event="spawn-throttle",
-                outcome="warning",
-                error={
-                    "type": "LegacyStampMigrationFailed",
-                    "message": str(exc),
-                    "role": role,
-                },
-            )
-        except Exception:
-            pass
-
-
-def _open_proc_log(lore_root: Path, role: str, *, keep: int = 3) -> int | None:
-    """Open .lore/proc/<role>.log for subprocess output, rotating previous generations."""
-    import contextlib
-
-    proc_dir = lore_root / ".lore" / "proc"
-    try:
-        proc_dir.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        return None
-    log_path = proc_dir / f"{role}.log"
-    with contextlib.suppress(OSError):
-        (proc_dir / f"{role}.log.{keep}").unlink(missing_ok=True)
-    for i in range(keep, 1, -1):
-        src = proc_dir / f"{role}.log.{i - 1}"
-        dst = proc_dir / f"{role}.log.{i}"
-        with contextlib.suppress(OSError):
-            os.replace(str(src), str(dst))
-    if log_path.exists():
-        with contextlib.suppress(OSError):
-            os.replace(str(log_path), str(proc_dir / f"{role}.log.1"))
-    try:
-        return os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
-    except OSError:
-        return None
-
-
-def _rotate_meta_sidecar(proc_dir: Path, role: str, *, keep: int = 3) -> None:
-    """Rotate <role>.meta.json alongside proc logs. Best-effort."""
-    import contextlib
-    with contextlib.suppress(OSError):
-        (proc_dir / f"{role}.meta.json.{keep}").unlink(missing_ok=True)
-    for i in range(keep, 1, -1):
-        src = proc_dir / f"{role}.meta.json.{i - 1}"
-        dst = proc_dir / f"{role}.meta.json.{i}"
-        with contextlib.suppress(OSError):
-            os.replace(str(src), str(dst))
-    current = proc_dir / f"{role}.meta.json"
-    if current.exists():
-        with contextlib.suppress(OSError):
-            os.replace(str(current), str(proc_dir / f"{role}.meta.json.1"))
-
-
-def _process_is_ours(pid: int) -> bool:
-    """True if ``pid`` is alive AND looks like a lore_cli process.
-
-    On Linux the cmdline check via ``/proc/<pid>/cmdline`` dodges PID-recycle
-    false positives — the kernel reuses PIDs aggressively, so a bare
-    ``os.kill(pid, 0)`` on a stale meta.json could match an unrelated
-    process. On non-Linux the cmdline file isn't present and we fall back
-    to the liveness probe alone (the rare false positive self-heals once
-    the next successful spawn rewrites meta.json).
-    """
-    if pid <= 1:
-        return False
-    try:
-        os.kill(pid, 0)
-    except (ProcessLookupError, PermissionError, OSError):
-        return False
-    cmdline_path = Path(f"/proc/{pid}/cmdline")
-    if not cmdline_path.exists():
-        return True  # non-Linux fallback
-    try:
-        cmdline = cmdline_path.read_bytes().replace(b"\x00", b" ")
-    except OSError:
-        return True  # alive but unreadable; assume ours
-    return b"lore_cli" in cmdline
-
-
-def _prior_spawn_runaway(
-    lore_root: Path, role: str, *, runaway_age_s: int
-) -> dict | None:
-    """Return runaway-process info if the prior spawn for ``role`` is hung.
-
-    "Hung" = sidecar meta.json says ``exit_code is None`` AND its recorded
-    ``pid`` is still alive on this host AND ``start_ts`` is older than
-    ``runaway_age_s`` seconds.
-
-    Returns ``None`` (safe to spawn) when meta.json is absent, malformed,
-    already exited, or the prior process is young/dead. The returned dict
-    carries ``pid``, ``age_s``, ``start_ts`` for telemetry.
-
-    Final gate before ``_spawn_detached`` commits a fresh subprocess —
-    catches the pile-up pattern where a child hangs (e.g. the v0.37.0 lock
-    spin) and the cooldown stamp keeps green-lighting new spawns on the
-    same broken state. See issue #42 for the related lockfile silent-
-    cleanup follow-up.
-    """
-    import json as _json
-    import time as _time
-
-    meta_path = lore_root / ".lore" / "proc" / f"{role}.meta.json"
-    try:
-        meta = _json.loads(meta_path.read_text())
-    except (OSError, ValueError):
-        return None
-    if meta.get("exit_code") is not None:
-        return None
-    pid = meta.get("pid")
-    start_ts = meta.get("start_ts")
-    if not isinstance(pid, int) or not isinstance(start_ts, (int, float)):
-        return None
-    age_s = _time.time() - start_ts
-    if age_s < runaway_age_s:
-        return None
-    if not _process_is_ours(pid):
-        return None
-    return {"pid": pid, "age_s": int(age_s), "start_ts": start_ts}
-
-
-def _spawn_detached(
-    lore_root: Path,
-    role: str,
-    cmd: list[str],
-    *,
-    cooldown_s: int,
-    migrate_stamp: bool = False,
-    runaway_age_s: int | None = None,
-) -> bool:
-    """Fire-and-forget a subprocess under a spawn lock + cooldown stamp.
-
-    Acquires a non-blocking flock on the per-role spawn lock. Returns False
-    if another process holds the lock OR the cooldown stamp is still fresh
-    OR the prior spawn for this role is still alive past the runaway
-    threshold (default ``cooldown_s * 5``).
-
-    The runaway gate is the safety net for "child hangs and cooldown keeps
-    green-lighting fresh spawns" — once tripped, a single warning event is
-    appended to ``hook-events.jsonl`` per ``cooldown_s * 10`` window
-    (throttled via ``curator-<role>.runaway.stamp``) so users running
-    ``lore status`` / grepping the log can see the issue without it
-    spamming on every UserPromptSubmit.
-    """
-    import contextlib
-    import subprocess
-    from lore_core.lockfile import try_acquire_spawn_lock
-
-    effective_runaway = (
-        runaway_age_s if runaway_age_s is not None else cooldown_s * 5
-    )
-
-    with try_acquire_spawn_lock(lore_root, role) as (held, stamp):
-        if not held:
-            return False
-        if _stamp_within_cooldown(stamp, cooldown_s):
-            return False
-        runaway = _prior_spawn_runaway(
-            lore_root, role, runaway_age_s=effective_runaway
-        )
-        if runaway is not None:
-            warn_stamp = (
-                lore_root / ".lore" / f"curator-{role}.runaway.stamp"
-            )
-            if not _stamp_within_cooldown(warn_stamp, cooldown_s * 10):
-                try:
-                    HookEventLogger(lore_root).emit(
-                        event="spawn-throttle",
-                        outcome="prior-runaway",
-                        role=role,
-                        error={
-                            "type": "PriorSpawnAlive",
-                            "pid": runaway["pid"],
-                            "age_s": runaway["age_s"],
-                            "runaway_threshold_s": effective_runaway,
-                        },
-                    )
-                except Exception:
-                    pass
-                with contextlib.suppress(OSError):
-                    _write_stamp(warn_stamp)
-            return False
-        if migrate_stamp:
-            _migrate_legacy_spawn_stamp(lore_root, role)
-        env = os.environ.copy()
-        # Re-inject as LORE_ROOT so child processes resolve identically
-        # without re-reading ~/.config/lore/config.yml. The child's
-        # lore_root_source() will report "env" even if the parent
-        # resolved via config — that's intentional. Resolution-source
-        # provenance is per-process; the path value is what matters
-        # across boundaries.
-        env["LORE_ROOT"] = str(lore_root)
-        env["LORE_CURATOR_MODE"] = "1"
-        log_fd = _open_proc_log(lore_root, role)
-        proc_dir = lore_root / ".lore" / "proc"
-        meta_path = proc_dir / f"{role}.meta.json"
-        _rotate_meta_sidecar(proc_dir, role)
-        wrapped_cmd = [
-            sys.executable, "-m", "lore_cli._proc_wrapper",
-            str(meta_path), "--", *cmd,
-        ]
-        try:
-            subprocess.Popen(
-                wrapped_cmd,
-                cwd=str(lore_root),
-                start_new_session=True,
-                stdout=log_fd if log_fd is not None else subprocess.DEVNULL,
-                stderr=log_fd if log_fd is not None else subprocess.DEVNULL,
-                stdin=subprocess.DEVNULL,
-                env=env,
-            )
-        except (OSError, subprocess.SubprocessError):
-            if log_fd is not None:
-                os.close(log_fd)
-            return False
-        if log_fd is not None:
-            os.close(log_fd)
-        with contextlib.suppress(OSError):
-            _write_stamp(stamp)
-        return True
-
-
-def _spawn_detached_curator_a(lore_root: Path, *, cooldown_s: int = 60) -> bool:
-    """Fire-and-forget `lore curator run` subprocess."""
-    return _spawn_detached(
-        lore_root, "a",
-        [sys.executable, "-m", "lore_cli", "curator", "run"],
-        cooldown_s=cooldown_s, migrate_stamp=True,
-    )
-
-
 _HANDOVER_RECENT_S = 3600   # 60 min — "the same Claude project recently"
 _HANDOVER_POLL_INTERVAL_S = 0.1
 
@@ -2715,41 +2477,6 @@ def _now_utc() -> "datetime":
     return _dt.now(UTC)
 
 
-def _curator_c_email() -> str:
-    """Resolve git user.email → hostname fallback → empty (offset=0)."""
-    from lore_core.git import git_user_email
-    return git_user_email(fallback_hostname=True)
-
-
-def _curator_c_jitter_seconds(email: str) -> int:
-    """Deterministic 0-48h offset from SHA-256(email). Empty → 0 (fire at Monday 00Z)."""
-    import hashlib
-    if not email:
-        return 0
-    h = hashlib.sha256(email.encode()).hexdigest()[:8]
-    return int(h, 16) % 172800  # 48h in seconds
-
-
-def _iso_week_monday_utc(ts: "datetime") -> "datetime":
-    """Monday 00:00Z of the ISO week containing ts."""
-    from datetime import datetime as _dt
-    from datetime import UTC, timedelta
-    weekday = ts.isocalendar().weekday  # 1..7, Monday=1
-    date = ts.date() - timedelta(days=weekday - 1)
-    return _dt(date.year, date.month, date.day, tzinfo=UTC)
-
-
-def _spawn_detached_curator_c(
-    lore_root: Path, *, cooldown_s: int = 3600
-) -> bool:
-    """Fire-and-forget `lore curator run --defrag` subprocess (Curator C)."""
-    return _spawn_detached(
-        lore_root, "c",
-        [sys.executable, "-m", "lore_cli", "curator", "run", "--defrag"],
-        cooldown_s=cooldown_s,
-    )
-
-
 def _render_drain_lines(lore_root: Path, cwd: Path) -> list[str]:
     """Compile the two drain-banner lines shown at SessionStart.
 
@@ -2864,35 +2591,6 @@ def _wiki_suffix(events, event_name: str) -> str:
     items = sorted(tally.items(), key=lambda kv: (-kv[1], kv[0]))
     bits = ", ".join(f"{n} in {w}" for w, n in items)
     return f" ({bits})"
-
-
-def _spawn_detached_transcript_sync(
-    lore_root: Path, *, cooldown_s: int = 300
-) -> bool:
-    """Fire-and-forget ``lore transcripts sync`` subprocess.
-
-    Runs on the same spawn-lock + cooldown pattern as the curators, so
-    a busy SessionStart hook can't stampede the filesystem with parallel
-    sync jobs. The P4a sync itself is idempotent; the lock exists purely
-    as a politeness budget.
-    """
-    return _spawn_detached(
-        lore_root, "transcripts",
-        [sys.executable, "-m", "lore_cli", "transcripts", "sync"],
-        cooldown_s=cooldown_s,
-    )
-
-
-def _spawn_detached_curator_b(
-    lore_root: Path, wiki_name: str, *, cooldown_s: int = 300
-) -> bool:
-    """Fire-and-forget `lore curator run --abstract --wiki <name>` subprocess."""
-    return _spawn_detached(
-        lore_root, "b",
-        [sys.executable, "-m", "lore_cli",
-         "curator", "run", "--abstract", "--wiki", wiki_name],
-        cooldown_s=cooldown_s, migrate_stamp=True,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/lib/lore_cli/spawn.py
+++ b/lib/lore_cli/spawn.py
@@ -1,0 +1,444 @@
+"""Detached subprocess machinery for the curator/transcript-sync hooks.
+
+This module owns the spawn-side safety net that the v0.37 hang storm forced
+us to build:
+
+* per-role flock + cooldown stamps so back-to-back hook events don't pile
+  parallel children onto the same broken state;
+* a runaway gate that refuses fresh spawns when the prior child for a role
+  is still alive past ``cooldown_s * 5``;
+* atomic log + meta-sidecar rotation so each generation is recoverable
+  after a crash;
+* a tiny ``SpawnRole`` registry + a single ``spawn(role, lore_root,
+  **extra)`` entry point so adding a new background process is one row.
+
+The legacy ``_spawn_detached_curator_{a,b,c}`` and
+``_spawn_detached_transcript_sync`` wrappers stay as one-liners that
+delegate to :func:`spawn` — existing call sites and test patch points
+keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lore_core.hook_log import HookEventLogger
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+# ---------------------------------------------------------------------------
+# Stamp primitives — used by spawn cooldowns AND the heartbeat throttles in
+# ``hooks.py`` (re-imported there).
+# ---------------------------------------------------------------------------
+
+
+def _stamp_within_cooldown(stamp: Path, cooldown_s: int) -> bool:
+    """True if stamp exists and is younger than cooldown_s seconds."""
+    import time as _time
+    try:
+        last = float(stamp.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    return (_time.time() - last) < cooldown_s
+
+
+def _write_stamp(stamp: Path) -> None:
+    """Atomic write of current unix timestamp into stamp. Best-effort."""
+    import time as _time
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    tmp = stamp.with_suffix(stamp.suffix + ".tmp")
+    tmp.write_text(f"{_time.time():.6f}")
+    os.replace(tmp, stamp)
+
+
+# ---------------------------------------------------------------------------
+# Process / log / sidecar machinery
+# ---------------------------------------------------------------------------
+
+
+def _migrate_legacy_spawn_stamp(lore_root: Path, role: str) -> None:
+    """Unlink the pre-flock stamp file if present; log to hook-events on failure."""
+    old = lore_root / ".lore" / f"last-curator-{role}-spawn"
+    try:
+        old.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        try:
+            HookEventLogger(lore_root).emit(
+                event="spawn-throttle",
+                outcome="warning",
+                error={
+                    "type": "LegacyStampMigrationFailed",
+                    "message": str(exc),
+                    "role": role,
+                },
+            )
+        except Exception:
+            pass
+
+
+def _open_proc_log(lore_root: Path, role: str, *, keep: int = 3) -> int | None:
+    """Open .lore/proc/<role>.log for subprocess output, rotating previous generations."""
+    import contextlib
+
+    proc_dir = lore_root / ".lore" / "proc"
+    try:
+        proc_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    log_path = proc_dir / f"{role}.log"
+    with contextlib.suppress(OSError):
+        (proc_dir / f"{role}.log.{keep}").unlink(missing_ok=True)
+    for i in range(keep, 1, -1):
+        src = proc_dir / f"{role}.log.{i - 1}"
+        dst = proc_dir / f"{role}.log.{i}"
+        with contextlib.suppress(OSError):
+            os.replace(str(src), str(dst))
+    if log_path.exists():
+        with contextlib.suppress(OSError):
+            os.replace(str(log_path), str(proc_dir / f"{role}.log.1"))
+    try:
+        return os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    except OSError:
+        return None
+
+
+def _rotate_meta_sidecar(proc_dir: Path, role: str, *, keep: int = 3) -> None:
+    """Rotate <role>.meta.json alongside proc logs. Best-effort."""
+    import contextlib
+    with contextlib.suppress(OSError):
+        (proc_dir / f"{role}.meta.json.{keep}").unlink(missing_ok=True)
+    for i in range(keep, 1, -1):
+        src = proc_dir / f"{role}.meta.json.{i - 1}"
+        dst = proc_dir / f"{role}.meta.json.{i}"
+        with contextlib.suppress(OSError):
+            os.replace(str(src), str(dst))
+    current = proc_dir / f"{role}.meta.json"
+    if current.exists():
+        with contextlib.suppress(OSError):
+            os.replace(str(current), str(proc_dir / f"{role}.meta.json.1"))
+
+
+def _process_is_ours(pid: int) -> bool:
+    """True if ``pid`` is alive AND looks like a lore_cli process.
+
+    On Linux the cmdline check via ``/proc/<pid>/cmdline`` dodges PID-recycle
+    false positives — the kernel reuses PIDs aggressively, so a bare
+    ``os.kill(pid, 0)`` on a stale meta.json could match an unrelated
+    process. On non-Linux the cmdline file isn't present and we fall back
+    to the liveness probe alone (the rare false positive self-heals once
+    the next successful spawn rewrites meta.json).
+    """
+    if pid <= 1:
+        return False
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    cmdline_path = Path(f"/proc/{pid}/cmdline")
+    if not cmdline_path.exists():
+        return True  # non-Linux fallback
+    try:
+        cmdline = cmdline_path.read_bytes().replace(b"\x00", b" ")
+    except OSError:
+        return True  # alive but unreadable; assume ours
+    return b"lore_cli" in cmdline
+
+
+def _prior_spawn_runaway(
+    lore_root: Path, role: str, *, runaway_age_s: int
+) -> dict | None:
+    """Return runaway-process info if the prior spawn for ``role`` is hung.
+
+    "Hung" = sidecar meta.json says ``exit_code is None`` AND its recorded
+    ``pid`` is still alive on this host AND ``start_ts`` is older than
+    ``runaway_age_s`` seconds.
+
+    Returns ``None`` (safe to spawn) when meta.json is absent, malformed,
+    already exited, or the prior process is young/dead. The returned dict
+    carries ``pid``, ``age_s``, ``start_ts`` for telemetry.
+
+    Final gate before ``_spawn_detached`` commits a fresh subprocess —
+    catches the pile-up pattern where a child hangs (e.g. the v0.37.0 lock
+    spin) and the cooldown stamp keeps green-lighting new spawns on the
+    same broken state. See issue #42 for the related lockfile silent-
+    cleanup follow-up.
+    """
+    import time as _time
+
+    meta_path = lore_root / ".lore" / "proc" / f"{role}.meta.json"
+    try:
+        meta = json.loads(meta_path.read_text())
+    except (OSError, ValueError):
+        return None
+    if meta.get("exit_code") is not None:
+        return None
+    pid = meta.get("pid")
+    start_ts = meta.get("start_ts")
+    if not isinstance(pid, int) or not isinstance(start_ts, (int, float)):
+        return None
+    age_s = _time.time() - start_ts
+    if age_s < runaway_age_s:
+        return None
+    if not _process_is_ours(pid):
+        return None
+    return {"pid": pid, "age_s": int(age_s), "start_ts": start_ts}
+
+
+def _spawn_detached(
+    lore_root: Path,
+    role: str,
+    cmd: list[str],
+    *,
+    cooldown_s: int,
+    migrate_stamp: bool = False,
+    runaway_age_s: int | None = None,
+) -> bool:
+    """Fire-and-forget a subprocess under a spawn lock + cooldown stamp.
+
+    Acquires a non-blocking flock on the per-role spawn lock. Returns False
+    if another process holds the lock OR the cooldown stamp is still fresh
+    OR the prior spawn for this role is still alive past the runaway
+    threshold (default ``cooldown_s * 5``).
+
+    The runaway gate is the safety net for "child hangs and cooldown keeps
+    green-lighting fresh spawns" — once tripped, a single warning event is
+    appended to ``hook-events.jsonl`` per ``cooldown_s * 10`` window
+    (throttled via ``curator-<role>.runaway.stamp``) so users running
+    ``lore status`` / grepping the log can see the issue without it
+    spamming on every UserPromptSubmit.
+    """
+    import contextlib
+    import subprocess
+    from lore_core.lockfile import try_acquire_spawn_lock
+
+    effective_runaway = (
+        runaway_age_s if runaway_age_s is not None else cooldown_s * 5
+    )
+
+    with try_acquire_spawn_lock(lore_root, role) as (held, stamp):
+        if not held:
+            return False
+        if _stamp_within_cooldown(stamp, cooldown_s):
+            return False
+        runaway = _prior_spawn_runaway(
+            lore_root, role, runaway_age_s=effective_runaway
+        )
+        if runaway is not None:
+            warn_stamp = (
+                lore_root / ".lore" / f"curator-{role}.runaway.stamp"
+            )
+            if not _stamp_within_cooldown(warn_stamp, cooldown_s * 10):
+                try:
+                    HookEventLogger(lore_root).emit(
+                        event="spawn-throttle",
+                        outcome="prior-runaway",
+                        role=role,
+                        error={
+                            "type": "PriorSpawnAlive",
+                            "pid": runaway["pid"],
+                            "age_s": runaway["age_s"],
+                            "runaway_threshold_s": effective_runaway,
+                        },
+                    )
+                except Exception:
+                    pass
+                with contextlib.suppress(OSError):
+                    _write_stamp(warn_stamp)
+            return False
+        if migrate_stamp:
+            _migrate_legacy_spawn_stamp(lore_root, role)
+        env = os.environ.copy()
+        # Re-inject as LORE_ROOT so child processes resolve identically
+        # without re-reading ~/.config/lore/config.yml. The child's
+        # lore_root_source() will report "env" even if the parent
+        # resolved via config — that's intentional. Resolution-source
+        # provenance is per-process; the path value is what matters
+        # across boundaries.
+        env["LORE_ROOT"] = str(lore_root)
+        env["LORE_CURATOR_MODE"] = "1"
+        log_fd = _open_proc_log(lore_root, role)
+        proc_dir = lore_root / ".lore" / "proc"
+        meta_path = proc_dir / f"{role}.meta.json"
+        _rotate_meta_sidecar(proc_dir, role)
+        wrapped_cmd = [
+            sys.executable, "-m", "lore_cli._proc_wrapper",
+            str(meta_path), "--", *cmd,
+        ]
+        try:
+            subprocess.Popen(
+                wrapped_cmd,
+                cwd=str(lore_root),
+                start_new_session=True,
+                stdout=log_fd if log_fd is not None else subprocess.DEVNULL,
+                stderr=log_fd if log_fd is not None else subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                env=env,
+            )
+        except (OSError, subprocess.SubprocessError):
+            if log_fd is not None:
+                os.close(log_fd)
+            return False
+        if log_fd is not None:
+            os.close(log_fd)
+        with contextlib.suppress(OSError):
+            _write_stamp(stamp)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Curator-C scheduling helpers — co-located with the role definition that
+# uses them (PRD §11). Pure functions, no I/O beyond ``git config``.
+# ---------------------------------------------------------------------------
+
+
+def _curator_c_email() -> str:
+    """Resolve git user.email → hostname fallback → empty (offset=0)."""
+    from lore_core.git import git_user_email
+    return git_user_email(fallback_hostname=True)
+
+
+def _curator_c_jitter_seconds(email: str) -> int:
+    """Deterministic 0-48h offset from SHA-256(email). Empty → 0 (fire at Monday 00Z)."""
+    import hashlib
+    if not email:
+        return 0
+    h = hashlib.sha256(email.encode()).hexdigest()[:8]
+    return int(h, 16) % 172800  # 48h in seconds
+
+
+def _iso_week_monday_utc(ts: "datetime") -> "datetime":
+    """Monday 00:00Z of the ISO week containing ts."""
+    from datetime import UTC, datetime as _dt
+    from datetime import timedelta
+    weekday = ts.isocalendar().weekday  # 1..7, Monday=1
+    date = ts.date() - timedelta(days=weekday - 1)
+    return _dt(date.year, date.month, date.day, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# SpawnRole registry + the single public ``spawn()`` entry point
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpawnRole:
+    """One row in the spawn-role registry.
+
+    ``argv_builder`` is called with the keyword arguments forwarded from
+    :func:`spawn` (currently only Curator B uses one — ``wiki_name``).
+    The returned argv is the *child* command; ``_spawn_detached`` wraps it
+    in ``python -m lore_cli._proc_wrapper`` for sidecar lifecycle tracking.
+    """
+
+    name: str
+    argv_builder: Callable[..., list[str]] = field(repr=False)
+    default_cooldown_s: int
+    migrate_stamp: bool = False
+
+
+SPAWN_ROLES: dict[str, SpawnRole] = {
+    "a": SpawnRole(
+        name="a",
+        argv_builder=lambda: [
+            sys.executable, "-m", "lore_cli", "curator", "run",
+        ],
+        default_cooldown_s=60,
+        migrate_stamp=True,
+    ),
+    "b": SpawnRole(
+        name="b",
+        argv_builder=lambda *, wiki_name: [
+            sys.executable, "-m", "lore_cli",
+            "curator", "run", "--abstract", "--wiki", wiki_name,
+        ],
+        default_cooldown_s=300,
+        migrate_stamp=True,
+    ),
+    "c": SpawnRole(
+        name="c",
+        argv_builder=lambda: [
+            sys.executable, "-m", "lore_cli",
+            "curator", "run", "--defrag",
+        ],
+        default_cooldown_s=3600,
+    ),
+    "transcripts": SpawnRole(
+        name="transcripts",
+        argv_builder=lambda: [
+            sys.executable, "-m", "lore_cli", "transcripts", "sync",
+        ],
+        default_cooldown_s=300,
+    ),
+}
+
+
+def spawn(
+    role: str, lore_root: Path, *, cooldown_s: int | None = None, **extra
+) -> bool:
+    """Public entry point — fire-and-forget the registered subprocess for ``role``.
+
+    Looks up :data:`SPAWN_ROLES`, builds the argv (forwarding ``**extra``
+    to the role's ``argv_builder``), and dispatches through
+    :func:`_spawn_detached` with the role's cooldown + stamp-migration
+    flags. ``cooldown_s`` overrides the registry default when caller has
+    a wiki-config-derived value.
+    """
+    role_def = SPAWN_ROLES[role]
+    return _spawn_detached(
+        lore_root,
+        role_def.name,
+        role_def.argv_builder(**extra),
+        cooldown_s=(
+            cooldown_s if cooldown_s is not None else role_def.default_cooldown_s
+        ),
+        migrate_stamp=role_def.migrate_stamp,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat wrappers — kept as one-liners over :func:`spawn` so
+# existing call sites and `patch("lore_cli.hooks._spawn_detached_curator_*")`
+# in the test suite keep working unchanged.
+# ---------------------------------------------------------------------------
+
+
+def _spawn_detached_curator_a(lore_root: Path, *, cooldown_s: int = 60) -> bool:
+    """Fire-and-forget `lore curator run` subprocess."""
+    return spawn("a", lore_root, cooldown_s=cooldown_s)
+
+
+def _spawn_detached_curator_b(
+    lore_root: Path, wiki_name: str, *, cooldown_s: int = 300
+) -> bool:
+    """Fire-and-forget `lore curator run --abstract --wiki <name>` subprocess."""
+    return spawn("b", lore_root, cooldown_s=cooldown_s, wiki_name=wiki_name)
+
+
+def _spawn_detached_curator_c(
+    lore_root: Path, *, cooldown_s: int = 3600
+) -> bool:
+    """Fire-and-forget `lore curator run --defrag` subprocess (Curator C)."""
+    return spawn("c", lore_root, cooldown_s=cooldown_s)
+
+
+def _spawn_detached_transcript_sync(
+    lore_root: Path, *, cooldown_s: int = 300
+) -> bool:
+    """Fire-and-forget ``lore transcripts sync`` subprocess.
+
+    Runs on the same spawn-lock + cooldown pattern as the curators, so
+    a busy SessionStart hook can't stampede the filesystem with parallel
+    sync jobs. The P4a sync itself is idempotent; the lock exists purely
+    as a politeness budget.
+    """
+    return spawn("transcripts", lore_root, cooldown_s=cooldown_s)

--- a/tests/test_proc_log_capture.py
+++ b/tests/test_proc_log_capture.py
@@ -66,7 +66,7 @@ def test_spawn_detached_writes_to_log(lore_root: Path) -> None:
             captured_kwargs.update(kwargs)
 
     with patch("subprocess.Popen", FakePopen):
-        with patch("lore_cli.hooks._stamp_within_cooldown", return_value=False):
+        with patch("lore_cli.spawn._stamp_within_cooldown", return_value=False):
             result = _spawn_detached(
                 lore_root, "a",
                 ["echo", "test"],
@@ -95,8 +95,8 @@ def test_spawn_detached_falls_back_to_devnull(lore_root: Path) -> None:
             captured_kwargs.update(kwargs)
 
     with patch("subprocess.Popen", FakePopen):
-        with patch("lore_cli.hooks._stamp_within_cooldown", return_value=False):
-            with patch("lore_cli.hooks._open_proc_log", return_value=None):
+        with patch("lore_cli.spawn._stamp_within_cooldown", return_value=False):
+            with patch("lore_cli.spawn._open_proc_log", return_value=None):
                 result = _spawn_detached(
                     lore_root, "a",
                     ["echo", "test"],

--- a/tests/test_spawn_runaway_detector.py
+++ b/tests/test_spawn_runaway_detector.py
@@ -99,7 +99,7 @@ def test_runaway_returns_none_when_pid_dead(tmp_path: Path) -> None:
         exit_code=None,
     )
     # PID 999999 is unlikely to exist; if it does the cmdline check rejects it.
-    with patch("lore_cli.hooks._process_is_ours", return_value=False):
+    with patch("lore_cli.spawn._process_is_ours", return_value=False):
         assert _prior_spawn_runaway(tmp_path, "a", runaway_age_s=300) is None
 
 
@@ -114,7 +114,7 @@ def test_runaway_detects_hung_prior_child(tmp_path: Path) -> None:
         start_ts=started,
         exit_code=None,
     )
-    with patch("lore_cli.hooks._process_is_ours", return_value=True):
+    with patch("lore_cli.spawn._process_is_ours", return_value=True):
         info = _prior_spawn_runaway(tmp_path, "a", runaway_age_s=300)
 
     assert info is not None
@@ -175,7 +175,7 @@ def test_spawn_detached_skips_when_prior_runaway(tmp_path: Path) -> None:
     runaway_info = {"pid": 12345, "age_s": 9999, "start_ts": time.time() - 9999}
 
     with patch("subprocess.Popen", FakePopen), \
-         patch("lore_cli.hooks._prior_spawn_runaway", return_value=runaway_info):
+         patch("lore_cli.spawn._prior_spawn_runaway", return_value=runaway_info):
         spawned = _spawn_detached(
             tmp_path, "a",
             ["python", "-m", "lore_cli", "curator", "run"],
@@ -213,7 +213,7 @@ def test_spawn_detached_runaway_warning_throttled(tmp_path: Path) -> None:
             raise AssertionError("Popen must not be called when runaway active")
 
     with patch("subprocess.Popen", FakePopen), \
-         patch("lore_cli.hooks._prior_spawn_runaway", return_value=runaway_info):
+         patch("lore_cli.spawn._prior_spawn_runaway", return_value=runaway_info):
         # Three back-to-back attempts within the throttle window.
         for _ in range(3):
             _spawn_detached(
@@ -251,7 +251,7 @@ def test_spawn_detached_proceeds_when_no_runaway(tmp_path: Path) -> None:
             popen_calls.append((args, kwargs))
 
     with patch("subprocess.Popen", FakePopen), \
-         patch("lore_cli.hooks._prior_spawn_runaway", return_value=None):
+         patch("lore_cli.spawn._prior_spawn_runaway", return_value=None):
         spawned = _spawn_detached(
             tmp_path, "a",
             ["python", "-m", "lore_cli", "curator", "run"],


### PR DESCRIPTION
## Summary

Third PR in the [#80 streamlining track](https://github.com/buchbend/lore/issues/80). Moves the spawn machinery (~310 LOC) out of `lib/lore_cli/hooks.py` into a new `lib/lore_cli/spawn.py` module and adds the `SpawnRole` dataclass + `SPAWN_ROLES` registry + `spawn(role, lore_root, **extra)` public entry point per the PRD.

**What lives in `spawn.py` now:**

- Stamp primitives: `_stamp_within_cooldown`, `_write_stamp` (used by both spawn cooldowns and the heartbeat throttles in `hooks.py`).
- Process / log machinery: `_process_is_ours`, `_open_proc_log`, `_rotate_meta_sidecar`, `_migrate_legacy_spawn_stamp`, `_prior_spawn_runaway`, `_spawn_detached`.
- Curator-C scheduling helpers (PRD §11 — co-located with the role definition that uses them): `_curator_c_email`, `_curator_c_jitter_seconds`, `_iso_week_monday_utc`.
- New: `SpawnRole` dataclass, `SPAWN_ROLES = {a, b, c, transcripts}` registry, and the single public `spawn(role, lore_root, *, cooldown_s=None, **extra) -> bool` entry point.
- Backward-compat wrappers: `_spawn_detached_curator_{a,b,c}` and `_spawn_detached_transcript_sync` are kept as one-liners that delegate to `spawn()`. Existing call sites in `hooks.py` and every test that patches `lore_cli.hooks._spawn_detached_curator_*` keep working unchanged.

**No-touch list honoured:** the spawn-core machinery (runaway gate, log-fd handling, sidecar rotation, proc-wrapper lifecycle) is moved verbatim — no behaviour change. PRD ratifies that this is safety machinery from the v0.37 hang storm and shouldn't be tinkered with in a structural PR.

**Net delta:**

- `hooks.py`: 3124 → 2815 LOC (-309).
- `spawn.py`: +444 LOC (dataclass + registry + module docstring + section headers — the one-time cost of the unification).
- Two test files: ~16 lines changed to repoint patch targets.
- Net across all files: **+142 LOC**. The visible win is the cohesion delta in `hooks.py`, not the line count — under the PRD's \"~150 LOC moved\" wording.

## Test plan

- [x] **Targeted suite green**: `tests/test_proc_log_capture.py`, `tests/test_spawn_throttle_concurrent.py`, `tests/test_spawn_runaway_detector.py`, `tests/test_hooks_curator_b_trigger.py`, `tests/test_doctor_no_side_effects.py`, `tests/test_heartbeat_session_drain.py`, `tests/test_auto_diagnostics_e2e.py` — **40 passed**.
- [x] **Full pytest sweep**: **2634 passed, 7 skipped**. Two pre-existing failures still unrelated and ignored: missing `openai` optional dep, `test_resume` fixture date drift (both noted in the PR-1 ship comment on #80).
- [x] **CLI surface byte-stable**: `lore hook --help` renders the same six subcommands.
- [x] **Registry parity**: `SPAWN_ROLES` exposes `{a, b, c, transcripts}` with cooldowns `{60, 300, 3600, 300}` and `migrate_stamp` `{True, True, False, False}` — matches the old wrapper defaults exactly.
- [x] **Test patch surgery** (the only test changes): `tests/test_proc_log_capture.py` and `tests/test_spawn_runaway_detector.py` repoint 6 patches from `lore_cli.hooks.<helper>` to `lore_cli.spawn.<helper>` because those tests patch helpers that `_spawn_detached` reads from its own module globals; patches at the `hooks` namespace no longer reach the spawn-side bindings. Tests that patch the **public wrappers** (`_spawn_detached_curator_*`) keep working unchanged because `hooks.py` still re-exports them.

Refs #80.