### PR TITLE
feat(#93): regions primitives + handle_read default-redact

### DIFF
--- a/lib/lore_core/regions.py
+++ b/lib/lore_core/regions.py
@@ -1,0 +1,86 @@
+"""Two-region note primitives — reload-safe vs human-only.
+
+A note body may carry a ``<!-- lore:human-only -->`` HTML-comment
+marker. Everything before the marker is the *reload-safe* region (what
+LLM retrieval is allowed to see); everything after is the *human-only*
+region (private scratch space the user keeps for themselves).
+
+The primitives are pure:
+
+* :data:`HUMAN_ONLY_MARKER` — the canonical marker literal.
+* :func:`split_regions` — forgiving parser returning
+  ``(reload_safe, human_only_or_None)``.
+* :func:`render_regions` — round-trip companion that omits the marker
+  cleanly when the human-only region is empty/``None``.
+* :func:`redact_human_only` — convenience returning only the
+  reload-safe portion; the default filter at every LLM-facing
+  boundary.
+
+Code-fence aware. A marker line that lives inside a fenced code
+block (``\\``` ``` / ``~~~``) is NOT a region boundary — symmetric to
+the fence handling in :mod:`lib.lore_core.wikilinks`.
+"""
+
+from __future__ import annotations
+
+import re
+
+HUMAN_ONLY_MARKER = "<!-- lore:human-only -->"
+
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+_MARKER_RE = re.compile(r"^\s*" + re.escape(HUMAN_ONLY_MARKER) + r"\s*$")
+
+
+def split_regions(body: str) -> tuple[str, str | None]:
+    """Split ``body`` at the first real ``HUMAN_ONLY_MARKER`` line.
+
+    Returns ``(reload_safe, human_only_or_None)``.
+
+    Rules:
+    * No marker → whole body is reload-safe; second tuple element is
+      ``None``.
+    * Multiple markers → first one wins; subsequent markers stay
+      verbatim in the human-only region.
+    * Whitespace tolerant — leading/trailing whitespace on the marker
+      line is ignored.
+    * Code-fence aware — a marker line inside a ``\\``` ``` or ``~~~``
+      fenced code block is NOT a boundary.
+    """
+    lines = body.splitlines(keepends=True)
+    in_fence = False
+    for idx, line in enumerate(lines):
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if _MARKER_RE.match(line):
+            reload_safe = "".join(lines[:idx])
+            human_only = "".join(lines[idx + 1:])
+            return reload_safe, human_only
+    return body, None
+
+
+def render_regions(reload_safe: str, human_only: str | None) -> str:
+    """Round-trip companion to :func:`split_regions`.
+
+    Emits the marker line only when ``human_only`` is non-empty. The
+    marker is delimited by single newlines so a subsequent
+    :func:`split_regions` call recovers the same regions verbatim
+    (modulo a possible trailing newline normalisation that does not
+    affect content).
+    """
+    if not human_only:
+        return reload_safe
+    sep_left = "" if reload_safe.endswith("\n") or reload_safe == "" else "\n"
+    return f"{reload_safe}{sep_left}{HUMAN_ONLY_MARKER}\n{human_only}"
+
+
+def redact_human_only(body: str) -> str:
+    """Return only the reload-safe portion of ``body``.
+
+    Convenience wrapper over :func:`split_regions` for the LLM-facing
+    default. Notes without a marker pass through unchanged.
+    """
+    reload_safe, _ = split_regions(body)
+    return reload_safe

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -43,6 +43,7 @@ from lore_core.freshness import (
     signal_to_dict,
 )
 from lore_core.freshness_filter import apply_search_filter
+from lore_core.regions import redact_human_only
 from lore_core.schema import extract_wikilinks, parse_frontmatter
 from lore_search.fts import FtsBackend
 
@@ -309,7 +310,10 @@ def _resolve_slug(wiki_path: Path, slug: str) -> str | None:
 
 
 def handle_read(
-    path: str, wiki: str | None = None, section: str | None = None
+    path: str,
+    wiki: str | None = None,
+    section: str | None = None,
+    include_human: bool = False,
 ) -> dict[str, Any]:
     wiki_path = _resolve_wiki(wiki)
     if wiki_path is None:
@@ -339,6 +343,13 @@ def handle_read(
     if not target.exists():
         return _mcp_error("path_not_found", f"not found: {path}")
     text = target.read_text(errors="replace")
+
+    # Two-region redaction (issue #93). The marker only ever appears in the
+    # body, never in YAML frontmatter, so applying redact_human_only to the
+    # full file text is safe and equivalent to body-only redaction. Old notes
+    # without a marker pass through unchanged → backwards compatible.
+    if not include_human:
+        text = redact_human_only(text)
 
     freshness = _freshness_block_for(
         wiki_path, path, orphan_set=load_orphan_set(wiki_path)
@@ -1163,7 +1174,10 @@ def _tool_schema() -> list[dict]:
                 "section (first match in document order, case-insensitive "
                 "substring; code-fence aware so ## inside fenced blocks is "
                 "ignored). Use `section` for long surface notes when you only "
-                "need one heading's content."
+                "need one heading's content. By default the response strips "
+                "the human-only region (everything after the "
+                "`<!-- lore:human-only -->` marker, if present). Pass "
+                "`include_human=true` to return the full note."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1175,6 +1189,16 @@ def _tool_schema() -> list[dict]:
                         "description": (
                             "If set, return only the matching H2 section "
                             "(heading + body to next H2 or EOF)."
+                        ),
+                    },
+                    "include_human": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": (
+                            "If true, include the human-only region of the "
+                            "note. Default false — LLM-facing callers should "
+                            "leave this off so private scratch content is "
+                            "never surfaced."
                         ),
                     },
                 },

