### PR TITLE
feat(#80): PR 6a — flip three grandfather fixtures to production defaults

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,83 +1,18 @@
 """Shared pytest fixtures.
 
-The autouse fixture below forces ``LORE_NOTEWORTHY_MODE=llm_only`` on
-every test. This is a *grandfather* clause — most existing curator
-tests were written against the v0.5 default (LLM decides every
-slice's verdict), and v0.6.0 promoted the feature-based cascade to
-default. Tests that assert on LLM-request shape or on session notes
-produced from minimal fixtures still need the old default to stay
-valid.
+The three autouse "grandfather" fixtures that pinned the test suite to
+pre-production defaults (``LORE_NOTEWORTHY_MODE=llm_only``,
+``LORE_PROJECT_FOLDERS=off``, ``LORE_BUFFER_FLUSH=0``) were removed in
+PR 6a of the streamlining track (issue #80). Tests now run under
+production defaults; tests that genuinely exercise the legacy paths
+opt in inline with ``monkeypatch.setenv``.
 
-The cascade default *itself* is exercised by:
-
-* ``tests/test_noteworthy.py::test_resolve_mode_default_is_cascade``
-  (and friends 287-341) — unit-level coverage of the resolver.
-* ``tests/test_curator_a_cascade_default.py`` — Phase 6 integration
-  test that opts *out* of the autouse and verifies an end-to-end
-  curator A pass under cascade.
-
-**Phase 6 migration policy:** new tests should *not* depend on the
-autouse override. If your test needs ``llm_only``, declare it
-explicitly with::
-
-    @pytest.fixture(autouse=False)
-    def _force_llm_only(monkeypatch):
-        monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
-
-…or set it inline. Old tests are grandfathered; they're only
-migrated when their behaviour changes.
-
-Tests that exercise cascade mode locally still work because
-``monkeypatch.setenv`` precedence guarantees the per-test override
-wins over the autouse.
+The legacy code paths themselves are still in the tree; PRs 6b/6c/6d
+delete them once the test suite stops protecting them.
 """
 from __future__ import annotations
 
 import pytest
-
-
-@pytest.fixture(autouse=True)
-def _default_noteworthy_mode_llm_only(monkeypatch):
-    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
-
-
-@pytest.fixture(autouse=True)
-def _default_project_folders_off(monkeypatch):
-    """Grandfather pre step-9 tests onto the legacy flat-path layout.
-
-    Step-9 of the projects-as-canonical-surface plan flipped the
-    production default of ``LORE_PROJECT_FOLDERS`` from off to on. Tests
-    written before the flip assume flat ``plans/<slug>.md``,
-    ``concepts/<slug>.md`` etc. and would break under the new default.
-    They keep the legacy default via this autouse fixture (matches the
-    ``LORE_BUFFER_FLUSH`` and ``LORE_NOTEWORTHY_MODE`` patterns).
-
-    Dual-mode tests that want the on-path set
-    ``monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")`` inline; the
-    monkeypatch precedence rule guarantees the per-test override wins.
-    """
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "off")
-
-
-@pytest.fixture(autouse=True)
-def _default_buffer_flush_off(monkeypatch):
-    """Grandfather pre-PR-3 tests onto the legacy classify-per-chunk path.
-
-    PR 3 of the very-good-thats-the-mossy-lobster plan flipped the
-    production default of ``curator.use_buffer_flush`` to ``True``.
-    Tests that drive ``run_curator_a`` end-to-end were written against
-    the legacy synthesise-on-append path; they keep the legacy default
-    via this autouse fixture (matches the noteworthy_mode pattern
-    above).
-
-    Tests that exercise the buffer-and-flush path itself — buffer_store
-    primitives, buffer_append, stub_note, synthesis, the reaper, the
-    SessionEnd / SessionStart wiring — call those modules directly and
-    aren't affected by this flag. Tests that want the buffer path
-    inside ``run_curator_a`` set ``monkeypatch.setenv("LORE_BUFFER_FLUSH", "1")``
-    inline (precedence rule guarantees per-test wins).
-    """
-    monkeypatch.setenv("LORE_BUFFER_FLUSH", "0")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_curator_a.py
+++ b/tests/test_curator_a.py
@@ -238,8 +238,9 @@ def test_curator_a_end_to_end_noteworthy_produces_note(tmp_path):
     assert entry.digested_hash == turns[-1].content_hash()
 
 
-def test_curator_a_non_noteworthy_advances_ledger_no_file(tmp_path):
+def test_curator_a_non_noteworthy_advances_ledger_no_file(tmp_path, monkeypatch):
     """Fake LLM returns noteworthy=False; no session note; ledger still advanced."""
