### PR TITLE
feat(#110): PR 1 — ResolvedModel value object + reasoning_effort config keys

### DIFF
--- a/lib/lore_core/root_config.py
+++ b/lib/lore_core/root_config.py
@@ -52,6 +52,15 @@ class OpenAIBackendConfig:
     the gitignored ``.lore/`` directory, and never appears in diffs.
     ``model_{simple,middle,high}`` override the Anthropic tier names; leave empty to fall
     back to the env var ``LORE_OPENAI_MODEL_{SIMPLE,MIDDLE,HIGH}`` or pass-through.
+
+    ``reasoning_effort_{simple,middle,high}`` opt the corresponding tier into a
+    reasoning-capable model's effort knob (``"low" | "medium" | "high"``).
+    Empty string means "unset" (no reasoning_effort forwarded). The empty-
+    string-means-unset convention lets the typed CLI set path (``lore config
+    set ...``) and the existing schema walker keep working without learning
+    about ``None`` as a YAML/CLI value. Validated and forwarded to the wire
+    by ``lore_curator.llm_client._resolve_openai_settings``; values from env
+    var ``LORE_OPENAI_REASONING_EFFORT_{SIMPLE,MIDDLE,HIGH}`` win over config.
     """
 
     base_url: str = ""
@@ -59,6 +68,9 @@ class OpenAIBackendConfig:
     model_simple: str = ""
     model_middle: str = ""
     model_high: str = ""
+    reasoning_effort_simple: str = ""
+    reasoning_effort_middle: str = ""
+    reasoning_effort_high: str = ""
 
 
 @dataclass

--- a/lib/lore_curator/llm_client.py
+++ b/lib/lore_curator/llm_client.py
@@ -5,8 +5,27 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Any, Callable, Literal, Protocol, runtime_checkable
 from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ResolvedModel:
+    """Per-tier resolved model identity plus any per-tier knobs.
+
+    Frozen value object — equality and hash come from the dataclass.
+    Currently carries the model id and an optional ``reasoning_effort``;
+    future per-tier knobs (max_tokens floor, response_format, …) belong
+    here so callers don't grow new positional plumbing every time.
+
+    Fields:
+      - ``id``: the literal model identifier the backend should send.
+      - ``reasoning_effort``: ``"low" | "medium" | "high"`` or ``None``
+        when the user has not opted in.
+    """
+
+    id: str
+    reasoning_effort: Literal["low", "medium", "high"] | None = None
 
 
 class LlmClientError(RuntimeError):
@@ -627,6 +646,13 @@ class OpenAICompatibleClient:
 
     Tier names (``simple``/``middle``/``high``) are resolved via
     ``tier_to_model``; literal model IDs are passed through unchanged.
+
+    ``tier_to_model`` accepts either a ``dict[str, ResolvedModel]`` (the
+    new shape used by :func:`_resolve_openai_settings`) or the legacy
+    ``dict[str, str]`` (back-compat path for tests and external callers
+    that pass plain model IDs). On the wire today only the model ``id``
+    is forwarded — slice 2 plumbs ``reasoning_effort`` through to the
+    underlying chat completions call.
     """
 
     def __init__(
@@ -634,12 +660,25 @@ class OpenAICompatibleClient:
         *,
         base_url: str,
         api_key: str,
-        tier_to_model: dict[str, str] | None = None,
+        tier_to_model: dict[str, ResolvedModel] | dict[str, str] | None = None,
     ) -> None:
         import openai  # lazy — optional dep
         self._client = openai.OpenAI(base_url=base_url, api_key=api_key)
-        self._tier_to_model = tier_to_model or {}
-        self.messages = _OpenAIMessagesAPI(self._client, self._tier_to_model)
+        # Back-compat: accept plain-string tier maps and wrap them into
+        # ResolvedModel internally. Tests that predate ResolvedModel still
+        # pass ``{"simple": "m", ...}``.
+        normalized: dict[str, ResolvedModel] = {}
+        for tier, val in (tier_to_model or {}).items():
+            if isinstance(val, ResolvedModel):
+                normalized[tier] = val
+            else:
+                normalized[tier] = ResolvedModel(id=val)
+        self._tier_to_model: dict[str, ResolvedModel] = normalized
+        # _OpenAIMessagesAPI stays on the plain-string shape in this slice
+        # — slice 2 lifts it to ResolvedModel when it starts forwarding
+        # reasoning_effort on the wire.
+        plain_tier_to_model = {tier: rm.id for tier, rm in normalized.items()}
+        self.messages = _OpenAIMessagesAPI(self._client, plain_tier_to_model)
 
     @property
     def backend_name(self) -> str:
@@ -685,15 +724,49 @@ def _make_sdk_client(api_key: str | None) -> "SDKClient":
     )
 
 
