### PR TITLE
feat(#110): PR 2 — plumb reasoning_effort end-to-end through OpenAI client + telemetry

### DIFF
--- a/lib/lore_curator/llm_client.py
+++ b/lib/lore_curator/llm_client.py
@@ -57,6 +57,12 @@ class LlmResponse:
     """Mimics an anthropic.types.Message for the subset curators use.
 
     ``total_cost_usd`` is a lore-only extension absent on the real SDK type.
+
+    ``reasoning_effort`` is a lore-only extension populated only by the
+    OpenAI-compatible backend; it lets the caller (e.g. Curator A's
+    telemetry) observe the effort level the client actually applied
+    without poking at private resolver state. Subprocess + SDK paths
+    leave it ``None`` — they don't carry a notion of reasoning effort.
     """
 
     # Narrow shape used by the SubprocessClient synthesiser.  SDKClient does
@@ -67,6 +73,7 @@ class LlmResponse:
     stop_reason: str = "end_turn"
     usage: dict[str, int] = field(default_factory=dict)  # input_tokens, output_tokens, …
     total_cost_usd: float | None = None
+    reasoning_effort: Literal["low", "medium", "high"] | None = None
 
 
 class _MessagesAPI(Protocol):
@@ -479,7 +486,7 @@ class _OpenAIMessagesAPI:
          LlmClientError with a message pointing at LORE_OPENAI_MODEL_*.
     """
 
-    def __init__(self, client: Any, tier_to_model: dict[str, str]):
+    def __init__(self, client: Any, tier_to_model: dict[str, ResolvedModel]):
         self._client = client
         self._tier_to_model = tier_to_model
 
@@ -491,13 +498,19 @@ class _OpenAIMessagesAPI:
         tools: list[dict[str, Any]] | None = None,
         tool_choice: dict[str, Any] | None = None,
         max_tokens: int | None = None,
-        **_extra: Any,
     ) -> LlmResponse:
         tier = _infer_tier(model)
+        # ``resolved`` is the ResolvedModel for the tier (carries id +
+        # optional reasoning_effort). When ``model`` is a literal pass-
+        # through (tier is None — e.g. "Mistral Small 4 119B") we have no
+        # ResolvedModel to consult, so ``resolved`` stays None and the
+        # forwarding logic below treats reasoning_effort as unset.
+        resolved: ResolvedModel | None = None
         if tier is not None:
             configured = self._tier_to_model.get(tier)
-            if configured:
-                resolved_model = configured
+            if configured is not None:
+                resolved = configured
+                resolved_model = configured.id
             else:
                 raise LlmClientError(
                     f"openai backend: no model configured for tier {tier!r} "
@@ -541,6 +554,13 @@ class _OpenAIMessagesAPI:
             kwargs["tools"] = openai_tools
         if openai_tool_choice is not None:
             kwargs["tool_choice"] = openai_tool_choice
+        # Forward reasoning_effort via ``extra_body`` only when the resolved
+        # tier opted in. When unset (or model was a literal pass-through),
+        # leave the key off entirely so the on-the-wire payload matches the
+        # pre-PRD-#110 byte sequence for users who haven't opted in.
+        applied_effort = resolved.reasoning_effort if resolved is not None else None
+        if applied_effort is not None:
+            kwargs["extra_body"] = {"reasoning_effort": applied_effort}
 
         try:
             completion = self._client.chat.completions.create(**kwargs)
@@ -632,6 +652,7 @@ class _OpenAIMessagesAPI:
             model=getattr(completion, "model", resolved_model) or resolved_model,
             stop_reason=getattr(choices[0], "finish_reason", "end_turn") or "end_turn",
             usage=usage_dict,
+            reasoning_effort=applied_effort,
         )
 
 
@@ -650,9 +671,11 @@ class OpenAICompatibleClient:
     ``tier_to_model`` accepts either a ``dict[str, ResolvedModel]`` (the
     new shape used by :func:`_resolve_openai_settings`) or the legacy
     ``dict[str, str]`` (back-compat path for tests and external callers
-    that pass plain model IDs). On the wire today only the model ``id``
-    is forwarded — slice 2 plumbs ``reasoning_effort`` through to the
-    underlying chat completions call.
+    that pass plain model IDs — these are normalized to
+    ``ResolvedModel(id=<str>, reasoning_effort=None)`` at construction
+    time). ResolvedModel flows through unchanged to :class:`_OpenAIMessagesAPI`
+    so ``reasoning_effort`` lands on the chat completions request via
+    ``extra_body``.
     """
 
     def __init__(
@@ -666,7 +689,9 @@ class OpenAICompatibleClient:
         self._client = openai.OpenAI(base_url=base_url, api_key=api_key)
         # Back-compat: accept plain-string tier maps and wrap them into
         # ResolvedModel internally. Tests that predate ResolvedModel still
-        # pass ``{"simple": "m", ...}``.
+        # pass ``{"simple": "m", ...}``; those callers get
+        # reasoning_effort=None implicitly, which means no extra_body on
+        # the wire (byte-identical to the pre-PRD-#110 payload).
         normalized: dict[str, ResolvedModel] = {}
         for tier, val in (tier_to_model or {}).items():
             if isinstance(val, ResolvedModel):
@@ -674,11 +699,7 @@ class OpenAICompatibleClient:
             else:
                 normalized[tier] = ResolvedModel(id=val)
         self._tier_to_model: dict[str, ResolvedModel] = normalized
-        # _OpenAIMessagesAPI stays on the plain-string shape in this slice
-        # — slice 2 lifts it to ResolvedModel when it starts forwarding
-        # reasoning_effort on the wire.
-        plain_tier_to_model = {tier: rm.id for tier, rm in normalized.items()}
-        self.messages = _OpenAIMessagesAPI(self._client, plain_tier_to_model)
+        self.messages = _OpenAIMessagesAPI(self._client, normalized)
 
     @property
     def backend_name(self) -> str:

--- a/lib/lore_curator/synthesis.py
+++ b/lib/lore_curator/synthesis.py
@@ -531,12 +531,20 @@ def compose_session_note(
                 title_out=title_out,
             )
     if logger is not None:
+        # Surface the literal model id the backend echoed back plus the
+        # reasoning_effort the client applied (if any) — lets future
+        # experiments correlate quality with the resolved setting without
+        # bypassing the wrapper. ``resp.model`` is populated by every
+        # backend (SDK, subprocess, openai-compatible); ``reasoning_effort``
+        # is a lore-only field that only the openai client populates today.
         logger.emit(
             "llm-response",
             call="compose-session-note",
             transcript_id=transcript_id,
             latency_ms=latency_ms,
             keys=sorted(data.keys()),
+            model_resolved=getattr(resp, "model", "") or "",
+            reasoning_effort=getattr(resp, "reasoning_effort", None),
         )
     return data
 

--- a/tests/test_reasoning_effort_plumbing.py
+++ b/tests/test_reasoning_effort_plumbing.py
@@ -1,0 +1,475 @@
+"""Tests for Slice 2 of PRD #110 — reasoning_effort plumbing.
+
+Covers:
+- ``_OpenAIMessagesAPI.create`` forwards ``extra_body={"reasoning_effort": ...}``
+  when the resolved tier opted in, and omits ``extra_body`` entirely when it
+  didn't (byte-identical to the pre-PRD-#110 payload).
+- ``LlmResponse.reasoning_effort`` carries the level applied — keeps the
+  knowledge inside the client boundary (PRD's "Reasoning lives in the
+  client + resolver, not the caller").
+- ``synthesis.compose_session_note`` emits ``model_resolved`` + the
+  applied ``reasoning_effort`` on the ``llm-response`` telemetry event.
+- Regression bar: existing-style ``dict[str, str]`` callers (legacy tests)
+  never see ``extra_body`` on the wire.
+
+Slice-1 lifts the config + resolver. Slice-2 (this file) is the wire +
+telemetry plumbing. Slice-3 already shipped the PHASE2 max-tokens bump.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake openai SDK — same minimal shape used by test_openai_backend.py
+# ---------------------------------------------------------------------------
+
+
+class _FakeFn:
+    def __init__(self, name: str, arguments: str) -> None:
+        self.name = name
+        self.arguments = arguments
+
+
+class _FakeToolCall:
+    def __init__(self, name: str, arguments: str) -> None:
+        self.id = "call_1"
+        self.type = "function"
+        self.function = _FakeFn(name, arguments)
+
+
+class _FakeMessage:
+    def __init__(self, tool_calls: list[_FakeToolCall] | None = None,
+                 content: str | None = None) -> None:
+        self.content = content
+        self.tool_calls = tool_calls or []
+        self.role = "assistant"
+
+
+class _FakeChoice:
+    def __init__(self, message: _FakeMessage,
+                 finish_reason: str = "tool_calls") -> None:
+        self.message = message
+        self.finish_reason = finish_reason
+
+
+class _FakeUsage:
+    prompt_tokens = 100
+    completion_tokens = 20
+    total_tokens = 120
+
+
+class _FakeCompletion:
+    def __init__(self, message: _FakeMessage, model: str = "echo-model") -> None:
+        self.choices = [_FakeChoice(message)]
+        self.model = model
+        self.usage = _FakeUsage()
+
+
+class _FakeChatCompletions:
+    def __init__(self, response: _FakeCompletion) -> None:
+        self._response = response
+        self.last_kwargs: dict[str, Any] | None = None
+
+    def create(self, **kwargs: Any) -> _FakeCompletion:
+        self.last_kwargs = kwargs
+        # Echo back the requested model id so callers can assert
+        # ``resp.model`` carries the resolved id (matches real OpenAI
+        # behaviour where the response payload echoes ``model``).
+        if isinstance(kwargs.get("model"), str):
+            self._response.model = kwargs["model"]
+        return self._response
+
+
+class _FakeChat:
+    def __init__(self, completions: _FakeChatCompletions) -> None:
+        self.completions = completions
+
+
+class _FakeOpenAI:
+    def __init__(self, **kwargs: Any) -> None:
+        self.init_kwargs = kwargs
+        default_payload = {
+            "title": "Reasoning fixture",
+            "summary": "stub",
+        }
+        msg = _FakeMessage(tool_calls=[_FakeToolCall(
+            name="compose",
+            arguments=json.dumps(default_payload),
+        )])
+        self._completions = _FakeChatCompletions(_FakeCompletion(msg))
+        self.chat = _FakeChat(self._completions)
+
+
+@pytest.fixture()
+def fake_openai(monkeypatch: pytest.MonkeyPatch):
+    fake_mod = types.ModuleType("openai")
+    fake_mod.OpenAI = _FakeOpenAI
+    monkeypatch.setitem(sys.modules, "openai", fake_mod)
+    return fake_mod
+
+
+# ---------------------------------------------------------------------------
+# (a) Positive: configured reasoning_effort lands as extra_body kwarg
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_model_with_reasoning_effort_forwards_extra_body(fake_openai):
+    """High-tier ResolvedModel with reasoning_effort=high → kwargs has
+    ``extra_body={"reasoning_effort": "high"}`` and model resolves to the id."""
+    from lore_curator.llm_client import (
+        OpenAICompatibleClient,
+        ResolvedModel,
+    )
+
+    client = OpenAICompatibleClient(
+        base_url="https://example.local/v1",
+        api_key="sk-test",
+        tier_to_model={
+            "high": ResolvedModel(id="X", reasoning_effort="high"),
+        },
+    )
+
+    client.messages.create(
+        model="high",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{
+            "name": "compose",
+            "description": "",
+            "input_schema": {"type": "object", "properties": {}},
+        }],
+        tool_choice={"type": "tool", "name": "compose"},
+    )
+
+    kwargs = client._client._completions.last_kwargs
+    assert kwargs is not None
+    assert kwargs["model"] == "X"
+    assert kwargs["extra_body"] == {"reasoning_effort": "high"}
+
+
+# ---------------------------------------------------------------------------
+# (b) Negative: reasoning_effort=None means extra_body key absent
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_model_without_reasoning_effort_omits_extra_body(fake_openai):
+    """ResolvedModel(reasoning_effort=None) → ``extra_body`` is NOT in kwargs."""
+    from lore_curator.llm_client import (
+        OpenAICompatibleClient,
+        ResolvedModel,
+    )
+
+    client = OpenAICompatibleClient(
+        base_url="https://example.local/v1",
+        api_key="sk-test",
+        tier_to_model={
+            "middle": ResolvedModel(id="Y", reasoning_effort=None),
+        },
+    )
+
+    client.messages.create(
+        model="middle",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{
+            "name": "compose",
+            "description": "",
+            "input_schema": {"type": "object", "properties": {}},
+        }],
+        tool_choice={"type": "tool", "name": "compose"},
+    )
+
+    kwargs = client._client._completions.last_kwargs
+    assert kwargs is not None
+    assert kwargs["model"] == "Y"
+    assert "extra_body" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# (c) LlmResponse carries the applied reasoning_effort
+# ---------------------------------------------------------------------------
+
+
+def test_llm_response_carries_reasoning_effort_high(fake_openai):
+    """The response object exposes ``reasoning_effort="high"`` when forwarded."""
+    from lore_curator.llm_client import (
+        OpenAICompatibleClient,
+        ResolvedModel,
+    )
+
+    client = OpenAICompatibleClient(
+        base_url="https://example.local/v1",
+        api_key="sk-test",
+        tier_to_model={
+            "high": ResolvedModel(id="X", reasoning_effort="high"),
+        },
+    )
+
+    resp = client.messages.create(
+        model="high",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{
+            "name": "compose",
+            "description": "",
+            "input_schema": {"type": "object", "properties": {}},
+        }],
+        tool_choice={"type": "tool", "name": "compose"},
+    )
+
+    assert resp.reasoning_effort == "high"
+    assert resp.model == "X"  # echoed back by the fake
+
+
+def test_llm_response_reasoning_effort_none_when_unset(fake_openai):
+    from lore_curator.llm_client import (
+        OpenAICompatibleClient,
+        ResolvedModel,
+    )
+
+    client = OpenAICompatibleClient(
+        base_url="https://example.local/v1",
+        api_key="sk-test",
+        tier_to_model={
+            "middle": ResolvedModel(id="Y", reasoning_effort=None),
+        },
+    )
+
+    resp = client.messages.create(
+        model="middle",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{
+            "name": "compose",
+            "description": "",
+            "input_schema": {"type": "object", "properties": {}},
+        }],
+        tool_choice={"type": "tool", "name": "compose"},
+    )
+
+    assert resp.reasoning_effort is None
+
+
+# ---------------------------------------------------------------------------
+# (d) Literal pass-through (non-tier) — no extra_body even if other tiers
+# have reasoning_effort configured. There's no ResolvedModel to consult.
+# ---------------------------------------------------------------------------
+
+
+def test_literal_model_passthrough_gets_no_extra_body(fake_openai):
+    """``model="Mistral Small 4 119B"`` is a literal — no tier inference,
+    no ResolvedModel lookup → no extra_body lands on the wire, even though
+    other tiers have reasoning_effort configured."""
+    from lore_curator.llm_client import (
+        OpenAICompatibleClient,
+        ResolvedModel,
+    )
+
+    client = OpenAICompatibleClient(
+        base_url="https://example.local/v1",
+        api_key="sk-test",
+        tier_to_model={
+            "high": ResolvedModel(id="X", reasoning_effort="high"),
+        },
+    )
+
+    client.messages.create(
+        model="Mistral Small 4 119B",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{
+            "name": "compose",
+            "description": "",
+            "input_schema": {"type": "object", "properties": {}},
+        }],
+        tool_choice={"type": "tool", "name": "compose"},
+    )
+
+    kwargs = client._client._completions.last_kwargs
+    assert kwargs is not None
+    assert kwargs["model"] == "Mistral Small 4 119B"
+    assert "extra_body" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# (e) Regression bar: legacy ``dict[str, str]`` callers (pre-ResolvedModel
+# tests, external scripts) MUST NOT trip extra_body on the wire.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_string_tier_map_still_omits_extra_body(fake_openai):
+    """``tier_to_model={"middle": "m-m"}`` — the legacy shape used by older
+    tests and external scripts. Internally normalized to
+    ResolvedModel(id="m-m", reasoning_effort=None), so no extra_body."""
+    from lore_curator.llm_client import OpenAICompatibleClient
+
+    client = OpenAICompatibleClient(
+        base_url="https://example.local/v1",
+        api_key="sk-test",
+        tier_to_model={"simple": "m-s", "middle": "m-m", "high": "m-h"},
+    )
+
+    client.messages.create(
+        model="middle",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{
+            "name": "compose",
+            "description": "",
+            "input_schema": {"type": "object", "properties": {}},
+        }],
+        tool_choice={"type": "tool", "name": "compose"},
+    )
+
+    kwargs = client._client._completions.last_kwargs
+    assert kwargs is not None
+    assert kwargs["model"] == "m-m"
+    assert "extra_body" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# (f) End-to-end: synthesis.compose_session_note → resolved request payload
+# carries reasoning_effort AND the llm-response telemetry event surfaces it.
+# ---------------------------------------------------------------------------
+
+
+def test_compose_session_note_end_to_end_carries_reasoning_effort(fake_openai):
+    """Drive the Phase 2 compose path with an OpenAI client whose ``high``
+    tier opted into reasoning_effort=high. Assert:
+
+    1. The recorded outgoing request kwargs carry
+       ``extra_body={"reasoning_effort": "high"}`` and ``model="reasoning-X"``.
+    2. The ``llm-response`` telemetry event carries the new
+       ``model_resolved`` + ``reasoning_effort`` fields so future
+       experiment writeups don't have to bypass the wrapper.
+    """
+    from lore_curator.llm_client import (
+        OpenAICompatibleClient,
+        ResolvedModel,
+    )
+    from lore_curator.synthesis import compose_session_note
+
+    client = OpenAICompatibleClient(
+        base_url="https://example.local/v1",
+        api_key="sk-test",
+        tier_to_model={
+            "high": ResolvedModel(id="reasoning-X", reasoning_effort="high"),
+        },
+    )
+
+    # Override the default fake response with one whose tool_call carries
+    # fields that exist in the work-shape Phase 2 schema (``shape=None``
+    # selects the work variant). Keys outside the schema get stripped by
+    # the caller-side filter; ``title`` + ``summary_lede`` both survive.
+    compose_payload = {
+        "title": "Reasoning-mode narration",
+        "description": "Stub description.",
+        "summary_lede": "Stub Phase 2 compose payload.",
+    }
+    client._client._completions._response = _FakeCompletion(
+        message=_FakeMessage(tool_calls=[_FakeToolCall(
+            name="compose",
+            arguments=json.dumps(compose_payload),
+        )]),
+        model="reasoning-X",
+    )
+
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    class _CaptureLogger:
+        run_id = "test"
+
+        def emit(self, name: str, **kw: Any) -> None:
+            events.append((name, kw))
+
+    out = compose_session_note(
+        turns_text="some session text",
+        activity_summary="",
+        is_continuation=False,
+        continues_wikilink=None,
+        llm_client=client,
+        model="high",  # tier name — Phase 2 resolves via tier_to_model
+        logger=_CaptureLogger(),
+        transcript_id="t-1",
+        shape=None,
+    )
+    assert out is not None
+    # ``title`` and ``summary_lede`` are real schema fields and survive
+    # the caller-side schema-key filter.
+    assert out["title"] == "Reasoning-mode narration"
+    assert out["summary_lede"] == "Stub Phase 2 compose payload."
+
+    # (1) On-the-wire payload carries reasoning_effort.
+    kwargs = client._client._completions.last_kwargs
+    assert kwargs is not None
+    assert kwargs["model"] == "reasoning-X"
+    assert kwargs["extra_body"] == {"reasoning_effort": "high"}
+
+    # (2) Telemetry event surfaces resolved model + effort.
+    resp_events = [(n, kw) for n, kw in events
+                   if n == "llm-response" and kw.get("call") == "compose-session-note"]
+    assert len(resp_events) == 1, events
+    _, payload = resp_events[0]
+    assert payload["model_resolved"] == "reasoning-X"
+    assert payload["reasoning_effort"] == "high"
+
+
+def test_compose_session_note_telemetry_when_reasoning_effort_unset(fake_openai):
+    """Negative-case telemetry: an openai client without reasoning_effort
+    configured still emits ``model_resolved`` (the literal model id) and
+    ``reasoning_effort=None`` so the field is observable either way."""
+    from lore_curator.llm_client import (
+        OpenAICompatibleClient,
+        ResolvedModel,
+    )
+    from lore_curator.synthesis import compose_session_note
+
+    client = OpenAICompatibleClient(
+        base_url="https://example.local/v1",
+        api_key="sk-test",
+        tier_to_model={
+            "middle": ResolvedModel(id="plain-Y", reasoning_effort=None),
+        },
+    )
+
+    compose_payload = {"title": "Plain", "summary_lede": "no reasoning."}
+    client._client._completions._response = _FakeCompletion(
+        message=_FakeMessage(tool_calls=[_FakeToolCall(
+            name="compose",
+            arguments=json.dumps(compose_payload),
+        )]),
+        model="plain-Y",
+    )
+
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    class _CaptureLogger:
+        run_id = "test"
+
+        def emit(self, name: str, **kw: Any) -> None:
+            events.append((name, kw))
+
+    out = compose_session_note(
+        turns_text="some session text",
+        activity_summary="",
+        is_continuation=False,
+        continues_wikilink=None,
+        llm_client=client,
+        model="middle",
+        logger=_CaptureLogger(),
+        transcript_id="t-2",
+        shape=None,
+    )
+    assert out is not None
+
+    kwargs = client._client._completions.last_kwargs
+    assert kwargs is not None
+    assert "extra_body" not in kwargs
+
+    resp_events = [(n, kw) for n, kw in events
+                   if n == "llm-response" and kw.get("call") == "compose-session-note"]
+    assert len(resp_events) == 1
+    payload = resp_events[0][1]
+    assert payload["model_resolved"] == "plain-Y"
+    assert payload["reasoning_effort"] is None


### PR DESCRIPTION
## Summary

Implements **Slice 2 of PRD #110** — closes the silent-kwargs-drop in the OpenAI-compatible curator client. After this PR, a user who configures `reasoning_effort_high: high` in `.lore/config.yml` (and routes Curator A through the `high` tier on the openai backend) actually gets `extra_body={"reasoning_effort": "high"}` on the wire. Curator-A telemetry now reflects which model and reasoning level was applied.

## What changed

- `_OpenAIMessagesAPI.__init__` now takes `dict[str, ResolvedModel]` (Slice 1's value object flows through).
- `_OpenAIMessagesAPI.create`: **dropped `**_extra: Any`** (the silent-swallow the PRD calls out). Attaches `extra_body={"reasoning_effort": ...}` only when non-None — byte-identical request payload for users who haven't opted in.
- `LlmResponse` gained an optional `reasoning_effort` field (Option 1 from the PRD prompt: keep reasoning-knowledge inside the client boundary). Populated by the OpenAI client; left `None` by the subprocess + SDK paths.
- `synthesis.py`: `llm-response` telemetry event now carries `model_resolved` (from `resp.model`) and `reasoning_effort` (from `resp.reasoning_effort`).
- `OpenAICompatibleClient.__init__` cleaned up: the down-conversion to `dict[str, str]` is gone; ResolvedModel flows through; legacy `dict[str, str]` callers still accepted by the constructor's normalizer.

## Test plan

- [x] New `tests/test_reasoning_effort_plumbing.py` (8 tests): positive forwarding (extra_body present); None-omits-extra_body (regression bar against `**_extra` re-introduction); literal-model pass-through gets no extra_body; LlmResponse field positive/negative; legacy dict-of-strings constructor path; end-to-end through `compose_session_note` asserting both outgoing payload and telemetry event.
- [x] `pytest tests/test_reasoning_effort_plumbing.py`: 8 passed.
- [x] Targeted suites (openai_backend, precedence, secrets_env, resolved_model, curator_openai_smoke, synthesis, curator_a, plus new file): 126 passed, 1 pre-existing failure (missing `openai` module in dev env — identical on main).
- [x] Full suite: 2607 passed, 16 pre-existing failures unrelated to this slice.