+    monkeypatch.setenv("LORE_BUFFER_FLUSH", "0")
     project_dir = tmp_path / "myproject"
     project_dir.mkdir()
     _write_claude_md(project_dir / "CLAUDE.md", wiki="private", scope="proj:test")
@@ -578,10 +579,12 @@ def test_curator_a_no_llm_client_records_skip(tmp_path):
     assert not sessions_dir.exists() or list(sessions_dir.rglob("*.md")) == []
 
 
-def test_curator_a_llm_client_error_skips_slice_without_aborting_run(tmp_path):
+def test_curator_a_llm_client_error_skips_slice_without_aborting_run(tmp_path, monkeypatch):
     """Gateway failure (5xx, timeout, oversize prompt) on one slice must not
     abort the whole curator run — the affected slice is skipped with a
     ``classify_failed`` reason so the rest of the queue proceeds."""
+    monkeypatch.setenv("LORE_BUFFER_FLUSH", "0")
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     project_dir = tmp_path / "myproject"
     project_dir.mkdir()
     _write_claude_md(project_dir / "CLAUDE.md", wiki="private", scope="proj:test")
@@ -664,13 +667,15 @@ def test_curator_a_result_counts_chunks_separately_from_transcripts(tmp_path):
     assert result.noteworthy_count == 3
 
 
-def test_curator_a_chunk_failure_does_not_advance_past_failed_chunk(tmp_path):
+def test_curator_a_chunk_failure_does_not_advance_past_failed_chunk(tmp_path, monkeypatch):
     """C1 regression: if chunk 0 raises, chunk 1's ledger advance must
     NOT overwrite the ledger past chunk 0 — that would silently lose
     chunk 0 forever on the next run.
 
     Behaviour: on chunk failure, abort the per-chunk loop. Subsequent
     chunks stay pending; next heartbeat retries the failing chunk."""
+    monkeypatch.setenv("LORE_BUFFER_FLUSH", "0")
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     from datetime import timedelta
 
     project_dir = tmp_path / "myproject"
@@ -735,11 +740,13 @@ def test_curator_a_chunk_failure_does_not_advance_past_failed_chunk(tmp_path):
     )
 
 
-def test_curator_a_day_split_produces_one_note_per_local_date(tmp_path):
+def test_curator_a_day_split_produces_one_note_per_local_date(tmp_path, monkeypatch):
     """Phase B: a slice spanning two local dates produces two session
     notes, one per day. Each chunk goes through cascade + classify
     independently; ledger advances after each so a mid-run failure
     doesn't lose committed work."""
+    monkeypatch.setenv("LORE_BUFFER_FLUSH", "0")
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     from datetime import timedelta
 
     project_dir = tmp_path / "myproject"
@@ -788,9 +795,11 @@ def test_curator_a_day_split_produces_one_note_per_local_date(tmp_path):
     assert entry.digested_hash == turns[-1].content_hash()
 
 
-def test_curator_a_single_day_slice_produces_one_note(tmp_path):
+def test_curator_a_single_day_slice_produces_one_note(tmp_path, monkeypatch):
     """Phase B regression guard: when all turns fall on one local date,
     behaviour is identical to pre-Phase-B (one chunk, one note)."""
+    monkeypatch.setenv("LORE_BUFFER_FLUSH", "0")
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     project_dir = tmp_path / "myproject"
     project_dir.mkdir()
     _write_claude_md(project_dir / "CLAUDE.md", wiki="private", scope="proj:test")

--- a/tests/test_mvp_capture_e2e.py
+++ b/tests/test_mvp_capture_e2e.py
@@ -294,6 +294,7 @@ def test_mvp_e2e_non_noteworthy_slice_produces_no_note(
     lore_root_with_attached_wiki, register_fake_claude_code, monkeypatch
 ):
     """Non-noteworthy classification: no session note, but ledger is advanced."""
+    monkeypatch.setenv("LORE_BUFFER_FLUSH", "0")
     lore_root, work = lore_root_with_attached_wiki
     turns = _make_turns(3)
     handle = _make_handle(work)

