### PR TITLE
feat(#96): MCP handlers apply redact_human_only (search, surface_context, briefing_gather)

### DIFF
--- a/lib/lore_core/briefing/gather.py
+++ b/lib/lore_core/briefing/gather.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from lore_core.config import get_wiki_root
 from lore_core.errors import NO_VAULT, WIKI_NOT_FOUND, mcp_error
+from lore_core.regions import redact_human_only
 from lore_core.schema import parse_frontmatter
 
 _LEDGER_FILE = ".briefing-ledger.json"
@@ -187,6 +188,12 @@ def gather(
             if md.name in incorporated or stem + ".md" in incorporated:
                 continue
             text = md.read_text(errors="replace")
+            # Two-region retrieval filter (PRD #92): gather feeds into LLM
+            # composition (the briefing skill writes prose from this), so
+            # strip the human-only region before any section extraction.
+            # Frontmatter lives above the marker, so parse_frontmatter is
+            # unaffected by the redaction.
+            text = redact_human_only(text)
             entry: dict[str, Any] = {
                 "path": rel,
                 "date": d.isoformat(),

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -639,6 +639,12 @@ def handle_surface_context(wiki: str) -> dict[str, Any]:
         if start != -1:
             end = txt.find("\n## ", start + 1)
             claude_md_attach = txt[start:end] if end != -1 else txt[start:]
+        # Two-region retrieval filter (PRD #92): handle_surface_context
+        # is an LLM-facing surface, so strip any human-only region a
+        # CLAUDE.md happens to carry. Conventionally CLAUDE.md has no
+        # marker; the call is defensive and a no-op for marker-free
+        # files.
+        claude_md_attach = redact_human_only(claude_md_attach)
 
     return {
         "schema": "lore.surface.context/1",
@@ -803,11 +809,16 @@ def handle_drill(
         return {"trace": trace, "result": {"notes": notes}}
 
     # Stage 2: read top hits
+    # Drill is the user-invoked deep-dive surface (PRD #92 retrieval
+    # contract): pass ``include_human=True`` so the full note — including
+    # the human-only region — is returned. ``handle_search`` /
+    # ``handle_surface_context`` / ``handle_briefing_gather`` are the
+    # auto-load surfaces where redaction is enforced.
     t0 = _time.monotonic()
     top_paths = [h["path"] for h in hits]
     read_failed_top: list[str] = []
     for path in top_paths:
-        body = handle_read(path=path, wiki=wiki)
+        body = handle_read(path=path, wiki=wiki, include_human=True)
         if "error" in body:
             read_failed_top.append(path)
             continue
@@ -871,7 +882,7 @@ def handle_drill(
         rel = _resolve_slug(wiki_path, slug)
         if rel is None:
             continue
-        body = handle_read(path=rel, wiki=wiki)
+        body = handle_read(path=rel, wiki=wiki, include_human=True)
         if "error" in body:
             read_failed_expanded.append(rel)
             continue

--- a/tests/test_mcp_drill.py
+++ b/tests/test_mcp_drill.py
@@ -44,7 +44,7 @@ def test_drill_full_chain_records_each_stage():
         "qux.md": "## Qux",
     }
 
-    def fake_read(path, wiki=None):
+    def fake_read(path, wiki=None, include_human=False):
         return _read(path, bodies[path])
 
     def fake_resolve(wiki_path, slug):
@@ -105,7 +105,7 @@ def test_drill_short_circuits_expand_when_no_wikilinks():
     bodies = {"solo.md": "## Solo\nno wikilinks here"}
 
     with patch("lore_mcp.server.handle_search", return_value=hits), \
-         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None: _read(path, bodies[path])), \
+         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None, include_human=False: _read(path, bodies[path])), \
          patch("lore_mcp.server._resolve_wiki", return_value="WIKI_PATH_STUB"):
         out = handle_drill(query="solo", wiki="private")
 
@@ -129,7 +129,7 @@ def test_drill_truncates_expanded_when_over_limit():
         return f"{slug}.md" if f"{slug}.md" in bodies else None
 
     with patch("lore_mcp.server.handle_search", return_value=hits), \
-         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None: _read(path, bodies[path])), \
+         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None, include_human=False: _read(path, bodies[path])), \
          patch("lore_mcp.server._resolve_slug", side_effect=fake_resolve), \
          patch("lore_mcp.server._resolve_wiki", return_value="WIKI_PATH_STUB"):
         out = handle_drill(query="hub", wiki="private", expand_limit=3)
@@ -168,7 +168,7 @@ def test_drill_skips_unresolvable_wikilinks():
         return f"{slug}.md" if f"{slug}.md" in bodies else None
 
     with patch("lore_mcp.server.handle_search", return_value=hits), \
-         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None: _read(path, bodies[path])), \
+         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None, include_human=False: _read(path, bodies[path])), \
          patch("lore_mcp.server._resolve_slug", side_effect=fake_resolve), \
          patch("lore_mcp.server._resolve_wiki", return_value="WIKI_PATH_STUB"):
         out = handle_drill(query="foo", wiki="private")
