### PR TITLE
feat(#97): FTS index splits body into reload_safe + human_only

### DIFF
--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -231,7 +231,9 @@ def handle_search(
 ) -> list[dict[str, Any]]:
     backend = FtsBackend()
     _maybe_reindex(backend, wiki)
-    hits = backend.search(query, wiki=wiki, for_repo=for_repo, k=k)
+    hits = backend.search(
+        query, wiki=wiki, for_repo=for_repo, k=k, redact_human_only=True
+    )
     # Cache one wiki-path resolution per (wiki-name) and one orphan-set
     # load per wiki-path to avoid re-walking ``$LORE_ROOT/wiki`` and
     # re-reading ``_catalog.json`` on every hit.

--- a/lib/lore_search/fts.py
+++ b/lib/lore_search/fts.py
@@ -25,6 +25,7 @@ from lore_core.lint import (
     discover_notes,
     discover_wikis,
 )
+from lore_core.regions import split_regions
 from lore_core.schema import parse_frontmatter
 
 
@@ -67,11 +68,11 @@ def _sha256(text: str) -> str:
 
 
 # Bump when the on-disk schema changes in a way that requires a rebuild.
-# The v1→v2 jump added `contentless_delete=1` to `notes_fts`; without
-# it, `DELETE FROM notes_fts WHERE rowid=?` raises
-# `OperationalError: cannot DELETE from contentless fts5 table: notes_fts`
-# on any reindex that updates or removes an already-indexed note.
-SCHEMA_VERSION = 2
+# v1→v2: added `contentless_delete=1` to `notes_fts` so DELETE works.
+# v2→v3: split `body` into `body_reload_safe` + `body_human_only` so
+# LLM-facing search can exclude the human-only region (PRD #92,
+# issue #97 — option (b) clean exclusion, no snippet preview).
+SCHEMA_VERSION = 3
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS notes (
@@ -91,7 +92,8 @@ CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
     title,
     description,
     tags,
-    body,
+    body_reload_safe,
+    body_human_only,
     content='',
     contentless_delete=1,
     tokenize='porter unicode61'
@@ -102,6 +104,12 @@ CREATE TABLE IF NOT EXISTS meta (
     value TEXT
 );
 """
+
+# Columns the LLM-facing search is allowed to match against. The
+# human-only body column is deliberately absent — a term that lives
+# *only* in human-only content must not surface to LLM retrieval
+# (PRD #92, option (b)).
+LLM_FACING_COLUMNS = ("title", "description", "tags", "body_reload_safe")
 
 
 def _stored_schema_version(conn: sqlite3.Connection) -> int:
@@ -311,10 +319,19 @@ class FtsBackend:
                 ),
             )
             rowid = cur.lastrowid
+        body_reload_safe, body_human_only = split_regions(rec.body)
         conn.execute(
-            "INSERT INTO notes_fts (rowid, title, description, tags, body) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (rowid, rec.title, rec.description, " ".join(rec.tags), rec.body),
+            "INSERT INTO notes_fts (rowid, title, description, tags, "
+            "body_reload_safe, body_human_only) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                rowid,
+                rec.title,
+                rec.description,
+                " ".join(rec.tags),
+                body_reload_safe,
+                body_human_only or "",
+            ),
         )
 
     def search(
@@ -324,6 +341,7 @@ class FtsBackend:
         wiki: str | None = None,
         for_repo: str | None = None,
         k: int = 5,
+        redact_human_only: bool = False,
     ) -> list[SearchHit]:
         """Hybrid AND-then-OR ranked search.
 
@@ -332,6 +350,12 @@ class FtsBackend:
         AND returns zero hits, retry with OR-joined tokens for graceful
         degradation. Single-token queries reduce to the same scan in
         both modes.
+
+        When ``redact_human_only=True`` (LLM-facing callers via MCP),
+        the MATCH expression is wrapped in an FTS5 column filter so
+        only the four LLM-facing columns are searched; a term that
+        lives only in the human-only body region produces no hit
+        (PRD #92 option (b) — clean exclusion, no snippet preview).
 
         Each query writes one record to ``$LORE_CACHE/query-log.jsonl``
         capturing both the AND and OR hit counts, so the
@@ -353,6 +377,10 @@ class FtsBackend:
                 results=[],
             )
             return []
+
+        if redact_human_only:
+            sanitized_and = _scope_to_columns(sanitized_and, LLM_FACING_COLUMNS)
+            sanitized_or = _scope_to_columns(sanitized_or, LLM_FACING_COLUMNS)
 
         conn = _connect()
         try:
@@ -415,7 +443,8 @@ class FtsBackend:
                     3.0,  -- title
                     2.0,  -- description
                     1.5,  -- tags
-                    1.0   -- body
+                    1.0,  -- body_reload_safe
+                    1.0   -- body_human_only
                ) AS score
         FROM notes_fts
         JOIN notes n ON n.id = notes_fts.rowid
@@ -496,6 +525,18 @@ def _sanitize_fts_query_or(q: str) -> str:
     if not tokens:
         return ""
     return " OR ".join(f'"{t}"' for t in tokens)
+
+
+def _scope_to_columns(match_str: str, columns: tuple[str, ...]) -> str:
+    """Wrap a sanitized MATCH string in an FTS5 column-set filter.
+
+    FTS5 syntax ``{col1 col2}: (expr)`` restricts every phrase in
+    ``expr`` to match within one of the listed columns. Used by the
+    LLM-facing search path to exclude the ``body_human_only`` column
+    from retrieval (PRD #92, issue #97).
+    """
+    col_set = " ".join(columns)
+    return f"{{{col_set}}}: ({match_str})"
 
 
 def _log_query(**fields: Any) -> None:

--- a/tests/test_fts_human_only_exclusion.py
+++ b/tests/test_fts_human_only_exclusion.py
@@ -1,0 +1,184 @@
+"""FTS5 index splits body into reload_safe + human_only.
+
+LLM-facing search (``redact_human_only=True``) returns notes only when
+the matching term appears in title / description / tags / reload-safe
+body. A term that lives *only* in the human-only region must NOT
+surface to the LLM — option (b) clean exclusion (no snippet preview,
+no ranked hit).
+
+Human-facing search (``redact_human_only=False``, the default) matches
+across the whole note including the human-only region.
+
+Backwards compatibility: a note without the marker indexes its entire
+body into ``body_reload_safe`` — old vaults work unchanged.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+
+@pytest.fixture
+def vault(tmp_path, monkeypatch):
+    """Vault with three notes exercising the two-region contract.
+
+    * ``human-only-secret``: matching term ONLY in human-only region.
+    * ``reload-safe-public``: matching term ONLY in reload-safe region.
+    * ``legacy-no-marker``: matching term in body, no marker — the
+      whole body is reload-safe.
+    """
+    vault_root = tmp_path / "vault"
+    wiki = vault_root / "wiki" / "demo"
+    (wiki / "sessions").mkdir(parents=True)
+
+    (wiki / "sessions" / "human-only-secret.md").write_text(dedent("""\
+        ---
+        schema_version: 2
+        type: session
+        description: "Session note with humanonly region"
+        tags: [session]
+        ---
+        # Session A
+
+        Public summary of work.
+
+        <!-- lore:human-only -->
+
+        Tentative thinking: we leaned toward the magicwordhuman approach,
+        but it might be wrong. This region is gated.
+        """))
+
+    (wiki / "sessions" / "reload-safe-public.md").write_text(dedent("""\
+        ---
+        schema_version: 2
+        type: session
+        description: "Session note with reloadsafe content only"
+        tags: [session]
+        ---
+        # Session B
+
+        The magicwordhuman appears here in the reload-safe region,
+        not gated.
+
+        <!-- lore:human-only -->
+
+        Some private thought unrelated to the search term.
+        """))
+
+    (wiki / "sessions" / "legacy-no-marker.md").write_text(dedent("""\
+        ---
+        schema_version: 2
+        type: session
+        description: "Legacy session with no marker"
+        tags: [session]
+        ---
+        # Legacy Session
+
+        The magicwordhuman appears here in a pre-two-region note.
+        Whole body is treated as reload-safe.
+        """))
+
+    monkeypatch.setenv("LORE_ROOT", str(vault_root))
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+    return vault_root
+
+
+def test_llm_facing_search_excludes_human_only_match(vault):
+    """A term that lives only in human-only must NOT surface to LLM-facing search."""
+    from lore_search.fts import FtsBackend
+
+    backend = FtsBackend()
+    backend.reindex()
+
+    hits = backend.search("magicwordhuman", redact_human_only=True)
+    paths = [h.path for h in hits]
+
+    # The note with the term only in human-only must not appear.
+    assert not any("human-only-secret" in p for p in paths), (
+        f"human-only-only match leaked into LLM-facing search: {paths}"
+    )
+    # The reload-safe note and the legacy-no-marker note DO appear.
+    assert any("reload-safe-public" in p for p in paths), paths
+    assert any("legacy-no-marker" in p for p in paths), paths
+
+
+def test_human_facing_search_returns_human_only_match(vault):
+    """Default search (human-facing) matches the whole note including human-only."""
+    from lore_search.fts import FtsBackend
+
+    backend = FtsBackend()
+    backend.reindex()
+
+    hits = backend.search("magicwordhuman")  # default redact_human_only=False
+    paths = [h.path for h in hits]
+
+    # All three notes contain the term somewhere — all three must surface.
+    assert any("human-only-secret" in p for p in paths), paths
+    assert any("reload-safe-public" in p for p in paths), paths
+    assert any("legacy-no-marker" in p for p in paths), paths
+
+
+def test_legacy_note_without_marker_indexes_full_body_as_reload_safe(vault):
+    """Old notes (no marker) are entirely reload-safe — backwards compat."""
+    from lore_search.fts import FtsBackend
+
+    backend = FtsBackend()
+    backend.reindex()
+
+    # LLM-facing must find the legacy note even though it predates the marker.
+    hits = backend.search("magicwordhuman", redact_human_only=True)
+    paths = [h.path for h in hits]
+    assert any("legacy-no-marker" in p for p in paths), (
+        f"legacy note without marker must index its full body into reload_safe: {paths}"
+    )
+
+
+def test_llm_facing_match_against_title_still_works(tmp_path, monkeypatch):
+    """Redact filter does not break matches against title / description / tags."""
+    vault_root = tmp_path / "vault"
+    wiki = vault_root / "wiki" / "demo"
+    (wiki / "concepts").mkdir(parents=True)
+    (wiki / "concepts" / "unique-title-token.md").write_text(dedent("""\
+        ---
+        schema_version: 2
+        type: concept
+        description: "Concept whose match-token is in the title"
+        tags: [demo]
+        ---
+        # Title-zzzunique-marker
+
+        Body content unrelated.
+
+        <!-- lore:human-only -->
+
+        Notes I keep private.
+        """))
+    monkeypatch.setenv("LORE_ROOT", str(vault_root))
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+
+    from lore_search.fts import FtsBackend
+    backend = FtsBackend()
+    backend.reindex()
+
+    hits = backend.search("zzzunique-marker", redact_human_only=True)
+    assert any("unique-title-token" in h.path for h in hits), hits
+
+
+def test_schema_has_separate_body_columns(vault):
+    """notes_fts virtual table declares body_reload_safe + body_human_only."""
+    import sqlite3
+    from lore_search.fts import FtsBackend, _db_path
+
+    FtsBackend().reindex()
+    conn = sqlite3.connect(_db_path())
+    try:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='notes_fts'"
+        ).fetchone()
+    finally:
+        conn.close()
+    sql = row[0] if row else ""
+    assert "body_reload_safe" in sql, f"missing body_reload_safe column: {sql!r}"
+    assert "body_human_only" in sql, f"missing body_human_only column: {sql!r}"


### PR DESCRIPTION
Closes #97. Implements the FTS half of PRD #92 (two-region session notes).

## Summary

- Schema v2→v3 splits `body` into `body_reload_safe` + `body_human_only` on `notes_fts`. Migration is transparent — the existing `_migrate_if_needed` drops the old table and the next reindex repopulates with the split.
- Indexer calls `lore_core.regions.split_regions` at upsert time. Notes without the marker put their full body into `body_reload_safe` (backwards compatible).
- `FtsBackend.search(..., redact_human_only=False)` gains a flag. When True, `_scope_to_columns` wraps the sanitised MATCH expression in `{title description tags body_reload_safe}: (...)` — option (b) clean exclusion: a term that lives only in human-only content produces no hit at all (no snippet preview).
- `lore_mcp/server.py:handle_search` is the sole call site opting into the redact. CLI search and `lore_core.resume` (human-facing per PRD) keep the default False.

## Test plan
- [x] `tests/test_fts_human_only_exclusion.py` — 5 tests: LLM exclusion, human-facing inclusion, legacy-no-marker compat, title-match still works, schema shape
- [x] `tests/test_fts_search.py` + `tests/test_fts_backend.py` still pass (regression check)
- [x] Full suite: 2682 passed, 7 skipped (excluding two pre-existing failures: missing optional `openai` dep + a resume.py test that fails on main too — both unrelated to this change)