### PR TITLE
Kill switches: disable Curator B/C and surface entry points (#119)

### DIFF
--- a/lib/lore_cli/__main__.py
+++ b/lib/lore_cli/__main__.py
@@ -89,7 +89,6 @@ def _build_app() -> typer.Typer:
         search_cmd,
         session_cmd,
         status_cmd,
-        surface_cmd,
         transcripts_cmd,
         wiki_cmd,
     )
@@ -118,7 +117,10 @@ def _build_app() -> typer.Typer:
     app.add_typer(drill_cmd.app, name="drill", rich_help_panel=_KN)
     app.add_typer(session_cmd.app, name="session", rich_help_panel=_KN)
     app.add_typer(project_cmd.app, name="project", rich_help_panel=_KN)
-    app.add_typer(surface_cmd.app, name="surface", rich_help_panel=_KN)
+    # `surface_cmd.app` is not mounted here — Curator B's surface extraction
+    # is retired and the surface-authoring CLI is a severed entry point.
+    # The module stays importable (tests exercise it directly) and unmounted
+    # is the only change; nothing under it was deleted.
     app.add_typer(wiki_cmd.app, name="wiki", rich_help_panel=_KN)
     app.add_typer(news_cmd.app, name="news", rich_help_panel=_KN)
     app.add_typer(resume_cmd.app, name="resume", rich_help_panel=_KN)

