### PR TITLE
feat(#110): PR 3 — bump Phase 2 max output tokens for reasoning-mode narration

### DIFF
--- a/lib/lore_curator/synthesis.py
+++ b/lib/lore_curator/synthesis.py
@@ -154,7 +154,7 @@ _DISCUSSION_LEADS = frozenset({
 _TITLE_WORD_CAP = 8
 BULLET_LINE_MAX = 280
 PHASE2_MAX_ATTEMPTS = 3
-PHASE2_MAX_OUTPUT_TOKENS = 1024
+PHASE2_MAX_OUTPUT_TOKENS = 4000
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements **Slice 3 of PRD #110** — bumps `PHASE2_MAX_OUTPUT_TOKENS` from 1024 → 4000 so reasoning-mode narration (GPT-OSS-120B with `reasoning_effort=high`) doesn't truncate mid-response. Experiment 007 used 6000 with headroom; 4000 is a safe production floor that still works fine for non-reasoning models without inflating Anthropic-side cost.

## OpenAI-backend wall-clock timeout audit (per PRD)

`OpenAICompatibleClient.__init__` (`lib/lore_curator/llm_client.py:640`) constructs `openai.OpenAI(base_url=..., api_key=...)` with **no explicit `timeout=`**. `_OpenAIMessagesAPI.create` (`:527`) likewise calls `chat.completions.create(**kwargs)` with no `timeout=`. Effective wall-clock is therefore the openai SDK default (~600s for openai ≥1.0), which comfortably covers the 80–100s GPT-OSS-120B reasoning latency. The `SubprocessClient`'s `LORE_CLAUDE_TIMEOUT_S` does NOT apply on the OpenAI path. **No new timeout knob added** — kept the PR focused; document the audit here so future reviewers don't redo it.

## Test plan

- [x] No `tests/` reference to `PHASE2_MAX_OUTPUT_TOKENS`; the two `max_tokens=1024` test occurrences are unrelated call arguments.
- [x] 74 synthesis/phase2/compose-related tests pass.
- [x] No CHANGELOG entry (file groups by release, not per-commit).