+_VALID_REASONING_EFFORTS = frozenset({"low", "medium", "high"})
+
+
+def _coerce_reasoning_effort(
+    raw: str | None, *, tier: str, source: str,
+) -> Literal["low", "medium", "high"] | None:
+    """Validate + lowercase-normalize a reasoning_effort value.
+
+    Empty/whitespace/None → None (i.e. "unset", no value forwarded).
+    Case-insensitive match against {low, medium, high}; anything else
+    raises ``LlmClientError`` naming both the tier and the bad value so
+    the user can find the source quickly.
+    """
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    lowered = stripped.lower()
+    if lowered not in _VALID_REASONING_EFFORTS:
+        raise LlmClientError(
+            f"invalid reasoning_effort for tier {tier!r} "
+            f"(from {source}): {raw!r} — "
+            f"expected one of low/medium/high (case-insensitive) or empty"
+        )
+    return lowered  # type: ignore[return-value]
+
+
 def _resolve_openai_settings(
     lore_root: "Path | None" = None,
-) -> tuple[str, str, dict[str, str]]:
-    """Resolve base_url, api_key, and tier→model map from env + root config.
+) -> tuple[str, str, dict[str, ResolvedModel]]:
+    """Resolve base_url, api_key, and tier→ResolvedModel map from env + root config.
 
     Precedence per field: process env > $LORE_ROOT/.lore/secrets.env > root
     config > empty. The secrets.env layer lets users persist the API key
     on disk without putting it in the diffable config.yml; the file itself
     sits inside the already-gitignored ``.lore/`` directory.