--- a/lib/lore_cli/curator_cmd.py
+++ b/lib/lore_cli/curator_cmd.py
@@ -1,9 +1,12 @@
 """`lore curator` — manual entry point for the curator triad.
 
 Bare `lore curator` runs the Curator C hygiene passes (stale, supersession,
-backfill, implements-propagation). `lore curator run` is the full pipeline:
-classify pending transcripts → file session notes → optional surface
-extraction (`--abstract`) and weekly defrag (`--defrag`).
+backfill, implements-propagation). `lore curator run` files session notes
+from pending transcripts (Curator A).
+
+Curator B's surface-extraction pass (`--abstract`) and Curator C's weekly
+LLM-defrag pass (`--defrag`) are retired; `run` no longer accepts either
+flag.
 
 Curator A / B / C labels are internal; user-facing copy says "Curator"
 or the role name.
@@ -136,59 +139,10 @@ def _print_backend_label(con: Console, llm_client: object) -> None:
 def run_command(
     scope: str = typer.Option(None, "--scope", help="Filter to one scope, e.g. 'mywiki:subproject'."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Classify but don't write notes or advance ledger."),
-    abstract: bool = typer.Option(False, "--abstract", help="Also run the surface-extraction pass after filing session notes."),
-    defrag: bool = typer.Option(False, "--defrag", help="Run Curator C weekly defragmentation (hygiene + LLM adjacent-merge / auto-supersede / orphan-repair / draft-promotion)."),
-    wiki: str = typer.Option(None, "--wiki", help="Limit the surface-extraction / defrag pass to a single wiki."),
     trace_llm: bool = typer.Option(False, "--trace-llm", help="Capture LLM prompts/responses to runs/<id>.trace.jsonl (equivalent to LORE_TRACE_LLM=1)."),
     backend: str = typer.Option(None, "--backend", help="LLM backend: subscription | api | openai | auto. Overrides LORE_LLM_BACKEND and curator.backend config."),
 ) -> None:
-    """Run the curator.
-
-    Default: classify pending transcripts and file session notes.
-    --abstract also runs the surface-extraction pass.
-    --defrag runs the weekly whole-wiki defragmentation (hygiene passes
-    + LLM proposals for adjacent-concept merges, auto-supersession,
-    orphan wikilink repair, and draft promotions).
-    """
-    if defrag:
-        # --defrag runs Curator C directly, not Curator A. Bypass the
-        # transcript classification path and go straight to the whole-wiki
-        # pipeline.
-        import os
-        from lore_cli._cli_helpers import lore_root_or_die
-        err_console = Console(stderr=True)
-        lore_root_defrag = lore_root_or_die(err_console)
-        effective_backend = _resolve_backend(backend, lore_root_defrag)
-
-        # LLM client resolution (same seam as Curator A).
-        from lore_curator.llm_client import LlmClientError, make_llm_client
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "") or None
-        try:
-            llm_client = make_llm_client(
-                backend=effective_backend,
-                api_key=api_key,
-                lore_root=lore_root_defrag,
-            )
-        except LlmClientError as exc:
-            err_console.print(f"[yellow]Warning:[/yellow] {exc}")
-            llm_client = None
-        if llm_client is None:
-            console.print(
-                "[yellow]Running --defrag without an LLM client — "
-                "LLM passes (adjacent-merge, auto-supersede, orphan-repair) "
-                "will be skipped.[/yellow]"
-            )
-        else:
-            _print_backend_label(console, llm_client)
-
-        run_curator_c(
-            wiki_filter=wiki,
-            dry_run=dry_run,
-            defrag=True,
-            llm_client=llm_client,
-        )
-        # Exit success — report already printed by run_curator_c.
-        return
+    """Run the curator: classify pending transcripts and file session notes."""
     import os
     from datetime import UTC, datetime
     from pathlib import Path
@@ -279,34 +233,6 @@ def run_command(
     )
     console.print(f"  skipped: {{{skipped_summary}}}")
     console.print(f"  took: {result.duration_seconds:.2f}s")
-
-    # Run Curator B if --abstract is specified
-    if abstract:
-        from lore_curator.daily_curator import run_curator_b
-
-        wikis_to_process = [wiki] if wiki else _discover_wikis(lore_root)
-
-        for wiki_name in wikis_to_process:
-            b_result = run_curator_b(
-                lore_root=lore_root,
-                wiki=wiki_name,
-                llm_client=llm_client,
-                dry_run=dry_run,
-                now=datetime.now(UTC),
-                lock_timeout=lock_timeout,
-            )
-
-            skipped_b_summary = ", ".join(
-                f"{k}: {v}" for k, v in b_result.skipped_reasons.items()
-            ) or "none"
-
-            console.print(
-                f"[bold]Curator B[/bold] ({wiki_name}) — {b_result.notes_considered} note(s) considered"
-            )
-            console.print(f"  clusters: {b_result.clusters_formed}")
-            console.print(f"  surfaces: {len(b_result.surfaces_emitted)}")
-            console.print(f"  skipped: {{{skipped_b_summary}}}")
-            console.print(f"  took: {b_result.duration_seconds:.2f}s")
 
 
 @app.command("flush")

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -992,13 +992,17 @@ import typer  # noqa: E402
 
 from lore_adapters import get_adapter  # noqa: E402
 from lore_core.hook_log import HookEventLogger  # noqa: E402
-from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry, WikiLedger  # noqa: E402
+from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry  # noqa: E402
 from lore_core.scope_resolver import resolve_scope  # noqa: E402
 from lore_cli._argv_compat import argv_main  # noqa: E402
 
 # Re-export the spawn machinery so hooks-internal heartbeat code and any
 # external test that patches ``lore_cli.hooks.<name>`` keep working without
-# tracking the move to ``lore_cli.spawn``.
+# tracking the move to ``lore_cli.spawn``. ``_spawn_detached_curator_b`` and
+# ``_spawn_detached_curator_c`` stay re-exported even though no call site in
+# this module invokes them any more — the SessionStart entry points to
+# Curator B/C are severed, but the underlying spawn primitives are exercised
+# directly by tests covering the flock/cooldown machinery itself.
 from lore_cli.spawn import (  # noqa: E402, F401
     _migrate_legacy_spawn_stamp,
     _open_proc_log,
@@ -1012,9 +1016,6 @@ from lore_cli.spawn import (  # noqa: E402, F401
     _spawn_detached_transcript_sync,
     _stamp_within_cooldown,
     _write_stamp,
-    _curator_c_email,
-    _curator_c_jitter_seconds,
-    _iso_week_monday_utc,
     spawn,
 )
 
@@ -1290,64 +1291,18 @@ def cmd_session_start(
         out = out + "\n" + auto_pull_warning
 
     # Side-effect spawns — suppressed under --probe.
+    #
+    # Curator B's day-rollover auto-spawn and Curator C's weekly auto-spawn
+    # used to fire from here (see git history for the removed blocks); both
+    # are retired and no longer reachable from SessionStart. The spawn
+    # primitives themselves (``_spawn_detached_curator_b/_c`` in
+    # ``lore_cli.spawn``) stay in place — this only severs the automatic
+    # call site.
     if not probe and scope is not None and lore_root is not None:
-        # Auto-trigger Curator B on calendar-day rollover.
-        try:
-            from datetime import UTC, datetime as dt
-
-            wledger = WikiLedger(lore_root, scope.wiki)
-            wentry = wledger.read()
-            today = dt.now(UTC).date()
-            last_b_date = wentry.last_curator_b.date() if wentry.last_curator_b else None
-            if last_b_date is None or today > last_b_date:
-                cfg_b = _load_wiki_cfg_from_scope(scope, lore_root)
-                _spawn_detached_curator_b(
-                    lore_root, scope.wiki, cooldown_s=cfg_b.curator.curator_b_cooldown_s
-                )
-        except Exception:
-            pass
-
         # Fire-and-forget transcript mirror (P4a). Idempotent, gitignored
         # destination, own spawn lock.
         try:
             _spawn_detached_transcript_sync(lore_root)
-        except Exception:
-            pass
-
-        # Auto-trigger Curator C weekly (UTC ISO-week + per-user 48h jitter).
-        # Flag-gated off by default; see project_curator_triad + spec §6.
-        try:
-            cfg = _load_wiki_cfg_from_scope(scope, lore_root)
-            c_cfg = cfg.curator.curator_c
-            if c_cfg.enabled:
-                if c_cfg.mode != "local":
-                    HookEventLogger(lore_root).emit(
-                        event="curator-c",
-                        outcome="central-mode-skipped",
-                        error={
-                            "message": "mode=central deferred to v2; local spawn skipped",
-                            "wiki": scope.wiki,
-                        },
-                    )
-                else:
-                    wledger = WikiLedger(lore_root, scope.wiki)
-                    wentry = wledger.read()
-                    now = _now_utc()
-                    last_c = wentry.last_curator_c
-                    if last_c is not None and last_c.tzinfo is None:
-                        from datetime import UTC as _UTC
-                        last_c = last_c.replace(tzinfo=_UTC)
-                    iso_now = now.isocalendar()
-                    needs_rollover = (
-                        last_c is None
-                        or last_c.isocalendar()[:2] != iso_now[:2]
-                    )
-                    if needs_rollover:
-                        monday = _iso_week_monday_utc(now)
-                        offset = _curator_c_jitter_seconds(_curator_c_email())
-                        from datetime import timedelta as _td
-                        if now >= monday + _td(seconds=offset):
-                            _spawn_detached_curator_c(lore_root)
         except Exception:
             pass
 

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -19,10 +19,13 @@ Exposed tools:
     lore_inbox_classify     — read-only inbox walk (file list with type +
                               routing hint); skill composes notes, then shells
                               out to `lore inbox archive`
-    lore_surface_context    — gather context pack for surface-authoring skills
-    lore_surface_validate   — validate draft-spec + preview diff (no writes)
     lore_repo_docs_list     — list a connected repo's ADRs or PRDs (pull-only)
     lore_repo_docs_fetch    — fetch one ADR or PRD's content (pull-only)
+
+Not registered: `handle_surface_context` / `handle_surface_validate` stay
+importable (exercised directly by tests) but their MCP tools are
+unregistered — Curator B's surface extraction is retired and no MCP path
+reaches surface authoring any more.
 
 Start:
     lore mcp
@@ -1432,34 +1435,6 @@ def _tool_schema() -> list[dict]:
             "inputSchema": {"type": "object", "properties": {}},
         },
         {
-            "name": "lore_surface_context",
-            "description": (
-                "Gather context for surface-authoring skills: current SURFACES.md, "
-                "CLAUDE.md attach block, sampled recent notes per surface, shipped templates."
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {"wiki": {"type": "string"}},
-                "required": ["wiki"],
-            },
-        },
-        {
-            "name": "lore_surface_validate",
-            "description": (
-                "Validate a surface draft-spec (append or init). Returns structured "
-                "issue list + rendered markdown + unified diff preview against the "
-                "current SURFACES.md. Never writes."
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "wiki": {"type": "string"},
-                    "draft": {"type": "object"},
-                },
-                "required": ["wiki", "draft"],
-            },
-        },
-        {
             "name": "lore_journal_write",
             "description": (
                 "Append a freeform entry to the AI or human journal "
@@ -1657,10 +1632,6 @@ def _dispatch(tool_name: str, args: dict) -> Any:
             return handle_briefing_gather(**args)
         case "lore_inbox_classify":
             return handle_inbox_classify(**args)
-        case "lore_surface_context":
-            return handle_surface_context(**args)
-        case "lore_surface_validate":
-            return handle_surface_validate(**args)
         case "lore_journal_write":
             return handle_journal_write(**args)
         case "lore_journal_read":

--- a/tests/test_cli_curator_run.py
+++ b/tests/test_cli_curator_run.py
@@ -1,15 +1,12 @@
 """Tests for `lore curator run` CLI command."""
+
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
 from pathlib import Path
 
-import pytest
-from typer.testing import CliRunner
-
 from lore_cli.__main__ import app
+from typer.testing import CliRunner
 
 runner = CliRunner()
 
@@ -120,41 +117,17 @@ def test_curator_run_missing_anthropic_key_warns(tmp_path, monkeypatch):
     # Warning now goes to stderr via err_console; check it mentions classification skip
     combined = ((result.output or "") + (result.stderr or "")).lower()
     assert (
-        "anthropic" in combined
-        or "api_key" in combined
-        or "key" in combined
-        or "skip" in combined
+        "anthropic" in combined or "api_key" in combined or "key" in combined or "skip" in combined
     )
 
 
 # ---------------------------------------------------------------------------
-# Tests for --abstract flag and Curator B
+# Kill switch: `curator run` no longer accepts --abstract (Curator B)
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class FakeCuratorBResult:
-    notes_considered: int = 0
-    clusters_formed: int = 0
-    surfaces_emitted: list = field(default_factory=list)
-    skipped_reasons: dict = field(default_factory=dict)
-    duration_seconds: float = 0.0
-
-
-def _make_fake_run_b(store: list, result=None):
-    """Return a fake run_curator_b that records kwargs and returns result."""
-    if result is None:
-        result = FakeCuratorBResult()
-
-    def fake_run(**kwargs):
-        store.append(kwargs)
-        return result
-
-    return fake_run
-
-
 def test_curator_run_default_does_not_invoke_curator_b(tmp_path, monkeypatch):
-    """Without --abstract, Curator B should not be invoked."""
+    """`curator run` (no flags) never touches Curator B."""
     lore_root = tmp_path / "lore_root"
     lore_root.mkdir()
     monkeypatch.setenv("LORE_ROOT", str(lore_root))
@@ -168,7 +141,7 @@ def test_curator_run_default_does_not_invoke_curator_b(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         "lore_curator.daily_curator.run_curator_b",
-        _make_fake_run_b(calls_b),
+        lambda **kwargs: calls_b.append(kwargs),
     )
 
     result = runner.invoke(app, ["curator", "run"])
@@ -177,116 +150,15 @@ def test_curator_run_default_does_not_invoke_curator_b(tmp_path, monkeypatch):
     assert len(calls_b) == 0
 
 
-def test_curator_run_abstract_invokes_curator_b(tmp_path, monkeypatch):
-    """With --abstract, both Curator A and B should be invoked."""
+def test_curator_run_rejects_abstract_flag(tmp_path, monkeypatch):
+    """`--abstract` is a severed entry point — the CLI no longer accepts it."""
     lore_root = tmp_path / "lore_root"
     lore_root.mkdir()
-    wiki_dir = lore_root / "wiki" / "default"
-    wiki_dir.mkdir(parents=True)
     monkeypatch.setenv("LORE_ROOT", str(lore_root))
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-
-    calls_a = []
-    calls_b = []
-    monkeypatch.setattr(
-        "lore_curator.session_curator.run_curator_a",
-        _make_fake_run(calls_a),
-    )
-    monkeypatch.setattr(
-        "lore_curator.daily_curator.run_curator_b",
-        _make_fake_run_b(calls_b),
-    )
 
     result = runner.invoke(app, ["curator", "run", "--abstract"])
-    assert result.exit_code == 0, result.output
-    assert len(calls_a) == 1
-    assert len(calls_b) == 1
-
-
-def test_curator_run_abstract_with_wiki_flag_filters_to_one_wiki(tmp_path, monkeypatch):
-    """With --abstract --wiki foo, only that wiki is passed to Curator B."""
-    lore_root = tmp_path / "lore_root"
-    lore_root.mkdir()
-    wiki_a = lore_root / "wiki" / "a"
-    wiki_b = lore_root / "wiki" / "b"
-    wiki_a.mkdir(parents=True)
-    wiki_b.mkdir(parents=True)
-    monkeypatch.setenv("LORE_ROOT", str(lore_root))
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-
-    calls_a = []
-    calls_b = []
-    monkeypatch.setattr(
-        "lore_curator.session_curator.run_curator_a",
-        _make_fake_run(calls_a),
-    )
-    monkeypatch.setattr(
-        "lore_curator.daily_curator.run_curator_b",
-        _make_fake_run_b(calls_b),
-    )
-
-    result = runner.invoke(app, ["curator", "run", "--abstract", "--wiki", "a"])
-    assert result.exit_code == 0, result.output
-    assert len(calls_a) == 1
-    assert len(calls_b) == 1
-    assert calls_b[0]["wiki"] == "a"
-
-
-def test_curator_run_abstract_dry_run_propagates(tmp_path, monkeypatch):
-    """With --abstract --dry-run, both A and B run with dry_run=True."""
-    lore_root = tmp_path / "lore_root"
-    lore_root.mkdir()
-    wiki_dir = lore_root / "wiki" / "default"
-    wiki_dir.mkdir(parents=True)
-    monkeypatch.setenv("LORE_ROOT", str(lore_root))
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-
-    calls_a = []
-    calls_b = []
-    monkeypatch.setattr(
-        "lore_curator.session_curator.run_curator_a",
-        _make_fake_run(calls_a),
-    )
-    monkeypatch.setattr(
-        "lore_curator.daily_curator.run_curator_b",
-        _make_fake_run_b(calls_b),
-    )
-
-    result = runner.invoke(app, ["curator", "run", "--abstract", "--dry-run"])
-    assert result.exit_code == 0, result.output
-    assert calls_a[0]["dry_run"] is True
-    assert calls_b[0]["dry_run"] is True
-
-
-def test_curator_run_abstract_iterates_all_wikis_when_no_wiki_flag(tmp_path, monkeypatch):
-    """With --abstract (no --wiki), all wikis are processed by Curator B."""
-    lore_root = tmp_path / "lore_root"
-    lore_root.mkdir()
-    wiki_a = lore_root / "wiki" / "a"
-    wiki_b = lore_root / "wiki" / "b"
-    wiki_a.mkdir(parents=True)
-    wiki_b.mkdir(parents=True)
-    monkeypatch.setenv("LORE_ROOT", str(lore_root))
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-
-    calls_a = []
-    calls_b = []
-    monkeypatch.setattr(
-        "lore_curator.session_curator.run_curator_a",
-        _make_fake_run(calls_a),
-    )
-    monkeypatch.setattr(
-        "lore_curator.daily_curator.run_curator_b",
-        _make_fake_run_b(calls_b),
-    )
-
-    result = runner.invoke(app, ["curator", "run", "--abstract"])
-    assert result.exit_code == 0, result.output
-    assert len(calls_a) == 1
-    assert len(calls_b) == 2
-    # Check that both wikis were processed
-    wikis_processed = sorted([call["wiki"] for call in calls_b])
-    assert wikis_processed == ["a", "b"]
+    assert result.exit_code != 0, result.output
+    assert "abstract" in result.output.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_surface_unregistered.py
+++ b/tests/test_cli_surface_unregistered.py
@@ -1,0 +1,22 @@
+"""Kill switch: `lore surface` is no longer a top-level CLI command.
+
+Curator B's surface-extraction pass is retired and PRD 0001's Deletions
+list names the surface CLI among the entry points to sever first (code
+stays on disk for a later physical-deletion slice). `surface_cmd.app`
+itself is untouched and still directly testable — see
+test_cli_surface.py — only its mount on the top-level `lore` dispatcher
+is removed.
+"""
+
+from __future__ import annotations
+
+from lore_cli.__main__ import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_surface_absent_from_top_level_app():
+    result = runner.invoke(app, ["surface", "lint"])
+    assert result.exit_code != 0
+    assert "no such command" in result.output.lower()

--- a/tests/test_curator_c_cli.py
+++ b/tests/test_curator_c_cli.py
@@ -1,102 +1,63 @@
-"""Task 4: `lore curator run --defrag [--dry-run]` CLI wiring."""
+"""Kill switch: `lore curator run --defrag` no longer exists.
+
+The weekly whole-wiki defragmentation pass (Curator C's LLM-adjacent-merge
+/ auto-supersede / orphan-repair / draft-promotion) is retired. The CLI no
+longer accepts `--defrag` at all — passing it is a typer parse error, not
+a code path that silently no-ops.
+
+The plain `lore curator [--wiki] [--apply]` hygiene pass (stale-flag /
+supersession / backfill / implements-propagation, backing the
+`/lore:curator` skill) is a separate, still-supported feature and is
+untouched by this kill switch.
+"""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from pathlib import Path
 from unittest.mock import patch
 
-from typer.testing import CliRunner
-
 from lore_cli.curator_cmd import app
-
+from typer.testing import CliRunner
 
 runner = CliRunner()
 
 
-def _seed_vault(tmp_path: Path) -> Path:
+def _seed_vault(tmp_path):
     lore_root = tmp_path / "vault"
     (lore_root / ".lore").mkdir(parents=True)
     (lore_root / "wiki" / "testwiki" / "sessions").mkdir(parents=True)
     return lore_root
 
 
-def test_defrag_flag_invokes_run_curator_c_with_defrag_true(tmp_path, monkeypatch) -> None:
+def test_defrag_flag_is_rejected(tmp_path, monkeypatch) -> None:
     lore_root = _seed_vault(tmp_path)
     monkeypatch.setenv("LORE_ROOT", str(lore_root))
 
-    captured_kwargs = []
-
-    def mock_run(*args, **kwargs):
-        captured_kwargs.append(kwargs)
-        return []
-
-    with patch("lore_cli.curator_cmd.run_curator_c", side_effect=mock_run):
-        result = runner.invoke(app, ["run", "--defrag"], catch_exceptions=False)
-
-    assert result.exit_code == 0
-    assert captured_kwargs, "run_curator_c should have been called"
-    assert captured_kwargs[0].get("defrag") is True
-
-
-def test_defrag_dry_run_passes_through(tmp_path, monkeypatch) -> None:
-    lore_root = _seed_vault(tmp_path)
-    monkeypatch.setenv("LORE_ROOT", str(lore_root))
-
-    captured_kwargs = []
-    with patch(
-        "lore_cli.curator_cmd.run_curator_c",
-        side_effect=lambda *a, **kw: captured_kwargs.append(kw) or [],
-    ):
-        runner.invoke(app, ["run", "--defrag", "--dry-run"], catch_exceptions=False)
-    assert captured_kwargs[0].get("dry_run") is True
-    assert captured_kwargs[0].get("defrag") is True
-
-
-def test_no_defrag_flag_uses_curator_a_path(tmp_path, monkeypatch) -> None:
-    """Without --defrag, the command still runs Curator A (pre-Plan-5 behavior)."""
-    lore_root = _seed_vault(tmp_path)
-    monkeypatch.setenv("LORE_ROOT", str(lore_root))
-
-    defrag_called = []
-
-    def mock_c(*a, **kw):
-        defrag_called.append(kw)
-        return []
-
-    with patch("lore_cli.curator_cmd.run_curator_c", side_effect=mock_c):
-        # Without --defrag, run_curator_c should NOT be called via the --defrag
-        # short-circuit. The command proceeds to Curator A.
-        result = runner.invoke(app, ["run"], catch_exceptions=False)
-
-    # run_curator_c may be called WITHOUT defrag=True later in the pipeline,
-    # but the --defrag branch is the only place the short-circuit goes. Since
-    # there's no --defrag flag, the CLI goes through Curator A's path.
-    # Assert no --defrag-branch call.
-    defrag_calls = [kw for kw in defrag_called if kw.get("defrag") is True]
-    assert defrag_calls == [], "no --defrag → no defrag-branch call to run_curator_c"
-
-
-def test_defrag_without_lore_root_exits_error(tmp_path, monkeypatch) -> None:
-    """Exit 2 (not 1) — issue #6 routed all CLI lore-root errors through
-    ``lore_root_or_die`` which uses exit code 2 to match the rest of the
-    CLI. The error message references config-file as well as env."""
-    monkeypatch.delenv("LORE_ROOT", raising=False)
     result = runner.invoke(app, ["run", "--defrag"], catch_exceptions=False)
-    assert result.exit_code == 2
-    assert "LORE_ROOT" in result.output
+
+    assert result.exit_code != 0
+    assert "defrag" in result.output.lower()
 
 
-def test_defrag_without_llm_client_warns_and_still_runs(tmp_path, monkeypatch) -> None:
-    """Missing LLM creds → run proceeds with clear warning; LLM passes skip."""
+def test_defrag_flag_rejected_even_with_dry_run(tmp_path, monkeypatch) -> None:
+    lore_root = _seed_vault(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+
+    result = runner.invoke(app, ["run", "--defrag", "--dry-run"], catch_exceptions=False)
+    assert result.exit_code != 0
+
+
+def test_run_without_defrag_flag_never_reaches_curator_c(tmp_path, monkeypatch) -> None:
+    """`curator run` (Curator A's path) never calls Curator C's run_curator_c."""
     lore_root = _seed_vault(tmp_path)
     monkeypatch.setenv("LORE_ROOT", str(lore_root))
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    # Force make_llm_client to return None (no client available).
-    with patch("lore_curator.llm_client.make_llm_client", return_value=None):
-        result = runner.invoke(app, ["run", "--defrag"], catch_exceptions=False)
+    calls = []
+    with patch(
+        "lore_curator.defrag_curator.run_curator_c",
+        side_effect=lambda *a, **kw: calls.append(kw) or [],
+    ):
+        result = runner.invoke(app, ["run"], catch_exceptions=False)
 
     assert result.exit_code == 0, result.output
-    # Clear warning about skipped LLM passes.
-    assert "LLM" in result.output or "llm" in result.output
+    assert calls == [], f"`curator run` must never invoke Curator C: {calls}"

--- a/tests/test_curator_c_trigger.py
+++ b/tests/test_curator_c_trigger.py
@@ -1,105 +1,77 @@
-"""Task 1: Curator C weekly SessionStart trigger.
+"""Kill switch: SessionStart no longer auto-triggers Curator C's weekly defrag.
 
-- UTC-pinned ISO-week check
-- Per-user 48h jitter via SHA-256 of git user.email (hostname fallback)
-- Feature-flag gated (curator.defrag_curator.enabled, mode=local)
-- Reuses Plan A's try_acquire_spawn_lock("c")
+The ISO-week + per-user-jitter SessionStart trigger is a severed entry
+point — `cmd_session_start` never calls `_spawn_detached_curator_c`,
+regardless of `curator_c.enabled`/`mode` or how stale `last_curator_c`
+is. The underlying spawn-lock concurrency guarantee in
+`lore_cli.spawn._spawn_detached_curator_c` is untouched and still
+covered directly below.
 """
 
 from __future__ import annotations
 
-import hashlib
 import multiprocessing as mp
-import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-from typer.testing import CliRunner
-
 from lore_cli.hooks import hook_app
 from lore_core.ledger import WikiLedger, WikiLedgerEntry
-
+from typer.testing import CliRunner
 
 runner = CliRunner()
 
 
-LORE_BLOCK = """\
-# Project
-
-## Lore
-
-- wiki: testwiki
-- scope: testscope
-- backend: none
-"""
-
-
-def _make_attached_project(
-    root: Path, *, enabled: bool = True, mode: str = "local"
-) -> Path:
+def _make_attached_project(root: Path, *, enabled: bool = True, mode: str = "local") -> Path:
     from datetime import UTC, datetime
+
     from lore_core.state.attachments import Attachment, AttachmentsFile
 
     project = root / "project"
     project.mkdir()
     (project / "wiki" / "testwiki").mkdir(parents=True)
     (project / ".lore").mkdir(parents=True, exist_ok=True)
-    af = AttachmentsFile(project); af.load()
-    af.add(Attachment(
-        path=project, wiki="testwiki", scope="testscope",
-        attached_at=datetime.now(UTC), source="manual",
-    ))
+    af = AttachmentsFile(project)
+    af.load()
+    af.add(
+        Attachment(
+            path=project,
+            wiki="testwiki",
+            scope="testscope",
+            attached_at=datetime.now(UTC),
+            source="manual",
+        )
+    )
     af.save()
-    # Per-wiki config enabling / configuring Curator C.
     wiki_cfg = project / "wiki" / "testwiki" / ".lore-wiki.yml"
     wiki_cfg.write_text(
-        "curator:\n"
-        f"  curator_c:\n"
-        f"    enabled: {str(enabled).lower()}\n"
-        f"    mode: {mode}\n"
+        f"curator:\n  curator_c:\n    enabled: {str(enabled).lower()}\n    mode: {mode}\n"
     )
     return project
 
 
-def _iso_week_monday(ts: datetime) -> datetime:
-    """Monday 00:00Z of the ISO week containing ts."""
-    # isocalendar().weekday is 1 (Mon) .. 7 (Sun)
-    d = ts.date()
-    weekday = ts.isocalendar().weekday
-    monday = d - timedelta(days=weekday - 1)
-    return datetime(monday.year, monday.month, monday.day, tzinfo=UTC)
-
-
-def _expected_jitter_seconds(email: str) -> int:
-    return int(hashlib.sha256(email.encode()).hexdigest()[:8], 16) % 172800
-
-
 # ---------------------------------------------------------------------------
-# ISO-week rollover
+# SessionStart never spawns Curator C, in any config shape
 # ---------------------------------------------------------------------------
 
 
-def test_trigger_fires_on_new_iso_week(tmp_path: Path) -> None:
-    """last_curator_c from prior ISO week → spawn."""
-    project = _make_attached_project(tmp_path, enabled=True)
+def test_session_start_never_spawns_curator_c_when_enabled_and_stale(tmp_path: Path) -> None:
+    """Even enabled + wildly stale last_curator_c, no spawn happens."""
+    project = _make_attached_project(tmp_path, enabled=True, mode="local")
     lore_root = project
+    now = datetime(2026, 4, 21, 23, 0, 0, tzinfo=UTC)
 
-    now = datetime(2026, 4, 21, 23, 0, 0, tzinfo=UTC)  # Tuesday of week 17
-    prior_week = now - timedelta(days=10)
     wledger = WikiLedger(lore_root, "testwiki")
-    wledger.write(WikiLedgerEntry(wiki="testwiki", last_curator_c=prior_week))
+    wledger.write(WikiLedgerEntry(wiki="testwiki", last_curator_c=now - timedelta(days=365)))
 
     spawns: list = []
-
-    def mock_spawn(lore_root_: Path, *a, **kw):
-        spawns.append(lore_root_)
-        return True
-
-    with patch("lore_cli.hooks._spawn_detached_curator_c", side_effect=mock_spawn), \
-         patch("lore_cli.hooks._now_utc", return_value=now), \
-         patch("lore_cli.hooks._curator_c_email", return_value="noop@test"):
+    with (
+        patch(
+            "lore_cli.hooks._spawn_detached_curator_c",
+            side_effect=lambda *a, **kw: spawns.append(1) or True,
+        ),
+        patch("lore_cli.hooks._now_utc", return_value=now),
+    ):
         result = runner.invoke(
             hook_app,
             ["session-start", "--cwd", str(project), "--plain"],
@@ -108,308 +80,71 @@ def test_trigger_fires_on_new_iso_week(tmp_path: Path) -> None:
         )
 
     assert result.exit_code == 0, result.output
-    assert len(spawns) == 1, f"expected spawn on new ISO week; got {spawns}"
+    assert spawns == [], f"Curator C entry point must be severed; got {spawns}"
 
 
-def test_trigger_skips_same_iso_week(tmp_path: Path) -> None:
-    """last_curator_c from current ISO week → no spawn."""
-    project = _make_attached_project(tmp_path, enabled=True)
-    lore_root = project
-    now = datetime(2026, 4, 21, 23, 0, 0, tzinfo=UTC)
-    # Same ISO week as `now`.
-    this_week = now - timedelta(hours=12)
-
-    wledger = WikiLedger(lore_root, "testwiki")
-    wledger.write(WikiLedgerEntry(wiki="testwiki", last_curator_c=this_week))
-
-    spawns: list = []
-
-    with patch("lore_cli.hooks._spawn_detached_curator_c",
-               side_effect=lambda *a, **kw: spawns.append(1) or True), \
-         patch("lore_cli.hooks._now_utc", return_value=now), \
-         patch("lore_cli.hooks._curator_c_email", return_value="noop@test"):
-        runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-
-    assert spawns == [], f"expected no spawn same ISO week; got {spawns}"
-
-
-# ---------------------------------------------------------------------------
-# Jitter
-# ---------------------------------------------------------------------------
-
-
-def test_trigger_respects_jitter_window(tmp_path: Path) -> None:
-    """Fixture email "fixture@test" has a specific computed offset.
-
-    hashlib.sha256("fixture@test".encode()).hexdigest()[:8] is a deterministic
-    value; the offset = int(.., 16) % 172800 is stable across machines.
-    Compute the expected value and use it to pin the before/after window.
-    """
-    email = "fixture@test"
-    offset = _expected_jitter_seconds(email)
-
-    project = _make_attached_project(tmp_path, enabled=True)
-    lore_root = project
-
-    # Last Monday's ISO-week we're about to fire for — pick a fresh one.
-    target_monday = datetime(2026, 4, 20, 0, 0, 0, tzinfo=UTC)  # Mon of wk 17
-
-    # last_curator_c from the previous week so the ISO-week condition is met.
-    wledger = WikiLedger(lore_root, "testwiki")
-    wledger.write(
-        WikiLedgerEntry(wiki="testwiki", last_curator_c=target_monday - timedelta(days=3))
-    )
-
-    # Time BEFORE jitter fires → no spawn.
-    before_fire = target_monday + timedelta(seconds=max(0, offset - 60))
-    spawns_before: list = []
-    with patch("lore_cli.hooks._spawn_detached_curator_c",
-               side_effect=lambda *a, **kw: spawns_before.append(1) or True), \
-         patch("lore_cli.hooks._now_utc", return_value=before_fire), \
-         patch("lore_cli.hooks._curator_c_email", return_value=email):
-        runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-
-    # Time AFTER jitter → spawn.
-    after_fire = target_monday + timedelta(seconds=offset + 60)
-    spawns_after: list = []
-    with patch("lore_cli.hooks._spawn_detached_curator_c",
-               side_effect=lambda *a, **kw: spawns_after.append(1) or True), \
-         patch("lore_cli.hooks._now_utc", return_value=after_fire), \
-         patch("lore_cli.hooks._curator_c_email", return_value=email):
-        runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-
-    assert spawns_before == [], f"before fire window, no spawn expected; got {spawns_before}"
-    assert spawns_after == [1], f"after fire window, spawn expected; got {spawns_after}"
-
-
-def test_trigger_jitter_fallback_when_git_email_unset(tmp_path: Path) -> None:
-    """Unset email falls back to hostname — still deterministic, still fires."""
-    import socket
-    project = _make_attached_project(tmp_path, enabled=True)
-    lore_root = project
-    target_monday = datetime(2026, 4, 20, 0, 0, 0, tzinfo=UTC)
-
-    wledger = WikiLedger(lore_root, "testwiki")
-    wledger.write(
-        WikiLedgerEntry(wiki="testwiki", last_curator_c=target_monday - timedelta(days=5))
-    )
-    hostname_offset = _expected_jitter_seconds(socket.gethostname())
-    after_fire = target_monday + timedelta(seconds=hostname_offset + 60)
-
-    spawns: list = []
-    with patch("lore_cli.hooks._spawn_detached_curator_c",
-               side_effect=lambda *a, **kw: spawns.append(1) or True), \
-         patch("lore_cli.hooks._now_utc", return_value=after_fire), \
-         patch("lore_cli.hooks._curator_c_email", return_value=""):
-        runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-    assert spawns == [1], "hostname fallback should still fire on same window"
-
-
-# ---------------------------------------------------------------------------
-# Feature-flag gates
-# ---------------------------------------------------------------------------
-
-
-def test_trigger_disabled_by_default(tmp_path: Path) -> None:
-    """Default enabled=False → no spawn regardless of cadence."""
+def test_session_start_never_spawns_curator_c_when_disabled(tmp_path: Path) -> None:
+    """Disabled config also never spawns (trivially — belt and suspenders)."""
     project = _make_attached_project(tmp_path, enabled=False)
     lore_root = project
     now = datetime(2026, 4, 21, 23, 0, 0, tzinfo=UTC)
 
     wledger = WikiLedger(lore_root, "testwiki")
-    wledger.write(
-        WikiLedgerEntry(wiki="testwiki", last_curator_c=now - timedelta(days=30))
-    )
+    wledger.write(WikiLedgerEntry(wiki="testwiki", last_curator_c=now - timedelta(days=30)))
 
     spawns: list = []
-    with patch("lore_cli.hooks._spawn_detached_curator_c",
-               side_effect=lambda *a, **kw: spawns.append(1) or True), \
-         patch("lore_cli.hooks._now_utc", return_value=now), \
-         patch("lore_cli.hooks._curator_c_email", return_value="noop@test"):
+    with (
+        patch(
+            "lore_cli.hooks._spawn_detached_curator_c",
+            side_effect=lambda *a, **kw: spawns.append(1) or True,
+        ),
+        patch("lore_cli.hooks._now_utc", return_value=now),
+    ):
         runner.invoke(
             hook_app,
             ["session-start", "--cwd", str(project), "--plain"],
             env={"LORE_ROOT": str(lore_root)},
             catch_exceptions=False,
         )
-    assert spawns == [], "disabled config must block spawn"
+    assert spawns == [], f"expected no spawn; got {spawns}"
 
 
-def test_trigger_central_mode_fails_loudly(tmp_path: Path, capsys) -> None:
-    """mode=central → no spawn, emits a warning event, does NOT silently skip."""
-    project = _make_attached_project(tmp_path, enabled=True, mode="central")
-    lore_root = project
-    now = datetime(2026, 4, 21, 23, 0, 0, tzinfo=UTC)
-
-    wledger = WikiLedger(lore_root, "testwiki")
-    wledger.write(
-        WikiLedgerEntry(wiki="testwiki", last_curator_c=now - timedelta(days=30))
-    )
-
-    spawns: list = []
-    with patch("lore_cli.hooks._spawn_detached_curator_c",
-               side_effect=lambda *a, **kw: spawns.append(1) or True), \
-         patch("lore_cli.hooks._now_utc", return_value=now), \
-         patch("lore_cli.hooks._curator_c_email", return_value="noop@test"):
-        runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-
-    assert spawns == [], "central mode must not spawn locally"
-    # Warning event surfaced to hook-events.jsonl (observable, not silent).
-    import json as _json
-    events = project / ".lore" / "hook-events.jsonl"
-    if events.exists():
-        lines = [
-            _json.loads(l) for l in events.read_text().splitlines() if l.strip()
-        ]
-        central_warnings = [
-            e for e in lines
-            if e.get("event") == "curator-c" and e.get("outcome") == "central-mode-skipped"
-        ]
-        assert central_warnings, (
-            f"central mode should emit a hook-event warning; got {lines}"
-        )
-
-
-# ---------------------------------------------------------------------------
-# ISO-week boundary
-# ---------------------------------------------------------------------------
-
-
-def test_trigger_fires_exactly_once_across_monday_boundary(tmp_path: Path) -> None:
-    """Sunday 23:59Z → no spawn; Monday 00:01Z + jitter → spawn."""
-    email = "boundary@test"
-    offset = _expected_jitter_seconds(email)
-
+def test_session_start_never_spawns_curator_c_never_run(tmp_path: Path) -> None:
+    """last_curator_c=None (never run) also never spawns."""
     project = _make_attached_project(tmp_path, enabled=True)
     lore_root = project
 
-    # Sunday of ISO week 17 (which ends Sun 2026-04-19, Mon 2026-04-20 starts wk 17 in ISO).
-    # Use 2026-04-19 23:59Z as Sunday; Monday 2026-04-20 begins new week.
-    sunday_late = datetime(2026, 4, 19, 23, 59, 0, tzinfo=UTC)
-    monday_target = datetime(2026, 4, 20, 0, 0, 0, tzinfo=UTC)
-
     wledger = WikiLedger(lore_root, "testwiki")
-    wledger.write(
-        WikiLedgerEntry(wiki="testwiki", last_curator_c=monday_target - timedelta(days=7))
-    )
+    wledger.write(WikiLedgerEntry(wiki="testwiki", last_curator_c=None))
 
-    # Sunday → same ISO week as last_curator_c-week-13 (no rollover yet from a new-week perspective;
-    # actually: last_curator_c was wk 16. sunday_late is wk 16. So same ISO week.
-    # Actually this test verifies ISO-week detection pinned to UTC; fix: set last_curator_c to wk 15.
-    wledger.write(
-        WikiLedgerEntry(wiki="testwiki", last_curator_c=monday_target - timedelta(days=10))
-    )
-    # Now sunday_late is in wk 16, monday_target onward is in wk 17, last_curator_c wk 15.
-
-    spawns_sun: list = []
-    with patch("lore_cli.hooks._spawn_detached_curator_c",
-               side_effect=lambda *a, **kw: spawns_sun.append(1) or True), \
-         patch("lore_cli.hooks._now_utc", return_value=sunday_late), \
-         patch("lore_cli.hooks._curator_c_email", return_value=email):
-        runner.invoke(
+    spawns: list = []
+    with patch(
+        "lore_cli.hooks._spawn_detached_curator_c",
+        side_effect=lambda *a, **kw: spawns.append(1) or True,
+    ):
+        result = runner.invoke(
             hook_app,
             ["session-start", "--cwd", str(project), "--plain"],
             env={"LORE_ROOT": str(lore_root)},
             catch_exceptions=False,
         )
-
-    # Post-jitter Monday.
-    fire_time = monday_target + timedelta(seconds=offset + 60)
-    spawns_mon: list = []
-    with patch("lore_cli.hooks._spawn_detached_curator_c",
-               side_effect=lambda *a, **kw: spawns_mon.append(1) or True), \
-         patch("lore_cli.hooks._now_utc", return_value=fire_time), \
-         patch("lore_cli.hooks._curator_c_email", return_value=email):
-        runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-
-    # Sunday-late may or may not fire depending on whether wk 16 > wk 15:
-    # last_curator_c is wk 15, sunday is wk 16 → rollover HAS happened.
-    # So sunday_late SHOULD fire too. The real boundary test: check that
-    # after firing on sunday, monday does not double-fire (same or newer week).
-    # Re-set: last_curator_c from far past (wk 14).
-    wledger.write(
-        WikiLedgerEntry(wiki="testwiki", last_curator_c=monday_target - timedelta(days=17))
-    )
-
-    # Pass 1: sunday_late should fire (wk 16 > wk 14)
-    spawns_sun_2: list = []
-    def sun_spawn(*a, **kw):
-        # Simulate the spawn updating last_curator_c to sunday_late.
-        wledger.update_last_curator("c", at=sunday_late)
-        spawns_sun_2.append(1)
-        return True
-
-    with patch("lore_cli.hooks._spawn_detached_curator_c", side_effect=sun_spawn), \
-         patch("lore_cli.hooks._now_utc", return_value=sunday_late), \
-         patch("lore_cli.hooks._curator_c_email", return_value=email):
-        runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-    assert spawns_sun_2 == [1], "Sunday with stale last_curator_c should fire"
-
-    # Pass 2: Monday of the NEW week — since last_curator_c is now sunday_late (wk 16),
-    # and monday_target is wk 17, it's a new ISO week — should fire again.
-    fire_time_new_week = monday_target + timedelta(seconds=offset + 60)
-    spawns_mon_new: list = []
-    with patch("lore_cli.hooks._spawn_detached_curator_c",
-               side_effect=lambda *a, **kw: spawns_mon_new.append(1) or True), \
-         patch("lore_cli.hooks._now_utc", return_value=fire_time_new_week), \
-         patch("lore_cli.hooks._curator_c_email", return_value=email):
-        runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-    assert spawns_mon_new == [1], "Monday of new ISO week should fire again"
+    assert result.exit_code == 0, result.output
+    assert spawns == [], f"expected no spawn; got {spawns}"
 
 
 # ---------------------------------------------------------------------------
-# Concurrency (flock regression guard)
+# Concurrency (flock regression guard) — exercises the surviving spawn.py
+# mechanism directly, independent of the (now severed) SessionStart trigger.
 # ---------------------------------------------------------------------------
 
 
 def _worker_c_spawn_attempt(lore_root_str: str, results_q, barrier) -> None:
     """Child process attempting to acquire the Curator C spawn lock."""
     from unittest.mock import patch
+
     with patch("subprocess.Popen"):
-        from lore_cli.hooks import _spawn_detached_curator_a
-        # Reuse A's spawn semantics via try_acquire_spawn_lock for generic role.
-        # But Curator C uses role="c" — call the dedicated helper.
         from lore_cli.hooks import _spawn_detached_curator_c
+
         barrier.wait(timeout=10)
         spawned = _spawn_detached_curator_c(Path(lore_root_str), cooldown_s=60)
     results_q.put(spawned)

--- a/tests/test_doctor_no_side_effects.py
+++ b/tests/test_doctor_no_side_effects.py
@@ -11,16 +11,14 @@ that suppresses ALL spawn side-effects. `lore doctor` invokes with
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
-
-from typer.testing import CliRunner
 
 from lore_cli import doctor_cmd
 from lore_cli.hooks import hook_app
 from lore_core.ledger import WikiLedger, WikiLedgerEntry
-
+from typer.testing import CliRunner
 
 runner = CliRunner()
 
@@ -47,14 +45,21 @@ def _make_attached_project(root: Path) -> Path:
     (project / "wiki" / "testwiki").mkdir(parents=True)
     (project / ".lore").mkdir(parents=True, exist_ok=True)
 
-    af = AttachmentsFile(project); af.load()
-    af.add(Attachment(
-        path=project, wiki="testwiki", scope="testscope",
-        attached_at=datetime.now(tz=timezone.utc), source="manual",
-    ))
+    af = AttachmentsFile(project)
+    af.load()
+    af.add(
+        Attachment(
+            path=project,
+            wiki="testwiki",
+            scope="testscope",
+            attached_at=datetime.now(tz=UTC),
+            source="manual",
+        )
+    )
     af.save()
 
-    sf = ScopesFile(project); sf.load()
+    sf = ScopesFile(project)
+    sf.load()
     sf.ingest_chain("testscope", "testwiki")
     sf.save()
 
@@ -62,13 +67,14 @@ def _make_attached_project(root: Path) -> Path:
 
 
 def _yesterday() -> datetime:
-    now = datetime.now(tz=timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    now = datetime.now(tz=UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     return now - timedelta(days=1)
 
 
 def _snapshot_dir(path: Path) -> dict[str, tuple[int, bytes]]:
     """Return {relative_path: (mtime_ns, content_hash_bytes)} for every file under path."""
     import hashlib
+
     out: dict[str, tuple[int, bytes]] = {}
     if not path.exists():
         return out
@@ -113,8 +119,10 @@ def test_session_start_probe_suppresses_curator_b_spawn(tmp_path: Path) -> None:
     )
 
 
-def test_session_start_no_probe_still_spawns_curator_b(tmp_path: Path) -> None:
-    """Baseline regression guard: without --probe, calendar-rollover still spawns."""
+def test_session_start_no_probe_also_does_not_spawn_curator_b(tmp_path: Path) -> None:
+    """Curator B's calendar-rollover entry point is severed entirely — with
+    or without --probe, SessionStart never spawns it (see
+    test_hooks_curator_b_trigger.py for the dedicated kill-switch coverage)."""
     project = _make_attached_project(tmp_path)
     lore_root = project
 
@@ -136,7 +144,7 @@ def test_session_start_no_probe_still_spawns_curator_b(tmp_path: Path) -> None:
         )
 
     assert result.exit_code == 0, result.output
-    assert len(calls) == 1, f"Without --probe, spawn must still happen: {calls}"
+    assert len(calls) == 0, f"Curator B entry point must be severed: {calls}"
 
 
 def test_session_start_probe_suppresses_curator_a_spawn(tmp_path: Path) -> None:
@@ -159,8 +167,10 @@ def test_session_start_probe_suppresses_curator_a_spawn(tmp_path: Path) -> None:
         a_calls.append((args, kw))
         return True
 
-    with patch("lore_cli.hooks._spawn_detached_curator_a", side_effect=mock_spawn_a), \
-         patch("lore_cli.hooks._spawn_detached_curator_b", return_value=True):
+    with (
+        patch("lore_cli.hooks._spawn_detached_curator_a", side_effect=mock_spawn_a),
+        patch("lore_cli.hooks._spawn_detached_curator_b", return_value=True),
+    ):
         result = runner.invoke(
             hook_app,
             ["session-start", "--cwd", str(project), "--plain", "--probe"],

--- a/tests/test_hooks_curator_b_trigger.py
+++ b/tests/test_hooks_curator_b_trigger.py
@@ -1,17 +1,22 @@
-"""Tests for SessionStart auto-trigger of Curator B on calendar-day rollover."""
+"""Kill switch: SessionStart no longer auto-triggers Curator B.
+
+Curator B's day-rollover spawn used to fire unconditionally (no config
+flag) from `cmd_session_start`. It is now a severed entry point —
+SessionStart never calls `_spawn_detached_curator_b`, regardless of the
+wiki ledger's `last_curator_b` state. The underlying spawn machinery
+(`_spawn_detached_curator_b` itself, in `lore_cli.spawn`) is untouched;
+only the automatic call site is gone.
+"""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-from typer.testing import CliRunner
-
 from lore_cli.hooks import hook_app
 from lore_core.ledger import WikiLedger, WikiLedgerEntry
-
+from typer.testing import CliRunner
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -39,17 +44,23 @@ def _make_attached_project(root: Path) -> Path:
     # wiki directory so _infer_lore_root walks up correctly
     (project / "wiki" / "testwiki").mkdir(parents=True)
     (project / ".lore").mkdir(parents=True, exist_ok=True)
-    af = AttachmentsFile(project); af.load()
-    af.add(Attachment(
-        path=project, wiki="testwiki", scope="testscope",
-        attached_at=_now(), source="manual",
-    ))
+    af = AttachmentsFile(project)
+    af.load()
+    af.add(
+        Attachment(
+            path=project,
+            wiki="testwiki",
+            scope="testscope",
+            attached_at=_now(),
+            source="manual",
+        )
+    )
     af.save()
     return project
 
 
 def _now() -> datetime:
-    return datetime.now(tz=timezone.utc)
+    return datetime.now(tz=UTC)
 
 
 def _today() -> datetime:
@@ -75,51 +86,13 @@ runner = CliRunner()
 # ---------------------------------------------------------------------------
 
 
-def test_session_start_spawns_curator_b_on_new_day(tmp_path: Path) -> None:
-    """Session-start spawns Curator B when last_curator_b is from yesterday."""
-    project = _make_attached_project(tmp_path)
-    lore_root = project  # In test setup, project is the lore_root
-
-    # Pre-populate wiki ledger with last_curator_b from yesterday
-    wledger = WikiLedger(lore_root, "testwiki")
-    entry = WikiLedgerEntry(
-        wiki="testwiki",
-        last_curator_b=_yesterday(),
-    )
-    wledger.write(entry)
-
-    # Monkeypatch _spawn_detached_curator_b to track calls
-    calls = []
-
-    def mock_spawn(lore_root: Path, wiki: str, **kw):
-        calls.append((lore_root, wiki))
-        return True
-
-    with patch("lore_cli.hooks._spawn_detached_curator_b", side_effect=mock_spawn):
-        result = runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-
-    assert result.exit_code == 0, result.output
-    assert len(calls) == 1, f"Expected 1 spawn call, got {len(calls)}: {calls}"
-    assert calls[0] == (lore_root, "testwiki")
-
-
-def test_session_start_does_not_spawn_curator_b_same_day(tmp_path: Path) -> None:
-    """Session-start does NOT spawn Curator B when last_curator_b is from today."""
+def test_session_start_never_spawns_curator_b_when_stale(tmp_path: Path) -> None:
+    """Even with a stale (yesterday's) last_curator_b, no spawn happens."""
     project = _make_attached_project(tmp_path)
     lore_root = project
 
-    # Pre-populate wiki ledger with last_curator_b from today
     wledger = WikiLedger(lore_root, "testwiki")
-    entry = WikiLedgerEntry(
-        wiki="testwiki",
-        last_curator_b=_today(),
-    )
-    wledger.write(entry)
+    wledger.write(WikiLedgerEntry(wiki="testwiki", last_curator_b=_yesterday()))
 
     calls = []
 
@@ -136,21 +109,16 @@ def test_session_start_does_not_spawn_curator_b_same_day(tmp_path: Path) -> None
         )
 
     assert result.exit_code == 0, result.output
-    assert len(calls) == 0, f"Expected no spawn calls, got {len(calls)}: {calls}"
+    assert calls == [], f"Curator B entry point must be severed; got {calls}"
 
 
-def test_session_start_spawns_curator_b_when_never_run(tmp_path: Path) -> None:
-    """Session-start spawns Curator B when last_curator_b is None (never run)."""
+def test_session_start_never_spawns_curator_b_when_never_run(tmp_path: Path) -> None:
+    """Even with last_curator_b=None (never run), no spawn happens."""
     project = _make_attached_project(tmp_path)
     lore_root = project
 
-    # Pre-populate wiki ledger with last_curator_b=None
     wledger = WikiLedger(lore_root, "testwiki")
-    entry = WikiLedgerEntry(
-        wiki="testwiki",
-        last_curator_b=None,
-    )
-    wledger.write(entry)
+    wledger.write(WikiLedgerEntry(wiki="testwiki", last_curator_b=None))
 
     calls = []
 
@@ -167,15 +135,13 @@ def test_session_start_spawns_curator_b_when_never_run(tmp_path: Path) -> None:
         )
 
     assert result.exit_code == 0, result.output
-    assert len(calls) == 1, f"Expected 1 spawn call, got {len(calls)}: {calls}"
-    assert calls[0] == (lore_root, "testwiki")
+    assert calls == [], f"Curator B entry point must be severed; got {calls}"
 
 
 def test_session_start_does_not_spawn_when_unattached(tmp_path: Path) -> None:
     """Session-start does NOT spawn when cwd is unattached (no ## Lore block)."""
     unattached = tmp_path / "unattached"
     unattached.mkdir()
-    # No CLAUDE.md with ## Lore
 
     calls = []
 
@@ -191,33 +157,4 @@ def test_session_start_does_not_spawn_when_unattached(tmp_path: Path) -> None:
         )
 
     assert result.exit_code == 0, result.output
