### PR TITLE
feat(#110): PR 4 — recommended openai-backend setup (GPT-OSS-120B + reasoning=high)

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,35 @@ a one-shot: `lore curator run --backend openai --dry-run --trace-llm` —
 the trace file under `$LORE_ROOT/.lore/runs/<id>.trace.jsonl` shows the
 exact prompt/response pair for inspection.
 
+### Recommended openai-backend setup (Curator A narration)
+
+The narrator used to default to Mistral-119B, which has a known structural
+failure on retraction-heavy transcripts — it asserts decisions and outcomes
+the transcript later walks back (see experiments **005**, **006**, **007**
+in the [`lore-experiments`](https://github.com/) repo). Swapping the high
+tier to **GPT-OSS-120B with `reasoning_effort=high`** roughly halves
+contradicted claims (4 → 2 on the 007 sample) and passes the pre-committed
+gate.
+
+```yaml
+curator:
+  openai:
+    base_url: https://chat.kiconnect.nrw/api/v1
+    model_high: "Openai GPT OSS 120B"
+    reasoning_effort_high: high
+# Per-wiki, in <wiki>/.lore-wiki.yml — route Curator A to the high tier:
+# curator:
+#   synthesis_model_tier: high
+```
+
+- **Latency**: GPT-OSS-120B at `reasoning_effort=high` takes 80–100s per
+  Curator A call vs ~10s for Mistral. The session-note pipeline is async,
+  so this is acceptable but worth knowing.
+- **Cost**: both Mistral-119B and GPT-OSS-120B are free on the
+  kiconnect.nrw endpoint Lore points at by default.
+- **Backwards compatibility**: existing Mistral-only configs keep working
+  unchanged — leave `reasoning_effort_high` unset and nothing flips.
+
 ## Scheduling the curator — cost-free defaults
 
 The curator (flags stale notes, detects superseded decisions, keeps

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -74,6 +74,14 @@ Resolution: env > `.lore/config.yml:curator.openai.*` > error.
 | `LORE_OPENAI_MODEL_SIMPLE` | `model_simple` |
 | `LORE_OPENAI_MODEL_MIDDLE` | `model_middle` |
 | `LORE_OPENAI_MODEL_HIGH`   | `model_high` |
+| `LORE_OPENAI_REASONING_EFFORT_SIMPLE` | `reasoning_effort_simple` |
+| `LORE_OPENAI_REASONING_EFFORT_MIDDLE` | `reasoning_effort_middle` |
+| `LORE_OPENAI_REASONING_EFFORT_HIGH`   | `reasoning_effort_high` |
+
+`reasoning_effort_*` values are `low | medium | high` (case-insensitive)
+or empty string for "unset" (no `reasoning_effort` forwarded). See
+[Recommended openai-backend setup](../../README.md#recommended-openai-backend-setup-curator-a-narration)
+in the README for the GPT-OSS-120B production recipe.
 
 Implemented in `lore_curator/llm_client.py:_resolve_openai_settings`.
 
@@ -109,7 +117,7 @@ Vault-wide policy. Schema lives in
 - `observability.runs.{keep, max_total_mb, keep_trace}`
 - `observability.proc.keep_generations`
 - `curator.backend` — `auto` | `subscription` | `api` | `openai`
-- `curator.openai.{base_url, api_key_env, model_simple, model_middle, model_high}`
+- `curator.openai.{base_url, api_key_env, model_simple, model_middle, model_high, reasoning_effort_simple, reasoning_effort_middle, reasoning_effort_high}`
 
 Loader: `load_root_config(lore_root) -> RootConfig`. Missing file →
 all defaults. Unknown keys → `warnings.warn` (not fatal). Malformed


### PR DESCRIPTION
## Summary

Implements **Slice 4 of PRD #110** — documentation. Adds a "Recommended openai-backend setup (Curator A narration)" section to `README.md` and extends `docs/architecture/config.md` with the new `reasoning_effort_*` keys + env vars.

## What's documented

- One-paragraph motivation tying back to experiments 005 / 006 / 007 in `lore-experiments` (4→2 contradicted claims, score 0.78→0.89 on 007).
- YAML config snippet showing the root-level `curator.openai.reasoning_effort_high: high` keys alongside the per-wiki `synthesis_model_tier: high` override (the latter shown commented out since it lives in the per-wiki `.lore-wiki.yml` rather than the root `.lore/config.yml`).
- Latency caveat: 80–100s per Curator-A call on GPT-OSS-120B at reasoning_effort=high (vs ~10s for Mistral).
- Cost caveat: both Mistral-119B and GPT-OSS-120B are free on the kiconnect.nrw endpoint.
- Backwards-compatibility statement: existing Mistral-only configs keep working unchanged.

## Schema-split decision

`synthesis_model_tier` lives on the per-wiki `WikiConfig.curator` (`lib/lore_core/wiki_config.py:49`, default `"middle"`); `reasoning_effort_*` are root-level under `OpenAIBackendConfig` (`lib/lore_core/root_config.py:44`, added in Slice 1). Documented respecting that split so users know which file each key lives in.

`docs/architecture/config.md` updated to mirror — added the three `LORE_OPENAI_REASONING_EFFORT_{TIER}` env-var rows and the new schema keys with the `low|medium|high|empty` value space.

## Test plan

- Docs-only PR — no code changes, no tests to update.