+
+    Each tier resolves to a :class:`ResolvedModel` that carries the model
+    id plus an optional ``reasoning_effort``. The reasoning_effort comes
+    from ``curator.openai.reasoning_effort_{tier}`` in config (empty =
+    unset) and is overridden by ``LORE_OPENAI_REASONING_EFFORT_{TIER}``
+    in env. Invalid reasoning_effort values raise ``LlmClientError``.
 
     Raises LlmClientError if base_url or api_key can't be found.
     """
@@ -708,7 +781,12 @@ def _resolve_openai_settings(
 
     base_url = os.environ.get("LORE_OPENAI_BASE_URL", "").strip()
     api_key_env_name = "LORE_OPENAI_API_KEY"
-    tier_to_model: dict[str, str] = {}
+    # Build the per-tier model id and reasoning_effort maps separately,
+    # then zip them into ResolvedModel at the end.
+    tier_to_id: dict[str, str] = {}
+    tier_to_effort: dict[str, Literal["low", "medium", "high"] | None] = {
+        "simple": None, "middle": None, "high": None,
+    }
 
     if lore_root is not None:
         try:
@@ -719,11 +797,29 @@ def _resolve_openai_settings(
             if cfg.api_key_env:
                 api_key_env_name = cfg.api_key_env
             if cfg.model_simple:
-                tier_to_model["simple"] = cfg.model_simple
+                tier_to_id["simple"] = cfg.model_simple
             if cfg.model_middle:
-                tier_to_model["middle"] = cfg.model_middle
+                tier_to_id["middle"] = cfg.model_middle
             if cfg.model_high:
-                tier_to_model["high"] = cfg.model_high
+                tier_to_id["high"] = cfg.model_high
+            # reasoning_effort from config (validated; empty → None).
+            tier_to_effort["simple"] = _coerce_reasoning_effort(
+                cfg.reasoning_effort_simple,
+                tier="simple",
+                source="curator.openai.reasoning_effort_simple",
+            )
+            tier_to_effort["middle"] = _coerce_reasoning_effort(
+                cfg.reasoning_effort_middle,
+                tier="middle",
+                source="curator.openai.reasoning_effort_middle",
+            )
+            tier_to_effort["high"] = _coerce_reasoning_effort(
+                cfg.reasoning_effort_high,
+                tier="high",
+                source="curator.openai.reasoning_effort_high",
+            )
+        except LlmClientError:
+            raise
         except Exception:
             pass
 
@@ -735,7 +831,19 @@ def _resolve_openai_settings(
     ):
         val = os.environ.get(env_name, "").strip()
         if val:
-            tier_to_model[tier] = val
+            tier_to_id[tier] = val
+
+    # Env-var reasoning_effort overrides config (same precedence as model).
+    for tier, env_name in (
+        ("simple", "LORE_OPENAI_REASONING_EFFORT_SIMPLE"),
+        ("middle", "LORE_OPENAI_REASONING_EFFORT_MIDDLE"),
+        ("high", "LORE_OPENAI_REASONING_EFFORT_HIGH"),
+    ):
+        raw_env = os.environ.get(env_name, "")
+        if raw_env.strip():
+            tier_to_effort[tier] = _coerce_reasoning_effort(
+                raw_env, tier=tier, source=f"env {env_name}",
+            )
 
     if not base_url:
         raise LlmClientError(
@@ -749,6 +857,10 @@ def _resolve_openai_settings(
             f"openai backend requested but {api_key_env_name} is not set"
         )
 
+    tier_to_model: dict[str, ResolvedModel] = {
+        tier: ResolvedModel(id=model_id, reasoning_effort=tier_to_effort.get(tier))
+        for tier, model_id in tier_to_id.items()
+    }
     return base_url, api_key, tier_to_model
 
 

--- a/tests/test_openai_backend.py
+++ b/tests/test_openai_backend.py
@@ -565,7 +565,7 @@ def test_make_llm_client_openai_from_env(monkeypatch, fake_openai):
 
     client = make_llm_client(backend="openai")
     assert isinstance(client, OpenAICompatibleClient)
-    assert client._tier_to_model["middle"] == "gpt-oss-120b"
+    assert client._tier_to_model["middle"].id == "gpt-oss-120b"
 
 
 def test_make_llm_client_openai_missing_base_url_raises(monkeypatch):

--- a/tests/test_openai_precedence.py
+++ b/tests/test_openai_precedence.py
@@ -35,7 +35,7 @@ def test_env_model_middle_beats_config(tmp_path: Path, monkeypatch: pytest.Monke
     monkeypatch.setenv("LORE_OPENAI_MODEL_MIDDLE", "from-env")
 
     base_url, api_key, tier_to_model = _resolve_openai_settings(tmp_path)
-    assert tier_to_model["middle"] == "from-env"
+    assert tier_to_model["middle"].id == "from-env"
 
 
 def test_env_model_simple_beats_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -52,7 +52,7 @@ def test_env_model_simple_beats_config(tmp_path: Path, monkeypatch: pytest.Monke
     monkeypatch.setenv("LORE_OPENAI_MODEL_SIMPLE", "from-env")
 
     _, _, tier_to_model = _resolve_openai_settings(tmp_path)
-    assert tier_to_model["simple"] == "from-env"
+    assert tier_to_model["simple"].id == "from-env"
 
 
 def test_env_base_url_beats_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -89,7 +89,7 @@ def test_config_used_when_env_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
     base_url, _, tier_to_model = _resolve_openai_settings(tmp_path)
     assert base_url == "https://config-only.example/v1"
-    assert tier_to_model["high"] == "only-from-config"
+    assert tier_to_model["high"].id == "only-from-config"
 
 
 def test_partial_env_override_leaves_other_tiers_from_config(
@@ -113,6 +113,6 @@ def test_partial_env_override_leaves_other_tiers_from_config(
     monkeypatch.delenv("LORE_OPENAI_MODEL_HIGH", raising=False)
 
     _, _, tier_to_model = _resolve_openai_settings(tmp_path)
-    assert tier_to_model["simple"] == "cfg-simple"
-    assert tier_to_model["middle"] == "env-middle"
-    assert tier_to_model["high"] == "cfg-high"
+    assert tier_to_model["simple"].id == "cfg-simple"
+    assert tier_to_model["middle"].id == "env-middle"
+    assert tier_to_model["high"].id == "cfg-high"

--- a/tests/test_openai_secrets_env.py
+++ b/tests/test_openai_secrets_env.py
@@ -130,7 +130,9 @@ def test_secrets_env_provides_models_and_config_provides_base_url(
     base_url, api_key, tier_to_model = _resolve_openai_settings(tmp_path)
     assert base_url == "https://gateway.example/v1"
     assert api_key == "sk-secret"
-    assert tier_to_model == {"simple": "tiny", "middle": "mid", "high": "big"}
+    assert tier_to_model["simple"].id == "tiny"
+    assert tier_to_model["middle"].id == "mid"
+    assert tier_to_model["high"].id == "big"
 
 
 def test_make_llm_client_picks_up_backend_from_secrets_env(

--- a/tests/test_resolved_model.py
+++ b/tests/test_resolved_model.py
@@ -1,0 +1,273 @@
+"""Tests for ResolvedModel + reasoning_effort plumbing through _resolve_openai_settings.
+
+Covers the new per-tier ``reasoning_effort_{simple,middle,high}`` config
+keys and the matching ``LORE_OPENAI_REASONING_EFFORT_{TIER}`` env vars.
+Slice 1 of PRD #110 stops at resolver level — on-the-wire forwarding of
+``extra_body.reasoning_effort`` to the chat completions endpoint lands
+in slice 2.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".lore"
+    cfg_dir.mkdir(exist_ok=True)
+    (cfg_dir / "config.yml").write_text(body)
+
+
+def _clear_reasoning_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "LORE_OPENAI_REASONING_EFFORT_SIMPLE",
+        "LORE_OPENAI_REASONING_EFFORT_MIDDLE",
+        "LORE_OPENAI_REASONING_EFFORT_HIGH",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# ResolvedModel value object basics
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_model_defaults_reasoning_effort_to_none() -> None:
+    from lore_curator.llm_client import ResolvedModel
+
+    rm = ResolvedModel(id="some-model")
+    assert rm.id == "some-model"
+    assert rm.reasoning_effort is None
+
+
+def test_resolved_model_is_frozen() -> None:
+    from dataclasses import FrozenInstanceError
+
+    from lore_curator.llm_client import ResolvedModel
+
+    rm = ResolvedModel(id="x")
+    with pytest.raises(FrozenInstanceError):
+        rm.id = "y"  # type: ignore[misc]
+
+
+def test_resolved_model_equality_and_hash() -> None:
+    """Frozen dataclass → equality + hashable, suitable for set/dict keys."""
+    from lore_curator.llm_client import ResolvedModel
+
+    a = ResolvedModel(id="m", reasoning_effort="high")
+    b = ResolvedModel(id="m", reasoning_effort="high")
+    c = ResolvedModel(id="m", reasoning_effort=None)
+    d = ResolvedModel(id="other", reasoning_effort="high")
+
+    assert a == b
+    assert a != c
+    assert a != d
+    assert hash(a) == hash(b)
+    # Usable as dict key
+    bag = {a: 1}
+    bag[b] = 2  # same key
+    assert bag == {a: 2}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_openai_settings — reasoning_effort from config
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_returns_reasoning_effort_per_tier_from_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lore_curator.llm_client import ResolvedModel, _resolve_openai_settings
+
+    _write_config(
+        tmp_path,
+        "curator:\n"
+        "  openai:\n"
+        "    base_url: https://x.example/v1\n"
+        "    model_simple: m-s\n"
+        "    model_middle: m-m\n"
+        "    model_high: m-h\n"
+        "    reasoning_effort_simple: low\n"
+        "    reasoning_effort_middle: medium\n"
+        "    reasoning_effort_high: high\n",
+    )
+    monkeypatch.setenv("LORE_OPENAI_API_KEY", "sk-test")
+    _clear_reasoning_env(monkeypatch)
+
+    _, _, tier_to_model = _resolve_openai_settings(tmp_path)
+    assert tier_to_model["simple"] == ResolvedModel(id="m-s", reasoning_effort="low")
+    assert tier_to_model["middle"] == ResolvedModel(id="m-m", reasoning_effort="medium")
+    assert tier_to_model["high"] == ResolvedModel(id="m-h", reasoning_effort="high")
+
+
+def test_resolver_returns_none_reasoning_effort_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backwards-compat: pre-PR config without the new keys → reasoning_effort=None."""
+    from lore_curator.llm_client import ResolvedModel, _resolve_openai_settings
+
+    _write_config(
+        tmp_path,
+        "curator:\n"
+        "  openai:\n"
+        "    base_url: https://x.example/v1\n"
+        "    model_simple: m-s\n"
+        "    model_middle: m-m\n"
+        "    model_high: m-h\n",
+    )
+    monkeypatch.setenv("LORE_OPENAI_API_KEY", "sk-test")
+    _clear_reasoning_env(monkeypatch)
+
+    _, _, tier_to_model = _resolve_openai_settings(tmp_path)
+    assert tier_to_model["simple"] == ResolvedModel(id="m-s", reasoning_effort=None)
+    assert tier_to_model["middle"] == ResolvedModel(id="m-m", reasoning_effort=None)
+    assert tier_to_model["high"] == ResolvedModel(id="m-h", reasoning_effort=None)
+
+
+def test_resolver_empty_reasoning_effort_string_is_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit empty string == unset; matches the dataclass default-empty convention."""
+    from lore_curator.llm_client import _resolve_openai_settings
+
+    _write_config(
+        tmp_path,
+        "curator:\n"
+        "  openai:\n"
+        "    base_url: https://x.example/v1\n"
+        "    model_high: m-h\n"
+        "    reasoning_effort_high: \"\"\n",
+    )
+    monkeypatch.setenv("LORE_OPENAI_API_KEY", "sk-test")
+    _clear_reasoning_env(monkeypatch)
+
+    _, _, tier_to_model = _resolve_openai_settings(tmp_path)
+    assert tier_to_model["high"].reasoning_effort is None
+
+
+def test_resolver_accepts_uppercase_reasoning_effort_case_insensitively(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``HIGH`` is a valid spelling and normalizes to lowercase."""
+    from lore_curator.llm_client import _resolve_openai_settings
+
+    _write_config(
+        tmp_path,
+        "curator:\n"
+        "  openai:\n"
+        "    base_url: https://x.example/v1\n"
+        "    model_high: m-h\n"
+        "    reasoning_effort_high: HIGH\n",
+    )
+    monkeypatch.setenv("LORE_OPENAI_API_KEY", "sk-test")
+    _clear_reasoning_env(monkeypatch)
+
+    _, _, tier_to_model = _resolve_openai_settings(tmp_path)
+    assert tier_to_model["high"].reasoning_effort == "high"
+
+
+# ---------------------------------------------------------------------------
+# Validation — invalid reasoning_effort values surface clearly
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_raises_on_invalid_reasoning_effort_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lore_curator.llm_client import LlmClientError, _resolve_openai_settings
+
+    _write_config(
+        tmp_path,
+        "curator:\n"
+        "  openai:\n"
+        "    base_url: https://x.example/v1\n"
+        "    model_middle: m-m\n"
+        "    reasoning_effort_middle: strong\n",
+    )
+    monkeypatch.setenv("LORE_OPENAI_API_KEY", "sk-test")
+    _clear_reasoning_env(monkeypatch)
+
+    with pytest.raises(LlmClientError) as excinfo:
+        _resolve_openai_settings(tmp_path)
+    msg = str(excinfo.value)
+    assert "middle" in msg
+    assert "strong" in msg
+
+
+def test_resolver_raises_on_invalid_reasoning_effort_env_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bad env-var value should surface with the env name in the message."""
+    from lore_curator.llm_client import LlmClientError, _resolve_openai_settings
+
+    _write_config(
+        tmp_path,
+        "curator:\n"
+        "  openai:\n"
+        "    base_url: https://x.example/v1\n"
+        "    model_high: m-h\n",
+    )
+    monkeypatch.setenv("LORE_OPENAI_API_KEY", "sk-test")
+    _clear_reasoning_env(monkeypatch)
+    monkeypatch.setenv("LORE_OPENAI_REASONING_EFFORT_HIGH", "yes")
+
+    with pytest.raises(LlmClientError) as excinfo:
+        _resolve_openai_settings(tmp_path)
+    msg = str(excinfo.value)
+    assert "high" in msg
+    assert "yes" in msg
+
+
+# ---------------------------------------------------------------------------
+# Env precedence — env beats config (same rule as model id)
+# ---------------------------------------------------------------------------
+
+
+def test_env_reasoning_effort_high_beats_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lore_curator.llm_client import _resolve_openai_settings
+
+    _write_config(
+        tmp_path,
+        "curator:\n"
+        "  openai:\n"
+        "    base_url: https://x.example/v1\n"
+        "    model_high: m-h\n"
+        "    reasoning_effort_high: medium\n",
+    )
+    monkeypatch.setenv("LORE_OPENAI_API_KEY", "sk-test")
+    _clear_reasoning_env(monkeypatch)
+    monkeypatch.setenv("LORE_OPENAI_REASONING_EFFORT_HIGH", "high")
+
+    _, _, tier_to_model = _resolve_openai_settings(tmp_path)
+    assert tier_to_model["high"].reasoning_effort == "high"
+
+
+def test_env_reasoning_effort_partial_leaves_other_tiers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting ENV for HIGH shouldn't blank out other tiers' config values."""
+    from lore_curator.llm_client import _resolve_openai_settings
+
+    _write_config(
+        tmp_path,
+        "curator:\n"
+        "  openai:\n"
+        "    base_url: https://x.example/v1\n"
+        "    model_simple: m-s\n"
+        "    model_middle: m-m\n"
+        "    model_high: m-h\n"
+        "    reasoning_effort_simple: low\n"
+        "    reasoning_effort_middle: medium\n"
+        "    reasoning_effort_high: low\n",
+    )
+    monkeypatch.setenv("LORE_OPENAI_API_KEY", "sk-test")
+    _clear_reasoning_env(monkeypatch)
+    monkeypatch.setenv("LORE_OPENAI_REASONING_EFFORT_HIGH", "high")
+
+    _, _, tier_to_model = _resolve_openai_settings(tmp_path)
+    assert tier_to_model["simple"].reasoning_effort == "low"
+    assert tier_to_model["middle"].reasoning_effort == "medium"
+    assert tier_to_model["high"].reasoning_effort == "high"


### PR DESCRIPTION
## Summary

Implements **Slice 1 of PRD #110** — foundation for routing `reasoning_effort` through the OpenAI-compatible curator backend.

- New `ResolvedModel` frozen dataclass (id + optional reasoning_effort) in `lore_curator.llm_client`.
- `OpenAIBackendConfig` gains `reasoning_effort_{simple,middle,high}: str = ""` (empty = unset; keeps existing CLI typed-set path working).
- `_resolve_openai_settings` return shape: `dict[str, str]` → `dict[str, ResolvedModel]`. New env vars `LORE_OPENAI_REASONING_EFFORT_{TIER}` follow the same env-beats-config precedence as the model env vars.
- Validation in the resolver: invalid values raise `LlmClientError` naming the tier and the bad value. Case-insensitive accept (`"HIGH"` ok, `"strong"` rejected).
- `OpenAICompatibleClient.__init__` accepts both `dict[str, str]` (back-compat) and `dict[str, ResolvedModel]` (new). The on-the-wire payload is unchanged — that lands in PR 2.

## What this does NOT do (deferred to later slices)

- Plumb `extra_body={"reasoning_effort": ...}` into `_OpenAIMessagesAPI.create` — PR 2.
- Enrich Curator-A telemetry with `model_resolved` / `reasoning_effort` — PR 2.
- Bump `PHASE2_MAX_OUTPUT_TOKENS` — PR 3.
- README recommendation section — PR 4.

## Test plan

- [x] `tests/test_resolved_model.py` (new, 11 tests) covers per-tier reads, absent-keys back-compat, case-insensitive accept, invalid-value rejection (config + env paths), env-beats-config precedence, partial overrides, and `ResolvedModel` equality/hash.
- [x] Existing `tests/test_openai_backend.py`, `test_openai_precedence.py`, `test_openai_secrets_env.py` updated for the new `.id` accessor on the return value.
- [x] Full suite: 2599 passed, 16 pre-existing failures on main unrelated to this slice (confirmed against `main` HEAD).