-    # No spawn should happen because scope resolution fails (unattached)
-    assert len(calls) == 0, f"Expected no spawn calls, got {len(calls)}: {calls}"
-
-
-def test_session_start_curator_b_spawn_does_not_break_hook_on_error(tmp_path: Path) -> None:
-    """Session-start does NOT break if _spawn_detached_curator_b raises an error."""
-    project = _make_attached_project(tmp_path)
-    lore_root = project
-
-    # Pre-populate wiki ledger with last_curator_b from yesterday to trigger spawn
-    wledger = WikiLedger(lore_root, "testwiki")
-    entry = WikiLedgerEntry(
-        wiki="testwiki",
-        last_curator_b=_yesterday(),
-    )
-    wledger.write(entry)
-
-    def mock_spawn_raises(lore_root: Path, wiki: str, **kw):
-        raise RuntimeError("Intentional spawn failure for testing")
-
-    with patch("lore_cli.hooks._spawn_detached_curator_b", side_effect=mock_spawn_raises):
-        result = runner.invoke(
-            hook_app,
-            ["session-start", "--cwd", str(project), "--plain"],
-            env={"LORE_ROOT": str(lore_root)},
-            catch_exceptions=False,
-        )
-
-    # Hook should still exit 0 even though spawn raised
-    assert result.exit_code == 0, f"Hook should not fail on spawn error. Output: {result.output}"
+    assert calls == [], f"Expected no spawn calls, got {calls}"

