### PR TITLE
MCP pull tools for repo ADRs and PRDs (#122)

### DIFF
--- a/lib/lore_core/repo_docs.py
+++ b/lib/lore_core/repo_docs.py
@@ -1,0 +1,106 @@
+"""Repo-native pull for ratified decisions — ADRs and PRDs.
+
+Reads directly from a connected repo's conventional, hard-coded homes
+(``docs/adr/``, ``docs/prd/``) instead of extracting decisions from
+session transcripts: repos own ratified decisions, lore owns session
+history (PRD 0001). Configurable homes are explicitly out of scope
+until adoption warrants it.
+
+Pure filesystem logic; the MCP layer (``lore_mcp.server``) wraps this
+in the pull-only tool handlers and never wires it into ambient
+context.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lore_core.schema import parse_frontmatter
+
+HOMES: dict[str, str] = {"adr": "docs/adr", "prd": "docs/prd"}
+
+_INDEX_NAMES = {"index.md", "readme.md"}
+
+
+def home_dir(repo_root: Path, kind: str) -> Path:
+    """Return the conventional home directory for `kind` under `repo_root`."""
+    return repo_root / HOMES[kind]
+
+
+def _title_from_body(text: str) -> str | None:
+    """First H1 in document order, or None if the doc has none."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# ") and not stripped.startswith("## "):
+            return stripped[2:].strip()
+    return None
+
+
+def _entry_for(path: Path, repo_root: Path) -> dict[str, Any]:
+    text = path.read_text(errors="replace")
+    fm = parse_frontmatter(text)
+    title = fm.get("title") or _title_from_body(text) or path.stem
+    return {
+        "path": str(path.relative_to(repo_root)),
+        "title": title,
+        "status": fm.get("status"),
+        "is_index": path.name.lower() in _INDEX_NAMES,
+    }
+
+
+def list_docs(repo_root: Path, kind: str) -> list[dict[str, Any]]:
+    """List ADR/PRD entries under `kind`'s home dir.
+
+    Empty list (not an error) when the home dir doesn't exist — most
+    repos have no ADRs yet, or don't use PRDs at all. Index files
+    (``README.md``/``index.md``) are included and sorted first.
+    """
+    d = home_dir(repo_root, kind)
+    if not d.is_dir():
+        return []
+    entries = [_entry_for(p, repo_root) for p in sorted(d.glob("*.md"))]
+    entries.sort(key=lambda e: (not e["is_index"], e["path"]))
+    return entries
+
+
+def resolve_doc(repo_root: Path, kind: str, path: str) -> Path | None:
+    """Resolve `path` to an absolute file under `kind`'s home dir.
+
+    Accepts a bare slug (``0001-x``), a filename (``0001-x.md``), or
+    the full repo-relative path (``docs/adr/0001-x.md``). Returns None
+    if the resolved file escapes the home dir, doesn't exist, or isn't
+    a file — callers don't need to distinguish "not found" from "path
+    escape", so both collapse to the same not-found result.
+    """
+    d = home_dir(repo_root, kind)
+    home = HOMES[kind]
+    p = path.strip()
+    if p.startswith(f"{home}/"):
+        p = p[len(home) + 1 :]
+    if not p.endswith(".md"):
+        p = f"{p}.md"
+    target = (d / p).resolve()
+    try:
+        target.relative_to(d.resolve())
+    except ValueError:
+        return None
+    if not target.is_file():
+        return None
+    return target
+
+
+def read_doc(repo_root: Path, kind: str, path: str) -> dict[str, Any] | None:
+    """Read one ADR/PRD file. None if not found, not a file, or escapes the home dir."""
+    target = resolve_doc(repo_root, kind, path)
+    if target is None:
+        return None
+    text = target.read_text(errors="replace")
+    fm = parse_frontmatter(text)
+    title = fm.get("title") or _title_from_body(text) or target.stem
+    return {
+        "path": str(target.relative_to(repo_root)),
+        "title": title,
+        "status": fm.get("status"),
+        "content": text,
+    }

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -1180,9 +1180,7 @@ def handle_repo_docs_list(kind: str, repo_path: str | None = None) -> dict[str, 
     from lore_core.repo_docs import HOMES, list_docs
 
     if kind not in HOMES:
-        return _mcp_error(
-            "invalid_kind", f"kind must be one of {sorted(HOMES)}, got {kind!r}"
-        )
+        return _mcp_error("invalid_kind", f"kind must be one of {sorted(HOMES)}, got {kind!r}")
     repo_root = _resolve_repo_root(repo_path)
     if repo_root is None:
         return _mcp_error(
@@ -1200,9 +1198,7 @@ def handle_repo_docs_list(kind: str, repo_path: str | None = None) -> dict[str, 
     }
 
 
-def handle_repo_docs_fetch(
-    kind: str, path: str, repo_path: str | None = None
-) -> dict[str, Any]:
+def handle_repo_docs_fetch(kind: str, path: str, repo_path: str | None = None) -> dict[str, Any]:
     """Fetch one ADR/PRD's content from a connected repo.
 
     `path` accepts a bare slug, a filename, or the full repo-relative
@@ -1211,9 +1207,7 @@ def handle_repo_docs_fetch(
     from lore_core.repo_docs import HOMES, read_doc
 
     if kind not in HOMES:
-        return _mcp_error(
-            "invalid_kind", f"kind must be one of {sorted(HOMES)}, got {kind!r}"
-        )
+        return _mcp_error("invalid_kind", f"kind must be one of {sorted(HOMES)}, got {kind!r}")
     repo_root = _resolve_repo_root(repo_path)
     if repo_root is None:
         return _mcp_error(

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -21,6 +21,8 @@ Exposed tools:
                               out to `lore inbox archive`
     lore_surface_context    — gather context pack for surface-authoring skills
     lore_surface_validate   — validate draft-spec + preview diff (no writes)
+    lore_repo_docs_list     — list a connected repo's ADRs or PRDs (pull-only)
+    lore_repo_docs_fetch    — fetch one ADR or PRD's content (pull-only)
 
 Start:
     lore mcp
@@ -1152,6 +1154,79 @@ def handle_wikilinks(note: str, wiki: str | None = None) -> dict[str, Any]:
     return _mcp_error("note_not_found", f"note not found: {note}")
 
 
+def _resolve_repo_root(repo_path: str | None) -> Path | None:
+    """Resolve the connected repo's root for the repo-docs pull tools.
+
+    Explicit `repo_path` wins (also how tests avoid needing a real git
+    repo). Otherwise auto-detect the git repo containing the server's
+    cwd — an MCP client normally launches this server from within the
+    project it's connected to.
+    """
+    if repo_path:
+        p = Path(repo_path).expanduser().resolve()
+        return p if p.is_dir() else None
+    from lore_core.git import git_repo_root
+
+    return git_repo_root(Path.cwd())
+
+
+def handle_repo_docs_list(kind: str, repo_path: str | None = None) -> dict[str, Any]:
+    """List ADR/PRD entries from a connected repo's conventional home.
+
+    Pull-only: fires on explicit MCP call, never at SessionStart. A
+    repo without `docs/adr` or `docs/prd` is not an error — `exists`
+    is False and `entries` is empty.
+    """
+    from lore_core.repo_docs import HOMES, list_docs
+
+    if kind not in HOMES:
+        return _mcp_error(
+            "invalid_kind", f"kind must be one of {sorted(HOMES)}, got {kind!r}"
+        )
+    repo_root = _resolve_repo_root(repo_path)
+    if repo_root is None:
+        return _mcp_error(
+            "repo_not_found",
+            "could not resolve the connected repo",
+            next_="pass `repo_path` explicitly, or run the MCP server from within a git repo",
+        )
+    return {
+        "schema": "lore.repo_docs.list/1",
+        "kind": kind,
+        "repo_root": str(repo_root),
+        "home": HOMES[kind],
+        "exists": (repo_root / HOMES[kind]).is_dir(),
+        "entries": list_docs(repo_root, kind),
+    }
+
+
+def handle_repo_docs_fetch(
+    kind: str, path: str, repo_path: str | None = None
+) -> dict[str, Any]:
+    """Fetch one ADR/PRD's content from a connected repo.
+
+    `path` accepts a bare slug, a filename, or the full repo-relative
+    path. Pull-only, same contract as :func:`handle_repo_docs_list`.
+    """
+    from lore_core.repo_docs import HOMES, read_doc
+
+    if kind not in HOMES:
+        return _mcp_error(
+            "invalid_kind", f"kind must be one of {sorted(HOMES)}, got {kind!r}"
+        )
+    repo_root = _resolve_repo_root(repo_path)
+    if repo_root is None:
+        return _mcp_error(
+            "repo_not_found",
+            "could not resolve the connected repo",
+            next_="pass `repo_path` explicitly, or run the MCP server from within a git repo",
+        )
+    doc = read_doc(repo_root, kind, path)
+    if doc is None:
+        return _mcp_error("doc_not_found", f"{kind} not found: {path}")
+    return {"schema": "lore.repo_docs.fetch/1", "kind": kind, **doc}
+
+
 # ---------------------------------------------------------------------------
 # MCP server wrapper
 # ---------------------------------------------------------------------------
@@ -1505,6 +1580,54 @@ def _tool_schema() -> list[dict]:
                 "required": ["wiki", "note", "verdict"],
             },
         },
+        {
+            "name": "lore_repo_docs_list",
+            "description": (
+                "List a connected repo's ADRs or PRDs from their conventional, "
+                "hard-coded homes (`docs/adr/`, `docs/prd/`; homes are not "
+                "configurable). Includes index files (README.md/index.md). "
+                "Pull-only: fires on explicit call, never injected ambiently. "
+                "A repo without the home directory is not an error — returns "
+                "`exists: false` and an empty `entries` list."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "string", "enum": ["adr", "prd"]},
+                    "repo_path": {
+                        "type": "string",
+                        "description": (
+                            "Override the repo root. Defaults to the git repo "
+                            "containing the server's working directory."
+                        ),
+                    },
+                },
+                "required": ["kind"],
+            },
+        },
+        {
+            "name": "lore_repo_docs_fetch",
+            "description": (
+                "Fetch one ADR or PRD's full content from a connected repo. "
+                "`path` accepts a bare slug (`0001-x`), a filename (`0001-x.md`), "
+                "or the full repo-relative path (`docs/adr/0001-x.md`). Pull-only."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "string", "enum": ["adr", "prd"]},
+                    "path": {"type": "string"},
+                    "repo_path": {
+                        "type": "string",
+                        "description": (
+                            "Override the repo root. Defaults to the git repo "
+                            "containing the server's working directory."
+                        ),
+                    },
+                },
+                "required": ["kind", "path"],
+            },
+        },
     ]
 
 
@@ -1552,6 +1675,10 @@ def _dispatch(tool_name: str, args: dict) -> Any:
             return handle_verdict(**args)
         case "lore_pending_verdicts":
             return handle_pending_verdicts(**args)
+        case "lore_repo_docs_list":
+            return handle_repo_docs_list(**args)
+        case "lore_repo_docs_fetch":
+            return handle_repo_docs_fetch(**args)
         case _:
             return _mcp_error("unknown_tool", f"unknown tool: {tool_name}")
 

--- a/tests/test_mcp_repo_docs.py
+++ b/tests/test_mcp_repo_docs.py
@@ -1,0 +1,140 @@
+"""MCP pull tools for repo ADRs/PRDs — `lore_repo_docs_list` / `lore_repo_docs_fetch`.
+
+Pull-only: these tools read a connected repo's ratified decisions from
+their conventional homes (`docs/adr/`, `docs/prd/`) on explicit MCP
+call. Nothing here is wired into SessionStart/ambient context — that
+stays the workflow plugin's job during coexistence (PRD 0001,
+"Ambient vs pull").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lore_mcp.server import _dispatch, _tool_schema, handle_repo_docs_fetch, handle_repo_docs_list
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+# ---- handle_repo_docs_list ----
+
+
+def test_list_returns_adr_entries(tmp_path: Path) -> None:
+    _write(tmp_path / "docs/adr/0001-x.md", "---\ntitle: X\nstatus: accepted\n---\nbody\n")
+    result = handle_repo_docs_list(kind="adr", repo_path=str(tmp_path))
+    assert result["schema"] == "lore.repo_docs.list/1"
+    assert result["kind"] == "adr"
+    assert result["home"] == "docs/adr"
+    assert result["exists"] is True
+    assert result["entries"] == [
+        {"path": "docs/adr/0001-x.md", "title": "X", "status": "accepted", "is_index": False}
+    ]
+
+
+def test_list_returns_prd_entries(tmp_path: Path) -> None:
+    _write(tmp_path / "docs/prd/0001-y.md", "---\ntitle: Y\nstatus: draft\n---\nbody\n")
+    result = handle_repo_docs_list(kind="prd", repo_path=str(tmp_path))
+    assert result["kind"] == "prd"
+    assert result["entries"][0]["title"] == "Y"
+
+
+def test_list_graceful_empty_when_home_missing(tmp_path: Path) -> None:
+    """A repo with no docs/adr or docs/prd is not an error — empty result."""
+    result = handle_repo_docs_list(kind="adr", repo_path=str(tmp_path))
+    assert "error" not in result
+    assert result["exists"] is False
+    assert result["entries"] == []
+
+    result = handle_repo_docs_list(kind="prd", repo_path=str(tmp_path))
+    assert "error" not in result
+    assert result["exists"] is False
+    assert result["entries"] == []
+
+
+def test_list_invalid_kind_error_envelope(tmp_path: Path) -> None:
+    result = handle_repo_docs_list(kind="bogus", repo_path=str(tmp_path))
+    assert result["error"]["code"] == "invalid_kind"
+
+
+def test_list_repo_not_found_when_not_a_git_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
+    result = handle_repo_docs_list(kind="adr")
+    assert result["error"]["code"] == "repo_not_found"
+    assert "next" in result["error"]
+
+
+# ---- handle_repo_docs_fetch ----
+
+
+def test_fetch_by_bare_slug(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "docs/adr/0001-x.md",
+        "---\ntitle: X\nstatus: accepted\n---\nDecision body.\n",
+    )
+    result = handle_repo_docs_fetch(kind="adr", path="0001-x", repo_path=str(tmp_path))
+    assert result["schema"] == "lore.repo_docs.fetch/1"
+    assert result["path"] == "docs/adr/0001-x.md"
+    assert result["title"] == "X"
+    assert result["status"] == "accepted"
+    assert "Decision body." in result["content"]
+
+
+def test_fetch_by_full_relative_path(tmp_path: Path) -> None:
+    _write(tmp_path / "docs/prd/0001-y.md", "---\ntitle: Y\n---\nbody\n")
+    result = handle_repo_docs_fetch(kind="prd", path="docs/prd/0001-y.md", repo_path=str(tmp_path))
+    assert result["path"] == "docs/prd/0001-y.md"
+
+
+def test_fetch_index_file(tmp_path: Path) -> None:
+    _write(tmp_path / "docs/adr/README.md", "# ADR index\n")
+    result = handle_repo_docs_fetch(kind="adr", path="README", repo_path=str(tmp_path))
+    assert "ADR index" in result["content"]
+
+
+def test_fetch_not_found_error_envelope(tmp_path: Path) -> None:
+    (tmp_path / "docs/adr").mkdir(parents=True)
+    result = handle_repo_docs_fetch(kind="adr", path="missing", repo_path=str(tmp_path))
+    assert result["error"]["code"] == "doc_not_found"
+
+
+def test_fetch_path_escape_does_not_leak_outside_home(tmp_path: Path) -> None:
+    (tmp_path / "docs/adr").mkdir(parents=True)
+    (tmp_path / "secret.md").write_text("top secret\n")
+    result = handle_repo_docs_fetch(kind="adr", path="../../secret", repo_path=str(tmp_path))
+    assert result["error"]["code"] == "doc_not_found"
+
+
+def test_fetch_invalid_kind_error_envelope(tmp_path: Path) -> None:
+    result = handle_repo_docs_fetch(kind="bogus", path="x", repo_path=str(tmp_path))
+    assert result["error"]["code"] == "invalid_kind"
+
+
+def test_fetch_repo_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
+    result = handle_repo_docs_fetch(kind="adr", path="0001-x")
+    assert result["error"]["code"] == "repo_not_found"
+
+
+# ---- tool schema + dispatch registration ----
+
+
+def test_tools_registered_in_schema() -> None:
+    names = {t["name"] for t in _tool_schema()}
+    assert "lore_repo_docs_list" in names
+    assert "lore_repo_docs_fetch" in names
+
+
+def test_dispatch_routes_list_and_fetch(tmp_path: Path) -> None:
+    _write(tmp_path / "docs/adr/0001-x.md", "---\ntitle: X\n---\nbody\n")
+    listed = _dispatch("lore_repo_docs_list", {"kind": "adr", "repo_path": str(tmp_path)})
+    assert listed["entries"][0]["path"] == "docs/adr/0001-x.md"
+
+    fetched = _dispatch(
+        "lore_repo_docs_fetch",
+        {"kind": "adr", "path": "0001-x", "repo_path": str(tmp_path)},
+    )
+    assert fetched["title"] == "X"

--- a/tests/test_repo_docs.py
+++ b/tests/test_repo_docs.py
@@ -1,0 +1,89 @@
+"""Core repo-native pull logic for ADRs/PRDs (`lore_core.repo_docs`).
+
+Reads a connected repo's ratified decisions from their conventional,
+hard-coded homes (``docs/adr/``, ``docs/prd/``) instead of extracting
+them from session transcripts — repos own decisions, lore owns session
+history. Configurable homes are explicitly out of scope.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_core.repo_docs import HOMES, list_docs, read_doc, resolve_doc
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_homes_are_hard_coded() -> None:
+    assert HOMES == {"adr": "docs/adr", "prd": "docs/prd"}
+
+
+def test_list_docs_empty_when_home_missing(tmp_path: Path) -> None:
+    assert list_docs(tmp_path, "adr") == []
+    assert list_docs(tmp_path, "prd") == []
+
+
+def test_list_docs_returns_entries_with_title_and_status(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "docs/adr/0001-use-sqlite.md",
+        "---\ntitle: Use SQLite\nstatus: accepted\n---\nBody text.\n",
+    )
+    entries = list_docs(tmp_path, "adr")
+    assert len(entries) == 1
+    assert entries[0]["path"] == "docs/adr/0001-use-sqlite.md"
+    assert entries[0]["title"] == "Use SQLite"
+    assert entries[0]["status"] == "accepted"
+    assert entries[0]["is_index"] is False
+
+
+def test_list_docs_falls_back_to_h1_then_filename_for_title(tmp_path: Path) -> None:
+    _write(tmp_path / "docs/prd/0002-no-frontmatter.md", "# A Plain Title\n\nBody.\n")
+    _write(tmp_path / "docs/prd/0003-bare.md", "No heading, no frontmatter.\n")
+    entries = {e["path"]: e for e in list_docs(tmp_path, "prd")}
+    assert entries["docs/prd/0002-no-frontmatter.md"]["title"] == "A Plain Title"
+    assert entries["docs/prd/0003-bare.md"]["title"] == "0003-bare"
+
+
+def test_list_docs_includes_index_file_and_sorts_it_first(tmp_path: Path) -> None:
+    _write(tmp_path / "docs/adr/0001-a.md", "---\ntitle: A\n---\nbody\n")
+    _write(tmp_path / "docs/adr/README.md", "# ADR index\n")
+    entries = list_docs(tmp_path, "adr")
+    assert [e["path"] for e in entries] == ["docs/adr/README.md", "docs/adr/0001-a.md"]
+    assert entries[0]["is_index"] is True
+    assert entries[1]["is_index"] is False
+
+
+def test_resolve_doc_accepts_bare_slug_filename_and_full_path(tmp_path: Path) -> None:
+    _write(tmp_path / "docs/adr/0001-x.md", "---\ntitle: X\n---\nbody\n")
+    expected = (tmp_path / "docs/adr/0001-x.md").resolve()
+    assert resolve_doc(tmp_path, "adr", "0001-x") == expected
+    assert resolve_doc(tmp_path, "adr", "0001-x.md") == expected
+    assert resolve_doc(tmp_path, "adr", "docs/adr/0001-x.md") == expected
+
+
+def test_resolve_doc_none_for_missing_or_escaping_path(tmp_path: Path) -> None:
+    _write(tmp_path / "docs/adr/0001-x.md", "body\n")
+    assert resolve_doc(tmp_path, "adr", "does-not-exist") is None
+    assert resolve_doc(tmp_path, "adr", "../../../etc/passwd") is None
+    assert resolve_doc(tmp_path, "adr", "../prd/0002-y") is None
+
+
+def test_read_doc_returns_content_title_status(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "docs/prd/0001-thing.md",
+        "---\ntitle: The Thing\nstatus: draft\n---\nBody of the PRD.\n",
+    )
+    doc = read_doc(tmp_path, "prd", "0001-thing")
+    assert doc is not None
+    assert doc["path"] == "docs/prd/0001-thing.md"
+    assert doc["title"] == "The Thing"
+    assert doc["status"] == "draft"
+    assert "Body of the PRD." in doc["content"]
+
+
+def test_read_doc_none_when_not_found(tmp_path: Path) -> None:
+    assert read_doc(tmp_path, "adr", "nope") is None

--- a/tests/test_repo_docs_no_ambient_injection.py
+++ b/tests/test_repo_docs_no_ambient_injection.py
@@ -1,0 +1,41 @@
+"""Repo ADR/PRD pull is explicit-call-only — never ambient.
+
+PRD 0001 ("Ambient vs pull") is explicit: nothing from ADRs/PRDs is
+injected into the SessionStart banner or any other ambient surface;
+depth comes only from an explicit MCP pull. This is a static guard —
+the hook module that renders ambient context must never reference the
+new repo-docs handlers.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_hooks_module_does_not_reference_repo_docs_handlers() -> None:
+    from lore_cli import hooks
+
+    source = inspect.getsource(hooks)
+    for needle in (
+        "repo_docs",
+        "handle_repo_docs_list",
+        "handle_repo_docs_fetch",
+        "lore_repo_docs_list",
+        "lore_repo_docs_fetch",
+    ):
+        assert needle not in source, f"ambient hook module references {needle!r}"
+
+
+def test_session_banner_render_is_unaffected_by_repo_docs(tmp_path, monkeypatch) -> None:
+    """A repo with populated docs/adr, docs/prd still renders the banner
+    without importing or touching the pull handlers."""
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    (tmp_path / "docs/adr").mkdir(parents=True)
+    (tmp_path / "docs/adr/0001-x.md").write_text("---\ntitle: X\n---\nbody\n")
+
+    from lore_cli.hooks import SessionFacts, render_session_banner
+
+    facts = SessionFacts(wiki_name="private", repo=None)
+    banner = render_session_banner(facts)
+    assert "0001-x" not in banner
+    assert "docs/adr" not in banner


### PR DESCRIPTION
Implements #122 (epic #131).

## Summary
- New MCP tools `lore_repo_docs_list` / `lore_repo_docs_fetch` read a connected repo's ratified decisions natively from their conventional, hard-coded homes (`docs/adr/`, `docs/prd/`). Configurability is explicitly deferred (PRD 0001).
- `list` returns entries (`path`, `title`, `status`, `is_index`) for every `.md` file under the home dir, including index files (`README.md`/`index.md`), sorted with the index first. A repo without `docs/adr` or `docs/prd` is not an error — `exists: false`, `entries: []`.
- `fetch` resolves a bare slug, a filename, or a full repo-relative path to one file's content, title, and status. Escaping the home dir or a missing file both resolve to a structured `doc_not_found` error (no distinction leaked).
- Repo root resolution: explicit `repo_path` wins; otherwise falls back to the git repo containing the MCP server's cwd.
- Pull-only by construction: nothing in `lore_cli/hooks.py` (SessionStart/ambient banner) references the new handlers or tool names — guarded by a static test plus a banner-render smoke test.

## Decisions
- Core filesystem logic lives in `lib/lore_core/repo_docs.py` (kind-generic over `adr`/`prd`); the MCP layer in `lib/lore_mcp/server.py` is a thin wrapper, following the existing surface-tools pattern.
- Two tools (`list`/`fetch`) rather than four (one pair per kind) — DRY over the `kind` parameter, matching how `lore_journal_write`/`lore_journal_read` split by verb rather than by artifact type.
- New error codes `invalid_kind`, `repo_not_found`, `doc_not_found` follow the existing `_mcp_error` envelope contract as raw string literals, matching `server.py`'s established local convention (its other handlers don't route through `lore_core.errors`' constants either).

## Test plan
- [x] `pytest` full suite green except 16 pre-existing baseline failures (confirmed via `git stash` — none touch the files this PR changes; unrelated to this change)
- [x] `ruff check` / `ruff format --check` clean on all new/changed files
- [x] RED→GREEN: collection errors for the new module/handlers before implementation, 25/25 new tests passing after
- [x] No version bump