### PR TITLE
feat(#94): curator emits two-region notes (compose schema + narrative prompt + renderer)

### DIFF
--- a/lib/lore_curator/synthesis.py
+++ b/lib/lore_curator/synthesis.py
@@ -54,6 +54,7 @@ import yaml
 from lore_adapters import Adapter, get_adapter
 from lore_core.io import atomic_write_text
 from lore_core.narrative_kind import NarrativeShape, select_shape
+from lore_core.regions import render_regions
 from lore_core.schema import parse_frontmatter, strip_frontmatter
 from lore_core.session_writer import (
     BodySections,
@@ -625,7 +626,18 @@ def _phase2_prompt(
             "takeaways distinctly from `discussion` (process narrative): "
             "takeaways = state-of-understanding, discussion = what was "
             "talked through. If the signal is thin, emit just the lede "
-            "and leave takeaways empty."
+            "and leave takeaways empty.\n\n"
+            "`summary_takeaways` are MARKERS, not claims, AND "
+            "self-contained references — they must read sensibly to a "
+            "cold reader who was not in the session. "
+            "✗ 'Explored two-region schema' — jargon, requires session "
+            "context. "
+            "✓ 'Explored splitting session notes into a reload-safe "
+            "region (LLM-accessible) and a human-only region (gated "
+            "retrieval) — the two-region shape' — referentially "
+            "complete. The test: would a colleague who was not in the "
+            "session understand this enough to know what the note is "
+            "about?"
         )
     else:
         summary_clause = (
@@ -719,6 +731,31 @@ def _phase2_prompt(
             adr_guidance,
         ])
 
+    # Narrative clause — unconditional, applies to both shapes (PRD #92,
+    # issue #94). The model decides per-session whether to emit content;
+    # empty is fine and encouraged for pure-grind sessions. Content
+    # lands in the human-only region (LLM-facing retrieval strips it).
+    parts.extend([
+        "",
+        "Write `narrative` as if telling a colleague what you did in "
+        "this session, at a level above implementation details (those "
+        "live in code / comments).",
+        "",
+        "- Calibrate length to substance. One sentence is fine. Empty "
+        "is fine. Sub-headings (### Investigation trail, "
+        "### Experiments) are fine when the session had a real arc.",
+        "- Voice: tentative for in-flight thinking (\"we leaned "
+        "toward\", \"the hot path turned out to be\"). Past-tense "
+        "investigation. Never \"decided X\" framing — promote to "
+        "`adr_candidates` if it's a real architectural fork, otherwise "
+        "leave it as story.",
+        "- Do NOT re-state files modified, outcomes, or loose-ends "
+        "from the structured section. Narrate around them.",
+        "- If the session was pure grind with no reasoning worth "
+        "telling a colleague, leave narrative empty. Padding is worse "
+        "than silence.",
+    ])
+
     if is_continuation and continues_wikilink:
         parts.extend([
             "",
@@ -790,6 +827,21 @@ def _phase2_tool_schema(shape: NarrativeShape | None = None) -> dict[str, Any]:
         # per candidate; the confabulation filter in _phase2_apply drops
         # any candidate that slips through with empty fields.
         "adr_candidates": adr_candidate.tool_schema_property(),
+        # Narrative is the human-only-region content (PRD #92 / issue #94).
+        # Optional, no length cap — the model self-calibrates length to
+        # substance. LLM-facing retrieval (lore_search, lore_read default,
+        # SessionStart, briefings) strips this region; only user-invoked
+        # paths (/lore:resume, /lore:context, direct read,
+        # lore_read --include_human=true) surface it.
+        "narrative": {
+            "type": "string",
+            "description": (
+                "Free-form prose carrying the investigation arc, "
+                "experiments, in-passing reasoning. Lands in the "
+                "human-only region; LLM-facing retrieval strips it by "
+                "default. Empty is fine — padding is worse than silence."
+            ),
+        },
     }
 
     if is_discussion:
@@ -1102,6 +1154,12 @@ def _phase2_apply(
         issues_closed=rb.activity_issues_closed,
         discussion=_bulletise(discussion),
     ))
+    # Two-region wiring (PRD #92, issue #94): wrap the structured body
+    # with the optional human-only narrative. ``render_regions`` omits
+    # the marker entirely when narrative is empty/None, so pure-grind
+    # sessions stay marker-free.
+    narrative_text = (composed.get("narrative") or "").strip()
+    body = render_regions(body, narrative_text or None)
     new_text = _render_markdown(fm, body, wiki_root=wiki_root)
     atomic_write_text(stub_path, new_text)
 

--- a/tests/fixtures/prompts/phase2_discussion.txt
+++ b/tests/fixtures/prompts/phase2_discussion.txt
@@ -5,6 +5,8 @@ Return your output via the `compose` tool. Bullet-count caps are hard: discussio
 Title: 6-8 words; content-named (NOT phase numbers or release labels); reads as a filename a year from now.
 Description: 1-2 sentences; what + why in one breath (retrieval-shaped — distinct from `summary_lede` which is outcome-shaped for scanning).
 Summary: emit `summary_lede` — ONE sentence (<= 160 chars) answering 'what is this note about' — plus 0-4 `summary_takeaways` bullets naming what was understood, weighed, or framed (no outcome shipped). Frame the takeaways distinctly from `discussion` (process narrative): takeaways = state-of-understanding, discussion = what was talked through. If the signal is thin, emit just the lede and leave takeaways empty.
+
+`summary_takeaways` are MARKERS, not claims, AND self-contained references — they must read sensibly to a cold reader who was not in the session. ✗ 'Explored two-region schema' — jargon, requires session context. ✓ 'Explored splitting session notes into a reload-safe region (LLM-accessible) and a human-only region (gated retrieval) — the two-region shape' — referentially complete. The test: would a colleague who was not in the session understand this enough to know what the note is about?
 Bullets: lead with a 2-5 word bold phrase, colon, then detail.
 Loose ends: past-tense / stative phrasing, never imperatives.
 
@@ -15,6 +17,13 @@ Wikilink discipline: `[[ ]]` is reserved for vault note slugs that actually exis
 `adr_candidates`: leave the array empty unless the user explicitly ratified a fork in the road — most sessions produce zero candidates. If emitting a candidate, ALL four fields are required: `choice` (6-12 word fork taken), `rationale` (1-sentence why-not-the-alternative), `evidence` (verbatim transcript quote OR 'user explicitly confirmed at turn N'), `alternative_rejected` (the road not taken). NEVER emit action-shaped entries ('catch error X', 'add test Y') — only genuine architectural forks where the user ratified one path over another. Any candidate missing a required field is rejected.
 
 Title shape: title MUST NOT promise work that did not happen. If you are reaching for a deliverable verb ('Refactor', 'Add', 'Fix', 'Implement', 'Migrate', 'Build', 'Ship', 'Create', 'Delete', 'Replace'), prefix it with 'Discussed:' / 'Explored:' / 'Sketched:' / 'Reviewed:' OR rephrase as a noun phrase. The deliverable verb on its own lies about what the session produced.
+
+Write `narrative` as if telling a colleague what you did in this session, at a level above implementation details (those live in code / comments).
+
+- Calibrate length to substance. One sentence is fine. Empty is fine. Sub-headings (### Investigation trail, ### Experiments) are fine when the session had a real arc.
+- Voice: tentative for in-flight thinking ("we leaned toward", "the hot path turned out to be"). Past-tense investigation. Never "decided X" framing — promote to `adr_candidates` if it's a real architectural fork, otherwise leave it as story.
+- Do NOT re-state files modified, outcomes, or loose-ends from the structured section. Narrate around them.
+- If the session was pure grind with no reasoning worth telling a colleague, leave narrative empty. Padding is worse than silence.
 
 Activity already populated (do not duplicate verbatim, but use it to anchor the narrative):
 1 commit, 0 issues

--- a/tests/fixtures/prompts/phase2_work.txt
+++ b/tests/fixtures/prompts/phase2_work.txt
@@ -14,6 +14,13 @@ Wikilink discipline: `[[ ]]` is reserved for vault note slugs that actually exis
 
 `adr_candidates`: leave the array empty unless the user explicitly ratified a fork in the road — most sessions produce zero candidates. If emitting a candidate, ALL four fields are required: `choice` (6-12 word fork taken), `rationale` (1-sentence why-not-the-alternative), `evidence` (verbatim transcript quote OR 'user explicitly confirmed at turn N'), `alternative_rejected` (the road not taken). NEVER emit action-shaped entries ('catch error X', 'add test Y') — only genuine architectural forks where the user ratified one path over another. Any candidate missing a required field is rejected.
 
+Write `narrative` as if telling a colleague what you did in this session, at a level above implementation details (those live in code / comments).
+
+- Calibrate length to substance. One sentence is fine. Empty is fine. Sub-headings (### Investigation trail, ### Experiments) are fine when the session had a real arc.
+- Voice: tentative for in-flight thinking ("we leaned toward", "the hot path turned out to be"). Past-tense investigation. Never "decided X" framing — promote to `adr_candidates` if it's a real architectural fork, otherwise leave it as story.
+- Do NOT re-state files modified, outcomes, or loose-ends from the structured section. Narrate around them.
+- If the session was pure grind with no reasoning worth telling a colleague, leave narrative empty. Padding is worse than silence.
+
 Activity already populated (do not duplicate verbatim, but use it to anchor the narrative):
 1 commit, 0 issues
 

--- a/tests/test_synthesis_narrative.py
+++ b/tests/test_synthesis_narrative.py
@@ -1,0 +1,265 @@
+"""Tests for the narrative field in Curator A's compose call (issue #94).
+
+Covers three integration points in lib/lore_curator/synthesis.py:
+
+* ``_phase2_tool_schema`` — adds the ``narrative`` field for both work
+  and discussion shapes.
+* ``_phase2_prompt`` — adds the unconditional narrative clause and the
+  tightened discussion-shape ``summary_takeaways`` rule.
+* Phase-2 body rendering — wraps the structured body through
+  ``regions.render_regions``; the ``<!-- lore:human-only -->`` marker
+  lands in the file iff narrative is non-empty.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lore_core.narrative_kind import NarrativeShape
+from lore_core.regions import HUMAN_ONLY_MARKER, split_regions
+from lore_core.schema import strip_frontmatter
+from lore_curator.synthesis import (
+    _phase2_prompt,
+    _phase2_tool_schema,
+    synth_and_close,
+)
+
+# Re-use the existing test-suite fakes and helpers by importing them
+# from tests/test_synthesis.py — keeps fixture wiring + shape defaults
+# consistent.
+from tests.test_synthesis import (  # noqa: E402
+    _FakeLlmClient,
+    _make_shape,
+    _ok_responder,
+    _seed_stub,
+    lore_root,  # fixture
+    patch_collectors,  # fixture
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema — narrative field present in both shapes
+# ---------------------------------------------------------------------------
+
+def test_schema_work_shape_includes_narrative_field():
+    schema = _phase2_tool_schema(_make_shape(has_edits=True))
+    props = schema["input_schema"]["properties"]
+    assert "narrative" in props
+    assert props["narrative"]["type"] == "string"
+    # Narrative is OPTIONAL — must not be in the required list.
+    assert "narrative" not in schema["input_schema"]["required"]
+
+
+def test_schema_discussion_shape_includes_narrative_field():
+    schema = _phase2_tool_schema(_make_shape(has_edits=False))
+    props = schema["input_schema"]["properties"]
+    assert "narrative" in props
+    assert props["narrative"]["type"] == "string"
+    assert "narrative" not in schema["input_schema"]["required"]
+
+
+def test_schema_none_shape_includes_narrative_field():
+    """Tests / callers passing ``shape=None`` (work-shape default) also
+    get the narrative slot — uniform schema."""
+    schema = _phase2_tool_schema(None)
+    assert "narrative" in schema["input_schema"]["properties"]
+
+
+def test_schema_narrative_has_no_length_cap():
+    """Narrative is free-form; no maxLength on the string."""
+    schema = _phase2_tool_schema(_make_shape(has_edits=True))
+    narrative_prop = schema["input_schema"]["properties"]["narrative"]
+    assert "maxLength" not in narrative_prop
+
+
+# ---------------------------------------------------------------------------
+# Prompt — narrative clause + tightened takeaways
+# ---------------------------------------------------------------------------
+
+def test_prompt_work_shape_includes_narrative_clause():
+    prompt = _phase2_prompt(
+        turns_text="some turns",
+        activity_summary="",
+        is_continuation=False,
+        continues_wikilink=None,
+        shape=_make_shape(has_edits=True),
+    )
+    # Anchor phrases from the PRD's prompt-contract block.
+    assert "narrative" in prompt
+    assert "telling a colleague" in prompt
+    assert "Calibrate length to substance" in prompt
+    # Voice rule.
+    assert "tentative" in prompt
+    # Anti-padding rule.
+    assert "Padding is worse than silence" in prompt
+    # Anti-duplication rule.
+    assert "Do NOT re-state files modified" in prompt
+
+
+def test_prompt_discussion_shape_includes_narrative_clause():
+    prompt = _phase2_prompt(
+        turns_text="some turns",
+        activity_summary="",
+        is_continuation=False,
+        continues_wikilink=None,
+        shape=_make_shape(has_edits=False),
+    )
+    assert "telling a colleague" in prompt
+    assert "Calibrate length to substance" in prompt
+
+
+def test_prompt_discussion_takeaways_clause_tightened_to_self_contained():
+    """Discussion ``summary_takeaways`` clause must teach the cold-reader
+    test — takeaways are self-contained references, not session-jargon."""
+    prompt = _phase2_prompt(
+        turns_text="some turns",
+        activity_summary="",
+        is_continuation=False,
+        continues_wikilink=None,
+        shape=_make_shape(has_edits=False),
+    )
+    # The tightening anchor — either the phrase "self-contained" or the
+    # explicit cold-reader test must appear in the discussion prompt.
+    assert (
+        "self-contained" in prompt
+        or "cold reader" in prompt
+        or "colleague who was not in the session" in prompt
+    )
+
+
+# ---------------------------------------------------------------------------
+# Renderer — marker lands iff narrative non-empty
+# ---------------------------------------------------------------------------
+
+def test_phase2_apply_emits_marker_when_narrative_non_empty(
+    lore_root, patch_collectors, monkeypatch,
+):
+    _, _, sidecar_path = _seed_stub(lore_root, monkeypatch)
+    composed = {
+        "title": "auth handler refactor",
+        "description": "Rebuilt auth.py against the policy decorator.",
+        "summary_lede": "auth.py now uses the policy decorator.",
+        "summary_outcomes": ["callbacks pulled out", "tests green"],
+        "worked_on": ["**auth.py** — pulled callbacks"],
+        "loose_ends": [],
+        "narrative": (
+            "We leaned toward the decorator chain after the callback "
+            "approach forced too much glue code. Tried two variants of "
+            "the policy lookup before settling on the registry shape."
+        ),
+    }
+    llm = _FakeLlmClient(_ok_responder(composed))
+    outcome = synth_and_close(
+        sidecar_path,
+        lore_root=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        llm_client=llm,
+        model="m",
+    )
+    assert outcome.phase2_completed is True
+    text = outcome.stub_path.read_text()
+    assert HUMAN_ONLY_MARKER in text
+    assert "decorator chain" in text
+
+
+def test_phase2_apply_no_marker_when_narrative_empty(
+    lore_root, patch_collectors, monkeypatch,
+):
+    """Curator emits an empty narrative for pure-grind sessions; the
+    marker MUST be omitted (clean omission, not an empty section)."""
+    _, _, sidecar_path = _seed_stub(lore_root, monkeypatch)
+    composed = {
+        "title": "tiny cleanup",
+        "description": "d",
+        "summary_lede": "tiny touch-up to auth.py.",
+        "summary_outcomes": [],
+        "worked_on": ["**auth.py** — touched"],
+        "loose_ends": [],
+        "narrative": "",
+    }
+    llm = _FakeLlmClient(_ok_responder(composed))
+    outcome = synth_and_close(
+        sidecar_path,
+        lore_root=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        llm_client=llm,
+        model="m",
+    )
+    text = outcome.stub_path.read_text()
+    assert HUMAN_ONLY_MARKER not in text
+
+
+def test_phase2_apply_no_marker_when_narrative_omitted(
+    lore_root, patch_collectors, monkeypatch,
+):
+    """Narrative is optional. A composed dict that doesn't carry the
+    key at all (legacy / older code paths) also produces no marker."""
+    _, _, sidecar_path = _seed_stub(lore_root, monkeypatch)
+    composed = {
+        "title": "no-narrative session",
+        "description": "d",
+        "summary_lede": "small fix.",
+        "summary_outcomes": [],
+        "worked_on": ["**x.py** — touched"],
+        "loose_ends": [],
+        # No "narrative" key at all.
+    }
+    llm = _FakeLlmClient(_ok_responder(composed))
+    outcome = synth_and_close(
+        sidecar_path,
+        lore_root=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        llm_client=llm,
+        model="m",
+    )
+    text = outcome.stub_path.read_text()
+    assert HUMAN_ONLY_MARKER not in text
+
+
+def test_end_to_end_split_recovers_both_regions(
+    lore_root, patch_collectors, monkeypatch,
+):
+    """Round-trip contract: render → strip frontmatter → split_regions
+    recovers structured body + narrative."""
+    _, _, sidecar_path = _seed_stub(lore_root, monkeypatch)
+    narrative_text = (
+        "### Investigation trail\n\n"
+        "We chased the wrong cache key for an hour before noticing the "
+        "stale namespace.\n\n"
+        "### Experiments\n\n"
+        "- Tried bypassing the cache wrapper entirely — too slow.\n"
+        "- Tried a custom hasher — fixed the collision.\n"
+    )
+    composed = {
+        "title": "cache investigation",
+        "description": "Tracked a stale-key bug to the namespace prefix.",
+        "summary_lede": "Cache key collision traced to namespace prefix mismatch.",
+        "summary_outcomes": ["fixed in cache.py", "regression test added"],
+        "worked_on": ["**cache.py** — fixed key hasher"],
+        "loose_ends": [],
+        "narrative": narrative_text,
+    }
+    llm = _FakeLlmClient(_ok_responder(composed))
+    outcome = synth_and_close(
+        sidecar_path,
+        lore_root=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        llm_client=llm,
+        model="m",
+    )
+    text = outcome.stub_path.read_text()
+    body = strip_frontmatter(text)
+    reload_safe, human_only = split_regions(body)
+    # Structured fields land in reload-safe.
+    assert "## Summary" in reload_safe
+    assert "Cache key collision" in reload_safe
+    # Narrative content lands in human-only.
+    assert human_only is not None
+    assert "Investigation trail" in human_only
+    assert "stale namespace" in human_only
+    # No leakage in either direction.
+    assert "Investigation trail" not in reload_safe
+    assert "## Summary" not in human_only


### PR DESCRIPTION
## Summary

PRD #92 slice 2 — teaches Curator A's `compose` call to emit narrative content into the human-only region and wires Phase-2 body rendering through `regions.render_regions` so the `<!-- lore:human-only -->` marker lands in the file.

- **Schema**: `narrative` added as a top-level optional string (no length cap) in both work and discussion shapes. Description tells the model it's gated retrieval.
- **Prompt**: unconditional narrative clause (voice, length-to-substance, anti-padding, anti-duplication). Discussion-shape `summary_takeaways` clause tightened to require self-contained references with the explicit cold-reader test.
- **Renderer**: structured body wrapped through `render_regions(body, narrative or None)` before `_render_markdown`. Empty narrative omits the marker entirely.

## Test plan

- [x] `tests/test_synthesis_narrative.py` (11 cases) — schema for work / discussion / None shapes, no length cap, prompt clauses for both shapes, tightened takeaways rule, marker iff narrative non-empty, end-to-end split recovers both regions.
- [x] Golden prompt fixtures regenerated (`tests/fixtures/prompts/phase2_*.txt`).
- [x] Curator + synthesis suites: 83/83 green.
- [x] Full suite: 2718 passed; 2 pre-existing failures unrelated to this change (`test_openai_backend` missing optional dep, `test_resume_subtree_aggregates_issues` date drift). One redaction test observed flaking on a single full-suite run; passes on retry and in isolation.

Closes #94