--- a/tests/test_mcp_surface_tools.py
+++ b/tests/test_mcp_surface_tools.py
@@ -1,7 +1,12 @@
-"""Tests for MCP surface-authoring tools."""
-from __future__ import annotations
+"""Tests for MCP surface-authoring tools.
 
-from pathlib import Path
+The handler functions below (``handle_surface_context``,
+``handle_surface_validate``) stay importable and directly testable —
+only their MCP tool *registration* (schema entry + dispatch case) is
+severed; see the kill-switch tests at the bottom of this file.
+"""
+
+from __future__ import annotations
 
 
 def test_surface_context_fresh_wiki(tmp_path, monkeypatch):
@@ -9,6 +14,7 @@ def test_surface_context_fresh_wiki(tmp_path, monkeypatch):
     monkeypatch.setenv("LORE_ROOT", str(tmp_path))
     (tmp_path / "wiki" / "science").mkdir(parents=True)
     from lore_mcp.server import handle_surface_context
+
     ctx = handle_surface_context(wiki="science")
     assert ctx["schema"] == "lore.surface.context/1"
     assert ctx["wiki"] == "science"
@@ -35,6 +41,7 @@ def test_surface_context_with_existing_surfaces_and_notes(tmp_path, monkeypatch)
         "---\ntype: concept\ncreated: 2026-04-02\ndescription: Beta\n---\nbody\n"
     )
     from lore_mcp.server import handle_surface_context