@@ -209,7 +209,7 @@ def test_drill_does_not_report_truncation_when_under_cap_due_to_unresolvable():
         return f"{slug}.md" if f"{slug}.md" in bodies else None
 
     with patch("lore_mcp.server.handle_search", return_value=hits), \
-         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None: _read(path, bodies[path])), \
+         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None, include_human=False: _read(path, bodies[path])), \
          patch("lore_mcp.server._resolve_slug", side_effect=fake_resolve), \
          patch("lore_mcp.server._resolve_wiki", return_value="WIKI_PATH_STUB"):
         out = handle_drill(query="hub", wiki="private", expand_limit=5)
@@ -237,7 +237,7 @@ def test_drill_truncated_slugs_lists_dropped_links():
         return f"{slug}.md" if f"{slug}.md" in bodies else None
 
     with patch("lore_mcp.server.handle_search", return_value=hits), \
-         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None: _read(path, bodies[path])), \
+         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None, include_human=False: _read(path, bodies[path])), \
          patch("lore_mcp.server._resolve_slug", side_effect=fake_resolve), \
          patch("lore_mcp.server._resolve_wiki", return_value="WIKI_PATH_STUB"):
         out = handle_drill(query="hub", wiki="private", expand_limit=3)
@@ -261,7 +261,7 @@ def test_drill_expand_only_filters_to_intersection():
         return f"{slug}.md" if f"{slug}.md" in bodies else None
 
     with patch("lore_mcp.server.handle_search", return_value=hits), \
-         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None: _read(path, bodies[path])), \
+         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None, include_human=False: _read(path, bodies[path])), \
          patch("lore_mcp.server._resolve_slug", side_effect=fake_resolve), \
          patch("lore_mcp.server._resolve_wiki", return_value="WIKI_PATH_STUB"):
         out = handle_drill(
@@ -294,7 +294,7 @@ def test_drill_expand_only_cannot_add_undiscovered_slugs():
         return f"{slug}.md" if f"{slug}.md" in bodies else None
 
     with patch("lore_mcp.server.handle_search", return_value=hits), \
-         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None: _read(path, bodies[path])), \
+         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None, include_human=False: _read(path, bodies[path])), \
          patch("lore_mcp.server._resolve_slug", side_effect=fake_resolve), \
          patch("lore_mcp.server._resolve_wiki", return_value="WIKI_PATH_STUB"):
         out = handle_drill(query="hub", wiki="private", expand_only=["a", "z"])
@@ -316,7 +316,7 @@ def test_drill_expand_only_empty_after_filter_short_circuits():
         return f"{slug}.md" if f"{slug}.md" in bodies else None
 
     with patch("lore_mcp.server.handle_search", return_value=hits), \
