### PR TITLE
feat(#80): PR 6d — delete LORE_PROJECT_FOLDERS=off legacy

### DIFF
--- a/lib/lore_core/projects/router.py
+++ b/lib/lore_core/projects/router.py
@@ -1,13 +1,10 @@
-"""Path resolver for project-folder-aware writes.
+"""Path resolver for project-folder-aware surface writes.
 
-Phase 3 of the projects-as-canonical rollout introduces a dual-mode
-schema where abstracted surfaces (concepts, decisions, threads) can
-live under their project's folder at ``projects/<slug>/<surface-dir>/``
-instead of the flat top-level ``<surface-dir>/``.
-
-The toggle ``LORE_PROJECT_FOLDERS=on`` opts into the new layout. When
-off (default), all writers use the legacy flat paths so existing
-vaults stay untouched until the migration session runs (Phase 9).
+Abstracted surfaces (concepts, decisions, threads) live under their
+project's folder at ``projects/<slug>/<surface-dir>/`` when a matching
+``projects/<slug>/`` exists in the wiki. Otherwise writers fall through
+to the legacy flat top-level ``<surface-dir>/`` path so vaults that
+haven't promoted a scope into a project folder yet keep working.
 
 Routing rule:
 - A scope's last colon-separated segment is the candidate project slug.
@@ -20,28 +17,7 @@ Empty/None scopes always fall through.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
-
-
-_TOGGLE_ENV = "LORE_PROJECT_FOLDERS"
-_TRUTHY = {"on", "1", "true", "yes"}
-_FALSY = {"off", "0", "false", "no"}
-
-
-def project_folders_enabled() -> bool:
-    """Return True when the ``LORE_PROJECT_FOLDERS`` toggle is on.
-
-    Default (post step-9 flip): on. Pass ``LORE_PROJECT_FOLDERS=off`` to
-    revert to legacy flat paths (emergency-rollback escape hatch).
-    Truthy values: ``on``, ``1``, ``true``, ``yes`` (case-insensitive).
-    """
-    val = os.environ.get(_TOGGLE_ENV, "").lower()
-    if val in _FALSY:
-        return False
-    if val in _TRUTHY:
-        return True
-    return True
 
 
 def project_slug_for_scope(scope: str | None) -> str | None:
@@ -61,14 +37,11 @@ def project_dir_for_scope(wiki_root: Path, scope: str | None) -> Path | None:
     """Return the project folder path for ``scope``, or None if unmapped.
 
     Returns None when:
-    - the toggle is off,
     - the scope is empty/None,
     - no ``projects/<slug>/`` folder exists in the wiki.
 
     Callers receiving None should fall through to the legacy flat path.
     """
-    if not project_folders_enabled():
-        return None
     slug = project_slug_for_scope(scope)
     if slug is None:
         return None
@@ -86,7 +59,7 @@ def resolve_surface_dir(
 ) -> Path:
     """Resolve the directory a surface note should be filed into.
 
-    With ``LORE_PROJECT_FOLDERS=on`` and a matching project folder:
+    With a matching project folder:
         ``<wiki_root>/projects/<slug>/<surface_subdir>``
     Otherwise (legacy flat path):
         ``<wiki_root>/<surface_subdir>``

--- a/lib/lore_curator/c_cross_scope_hoist.py
+++ b/lib/lore_curator/c_cross_scope_hoist.py
@@ -16,10 +16,6 @@ it via :func:`lore_core.projects.stub_generator.stub_project_note` with
 skeleton). Slug-collision against any non-project basename in the wiki
 aborts the auto-stub for that hoist.
 
-Toggle: requires ``LORE_PROJECT_FOLDERS=on`` (uses the same gate as the
-surface filer router). Without the toggle, project folders may not exist
-and the pass returns a "skipped" count.
-
 Threshold rationale: title-slug fuzz at 0.6 matches the existing
 adjacent-merge primitive (``c_adjacent_merge.py:43``). A pair-level
 match is an adjacent-merge candidate; a cross-sibling cluster of ≥2 is
@@ -34,7 +30,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from lore_core.projects.router import project_folders_enabled
 from lore_core.projects.stub_generator import stub_project_note
 from lore_core.schema import parse_frontmatter
 from lore_core.wikilinks import existing_slugs
@@ -187,14 +182,10 @@ def cross_scope_hoist_pass(
 
     Returns counters with keys:
       - ``cross_scope_hoist_proposed`` — new proposal notes written
-      - ``cross_scope_hoist_skipped_toggle_off`` — toggle off, no-op
       - ``cross_scope_hoist_skipped_collision`` — parent slug collides
         with a non-project basename, auto-stub aborted
       - ``cross_scope_hoist_existing`` — proposal already on disk, skipped
     """
-    if not project_folders_enabled():
-        return {"cross_scope_hoist_skipped_toggle_off": 1}
-
     projects = _scan_projects(wiki_path)
     if not projects:
         return {"cross_scope_hoist_proposed": 0}

--- a/lib/lore_curator/surface_filer.py
+++ b/lib/lore_curator/surface_filer.py
@@ -39,10 +39,10 @@ def file_surface(
 ) -> FiledSurface:
     """Write a curator-authored surface note. Always draft:true.
 
-    Path resolution (Phase 3 dual-mode):
-      - When ``LORE_PROJECT_FOLDERS=on`` AND a ``projects/<slug>/`` exists
-        for ``scope`` (last segment of the colon-separated chain), the
-        note lands at ``<wiki_root>/projects/<slug>/<surface-plural>/<slug>.md``.
+    Path resolution:
+      - When a ``projects/<slug>/`` exists for ``scope`` (last segment
+        of the colon-separated chain), the note lands at
+        ``<wiki_root>/projects/<slug>/<surface-plural>/<slug>.md``.
       - Otherwise (legacy flat path):
         ``<wiki_root>/<plural-of-surface-name>/<slug>.md``
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,10 @@
 The three autouse "grandfather" fixtures that pinned the test suite to
 pre-production defaults (``LORE_NOTEWORTHY_MODE=llm_only``,
 ``LORE_PROJECT_FOLDERS=off``, ``LORE_BUFFER_FLUSH=0``) were removed in
-PR 6a of the streamlining track (issue #80). PR 6b deleted the
-buffer-flush legacy code path and the ``LORE_BUFFER_FLUSH`` env var;
-PR 6c deleted the ``LORE_NOTEWORTHY_MODE=llm_only`` branch and env var.
-The remaining ``LORE_PROJECT_FOLDERS=off`` legacy is slated for PR 6d.
-Tests that genuinely exercise it opt in inline with ``monkeypatch.setenv``.
+PR 6a of the streamlining track (issue #80). PRs 6b/6c/6d deleted the
+underlying legacy branches and env vars (buffer-flush,
+``noteworthy_mode=llm_only``, ``LORE_PROJECT_FOLDERS=off``), closing
+out the grandfather track.
 """
 from __future__ import annotations
 

--- a/tests/test_c_cross_scope_hoist.py
+++ b/tests/test_c_cross_scope_hoist.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from lore_curator.c_cross_scope_hoist import cross_scope_hoist_pass
 
 
@@ -69,19 +67,7 @@ def _scope_for_project(wiki: Path, project_slug: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_hoist_pass_skipped_when_toggle_off(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "off")
-    _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
-    _write_orientation(tmp_path, "data-transfer", "ccat:data-center:data-transfer")
-    _write_concept(tmp_path, "ops-db", "event-sourcing-pattern")
-    _write_concept(tmp_path, "data-transfer", "event-sourcing-pattern")
-
-    counts = cross_scope_hoist_pass(tmp_path, llm_client=None, dry_run=False)
-    assert counts.get("cross_scope_hoist_skipped_toggle_off") == 1
-
-
-def test_hoist_pass_proposes_when_two_siblings_share_concept(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_hoist_pass_proposes_when_two_siblings_share_concept(tmp_path):
     _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
     _write_orientation(tmp_path, "data-transfer", "ccat:data-center:data-transfer")
     _write_concept(tmp_path, "ops-db", "event-sourcing-pattern")
@@ -107,9 +93,8 @@ def test_hoist_pass_proposes_when_two_siblings_share_concept(tmp_path, monkeypat
     assert "ccat:data-center" in text
 
 
-def test_hoist_pass_skips_when_only_one_sibling_has_concept(tmp_path, monkeypatch):
+def test_hoist_pass_skips_when_only_one_sibling_has_concept(tmp_path):
     """Pair-level recurrence is adjacent-merge territory, not hoist."""
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
     _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
     _write_orientation(tmp_path, "data-transfer", "ccat:data-center:data-transfer")
     _write_concept(tmp_path, "ops-db", "ops-db-only")
@@ -120,10 +105,9 @@ def test_hoist_pass_skips_when_only_one_sibling_has_concept(tmp_path, monkeypatc
     assert counts["cross_scope_hoist_proposed"] == 0
 
 
-def test_hoist_pass_uses_existing_parent_project_folder(tmp_path, monkeypatch):
+def test_hoist_pass_uses_existing_parent_project_folder(tmp_path):
     """Parent project already exists → pass does not auto-stub a new one,
     just files the proposal inside the existing parent."""
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
     _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
     _write_orientation(tmp_path, "data-transfer", "ccat:data-center:data-transfer")
     _write_orientation(tmp_path, "data-center", "ccat:data-center")
@@ -142,9 +126,8 @@ def test_hoist_pass_uses_existing_parent_project_folder(tmp_path, monkeypatch):
     )
 
 
-def test_hoist_pass_idempotent(tmp_path, monkeypatch):
+def test_hoist_pass_idempotent(tmp_path):
     """Second run finds the proposal already exists and skips."""
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
     _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
     _write_orientation(tmp_path, "data-transfer", "ccat:data-center:data-transfer")
     _write_concept(tmp_path, "ops-db", "event-sourcing-pattern")
@@ -156,9 +139,8 @@ def test_hoist_pass_idempotent(tmp_path, monkeypatch):
     assert counts["cross_scope_hoist_proposed"] == 0
 
 
-def test_hoist_pass_does_not_edit_source_concepts(tmp_path, monkeypatch):
+def test_hoist_pass_does_not_edit_source_concepts(tmp_path):
     """Originals stay untouched — Curator C is proposal-only."""
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
     _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
     _write_orientation(tmp_path, "data-transfer", "ccat:data-center:data-transfer")
     a = _write_concept(tmp_path, "ops-db", "event-sourcing-pattern")
@@ -172,8 +154,7 @@ def test_hoist_pass_does_not_edit_source_concepts(tmp_path, monkeypatch):
     assert b.read_text() == pre_b
 
 
-def test_hoist_pass_dry_run_writes_nothing(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_hoist_pass_dry_run_writes_nothing(tmp_path):
     _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
     _write_orientation(tmp_path, "data-transfer", "ccat:data-center:data-transfer")
     _write_concept(tmp_path, "ops-db", "event-sourcing-pattern")
@@ -191,10 +172,9 @@ def test_hoist_pass_dry_run_writes_nothing(tmp_path, monkeypatch):
     assert not proposal.exists()
 
 
-def test_hoist_pass_refuses_on_slug_collision(tmp_path, monkeypatch):
+def test_hoist_pass_refuses_on_slug_collision(tmp_path):
     """If the parent slug collides with a non-project basename anywhere
     in the wiki, auto-stub is refused for that hoist candidate."""
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
     _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
     _write_orientation(tmp_path, "data-transfer", "ccat:data-center:data-transfer")
     _write_concept(tmp_path, "ops-db", "event-sourcing-pattern")
@@ -218,9 +198,8 @@ def test_hoist_pass_refuses_on_slug_collision(tmp_path, monkeypatch):
     assert not proposal.exists()
 
 
-def test_hoist_pass_only_groups_actual_siblings(tmp_path, monkeypatch):
+def test_hoist_pass_only_groups_actual_siblings(tmp_path):
     """Projects whose scopes do NOT share a parent are not hoist candidates."""
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
     _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
     _write_orientation(tmp_path, "telescope", "ccat:telescope")
     _write_concept(tmp_path, "ops-db", "event-sourcing-pattern")
@@ -233,10 +212,9 @@ def test_hoist_pass_only_groups_actual_siblings(tmp_path, monkeypatch):
     assert counts["cross_scope_hoist_proposed"] == 0
 
 
-def test_hoist_pass_handles_three_siblings(tmp_path, monkeypatch):
+def test_hoist_pass_handles_three_siblings(tmp_path):
     """Three sibling projects all sharing a concept → one hoist proposal
     listing all three sources."""
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
     _write_orientation(tmp_path, "ops-db", "ccat:data-center:ops-db")
     _write_orientation(tmp_path, "data-transfer", "ccat:data-center:data-transfer")
     _write_orientation(tmp_path, "workflow-manager", "ccat:data-center:workflow-manager")

--- a/tests/test_projects_router.py
+++ b/tests/test_projects_router.py
@@ -1,10 +1,10 @@
-"""Tests for project-folder-aware surface routing (Phase 3 dual-mode).
+"""Tests for project-folder-aware surface routing.
 
 The router decides whether a surface write goes to the legacy flat
 path (``<wiki_root>/<surface-subdir>/<slug>.md``) or to the new
 project-folder layout (``<wiki_root>/projects/<slug>/<surface-subdir>/<slug>.md``).
-The decision is gated by ``LORE_PROJECT_FOLDERS=on`` AND the existence
-of a matching ``projects/<slug>/`` folder.
+The decision is gated solely by the existence of a matching
+``projects/<slug>/`` folder.
 """
 
 from __future__ import annotations
@@ -15,40 +15,9 @@ import pytest
 
 from lore_core.projects.router import (
     project_dir_for_scope,
-    project_folders_enabled,
     project_slug_for_scope,
     resolve_surface_dir,
 )
-
-
-# ---------------------------------------------------------------------------
-# project_folders_enabled — env toggle
-# ---------------------------------------------------------------------------
-
-
-def test_toggle_on_by_default(monkeypatch):
-    """Step-9 flipped the default to on; the env var is now an off-switch."""
-    monkeypatch.delenv("LORE_PROJECT_FOLDERS", raising=False)
-    assert project_folders_enabled() is True
-
-
-def test_toggle_on_truthy(monkeypatch):
-    for value in ("on", "ON", "1", "true", "True", "yes"):
-        monkeypatch.setenv("LORE_PROJECT_FOLDERS", value)
-        assert project_folders_enabled() is True, f"value {value!r} should be truthy"
-
-
-def test_toggle_off_for_explicit_falsy(monkeypatch):
-    for value in ("off", "false", "no", "0"):
-        monkeypatch.setenv("LORE_PROJECT_FOLDERS", value)
-        assert project_folders_enabled() is False, f"value {value!r} should be off"
-
-
-def test_toggle_on_for_unknown_value(monkeypatch):
-    """Unknown / empty values fall through to the new on-default."""
-    for value in ("", "maybe"):
-        monkeypatch.setenv("LORE_PROJECT_FOLDERS", value)
-        assert project_folders_enabled() is True, f"value {value!r} should default-on"
 
 
 # ---------------------------------------------------------------------------
@@ -72,33 +41,23 @@ def test_project_slug_for_scope(scope, expected):
 
 
 # ---------------------------------------------------------------------------
-# project_dir_for_scope — folder existence + toggle gate
+# project_dir_for_scope — folder existence gates the decision
 # ---------------------------------------------------------------------------
 
 
-def test_project_dir_returns_none_when_toggle_off(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "off")
-    (tmp_path / "projects" / "ops-db").mkdir(parents=True)
-    # Even with the folder present, toggle off → None.
-    assert project_dir_for_scope(tmp_path, "ccat:ops-db") is None
-
-
-def test_project_dir_returns_path_when_toggle_on_and_folder_exists(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_project_dir_returns_path_when_folder_exists(tmp_path):
     target = tmp_path / "projects" / "ops-db"
     target.mkdir(parents=True)
     assert project_dir_for_scope(tmp_path, "ccat:ops-db") == target
 
 
-def test_project_dir_returns_none_when_folder_missing(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_project_dir_returns_none_when_folder_missing(tmp_path):
     # Wiki has projects/ but no ops-db inside.
     (tmp_path / "projects").mkdir()
     assert project_dir_for_scope(tmp_path, "ccat:ops-db") is None
 
 
-def test_project_dir_returns_none_for_empty_scope(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_project_dir_returns_none_for_empty_scope(tmp_path):
     (tmp_path / "projects" / "ops-db").mkdir(parents=True)
     assert project_dir_for_scope(tmp_path, "") is None
     assert project_dir_for_scope(tmp_path, None) is None
@@ -109,16 +68,7 @@ def test_project_dir_returns_none_for_empty_scope(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_surface_dir_legacy_flat_when_toggle_off(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "off")
-    (tmp_path / "projects" / "ops-db").mkdir(parents=True)
-    assert resolve_surface_dir(
-        tmp_path, "concepts", scope="ccat:ops-db",
-    ) == tmp_path / "concepts"
-
-
-def test_resolve_surface_dir_project_when_toggle_on_and_match(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_resolve_surface_dir_project_when_match(tmp_path):
     project_dir = tmp_path / "projects" / "ops-db"
     project_dir.mkdir(parents=True)
     assert resolve_surface_dir(
@@ -126,21 +76,19 @@ def test_resolve_surface_dir_project_when_toggle_on_and_match(tmp_path, monkeypa
     ) == project_dir / "concepts"
 
 
-def test_resolve_surface_dir_falls_back_to_flat_when_no_project_folder(tmp_path, monkeypatch):
-    """Toggle on but no ``projects/<slug>/`` for this scope → flat path.
+def test_resolve_surface_dir_falls_back_to_flat_when_no_project_folder(tmp_path):
+    """No ``projects/<slug>/`` for this scope → flat path.
 
     Migration is gradual; vaults with some scopes-as-projects and others
     not yet promoted must keep filing the unpromoted ones at the flat
     path until the project folder gets created.
     """
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
     assert resolve_surface_dir(
         tmp_path, "decisions", scope="ccat:nonexistent",
     ) == tmp_path / "decisions"
 
 
-def test_resolve_surface_dir_flat_for_empty_scope(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_resolve_surface_dir_flat_for_empty_scope(tmp_path):
     (tmp_path / "projects" / "anything").mkdir(parents=True)
     # Empty scope can't pick a project folder.
     assert resolve_surface_dir(

--- a/tests/test_surface_filer_dual_mode.py
+++ b/tests/test_surface_filer_dual_mode.py
@@ -1,17 +1,14 @@
-"""Integration tests for ``file_surface`` Phase 3 dual-mode routing.
+"""Integration tests for ``file_surface`` project-folder routing.
 
-When ``LORE_PROJECT_FOLDERS=on`` AND a ``projects/<slug>/`` folder exists
-for the cluster's scope, the note lands inside that project's
-``concepts/`` (or ``decisions/``, etc.) subfolder. Otherwise the note
-lands at the legacy flat path.
+When a ``projects/<slug>/`` folder exists for the cluster's scope, the
+note lands inside that project's ``concepts/`` (or ``decisions/``, etc.)
+subfolder. Otherwise the note lands at the legacy flat path.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
-
-import pytest
 
 from lore_core.surfaces import SurfaceDef, SurfacesDoc
 from lore_curator.surface_filer import file_surface
@@ -41,27 +38,7 @@ def _surfaces_doc() -> SurfacesDoc:
     )
 
 
-def test_file_surface_legacy_flat_when_toggle_off(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "off")
-    # A project folder exists, but the toggle is off — must use flat.
-    (tmp_path / "projects" / "ops-db").mkdir(parents=True)
-
-    filed = file_surface(
-        surface_name="concept",
-        title="Event Sourcing Pattern",
-        body="...",
-        sources=["[[2026-04-28-foo]]"],
-        wiki_root=tmp_path,
-        surfaces_doc=_surfaces_doc(),
-        extra_frontmatter={"tags": ["topic/db"]},
-        now=_NOW,
-        scope="ccat:ops-db",
-    )
-    assert filed.path == tmp_path / "concepts" / "event-sourcing-pattern.md"
-
-
-def test_file_surface_routes_into_project_folder_when_toggle_on(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_file_surface_routes_into_project_folder_when_match(tmp_path):
     project_dir = tmp_path / "projects" / "ops-db"
     project_dir.mkdir(parents=True)
 
@@ -79,9 +56,8 @@ def test_file_surface_routes_into_project_folder_when_toggle_on(tmp_path, monkey
     assert filed.path == project_dir / "concepts" / "event-sourcing-pattern.md"
 
 
-def test_file_surface_falls_back_to_flat_when_project_folder_missing(tmp_path, monkeypatch):
-    """Toggle on, but no project folder for this scope → flat fallback."""
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_file_surface_falls_back_to_flat_when_project_folder_missing(tmp_path):
+    """No project folder for this scope → flat fallback."""
     # Wiki has no projects/ subtree at all.
 
     filed = file_surface(
@@ -98,8 +74,7 @@ def test_file_surface_falls_back_to_flat_when_project_folder_missing(tmp_path, m
     assert filed.path == tmp_path / "decisions" / "use-postgres.md"
 
 
-def test_file_surface_no_scope_uses_flat_path(tmp_path, monkeypatch):
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
+def test_file_surface_no_scope_uses_flat_path(tmp_path):
     (tmp_path / "projects" / "ops-db").mkdir(parents=True)
 
     filed = file_surface(
@@ -116,9 +91,8 @@ def test_file_surface_no_scope_uses_flat_path(tmp_path, monkeypatch):
     assert filed.path == tmp_path / "concepts" / "generic-concept.md"
 
 
-def test_file_surface_keeps_existing_callers_working(tmp_path, monkeypatch):
+def test_file_surface_keeps_existing_callers_working(tmp_path):
     """Backward compat: callers that don't pass ``scope`` keep using flat path."""
-    monkeypatch.setenv("LORE_PROJECT_FOLDERS", "on")
     (tmp_path / "projects" / "ops-db").mkdir(parents=True)
 
     filed = file_surface(


### PR DESCRIPTION
## Summary

Closes the grandfather track of issue #80. With the autouse fixture removed in PR 6a, no test was exercising the `LORE_PROJECT_FOLDERS=off` flat-path branch — this PR deletes it, the `project_folders_enabled()` gate, and the env var.

Stacked on **#103** (PR 6c) → which is stacked on **#101** → **#99**.

## Changes

- `lib/lore_core/projects/router.py`: removed `project_folders_enabled()`, `_TOGGLE_ENV`, `_TRUTHY`, `_FALSY`; dropped the toggle gate inside `project_dir_for_scope`; updated module + `resolve_surface_dir` docstrings. The routing rule is now: folder exists → project layout, otherwise flat fallback.
- `lib/lore_curator/c_cross_scope_hoist.py`: removed the `project_folders_enabled` import, the early `skipped_toggle_off` bailout, and the toggle paragraph in the module docstring. The pass keeps its existing scan-for-projects behaviour, which already no-ops when no project folders exist.
- `lib/lore_curator/surface_filer.py`: docstring no longer mentions the toggle.
- `tests/test_projects_router.py`: dropped the four `test_toggle_*` env-toggle tests and the `toggle_off → flat` cases. Folder-existence is now the only gate; tests cover it directly.
- `tests/test_surface_filer_dual_mode.py` + `tests/test_c_cross_scope_hoist.py`: stripped every `monkeypatch.setenv("LORE_PROJECT_FOLDERS", …)` line (15+ sites) and deleted the toggle-off-skip test in each.
- `tests/conftest.py`: docstring closes out the grandfather track narrative — all three grandfather env vars deleted across 6b/6c/6d.

## Numbers

- **Net -137 LOC** across 7 files (lib -29, tests -108). PRD estimated ~200-300; came in lighter because the surface_filer/router/hoist logic was already cleanly factored — only the toggle gate + the explicit `=off` tests needed to die.
- `lib/lore_core/projects/router.py`: 99 → 70 LOC (-29).

## Test plan

- [x] Targeted: `pytest tests/test_projects_router.py tests/test_surface_filer_dual_mode.py tests/test_c_cross_scope_hoist.py` → 25 passed.
- [x] Full suite: **2551 passed, 7 skipped**, 4 pre-existing failures unrelated to this PR (openai optional dep; test_resume fixture date; two phase-2 prompt goldens inherited from the PR 6b stack base — main has newer prompt content from #94's two-region landing).
- [x] Grep clean: `grep -rn "LORE_PROJECT_FOLDERS\|project_folders_enabled" lib/ tests/` returns no hits.

## Next

Grandfather track closed. Reassessment from PR 5's reopen-question still stands as the next conversation point.