+
     ctx = handle_surface_context(wiki="science")
     assert ctx["surfaces_md_exists"] is True
     assert len(ctx["current_surfaces"]) == 1
@@ -50,11 +57,17 @@ def test_surface_validate_happy_path_append(tmp_path, monkeypatch):
         "# Surfaces\nschema_version: 2\n\n## concept\nA.\n\n```yaml\nrequired: [type]\noptional: []\n```\n"
     )
     from lore_mcp.server import handle_surface_validate
+
     draft = {
         "schema": "lore.surface.draft/1",
         "wiki": "x",
         "operation": "append",
-        "surface": {"name": "paper", "description": "A paper.", "required": ["type"], "optional": []},
+        "surface": {
+            "name": "paper",
+            "description": "A paper.",
+            "required": ["type"],
+            "optional": [],
+        },
     }
     result = handle_surface_validate(wiki="x", draft=draft)
     assert result["schema"] == "lore.surface.validate/1"
@@ -72,6 +85,7 @@ def test_surface_validate_surfaces_issues(tmp_path, monkeypatch):
         "# Surfaces\nschema_version: 2\n\n## paper\nA.\n\n```yaml\nrequired: [type]\noptional: []\n```\n"
     )
     from lore_mcp.server import handle_surface_validate
+
     draft = {
         "schema": "lore.surface.draft/1",
         "wiki": "x",
@@ -87,6 +101,7 @@ def test_surface_validate_init_diff_is_new_file(tmp_path, monkeypatch):
     monkeypatch.setenv("LORE_ROOT", str(tmp_path))
     (tmp_path / "wiki" / "x").mkdir(parents=True)
     from lore_mcp.server import handle_surface_validate
+
     draft = {
         "schema": "lore.surface.draft/1",
         "wiki": "x",
@@ -97,3 +112,37 @@ def test_surface_validate_init_diff_is_new_file(tmp_path, monkeypatch):
     result = handle_surface_validate(wiki="x", draft=draft)
     assert result["ok"] is True
     assert result["diff_preview"].count("\n+") >= 3
+
+
+# ---------------------------------------------------------------------------
+# Kill switch: neither surface tool is MCP-registered any more
+# ---------------------------------------------------------------------------
+
+
+def test_surface_tools_absent_from_tool_schema():
+    from lore_mcp.server import _tool_schema
+
+    names = {t["name"] for t in _tool_schema()}
+    assert "lore_surface_context" not in names
+    assert "lore_surface_validate" not in names
+
+
+def test_surface_context_unreachable_via_dispatch(tmp_path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    (tmp_path / "wiki" / "x").mkdir(parents=True)
+    from lore_mcp.server import _dispatch
+
+    result = _dispatch("lore_surface_context", {"wiki": "x"})
+    assert result["error"]["code"] == "unknown_tool"
+
+
+def test_surface_validate_unreachable_via_dispatch(tmp_path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    (tmp_path / "wiki" / "x").mkdir(parents=True)
+    from lore_mcp.server import _dispatch
+
+    result = _dispatch(
+        "lore_surface_validate",
+        {"wiki": "x", "draft": {"schema": "lore.surface.draft/1"}},
+    )
+    assert result["error"]["code"] == "unknown_tool"


### PR DESCRIPTION
Implements #119 (epic #131).

## Summary
- SessionStart no longer auto-spawns Curator B (day-rollover) or Curator C (weekly ISO-week + per-user jitter). The spawn primitives (`_spawn_detached_curator_b/_c` in `lore_cli.spawn`) stay in place — only the automatic call sites in `cmd_session_start` are removed.
- `lore curator run` no longer accepts `--abstract` (Curator B surface extraction) or `--defrag` (Curator C weekly LLM defrag); passing either is now a typer parse error.
- The `lore_surface_context` / `lore_surface_validate` MCP tools are unregistered (removed from `_tool_schema()` and `_dispatch()`); the handler functions stay importable and directly tested.

## Explicitly out of scope (left untouched, on purpose)
- The bare `lore curator [--wiki] [--apply]` hygiene pass (stale-flag / supersession / backfill / implements-propagation) — this backs the still-documented, user-invocable `/lore:curator` skill and is a separate, currently-supported feature, distinct from the retired weekly LLM defrag.
- The `lore surface commit/add/init/lint` CLI — the `/lore:surface` skill already has a "MCP unreachable → stop honestly" rule, so severing only the MCP tools is the intended kill switch there; the CLI itself isn't part of this slice.
- README.md still describes Curator B's day-rollover spawn and `--abstract`/`--defrag` as current features — fixing this is `docs reset` scope per PRD 0001, not this slice.
- No implementation code (daily_curator.py, defrag_curator.py, surfaces.py, surface_cmd.py) was deleted — that's #124.

## Test plan
- [x] New/updated tests for each severed entry point (SessionStart spawns, CLI flags, MCP registration), each captured red before the corresponding fix.
- [x] Full suite green except 3 pre-existing, unrelated failures (verified identical on `epic/131` HEAD in an isolated worktree): a stale hardcoded date in `test_resume.py`, a version-bump assertion in `test_lore_verify_skill.py`, and an OpenAI-backend assertion in `test_openai_backend.py`.
- [x] `ruff check`/`ruff format --check` on every file I touched shows zero new findings — confirmed by diffing rule-for-rule against the pre-change versions of `hooks.py`, `curator_cmd.py`, `server.py` (all three already carry large pre-existing lint/format debt, byte-identical before/after this diff). The 6 test files I authored/rewrote are fully ruff- and format-clean except 3 pre-existing long string literals I didn't touch.