--- a/tests/test_mcp_read_redaction.py
+++ b/tests/test_mcp_read_redaction.py
@@ -1,0 +1,141 @@
+"""Tests for handle_read default-redact behaviour (issue #93)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from lore_core.regions import HUMAN_ONLY_MARKER
+from lore_mcp.server import handle_read
+
+
+def _setup_wiki(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    body: str,
+    name: str = "note.md",
+) -> Path:
+    wiki = tmp_path / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    (wiki / "concepts" / name).write_text(body)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    return wiki
+
+
+def test_default_read_redacts_human_only(tmp_path, monkeypatch):
+    body = dedent(f"""\
+        # Title
+
+        Reload-safe content here.
+
+        {HUMAN_ONLY_MARKER}
+        Private scratch — should never reach the LLM.
+        """)
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read("concepts/note.md", wiki="demo")
+    assert "error" not in result
+    assert "Reload-safe content here." in result["content"]
+    assert "Private scratch" not in result["content"]
+    assert HUMAN_ONLY_MARKER not in result["content"]
+
+
+def test_include_human_true_returns_full_note(tmp_path, monkeypatch):
+    body = dedent(f"""\
+        # Title
+
+        Reload-safe content here.
+
+        {HUMAN_ONLY_MARKER}
+        Private scratch — visible only when include_human=true.
+        """)
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read("concepts/note.md", wiki="demo", include_human=True)
+    assert "error" not in result
+    assert result["content"] == body
+    assert "Private scratch" in result["content"]
+    assert HUMAN_ONLY_MARKER in result["content"]
+
+
+def test_old_note_without_marker_returned_in_full_default(tmp_path, monkeypatch):
+    """Backwards compatibility: notes pre-dating the two-region design have
+    no marker and must round-trip unchanged through the default filter."""
+    body = "# Old Note\n\nNo marker, all content is reload-safe.\n"
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read("concepts/note.md", wiki="demo")
+    assert "error" not in result
+    assert result["content"] == body
+
+
+def test_old_note_without_marker_returned_in_full_with_include_human(
+    tmp_path, monkeypatch
+):
+    body = "# Old Note\n\nNo marker anywhere.\n"
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read(
+        "concepts/note.md", wiki="demo", include_human=True
+    )
+    assert "error" not in result
+    assert result["content"] == body
+
+
+def test_section_arg_works_against_redacted_text(tmp_path, monkeypatch):
+    """When `section` is requested on a note with both regions, the H2
+    lookup runs against the *redacted* text — a section that lives only
+    in the human-only region must be invisible to the default reader."""
+    body = dedent(f"""\
+        # Title
+
+        ## Public
+
+        public body
+
+        {HUMAN_ONLY_MARKER}
+        ## Private
+
+        private body
+        """)
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read(
+        "concepts/note.md", wiki="demo", section="public"
+    )
+    assert "error" not in result
+    assert "public body" in result["content"]
+
+    # The Private section must NOT be retrievable by default.
+    missed = handle_read(
+        "concepts/note.md", wiki="demo", section="private"
+    )
+    assert "error" in missed
+    assert missed["error"]["code"] == "section_not_found"
+
+    # …but include_human=true makes it visible.
+    found = handle_read(
+        "concepts/note.md",
+        wiki="demo",
+        section="private",
+        include_human=True,
+    )
+    assert "error" not in found
+    assert "private body" in found["content"]
+
+
+def test_marker_inside_code_fence_is_not_a_boundary(tmp_path, monkeypatch):
+    """A marker that lives inside a fenced code block (e.g. documenting
+    the marker in a note about Lore itself) does NOT redact anything."""
+    body = dedent(f"""\
+        # About the marker
+
+        The marker literal is:
+
+        ```markdown
+        {HUMAN_ONLY_MARKER}
+        ```
+
+        And this paragraph is still reload-safe.
+        """)
+    _setup_wiki(tmp_path, monkeypatch, body=body)
+    result = handle_read("concepts/note.md", wiki="demo")
+    assert "error" not in result
+    assert result["content"] == body
+    assert "still reload-safe" in result["content"]

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,0 +1,204 @@
+"""Tests for lib/lore_core/regions.py — two-region note primitives."""
+from __future__ import annotations
+
+import pytest
+
+from lore_core.regions import (
+    HUMAN_ONLY_MARKER,
+    redact_human_only,
+    render_regions,
+    split_regions,
+)
+
+
+# ---------------------------------------------------------------------------
+# split_regions — basic
+# ---------------------------------------------------------------------------
+
+def test_split_no_marker_returns_whole_body():
+    body = "# Title\n\nSome content.\n"
+    reload_safe, human_only = split_regions(body)
+    assert reload_safe == body
+    assert human_only is None
+
+
+def test_split_with_marker():
+    body = (
+        "# Title\n\n"
+        "Reload-safe content.\n"
+        f"{HUMAN_ONLY_MARKER}\n"
+        "Human-only scratch.\n"
+    )
+    reload_safe, human_only = split_regions(body)
+    assert reload_safe == "# Title\n\nReload-safe content.\n"
+    assert human_only == "Human-only scratch.\n"
+
+
+def test_split_empty_body():
+    reload_safe, human_only = split_regions("")
+    assert reload_safe == ""
+    assert human_only is None
+
+
+def test_split_marker_only():
+    body = f"{HUMAN_ONLY_MARKER}\n"
+    reload_safe, human_only = split_regions(body)
+    assert reload_safe == ""
+    assert human_only == ""
+
+
+def test_split_human_only_with_sub_headings():
+    body = (
+        "Public lede.\n"
+        f"{HUMAN_ONLY_MARKER}\n"
+        "## My private notes\n\n"
+        "- thought 1\n"
+        "- thought 2\n"
+    )
+    reload_safe, human_only = split_regions(body)
+    assert reload_safe == "Public lede.\n"
+    assert "## My private notes" in human_only
+    assert "thought 2" in human_only
+
+
+# ---------------------------------------------------------------------------
+# split_regions — forgiveness
+# ---------------------------------------------------------------------------
+
+def test_split_multiple_markers_first_wins():
+    body = (
+        "A\n"
+        f"{HUMAN_ONLY_MARKER}\n"
+        "B\n"
+        f"{HUMAN_ONLY_MARKER}\n"
+        "C\n"
+    )
+    reload_safe, human_only = split_regions(body)
+    assert reload_safe == "A\n"
+    # Subsequent markers stay verbatim in the human-only region.
+    assert human_only == f"B\n{HUMAN_ONLY_MARKER}\nC\n"
+
+
+def test_split_whitespace_tolerant_marker():
+    body = f"A\n   {HUMAN_ONLY_MARKER}   \nB\n"
+    reload_safe, human_only = split_regions(body)
+    assert reload_safe == "A\n"
+    assert human_only == "B\n"
+
+
+# ---------------------------------------------------------------------------
+# split_regions — code-fence aware
+# ---------------------------------------------------------------------------
+
+def test_split_marker_inside_fenced_block_is_not_a_boundary():
+    body = (
+        "Public.\n\n"
+        "```markdown\n"
+        f"{HUMAN_ONLY_MARKER}\n"
+        "```\n\n"
+        "Still public.\n"
+    )
+    reload_safe, human_only = split_regions(body)
+    assert reload_safe == body
+    assert human_only is None
+
+
+def test_split_real_marker_after_closed_fence():
+    body = (
+        "Public.\n\n"
+        "```python\n"
+        f"# {HUMAN_ONLY_MARKER}\n"
+        "```\n\n"
+        f"{HUMAN_ONLY_MARKER}\n"
+        "Private.\n"
+    )
+    reload_safe, human_only = split_regions(body)
+    assert "Public." in reload_safe
+    assert "```python" in reload_safe
+    assert HUMAN_ONLY_MARKER not in reload_safe.split("```")[2] if "```" in reload_safe else True
+    assert human_only == "Private.\n"
+
+
+def test_split_tilde_fence_aware():
+    body = (
+        "Public.\n\n"
+        "~~~\n"
+        f"{HUMAN_ONLY_MARKER}\n"
+        "~~~\n"
+    )
+    reload_safe, human_only = split_regions(body)
+    assert reload_safe == body
+    assert human_only is None
+
+
+# ---------------------------------------------------------------------------
+# render_regions
+# ---------------------------------------------------------------------------
+
+def test_render_no_human_only_omits_marker():
+    rendered = render_regions("Just reload-safe.\n", None)
+    assert rendered == "Just reload-safe.\n"
+    assert HUMAN_ONLY_MARKER not in rendered
+
+
+def test_render_empty_human_only_omits_marker():
+    rendered = render_regions("Just reload-safe.\n", "")
+    assert rendered == "Just reload-safe.\n"
+    assert HUMAN_ONLY_MARKER not in rendered
+
+
+def test_render_with_human_only():
+    rendered = render_regions("Public.\n", "Private.\n")
+    assert HUMAN_ONLY_MARKER in rendered
+    assert rendered.startswith("Public.\n")
+    assert rendered.endswith("Private.\n")
+
+
+def test_render_handles_missing_trailing_newline():
+    rendered = render_regions("Public.", "Private.\n")
+    # Should still parse back cleanly.
+    rs, ho = split_regions(rendered)
+    assert "Public." in rs
+    assert ho == "Private.\n"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip identity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "# Title\n\nNo marker here.\n",
+        f"# Title\n\nPublic.\n{HUMAN_ONLY_MARKER}\nPrivate.\n",
+        f"Public.\n{HUMAN_ONLY_MARKER}\n## Subheading\n\n- a\n- b\n",
+        "```\n" + HUMAN_ONLY_MARKER + "\n```\nstill public\n",
+    ],
+)
+def test_roundtrip_split_render_split_is_identity(fixture):
+    rs1, ho1 = split_regions(fixture)
+    rendered = render_regions(rs1, ho1)
+    rs2, ho2 = split_regions(rendered)
+    assert rs2 == rs1
+    assert ho2 == ho1
+
+
+# ---------------------------------------------------------------------------
+# redact_human_only
+# ---------------------------------------------------------------------------
+
+def test_redact_no_marker_unchanged():
+    body = "# Title\n\nNo marker.\n"
+    assert redact_human_only(body) == body
+
+
+def test_redact_drops_human_only_region():
+    body = (
+        "Public.\n"
+        f"{HUMAN_ONLY_MARKER}\n"
+        "Private — should not appear.\n"
+    )
+    out = redact_human_only(body)
+    assert "Public." in out
+    assert "Private" not in out
+    assert HUMAN_ONLY_MARKER not in out


### PR DESCRIPTION
## Summary

Implements issue #93 — pure two-region note primitives + LLM-facing default redaction at the `lore_read` MCP boundary.

- `lib/lore_core/regions.py` — `HUMAN_ONLY_MARKER`, `split_regions`, `render_regions`, `redact_human_only`. Pure functions, code-fence aware (mirrors `wikilinks.py` fence handling), whitespace-tolerant marker matching, first-marker-wins forgiveness.
- `lib/lore_mcp/server.py` — `handle_read` applies `redact_human_only` by default; new `include_human: bool = False` parameter bypasses the filter. Tool schema exposes the new param.

Backwards compatible: notes without the marker pass through unchanged under both defaults.

## Test plan

- [x] `tests/test_regions.py` — 20 cases: no marker, with marker, multiple markers (first wins), whitespace tolerance, sub-headings in human-only region, backtick + tilde code-fence awareness, round-trip identity (parametrized).
- [x] `tests/test_mcp_read_redaction.py` — 6 cases covering acceptance criteria: default redacts, `include_human=true` returns full, old notes (no marker) returned in full under both modes, `section` arg interacts correctly with redaction, marker inside fenced code stays inert.
- [x] Full suite: 2707 passed locally; 2 pre-existing failures unrelated to this change (`test_openai_backend` missing optional dep, `test_resume_subtree_aggregates_issues` date-drift assertion).

Closes #93