--- a/tests/test_mvp_capture_subprocess_e2e.py
+++ b/tests/test_mvp_capture_subprocess_e2e.py
@@ -177,9 +177,11 @@ _MERGE_PAYLOAD = {
 
 
 def test_e2e_subprocess_backend_produces_session_note(
-    lore_root_with_attached_wiki, register_fake_claude_code
+    lore_root_with_attached_wiki, register_fake_claude_code, monkeypatch
 ):
     """Full Curator A run using SubprocessClient + fake runner creates a session note."""
+    monkeypatch.setenv("LORE_BUFFER_FLUSH", "0")
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     lore_root, work = lore_root_with_attached_wiki
     turns = _make_turns(3)
     handle = _make_handle(work)

--- a/tests/test_noteworthy.py
+++ b/tests/test_noteworthy.py
@@ -74,7 +74,8 @@ def _simple_turns() -> list[Turn]:
 # ---------------------------------------------------------------------------
 
 
-def test_classify_returns_noteworthy_true_for_substantive_slice():
+def test_classify_returns_noteworthy_true_for_substantive_slice(monkeypatch):
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     data = {
         "noteworthy": True,
         "reason": "substantive refactor",
@@ -94,11 +95,12 @@ def test_classify_returns_noteworthy_true_for_substantive_slice():
     assert "append-only ledger" in result.description
 
 
-def test_classify_back_compat_summary_field_lands_in_description():
+def test_classify_back_compat_summary_field_lands_in_description(monkeypatch):
     """Older fixtures and any cached tool replays may still emit ``summary``.
     The classifier accepts it as a synonym for ``description`` so we don't
     silently lose content during the v2 → revised v2 migration window.
     """
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     data = {
         "noteworthy": True,
         "reason": "substantive",
@@ -110,7 +112,8 @@ def test_classify_back_compat_summary_field_lands_in_description():
     assert result.description == "Legacy paragraph that should land as description."
 
 
-def test_classify_returns_noteworthy_false_for_trivial():
+def test_classify_returns_noteworthy_false_for_trivial(monkeypatch):
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     data = {
         "noteworthy": False,
         "reason": "single tool question",
@@ -126,7 +129,8 @@ def test_classify_returns_noteworthy_false_for_trivial():
     assert result.reason == "single tool question"
 
 
-def test_classify_truncates_long_tool_results_in_prompt():
+def test_classify_truncates_long_tool_results_in_prompt(monkeypatch):
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     long_output = "\n".join(f"line {i}" for i in range(1000))
     tool_result = ToolResult(tool_call_id="t1", output=long_output)
     turns = [_t(role="tool", tool_result=tool_result)]
@@ -140,7 +144,8 @@ def test_classify_truncates_long_tool_results_in_prompt():
     assert "line 999" not in sent
 
 
-def test_classify_drops_thinking_blocks_from_prompt():
+def test_classify_drops_thinking_blocks_from_prompt(monkeypatch):
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     turns = [_t(role="assistant", reasoning="secret plan", text=None)]
     data = {"noteworthy": False, "reason": "trivial", "title": "t"}
     client = _make_client(data)
@@ -150,7 +155,8 @@ def test_classify_drops_thinking_blocks_from_prompt():
     assert "secret plan" not in sent
 
 
-def test_classify_uses_middle_tier_by_default():
+def test_classify_uses_middle_tier_by_default(monkeypatch):
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     recorded = []
 
     def recording_resolver(tier: str) -> str:
@@ -162,7 +168,8 @@ def test_classify_uses_middle_tier_by_default():
     assert recorded == ["middle"]
 
 
-def test_classify_uses_simple_tier_when_configured(tmp_path):
+def test_classify_uses_simple_tier_when_configured(tmp_path, monkeypatch):
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     recorded = []
 
     def recording_resolver(tier: str) -> str:
@@ -219,20 +226,23 @@ def test_simple_tier_without_lore_root_is_silent():
     assert result.noteworthy is False
 
 
-def test_classify_returns_valueerror_on_missing_tool_use():
+def test_classify_returns_valueerror_on_missing_tool_use(monkeypatch):
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     client = _make_text_client()
     with pytest.raises(ValueError, match="no tool_use block"):
         classify_slice(_simple_turns(), model_resolver=_resolver, llm_client=client)
 
 
-def test_classify_sends_correct_model_name():
+def test_classify_sends_correct_model_name(monkeypatch):
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     client = _make_client({"noteworthy": True, "reason": "r", "title": "t"})
     classify_slice(_simple_turns(), model_resolver=lambda _: "claude-sonnet-4-6",
                    llm_client=client)
     assert client.messages.calls[0]["model"] == "claude-sonnet-4-6"
 
 
-def test_classify_forces_tool_choice():
+def test_classify_forces_tool_choice(monkeypatch):
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     client = _make_client({"noteworthy": True, "reason": "r", "title": "t"})
     classify_slice(_simple_turns(), model_resolver=_resolver, llm_client=client)
     assert client.messages.calls[0]["tool_choice"] == {"type": "tool", "name": "classify"}
@@ -509,12 +519,13 @@ def test_classify_cascade_mode_calls_llm_on_uncertain(monkeypatch):
     assert result.reason == "llm_said_no"
 
 
-def test_classify_emits_prompt_chars_telemetry():
+def test_classify_emits_prompt_chars_telemetry(monkeypatch):
     """v0.5.8 replaced hardcoded token_count=0 with real prompt_chars.
 
     The noteworthy run-log events must now carry prompt_chars + usage so
     the operator can answer "which transcript ate my budget?"
     """
+    monkeypatch.setenv("LORE_NOTEWORTHY_MODE", "llm_only")
     from lore_core.run_log import RunLogger
 
     class _UsageShape:

--- a/tests/test_wiki_ledger_last_curator.py
+++ b/tests/test_wiki_ledger_last_curator.py
@@ -243,13 +243,14 @@ def test_curator_a_does_not_update_untouched_wikis(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_partial_failure_does_not_clobber_prior_last_curator_a(tmp_path: Path) -> None:
+def test_partial_failure_does_not_clobber_prior_last_curator_a(tmp_path: Path, monkeypatch) -> None:
     """If Curator A raises mid-run, last_curator_a is either prior OR new — never cleared.
 
     Atomic-or-unchanged contract. Guards against a future bug where
     update_last_curator is called before the work completes and an
     exception leaves a partially-updated ledger.
     """
+    monkeypatch.setenv("LORE_BUFFER_FLUSH", "0")
     project_dir, turns = _minimal_curator_a_setup(tmp_path)
 
     # Seed a prior last_curator_a value so we can detect clobber.


### PR DESCRIPTION
## Summary

- Deletes the three autouse "grandfather" fixtures from `tests/conftest.py` that pinned the suite to legacy defaults (`LORE_NOTEWORTHY_MODE=llm_only`, `LORE_PROJECT_FOLDERS=off`, `LORE_BUFFER_FLUSH=0`).
- Migrates 19 tests that genuinely exercise legacy code paths to inline `monkeypatch.setenv` opt-ins (per PRD: option (b) — "only when the test genuinely exercises rollback behaviour").
- No legacy code deleted yet — that's PRs 6b/6c/6d. This PR's job is just "land green under production defaults."

## Scope

Per the streamlining track PRD on issue #80, this is the riskiest PR in the track (user story #30: the conftest-flip "golden-output fallout" PR). The follow-on PRs delete the legacy code paths the fixtures were protecting:

- **PR 6b** — buffer-flush legacy delete (`summary_merge.py`, `_process_chunk`, `_buffer_flush_enabled`, `LORE_BUFFER_FLUSH`).
- **PR 6c** — `noteworthy_mode: llm_only` branch delete (`LORE_NOTEWORTHY_MODE`, `noteworthy_mode` config field, `llm_only` branch in `noteworthy.py`).
- **PR 6d** — `LORE_PROJECT_FOLDERS=off` legacy flat-path delete.

The 19 inline opt-ins in this PR get deleted alongside their target code in 6b/6c.

## Test Plan

- [x] `tests/conftest.py` rewritten — grandfather fixtures removed, `_isolate_user_config` preserved, module docstring updated to point at PRs 6b/6c/6d.
- [x] `tests/test_noteworthy.py` — 11 `test_classify_*` tests opt back into `llm_only` (cascade short-circuits the mock LLM client otherwise).
- [x] `tests/test_curator_a.py` — 5 tests opt into `LORE_BUFFER_FLUSH=0`; 4 of those also need `LORE_NOTEWORTHY_MODE=llm_only` (cascade returns trivial for minimal fixtures, so the mock noteworthy-true client is never reached).
- [x] `tests/test_mvp_capture_e2e.py`, `tests/test_mvp_capture_subprocess_e2e.py`, `tests/test_wiki_ledger_last_curator.py` — 3 tests opt back into the legacy buffer-flush path.
- [x] Full pytest suite: **2681 passed, 2 pre-existing failures** (`openai` optional dep, `test_resume` fixture date — both also fail on `main`). Net +1 vs the pre-flip baseline (a flaky `test_redaction` case cleared up).

## Reassessment context

This PR ships with the reassessment-checkpoint answer recorded as "still fights you" — but the rewrite question stays parked; we proceed into the grandfather track 6a → 6b → 6c → 6d. The follow-on PRs are the larger LOC deletes (PR 6b alone is the largest single delete in the track, est. ~700-900 LOC).

Refs #80.