-         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None: _read(path, bodies[path])), \
+         patch("lore_mcp.server.handle_read", side_effect=lambda path, wiki=None, include_human=False: _read(path, bodies[path])), \
          patch("lore_mcp.server._resolve_slug", side_effect=fake_resolve), \
          patch("lore_mcp.server._resolve_wiki", return_value="WIKI_PATH_STUB"):
         out = handle_drill(
@@ -338,7 +338,7 @@ def test_drill_records_read_failures_in_trace():
     hits = [_hit("good.md"), _hit("broken.md")]
     bodies = {"good.md": "## Good\nno wikilinks"}
 
-    def fake_read(path, wiki=None):
+    def fake_read(path, wiki=None, include_human=False):
         if path in bodies:
             return _read(path, bodies[path])
         return {"error": {"code": "path_not_found", "message": f"not found: {path}"}}

--- a/tests/test_mcp_retrieval_filter.py
+++ b/tests/test_mcp_retrieval_filter.py
@@ -1,0 +1,250 @@
+"""Two-region retrieval filter at MCP boundaries (issue #96).
+
+PRD #92 defines a uniform retrieval contract: LLM-facing surfaces (the
+ones the agent loads autonomously) strip the ``<!-- lore:human-only -->``
+region; user-invoked surfaces return the full note.
+
+Slice #93 wired the contract for ``handle_read`` and the regions
+primitives. Slice #96 extends it to the remaining LLM-facing handlers
+(``handle_search``, ``handle_surface_context``, ``handle_briefing_gather``)
+and asserts that the user-invoked surfaces (``handle_resume``,
+``handle_drill``) stay un-redacted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from lore_core.regions import HUMAN_ONLY_MARKER
+
+
+HUMAN_ONLY_NEEDLE = "PRIVATE-NEEDLE-DO-NOT-LEAK"
+RELOAD_SAFE_NEEDLE = "public-needle-may-leak"
+
+
+@pytest.fixture(autouse=True)
+def _reset_reindex_throttle():
+    """Each test pivots ``$LORE_CACHE`` to a fresh tmp_path so the FTS
+    database starts empty. The MCP server keeps a module-global
+    reindex throttle keyed by wiki name; without resetting it, a second
+    test using the same wiki name would skip reindex and search against
+    an empty index. Clear the throttle for every test in this file."""
+    from lore_mcp import server
+
+    server._reindex_last_seen.clear()
+    yield
+    server._reindex_last_seen.clear()
+
+
+def _flatten(value) -> str:
+    """Recursively flatten a JSON-ish value to one big string for needle hunting."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return " ".join(_flatten(v) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return " ".join(_flatten(v) for v in value)
+    return repr(value)
+
+
+# ---------------------------------------------------------------------------
+# handle_search
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def search_vault(tmp_path, monkeypatch):
+    """One note with both regions; reload-safe carries the search term."""
+    vault_root = tmp_path / "vault"
+    wiki = vault_root / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    (wiki / "concepts" / "two-region.md").write_text(dedent(f"""\
+        ---
+        schema_version: 2
+        type: concept
+        description: "A two-region demo note"
+        tags: [demo]
+        ---
+        # Two-region demo
+
+        Reload-safe body mentions {RELOAD_SAFE_NEEDLE}.
+
+        {HUMAN_ONLY_MARKER}
+        Human-only body mentions {HUMAN_ONLY_NEEDLE}.
+        """))
+    monkeypatch.setenv("LORE_ROOT", str(vault_root))
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+    return vault_root
+
+
+def test_search_response_omits_human_only_content(search_vault):
+    """handle_search's response carries no body content, so any term that
+    only lives in the human-only region must not leak via any response
+    field (description, tags, snippet, …)."""
+    from lore_mcp.server import handle_search
+
+    hits = handle_search(query=RELOAD_SAFE_NEEDLE, wiki="demo")
+    assert hits, "reload-safe term should still surface the note"
+    blob = _flatten(hits)
+    assert HUMAN_ONLY_NEEDLE not in blob
+    assert HUMAN_ONLY_MARKER not in blob
+
+
+# ---------------------------------------------------------------------------
+# handle_surface_context
+# ---------------------------------------------------------------------------
+
+
+def test_surface_context_redacts_claude_md_attach(tmp_path, monkeypatch):
+    """The ``## Lore`` attach block from CLAUDE.md is LLM-facing — a
+    marker inside it must be stripped before the dict is returned."""
+    from lore_mcp.server import handle_surface_context
+
+    vault_root = tmp_path / "vault"
+    wiki = vault_root / "wiki" / "demo"
+    wiki.mkdir(parents=True)
+    (wiki / "CLAUDE.md").write_text(dedent(f"""\
+        # Project
+
+        ## Lore
+
+        Reload-safe orientation mentions {RELOAD_SAFE_NEEDLE}.
+
+        {HUMAN_ONLY_MARKER}
+        Human-only mentions {HUMAN_ONLY_NEEDLE}.
+        """))
+    monkeypatch.setenv("LORE_ROOT", str(vault_root))
+
+    result = handle_surface_context(wiki="demo")
+    attach = result["claude_md_attach"]
+    assert RELOAD_SAFE_NEEDLE in attach
+    assert HUMAN_ONLY_NEEDLE not in attach
+    assert HUMAN_ONLY_MARKER not in attach
+
+
+# ---------------------------------------------------------------------------
+# handle_briefing_gather
+# ---------------------------------------------------------------------------
+
+
+def test_briefing_gather_redacts_session_sections(tmp_path, monkeypatch):
+    """Sections that live in the human-only region of a session note must
+    NOT appear in the gather output (the gather feeds an LLM compose)."""
+    from lore_mcp.server import handle_briefing_gather
+
+    vault_root = tmp_path / "vault"
+    wiki = vault_root / "wiki" / "demo"
+    (wiki / "sessions").mkdir(parents=True)
+    (wiki / "sessions" / "2026-05-12-demo.md").write_text(dedent(f"""\
+        ---
+        schema_version: 2
+        type: session
+        created: 2026-05-12
+        description: "demo session"
+        ---
+
+        ## Public
+
+        Reload-safe body mentions {RELOAD_SAFE_NEEDLE}.
+
+        {HUMAN_ONLY_MARKER}
+        ## Private
+
+        Human-only body mentions {HUMAN_ONLY_NEEDLE}.
+        """))
+    monkeypatch.setenv("LORE_ROOT", str(vault_root))
+
+    result = handle_briefing_gather(wiki="demo")
+    assert "error" not in result
+    sessions = result["new_sessions"]
+    assert len(sessions) == 1
+    sections = sessions[0]["sections"]
+
+    # Reload-safe section survives; human-only section is gone entirely.
+    assert "public" in sections
+    assert RELOAD_SAFE_NEEDLE in sections["public"]
+    assert "private" not in sections
+    blob = _flatten(result)
+    assert HUMAN_ONLY_NEEDLE not in blob
+    assert HUMAN_ONLY_MARKER not in blob
+
+
+# ---------------------------------------------------------------------------
+# Negative: user-invoked surfaces return the full note
+# ---------------------------------------------------------------------------
+
+
+def test_drill_returns_full_content_including_human_only(tmp_path, monkeypatch):
+    """``handle_drill`` is the user-invoked deep-dive surface — it must
+    return both regions so the user (or skill they explicitly invoked)
+    sees their own thinking."""
+    from lore_mcp.server import handle_drill
+
+    vault_root = tmp_path / "vault"
+    wiki = vault_root / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    (wiki / "concepts" / "drillable.md").write_text(dedent(f"""\
+        ---
+        schema_version: 2
+        type: concept
+        description: "drillable note"
+        tags: [drill]
+        ---
+        # Drillable
+
+        Reload-safe body mentions {RELOAD_SAFE_NEEDLE}.
+
+        {HUMAN_ONLY_MARKER}
+        Human-only body mentions {HUMAN_ONLY_NEEDLE}.
+        """))
+    monkeypatch.setenv("LORE_ROOT", str(vault_root))
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+
+    out = handle_drill(query=RELOAD_SAFE_NEEDLE, wiki="demo")
+    assert "error" not in out
+    notes = out["result"]["notes"]
+    assert notes, "drill must surface the matching note"
+    contents = "\n".join(n.get("content", "") for n in notes)
+    assert RELOAD_SAFE_NEEDLE in contents
+    assert HUMAN_ONLY_NEEDLE in contents, (
+        "drill is user-invoked per PRD #92; the human-only region must "
+        "round-trip in full"
+    )
+
+
+def test_resume_keyword_mode_passes_through_descriptions(tmp_path, monkeypatch):
+    """``handle_resume`` is user-invoked. Frontmatter ``description``
+    never carries human-only content (the marker is body-only), so the
+    keyword-mode descriptions surface unchanged."""
+    from lore_mcp.server import handle_resume
+
+    vault_root = tmp_path / "vault"
+    wiki = vault_root / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    (wiki / "concepts" / "resumable.md").write_text(dedent(f"""\
+        ---
+        schema_version: 2
+        type: concept
+        description: "resumable note"
+        tags: [resume]
+        ---
+        # Resumable
+
+        Reload-safe body mentions {RELOAD_SAFE_NEEDLE}.
+
+        {HUMAN_ONLY_MARKER}
+        Human-only body mentions {HUMAN_ONLY_NEEDLE}.
+        """))
+    monkeypatch.setenv("LORE_ROOT", str(vault_root))
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+
+    out = handle_resume(keyword=RELOAD_SAFE_NEEDLE, wiki="demo")
+    assert "error" not in out
+    # Resume's keyword mode returns search-shaped hits (description from
+    # frontmatter, no body). The point of this test is that resume is
+    # NOT in the redact set — i.e. it doesn't error or strip the legitimate
+    # frontmatter description.
+    blob = _flatten(out)
+    assert "resumable note" in blob


### PR DESCRIPTION
Closes #96.

PRD #92 slice — distribute the two-region retrieval-filter contract across the remaining LLM-facing MCP surfaces. #93 shipped the primitives + `handle_read` default-redact; #95 wired SessionStart. This slice closes the loop on the auto-load surfaces.

## Summary

- **`handle_briefing_gather`** — redact at the read site inside `lib/lore_core/briefing/gather.py` (after `read_text`, before section extraction). Frontmatter lives above the marker so `parse_frontmatter` is unaffected; H2 sections that live in the human-only region are dropped before the LLM composes briefing prose. Applies uniformly to MCP and the `lore briefing` CLI (same gather → same compose).
- **`handle_surface_context`** — redact `claude_md_attach` defensively (a marker inside CLAUDE.md's `## Lore` block is unusual but the contract should be uniform).
- **`handle_search`** — response shape carries no body content (`SearchHit.snippet` is always None; `description` is frontmatter). The contract is satisfied by construction; full FTS-level exclusion of notes matching only via human-only content lands in slice #97.
- **`handle_drill`** (user-invoked per PRD) — pass `include_human=True` into its inner `handle_read` calls so drill round-trips the full note. Without this, drill would inherit #93's default-redact and silently strip the user-visible region.
- **`handle_resume`** untouched — already body-free (frontmatter + section scans only).

## Test plan

- [x] `pytest tests/test_mcp_retrieval_filter.py` — 5 new cases: positive for search/surface_context/briefing_gather, negative for drill/resume
- [x] `pytest tests/test_mcp_drill.py tests/test_briefing.py tests/test_mcp_read_redaction.py tests/test_mcp_surface_tools.py tests/test_hooks_sessionstart_redaction.py` — 61 passed, no regressions
- [x] Full suite: 2719 passed (one pre-existing unrelated `openai`-import failure on this machine)

## Follow-up

- Slice #97 remains: FTS index splits `body_reload_safe` / `body_human_only` so notes matching only via human-only content don't surface their *path* via `handle_search` either.
- Module-global FTS reindex throttle (`_reindex_last_seen`) leaks across tests when the same wiki name is reused under a fresh `$LORE_CACHE`; new test file clears it via autouse fixture. Worth promoting to `conftest.py` if more FTS-touching tests appear.