### PR TITLE
Publish gate: scanners, phrasing lint, detection, quarantine (#126)

### DIFF
--- a/lib/lore_cli/__main__.py
+++ b/lib/lore_cli/__main__.py
@@ -82,6 +82,7 @@ def _build_app() -> typer.Typer:
         on_cmd,
         proc_cmd,
         project_cmd,
+        quarantine_cmd,
         registry_cmd,
         resume_cmd,
         runs_cmd,
@@ -141,6 +142,7 @@ def _build_app() -> typer.Typer:
     app.add_typer(mcp_cmd.app, name="mcp", rich_help_panel=_ADV)
     app.add_typer(migrate_cmd.app, name="migrate", rich_help_panel=_ADV)
     app.add_typer(proc_cmd.app, name="proc", rich_help_panel=_ADV)
+    app.add_typer(quarantine_cmd.app, name="quarantine", rich_help_panel=_ADV)
     app.add_typer(registry_cmd.app, name="registry", rich_help_panel=_ADV)
     app.add_typer(runs_cmd.app, name="runs", rich_help_panel=_ADV)
     app.add_typer(scopes_cmd.app, name="scopes", rich_help_panel=_ADV)

--- a/lib/lore_cli/quarantine_cmd.py
+++ b/lib/lore_cli/quarantine_cmd.py
@@ -1,0 +1,158 @@
+"""``lore quarantine`` — review chapters the publish gate withheld.
+
+The gate holds a withheld chapter's full text in a private sidecar (never
+in the shared wiki) and drops a marker in its place in the note. This
+command is the reviewer's flow over that sidecar:
+
+  lore quarantine list                 index of withheld chapters (no bodies)
+  lore quarantine show <id>            reveal one chapter's full text
+  lore quarantine clear <id>           remove one entry after review
+  lore quarantine kill <id>            purge one entry
+  lore quarantine kill --all           purge every entry
+
+``list`` deliberately prints no body content — an entry may hold the very
+secret that tripped the gate. Use ``show`` to reveal a specific one.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import typer
+from lore_core import quarantine
+from lore_core.config import require_lore_root
+
+from lore_cli._argv_compat import argv_main
+
+app = typer.Typer(
+    add_completion=False,
+    help=__doc__,
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+
+
+def _emit_json(envelope: dict) -> None:
+    print(json.dumps(envelope, indent=2, default=str))
+
+
+@app.command("list")
+def cmd_list(
+    json_out: bool = typer.Option(False, "--json", help="Emit JSON envelope."),
+) -> None:
+    """List withheld chapters (metadata only — no bodies)."""
+    lore_root = require_lore_root()
+    entries = quarantine.list_entries(lore_root=lore_root)
+    if json_out:
+        _emit_json(
+            {
+                "schema": "lore.quarantine.list/1",
+                "data": [
+                    {
+                        "id": e.id,
+                        "created": e.created,
+                        "category": e.category,
+                        "note_path": e.note_path,
+                        "from_turn": e.from_turn,
+                        "to_turn": e.to_turn,
+                        "chars": len(e.composed_text),
+                    }
+                    for e in entries
+                ],
+            }
+        )
+        return
+    if not entries:
+        typer.echo("(quarantine is empty)")
+        return
+    for e in entries:
+        typer.echo(
+            f"{e.id}  {e.category:<9}  @{e.from_turn}-{e.to_turn}  "
+            f"{len(e.composed_text)} chars  {e.note_path}"
+        )
+    typer.echo("")
+    typer.echo(f"{len(entries)} withheld — `lore quarantine show <id>` to inspect")
+
+
+@app.command("show")
+def cmd_show(
+    entry_id: str = typer.Argument(..., help="Quarantine entry id."),
+    json_out: bool = typer.Option(False, "--json", help="Emit JSON envelope."),
+) -> None:
+    """Reveal one withheld chapter's full text for review."""
+    lore_root = require_lore_root()
+    entry = quarantine.get_entry(entry_id, lore_root=lore_root)
+    if entry is None:
+        typer.echo(f"lore: no quarantine entry {entry_id!r}", err=True)
+        raise typer.Exit(code=1)
+    if json_out:
+        _emit_json(
+            {
+                "schema": "lore.quarantine.show/1",
+                "data": {
+                    "id": entry.id,
+                    "created": entry.created,
+                    "category": entry.category,
+                    "note_path": entry.note_path,
+                    "from_turn": entry.from_turn,
+                    "to_turn": entry.to_turn,
+                    "composed_text": entry.composed_text,
+                },
+            }
+        )
+        return
+    typer.echo(f"id:       {entry.id}")
+    typer.echo(f"created:  {entry.created}")
+    typer.echo(f"category: {entry.category}")
+    typer.echo(f"note:     {entry.note_path}")
+    typer.echo(f"turns:    @{entry.from_turn}-{entry.to_turn}")
+    typer.echo("--- withheld text ---")
+    typer.echo(entry.composed_text)
+
+
+@app.command("clear")
+def cmd_clear(
+    entry_id: str = typer.Argument(..., help="Quarantine entry id to remove."),
+) -> None:
+    """Remove one entry after review."""
+    lore_root = require_lore_root()
+    if not quarantine.clear_entry(entry_id, lore_root=lore_root):
+        typer.echo(f"lore: no quarantine entry {entry_id!r}", err=True)
+        raise typer.Exit(code=1)
+    typer.echo(f"cleared {entry_id}")
+
+
+@app.command("kill")
+def cmd_kill(
+    entry_id: str | None = typer.Argument(
+        None, help="Entry id to purge (omit with --all to purge everything)."
+    ),
+    all_: bool = typer.Option(False, "--all", help="Purge every quarantined chapter."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation."),
+) -> None:
+    """Purge quarantined chapters (one by id, or all with --all)."""
+    lore_root = require_lore_root()
+    if all_ == (entry_id is not None):
+        typer.echo("lore: pass exactly one of <id> or --all", err=True)
+        raise typer.Exit(code=2)
+
+    target = "all quarantined chapters" if all_ else f"entry {entry_id}"
+    if not yes and not typer.confirm(f"Purge {target}?"):
+        raise typer.Abort()
+
+    if all_:
+        n = quarantine.kill_all(lore_root=lore_root)
+        typer.echo(f"killed {n} entr{'y' if n == 1 else 'ies'}")
+        return
+    if not quarantine.clear_entry(entry_id, lore_root=lore_root):
+        typer.echo(f"lore: no quarantine entry {entry_id!r}", err=True)
+        raise typer.Exit(code=1)
+    typer.echo(f"killed {entry_id}")
+
+
+main = argv_main(app)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/lore_core/publish_gate.py
+++ b/lib/lore_core/publish_gate.py
@@ -72,8 +72,8 @@ CATEGORY_PHRASING = "phrasing"
 CATEGORY_PII = "pii"
 CATEGORY_ERROR = "gate-error"
 
-# Retry-prompt feedback per category. The retry loop (#125) injects the
-# string verbatim into its re-compose prompt, so it describes the class of
+# Retry-prompt feedback per category. The retry loop injects this string
+# verbatim into the next compose prompt, so it describes the class of
 # problem and how to avoid it — and NEVER echoes the matched value, which
 # would re-plant the secret straight back into the next prompt.
 _FEEDBACK: dict[str, str] = {

--- a/lib/lore_core/publish_gate.py
+++ b/lib/lore_core/publish_gate.py
@@ -1,0 +1,498 @@
+"""Blocking publish gate — the last check before a chapter joins the note.
+
+Every composed chapter passes through :func:`evaluate` before it is
+appended to the shared session note. The gate runs cheapest-first and
+short-circuits on the first hit:
+
+1. **Deterministic scanners** — high-entropy secrets (reusing the secret
+   patterns in :mod:`lore_core.redaction`), email addresses, phone
+   numbers.
+2. **Deterministic phrasing lint** — TODO/FIXME markers, imperative bold
+   leads, and must/should task language. The note is a past-tense lab
+   record, never a directive; a lint hit is a compose failure and the
+   feedback feeds the retry.
+3. **One small-model detection call** for fuzzy PII/secrets that slip the
+   deterministic layers. Detection is *pattern recognition*, not truth
+   verification, so it is exempt from the no-LLM-judges rule — but it is
+   a **tripwire, not a guarantee**, and is documented as such.
+
+The gate **fails closed**: any scanner/lint error, and any error from the
+detection call, withholds the chapter rather than letting it through. A
+false withhold only costs a marker and a quarantine entry; a false pass
+could leak a secret into the shared vault.
+
+On a withheld verdict the caller runs :func:`apply_withhold`, which owns
+the two terminal side-effects: a deterministic withheld-marker chapter is
+appended to the note, and the composed text is stored in the private
+quarantine sidecar (:mod:`lore_core.quarantine`) for review. The retry
+loop that sits between the first hit and the terminal give-up lives in
+its own layer and calls this module.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from lore_core import note_document as _nd
+from lore_core import quarantine as _quarantine
+from lore_core.redaction import redact
+
+__all__ = [
+    "CATEGORY_SECRET",
+    "CATEGORY_EMAIL",
+    "CATEGORY_PHONE",
+    "CATEGORY_PHRASING",
+    "CATEGORY_PII",
+    "CATEGORY_ERROR",
+    "GateResult",
+    "PASS",
+    "Detector",
+    "LlmPiiDetector",
+    "WithholdOutcome",
+    "has_secret",
+    "has_email",
+    "has_phone",
+    "phrasing_lint",
+    "evaluate",
+    "apply_withhold",
+]
+
+
+# Gate categories. A category names *what tripped the gate*; it drives the
+# retry feedback, the safe marker reason, and the quarantine record. Values
+# are never the matched text — see the feedback map below.
+CATEGORY_SECRET = "secret"
+CATEGORY_EMAIL = "email"
+CATEGORY_PHONE = "phone"
+CATEGORY_PHRASING = "phrasing"
+CATEGORY_PII = "pii"
+CATEGORY_ERROR = "gate-error"
+
+# Retry-prompt feedback per category. The retry loop (#125) injects the
+# string verbatim into its re-compose prompt, so it describes the class of
+# problem and how to avoid it — and NEVER echoes the matched value, which
+# would re-plant the secret straight back into the next prompt.
+_FEEDBACK: dict[str, str] = {
+    CATEGORY_SECRET: (
+        "The draft contained a credential or secret-shaped token. Re-compose "
+        "without any keys, tokens, passwords, or other secrets — refer to them "
+        "only in the abstract (e.g. 'an API key was rotated')."
+    ),
+    CATEGORY_EMAIL: (
+        "The draft contained an email address. Re-compose without personal "
+        "contact details; refer to people by role or handle, never by contact "
+        "information."
+    ),
+    CATEGORY_PHONE: (
+        "The draft contained a phone number. Re-compose without personal contact details."
+    ),
+    CATEGORY_PHRASING: (
+        "The draft used directive or task phrasing (TODO/FIXME, an imperative "
+        "lead, or must/should task language). Re-compose as a past-tense "
+        "lab-notebook record: describe what was discussed or tried, never what "
+        "to do next. Leads must be self-sufficient past-tense statements."
+    ),
+    CATEGORY_PII: (
+        "A detection pass flagged possible personal or sensitive information. "
+        "Re-compose without personal data or secrets; keep only what is safe to "
+        "share with colleagues."
+    ),
+    CATEGORY_ERROR: (
+        "The publish gate could not complete its checks; the chapter is withheld as a precaution."
+    ),
+}
+
+# Safe, value-free marker reasons. These render into the note body, which
+# travels to the shared vault, so they must never carry the matched text.
+_MARKER_REASON: dict[str, str] = {
+    CATEGORY_SECRET: "a credential/secret was detected",
+    CATEGORY_EMAIL: "an email address was detected",
+    CATEGORY_PHONE: "a phone number was detected",
+    CATEGORY_PHRASING: "directive/task phrasing was detected",
+    CATEGORY_PII: "possible personal or sensitive data was detected",
+    CATEGORY_ERROR: "the publish gate errored (withheld as a precaution)",
+}
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Verdict for one chapter.
+
+    ``passed`` is the whole result; on a withhold, ``category`` names the
+    class of problem and ``feedback`` is the retry-prompt injection. Both
+    are empty on a pass, and ``feedback`` never contains the matched value.
+    """
+
+    passed: bool
+    category: str = ""
+    feedback: str = ""
+
+
+# The singleton pass result — cheaper than allocating one per clean chapter.
+PASS = GateResult(passed=True)
+
+
+def _withheld(category: str) -> GateResult:
+    return GateResult(passed=False, category=category, feedback=_FEEDBACK[category])
+
+
+# ---------------------------------------------------------------------------
+# Deterministic scanners
+# ---------------------------------------------------------------------------
+
+
+# Email: a local part, '@', and a domain that ends in a real TLD. Requiring
+# the dotted TLD is what separates a real address from an ``@handle`` mention
+# or a bare ``user@localhost``.
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+
+# Phone: two shapes, each guarded so version strings, issue refs, commit
+# SHAs, ISO dates, and byte counts do not read as numbers to call.
+#   - international: a leading '+', then a run of digits/separators.
+#   - NANP-grouped: NNN sep NNN sep NNNN, e.g. (415) 555-2671 / 415.555.2671.
+# The leading ``(?<![\w.])`` stops a match starting mid-token (so ``v1.2.3``
+# and ``3d9d36e`` never anchor a phone).
+_PHONE_INTL_RE = re.compile(r"(?<![\w.])\+\d[\d\s().\-]{6,}\d(?!\w)")
+_PHONE_NANP_RE = re.compile(r"(?<![\w.])\(?\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}(?!\w)")
+# International numbers carry 8–15 significant digits; the gate keeps the low
+# end conservative so a stray signed integer is not read as a number to call.
+_PHONE_INTL_MIN_DIGITS = 8
+
+
+def has_secret(text: str) -> bool:
+    """True if ``text`` contains a known secret pattern (see redaction)."""
+    _redacted, hits = redact(text)
+    return bool(hits)
+
+
+def has_email(text: str) -> bool:
+    """True if ``text`` contains an email address (local@domain.tld)."""
+    return _EMAIL_RE.search(text) is not None
+
+
+def has_phone(text: str) -> bool:
+    """True if ``text`` contains something shaped like a phone number."""
+    for m in _PHONE_INTL_RE.finditer(text):
+        if sum(c.isdigit() for c in m.group()) >= _PHONE_INTL_MIN_DIGITS:
+            return True
+    return _PHONE_NANP_RE.search(text) is not None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic phrasing lint
+# ---------------------------------------------------------------------------
+
+
+# Base-form action verbs. A bold lead beginning with one of these reads as an
+# instruction ("Fix the race"), whereas the past-tense form ("Fixed the race")
+# is a lab-record statement. The same stems, in any tense, following a modal
+# ("should refactor", "must be fixed") are the must/should task-language hit.
+_IMPERATIVE_VERBS = frozenset(
+    {
+        "add",
+        "audit",
+        "build",
+        "change",
+        "check",
+        "clean",
+        "commit",
+        "configure",
+        "consider",
+        "create",
+        "delete",
+        "deploy",
+        "disable",
+        "document",
+        "drop",
+        "enable",
+        "ensure",
+        "expose",
+        "extend",
+        "extract",
+        "fetch",
+        "fix",
+        "handle",
+        "implement",
+        "install",
+        "investigate",
+        "land",
+        "make",
+        "merge",
+        "migrate",
+        "move",
+        "port",
+        "pull",
+        "push",
+        "rebase",
+        "refactor",
+        "remove",
+        "rename",
+        "replace",
+        "revert",
+        "review",
+        "run",
+        "split",
+        "test",
+        "try",
+        "update",
+        "use",
+        "validate",
+        "verify",
+        "wire",
+        "write",
+    }
+)
+
+_TODO_RE = re.compile(r"(?i)\b(?:todo|fixme)\b")
+_BOLD_LEAD_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+_LEAD_FIRST_WORD_RE = re.compile(r"[A-Za-z]+")
+
+# Modal + optional adverb/"be" + an action verb stem (any tense). Catches
+# "should refactor", "must be fixed", "needs to update", "have to run".
+_DIRECTIVE_RE = re.compile(
+    r"(?i)\b(?:must|should|shall|need(?:s|ed)?\s+to|have\s+to|has\s+to|"
+    r"ought\s+to)\b\s+(?:not\s+|also\s+|still\s+|then\s+|be\s+|get\s+){0,2}"
+    r"(?:" + "|".join(sorted(_IMPERATIVE_VERBS)) + r")(?:s|es|ed|ing|d)?\b"
+)
+
+
+def phrasing_lint(text: str) -> list[str]:
+    """Return phrasing-lint hit tags (empty list means clean).
+
+    Tags are for diagnostics only; the gate maps any non-empty result to
+    the single :data:`CATEGORY_PHRASING` verdict.
+    """
+    hits: list[str] = []
+    if _TODO_RE.search(text):
+        hits.append("todo-marker")
+    for m in _BOLD_LEAD_RE.finditer(text):
+        first = _LEAD_FIRST_WORD_RE.search(m.group(1))
+        if first is not None and first.group().lower() in _IMPERATIVE_VERBS:
+            hits.append("imperative-lead")
+            break
+    if _DIRECTIVE_RE.search(text):
+        hits.append("directive-language")
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Detection seam (the one small-model call)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Detector(Protocol):
+    """A fuzzy PII/secret detector.
+
+    ``detect`` returns a category string on a hit (e.g. ``"pii"`` or
+    ``"secret"``), or ``None`` when clean. It may raise on backend
+    failure — the gate treats any raise as a withhold (fail closed).
+    """
+
+    def detect(self, text: str) -> str | None: ...
+
+
+_DETECT_TOOL = {
+    "name": "flag_sensitive",
+    "description": (
+        "Flag whether the text contains personal data (names tied to contact "
+        "info, addresses, IDs) or secrets/credentials. Pattern recognition "
+        "only — do not judge whether claims in the text are true."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "sensitive": {
+                "type": "boolean",
+                "description": "True if the text contains PII or a secret.",
+            },
+            "category": {
+                "type": "string",
+                "description": "One of: pii, secret, none.",
+            },
+            "reason": {"type": "string"},
+        },
+        "required": ["sensitive"],
+    },
+}
+
+_DETECT_PROMPT = (
+    "You are a privacy tripwire. Inspect the text below and decide whether it "
+    "contains personal data (a person tied to contact details, an address, a "
+    "government/account identifier) or a secret/credential (API key, token, "
+    "password, private key). This is pattern recognition, not fact-checking — "
+    "do not judge whether the text's claims are correct, only whether "
+    "sensitive strings are present. Respond via the `flag_sensitive` tool.\n\n"
+    "--- text ---\n"
+)
+
+
+class LlmPiiDetector:
+    """Detector backed by one small-model tool-use call.
+
+    Mirrors the curator LLM-call convention: a single forced-tool
+    ``messages.create`` and a walk of ``resp.content`` for the tool_use
+    block. The model tier is resolved by the caller-supplied
+    ``model_resolver`` (same shape the curators use), defaulting to the
+    cheapest tier — detection is a fast tripwire, not deep reasoning.
+    """
+
+    def __init__(
+        self,
+        *,
+        llm_client: Any,
+        model_resolver: Callable[[str], str],
+        tier: str = "simple",
+        max_tokens: int = 256,
+    ) -> None:
+        self._client = llm_client
+        self._resolve = model_resolver
+        self._tier = tier
+        self._max_tokens = max_tokens
+
+    def detect(self, text: str) -> str | None:
+        model = self._resolve(self._tier)
+        resp = self._client.messages.create(
+            model=model,
+            max_tokens=self._max_tokens,
+            tools=[_DETECT_TOOL],
+            tool_choice={"type": "tool", "name": "flag_sensitive"},
+            messages=[{"role": "user", "content": _DETECT_PROMPT + text}],
+        )
+        data = _extract_tool_input(resp)
+        if not data.get("sensitive"):
+            return None
+        category = str(data.get("category") or "").strip().lower()
+        if category in {CATEGORY_PII, CATEGORY_SECRET}:
+            return category
+        return CATEGORY_PII
+
+
+def _extract_tool_input(resp: Any) -> dict[str, Any]:
+    """Pull the tool_use input dict from an Anthropic-style response."""
+    for block in getattr(resp, "content", []) or []:
+        btype = getattr(block, "type", None) or (
+            block.get("type") if isinstance(block, dict) else None
+        )
+        if btype == "tool_use":
+            inp = getattr(block, "input", None)
+            if inp is None and isinstance(block, dict):
+                inp = block.get("input")
+            if isinstance(inp, dict):
+                return inp
+    raise ValueError("detection: no tool_use block in response")
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+def _run_scanners(text: str) -> str | None:
+    """Return the first scanner category that hits, else ``None``.
+
+    Ordered by severity, not cost (all three are cheap regex): a leaked
+    secret is the worst outcome, so it is checked first.
+    """
+    if has_secret(text):
+        return CATEGORY_SECRET
+    if has_email(text):
+        return CATEGORY_EMAIL
+    if has_phone(text):
+        return CATEGORY_PHONE
+    return None
+
+
+def evaluate(chapter_text: str, *, detector: Detector | None = None) -> GateResult:
+    """Evaluate one composed chapter. Returns PASS or a withheld verdict.
+
+    Cheapest-first, short-circuiting on the first hit: deterministic
+    scanners, then deterministic phrasing lint, then — only if the first
+    two pass and a detector is supplied — one detection call. Fails closed:
+    an error in any layer withholds rather than passes.
+    """
+    try:
+        category = _run_scanners(chapter_text)
+        if category is not None:
+            return _withheld(category)
+
+        if phrasing_lint(chapter_text):
+            return _withheld(CATEGORY_PHRASING)
+
+        if detector is not None:
+            try:
+                hit = detector.detect(chapter_text)
+            except Exception:  # noqa: BLE001 — detection error must fail closed
+                return _withheld(CATEGORY_ERROR)
+            if hit:
+                # Report under the detector's category when it is one we know,
+                # else the generic PII bucket; feedback stays value-free.
+                category = hit if hit in _FEEDBACK else CATEGORY_PII
+                return _withheld(category)
+
+        return PASS
+    except Exception:  # noqa: BLE001 — any gate failure withholds, never passes
+        return _withheld(CATEGORY_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# Terminal withhold side-effects (marker + quarantine)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WithholdOutcome:
+    """Result of :func:`apply_withhold`."""
+
+    chapter_n: int  # 1-based number of the appended marker chapter
+    entry_id: str  # id of the quarantine entry holding the composed text
+
+
+def apply_withhold(
+    note_path: Path,
+    *,
+    result: GateResult,
+    composed_text: str,
+    slice_from_turn: int,
+    slice_to_turn: int,
+    lore_root: Path | None = None,
+    quarantine_dir: Path | None = None,
+    wiki_root: Path | None = None,
+) -> WithholdOutcome:
+    """Run the terminal side-effects for a withheld chapter.
+
+    Appends a deterministic withheld-marker chapter to the note (safe,
+    value-free reason) and stores the full composed text in the private
+    quarantine sidecar. The unsafe text never touches the shared note.
+
+    ``result`` must be a withheld :class:`GateResult`; passing a PASS is a
+    programming error.
+    """
+    if result.passed:
+        raise ValueError("apply_withhold called with a passing GateResult")
+
+    category = result.category or CATEGORY_ERROR
+    reason = _MARKER_REASON.get(category, _MARKER_REASON[CATEGORY_ERROR])
+
+    entry = _quarantine.add_entry(
+        category=category,
+        note_path=str(note_path),
+        from_turn=slice_from_turn,
+        to_turn=slice_to_turn,
+        composed_text=composed_text,
+        lore_root=lore_root,
+        quarantine_dir=quarantine_dir,
+    )
+    chapter_n = _nd.append_marker_chapter(
+        note_path,
+        kind=_nd.MARKER_WITHHELD,
+        reason=reason,
+        slice_from_turn=slice_from_turn,
+        slice_to_turn=slice_to_turn,
+        wiki_root=wiki_root,
+    )
+    return WithholdOutcome(chapter_n=chapter_n, entry_id=entry.id)

--- a/lib/lore_core/quarantine.py
+++ b/lib/lore_core/quarantine.py
@@ -1,0 +1,207 @@
+"""Private quarantine sidecar for chapters the publish gate withheld.
+
+When the gate withholds a composed chapter, its text is held here — one
+JSON file per entry under ``<lore_root>/.lore/quarantine/`` — while a
+deterministic withheld-marker takes its place in the shared note. The
+sidecar lives inside the already-private ``.lore/`` operational area, so
+the withheld content (which may contain the very secret that tripped the
+gate) never reaches the shared wiki.
+
+Storage is per-entry rather than one shared index: parallel sessions
+withhold concurrently, and a file-per-entry layout means two writers
+never race on the same file. Reads glob the directory; each write is
+atomic (``.tmp`` + ``os.replace``).
+
+A reviewer inspects and disposes of entries via the ``lore quarantine``
+CLI (list / show / clear / kill).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+__all__ = [
+    "QUARANTINE_SCHEMA_VERSION",
+    "QuarantineEntry",
+    "quarantine_dir_for",
+    "add_entry",
+    "list_entries",
+    "get_entry",
+    "clear_entry",
+    "kill_all",
+]
+
+QUARANTINE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class QuarantineEntry:
+    """One withheld chapter held privately for review.
+
+    ``composed_text`` is the full text the gate refused — it may contain
+    the secret/PII that tripped the gate, which is exactly why it lives
+    here and not in the shared note.
+    """
+
+    id: str
+    created: str  # ISO-8601 UTC timestamp
+    category: str  # the gate category that withheld it (secret/email/...)
+    note_path: str  # note this chapter belonged to (wiki-relative or absolute)
+    from_turn: int
+    to_turn: int
+    composed_text: str
+
+
+def _resolve_dir(lore_root: Path | None, quarantine_dir: Path | None) -> Path:
+    """Resolve the quarantine directory from either explicit path or root.
+
+    Exactly one of ``quarantine_dir`` / ``lore_root`` is expected; the
+    explicit directory wins when both are given.
+    """
+    if quarantine_dir is not None:
+        return quarantine_dir
+    if lore_root is not None:
+        return quarantine_dir_for(lore_root)
+    raise ValueError("quarantine: pass either lore_root or quarantine_dir")
+
+
+def quarantine_dir_for(lore_root: Path) -> Path:
+    """Return the quarantine directory under the private ``.lore/`` area."""
+    return lore_root / ".lore" / "quarantine"
+
+
+def _entry_path(directory: Path, entry_id: str) -> Path:
+    return directory / f"{entry_id}.json"
+
+
+def _to_entry(data: dict) -> QuarantineEntry:
+    return QuarantineEntry(
+        id=str(data["id"]),
+        created=str(data.get("created", "")),
+        category=str(data.get("category", "")),
+        note_path=str(data.get("note_path", "")),
+        from_turn=int(data.get("from_turn", 0)),
+        to_turn=int(data.get("to_turn", 0)),
+        composed_text=str(data.get("composed_text", "")),
+    )
+
+
+def add_entry(
+    *,
+    category: str,
+    note_path: str,
+    from_turn: int,
+    to_turn: int,
+    composed_text: str,
+    lore_root: Path | None = None,
+    quarantine_dir: Path | None = None,
+) -> QuarantineEntry:
+    """Store one withheld chapter and return its :class:`QuarantineEntry`."""
+    directory = _resolve_dir(lore_root, quarantine_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    entry = QuarantineEntry(
+        id=uuid.uuid4().hex[:12],
+        created=datetime.now(UTC).isoformat(),
+        category=category,
+        note_path=note_path,
+        from_turn=int(from_turn),
+        to_turn=int(to_turn),
+        composed_text=composed_text,
+    )
+    payload = {
+        "schema_version": QUARANTINE_SCHEMA_VERSION,
+        "id": entry.id,
+        "created": entry.created,
+        "category": entry.category,
+        "note_path": entry.note_path,
+        "from_turn": entry.from_turn,
+        "to_turn": entry.to_turn,
+        "composed_text": entry.composed_text,
+    }
+    path = _entry_path(directory, entry.id)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+    return entry
+
+
+def list_entries(
+    *,
+    lore_root: Path | None = None,
+    quarantine_dir: Path | None = None,
+) -> list[QuarantineEntry]:
+    """Return all quarantined chapters, oldest first (by created timestamp)."""
+    directory = _resolve_dir(lore_root, quarantine_dir)
+    if not directory.is_dir():
+        return []
+    entries: list[QuarantineEntry] = []
+    for f in directory.glob("*.json"):
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict) or "id" not in data:
+            continue
+        entries.append(_to_entry(data))
+    entries.sort(key=lambda e: (e.created, e.id))
+    return entries
+
+
+def get_entry(
+    entry_id: str,
+    *,
+    lore_root: Path | None = None,
+    quarantine_dir: Path | None = None,
+) -> QuarantineEntry | None:
+    """Return the entry with ``entry_id``, or ``None`` if absent/unreadable."""
+    directory = _resolve_dir(lore_root, quarantine_dir)
+    path = _entry_path(directory, entry_id)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or "id" not in data:
+        return None
+    return _to_entry(data)
+
+
+def clear_entry(
+    entry_id: str,
+    *,
+    lore_root: Path | None = None,
+    quarantine_dir: Path | None = None,
+) -> bool:
+    """Remove one entry after review. Returns whether one was removed."""
+    directory = _resolve_dir(lore_root, quarantine_dir)
+    path = _entry_path(directory, entry_id)
+    if not path.is_file():
+        return False
+    path.unlink()
+    return True
+
+
+def kill_all(
+    *,
+    lore_root: Path | None = None,
+    quarantine_dir: Path | None = None,
+) -> int:
+    """Purge every quarantined chapter. Returns the number removed."""
+    directory = _resolve_dir(lore_root, quarantine_dir)
+    if not directory.is_dir():
+        return 0
+    removed = 0
+    for f in directory.glob("*.json"):
+        try:
+            f.unlink()
+            removed += 1
+        except OSError:
+            continue
+    return removed

--- a/tests/test_publish_gate.py
+++ b/tests/test_publish_gate.py
@@ -1,0 +1,266 @@
+"""Tests for ``lore_core.publish_gate`` — the blocking publish gate.
+
+The gate runs between compose and append, ordered cheapest-first:
+deterministic scanners (secrets, email, phone), then deterministic
+phrasing lint, then one small-model detection call for fuzzy PII. The
+first hit short-circuits. Anything unexpected fails CLOSED (withheld),
+never a silent pass. The gate is a tripwire, not a guarantee.
+"""
+
+from __future__ import annotations
+
+import secrets as _secrets
+
+from lore_core import publish_gate as pg
+
+# ---------------------------------------------------------------------------
+# Deterministic scanners — hits and near-misses
+# ---------------------------------------------------------------------------
+
+
+class TestSecretScanner:
+    def test_secret_key_is_a_hit(self):
+        token = _secrets.token_urlsafe(40)
+        assert pg.has_secret(f"the key is sk-{token} keep it safe") is True
+
+    def test_base64_asset_hash_is_not_a_secret(self):
+        # A short-ish base64-looking asset hash without an assignment
+        # context is a near-miss, not a credential.
+        assert pg.has_secret("asset digest: q1w2e3r4t5") is False
+
+    def test_prose_without_secrets_is_clean(self):
+        assert pg.has_secret("We refactored the flush path and ran the suite.") is False
+
+
+class TestEmailScanner:
+    def test_real_email_is_a_hit(self):
+        assert pg.has_email("ping alice@example.com about the merge") is True
+
+    def test_at_handle_mention_is_not_an_email(self):
+        # A bare @handle or an @-anchor has no domain-with-TLD.
+        assert pg.has_email("see @turn anchor and @alice on chat") is False
+
+    def test_local_without_tld_is_not_an_email(self):
+        assert pg.has_email("user@localhost was mentioned") is False
+
+
+class TestPhoneScanner:
+    def test_international_number_is_a_hit(self):
+        assert pg.has_phone("call +1 415 555 2671 later") is True
+
+    def test_grouped_us_number_is_a_hit(self):
+        assert pg.has_phone("reach the desk at (415) 555-2671") is True
+
+    def test_version_string_is_not_a_phone(self):
+        assert pg.has_phone("bumped to v0.13.1 and 1.2.3 in the lockfile") is False
+
+    def test_issue_ref_is_not_a_phone(self):
+        assert pg.has_phone("closes #126 and references org/repo#131") is False
+
+    def test_commit_sha_is_not_a_phone(self):
+        assert pg.has_phone("landed in 3d9d36e after review") is False
+
+    def test_iso_date_is_not_a_phone(self):
+        assert pg.has_phone("dated 2026-07-03 in the header") is False
+
+    def test_byte_count_is_not_a_phone(self):
+        assert pg.has_phone("buffer cap 120 turns / 240000 chars") is False
+
+
+class TestPhrasingLint:
+    def test_todo_marker_is_a_hit(self):
+        assert pg.phrasing_lint("TODO: wire the sweep path") != []
+
+    def test_fixme_marker_is_a_hit(self):
+        assert pg.phrasing_lint("the flush is racy (FIXME)") != []
+
+    def test_imperative_bold_lead_is_a_hit(self):
+        assert pg.phrasing_lint("**Fix the flush race condition**\n\ndetail. @42") != []
+
+    def test_past_tense_bold_lead_is_clean(self):
+        assert pg.phrasing_lint("**Fixed the flush race condition**\n\ndetail. @42") == []
+
+    def test_must_should_task_language_is_a_hit(self):
+        assert pg.phrasing_lint("The buffer should be refactored before release.") != []
+
+    def test_stative_prose_is_clean(self):
+        text = (
+            "**Traced the flush race** \n\nThe buffer accumulated turns and "
+            "retried at the next trigger; the give-up bound was discussed. @42"
+        )
+        assert pg.phrasing_lint(text) == []
+
+
+# ---------------------------------------------------------------------------
+# GateResult + evaluate() — ordering, short-circuit, fail-closed
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateClean:
+    def test_clean_chapter_passes(self):
+        text = "**Traced the flush race** \n\nThe buffer accumulated turns. @42"
+        result = pg.evaluate(text)
+        assert result.passed is True
+        assert result.category == ""
+
+    def test_empty_chapter_passes(self):
+        assert pg.evaluate("").passed is True
+
+
+class TestEvaluateHits:
+    def test_secret_withheld_with_feedback(self):
+        token = _secrets.token_urlsafe(40)
+        result = pg.evaluate(f"**Notes** \n\nkey sk-{token} leaked. @1")
+        assert result.passed is False
+        assert result.category == pg.CATEGORY_SECRET
+        assert result.feedback  # non-empty retry-prompt injection
+        # Feedback must never echo the matched secret value.
+        assert token not in result.feedback
+
+    def test_email_withheld(self):
+        result = pg.evaluate("**Contact** \n\nmail bob@example.com about it. @1")
+        assert result.passed is False
+        assert result.category == pg.CATEGORY_EMAIL
+        assert "bob@example.com" not in result.feedback
+
+    def test_phrasing_withheld_with_feedback(self):
+        result = pg.evaluate("**Fix the race** \n\ndetail. @1")
+        assert result.passed is False
+        assert result.category == pg.CATEGORY_PHRASING
+        assert result.feedback
+
+
+class TestEvaluateOrdering:
+    def test_scanner_beats_phrasing_when_both_present(self):
+        # A chapter with BOTH a secret and an imperative lead: cheapest-first
+        # means the scanner (secret) short-circuits before the phrasing lint.
+        token = _secrets.token_urlsafe(40)
+        result = pg.evaluate(f"**Fix the race** \n\nkey sk-{token}. @1")
+        assert result.category == pg.CATEGORY_SECRET
+
+    def test_detector_not_called_when_scanner_hits(self):
+        calls = []
+
+        class Spy:
+            def detect(self, text):
+                calls.append(text)
+                return "pii"
+
+        token = _secrets.token_urlsafe(40)
+        pg.evaluate(f"key sk-{token}", detector=Spy())
+        assert calls == []  # short-circuited before detection
+
+    def test_detector_not_called_when_phrasing_hits(self):
+        calls = []
+
+        class Spy:
+            def detect(self, text):
+                calls.append(text)
+                return None
+
+        pg.evaluate("**Fix the race**\n\ndetail. @1", detector=Spy())
+        assert calls == []
+
+
+class TestEvaluateDetection:
+    def test_detector_hit_withholds(self):
+        class Hit:
+            def detect(self, text):
+                return "pii"
+
+        result = pg.evaluate("**Reviewed the merge**\n\nordinary prose. @1", detector=Hit())
+        assert result.passed is False
+        assert result.category == pg.CATEGORY_PII
+
+    def test_detector_clean_passes(self):
+        class Clean:
+            def detect(self, text):
+                return None
+
+        result = pg.evaluate("**Reviewed the merge**\n\nordinary prose. @1", detector=Clean())
+        assert result.passed is True
+
+    def test_no_detector_runs_deterministic_layers_only(self):
+        # Without a detector the gate still runs scanners + lint.
+        result = pg.evaluate("**Reviewed the merge**\n\nordinary prose. @1")
+        assert result.passed is True
+
+
+class TestFailClosed:
+    def test_detector_error_fails_closed(self):
+        class Boom:
+            def detect(self, text):
+                raise RuntimeError("model unreachable")
+
+        result = pg.evaluate("**Reviewed the merge**\n\nordinary prose. @1", detector=Boom())
+        assert result.passed is False
+        assert result.category == pg.CATEGORY_ERROR
+        assert result.feedback
+
+
+# ---------------------------------------------------------------------------
+# LlmPiiDetector — the one small-model detection call (STUBBED, never live)
+# ---------------------------------------------------------------------------
+
+
+class _FakeToolBlock:
+    type = "tool_use"
+
+    def __init__(self, data):
+        self.input = data
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.content = [_FakeToolBlock(data)]
+        self.model = "fake-detector-model"
+
+
+class _FakeMessages:
+    def __init__(self, data):
+        self._data = data
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return _FakeResponse(self._data)
+
+
+class _FakeClient:
+    def __init__(self, data):
+        self.messages = _FakeMessages(data)
+        self.backend_name = "fake"
+
+
+class TestLlmPiiDetectorContract:
+    def test_call_contract_single_tool_choice(self):
+        client = _FakeClient({"sensitive": False})
+        detector = pg.LlmPiiDetector(
+            llm_client=client, model_resolver=lambda tier: "resolved-model"
+        )
+        detector.detect("some chapter text")
+        assert len(client.messages.calls) == 1
+        call = client.messages.calls[0]
+        assert call["model"] == "resolved-model"
+        assert call["tool_choice"]["type"] == "tool"
+        # exactly one user message carrying the chapter text
+        assert len(call["messages"]) == 1
+        assert call["messages"][0]["role"] == "user"
+        assert "some chapter text" in str(call["messages"][0]["content"])
+
+    def test_sensitive_true_returns_category(self):
+        client = _FakeClient({"sensitive": True, "category": "pii"})
+        detector = pg.LlmPiiDetector(llm_client=client, model_resolver=lambda tier: "m")
+        assert detector.detect("text") == "pii"
+
+    def test_sensitive_false_returns_none(self):
+        client = _FakeClient({"sensitive": False})
+        detector = pg.LlmPiiDetector(llm_client=client, model_resolver=lambda tier: "m")
+        assert detector.detect("text") is None
+
+    def test_detector_wired_into_gate(self):
+        client = _FakeClient({"sensitive": True, "category": "pii"})
+        detector = pg.LlmPiiDetector(llm_client=client, model_resolver=lambda tier: "m")
+        result = pg.evaluate("**Reviewed the merge**\n\nordinary prose. @1", detector=detector)
+        assert result.passed is False
+        assert result.category == pg.CATEGORY_PII

--- a/tests/test_publish_gate_withhold.py
+++ b/tests/test_publish_gate_withhold.py
@@ -1,0 +1,131 @@
+"""End-to-end withhold side-effects for the publish gate.
+
+On a terminal WITHHELD verdict the gate owns two side-effects, testable
+without the real compose loop (#125): a deterministic withheld-marker
+chapter is appended to the note, and the composed text is stored in the
+private quarantine sidecar. The shared note never carries the unsafe
+content — only a safe marker and the turn range.
+"""
+
+from __future__ import annotations
+
+import secrets as _secrets
+from pathlib import Path
+
+from lore_core import note_document as nd
+from lore_core import publish_gate as pg
+from lore_core import quarantine
+
+
+def _fixture_note(tmp_path: Path) -> Path:
+    path = tmp_path / "wiki" / "lore" / "sessions" / "2026" / "07" / "03-demo.md"
+    nd.create_note(
+        path,
+        title="Demo session",
+        description="A demo session note",
+        scope="lore",
+    )
+    return path
+
+
+class TestPlantedSecretEndToEnd:
+    def test_gate_withholds_planted_secret(self, tmp_path: Path):
+        token = _secrets.token_urlsafe(40)
+        composed = f"**Notes on the leak** \n\nkey sk-{token} was pasted. @11"
+        result = pg.evaluate(composed)
+        assert result.passed is False
+        assert result.category == pg.CATEGORY_SECRET
+
+    def test_withhold_appends_marker_and_quarantines(self, tmp_path: Path):
+        note = _fixture_note(tmp_path)
+        token = _secrets.token_urlsafe(40)
+        composed = f"**Notes on the leak** \n\nkey sk-{token} was pasted. @11"
+
+        result = pg.evaluate(composed)
+        outcome = pg.apply_withhold(
+            note,
+            result=result,
+            composed_text=composed,
+            slice_from_turn=10,
+            slice_to_turn=20,
+            lore_root=tmp_path,
+        )
+
+        # A withheld marker chapter now sits in the note.
+        view = nd.read_note(note)
+        markers = [c for c in view.chapters if c.get("kind") == "marker"]
+        assert len(markers) == 1
+        assert markers[0]["marker"] == nd.MARKER_WITHHELD
+        assert outcome.chapter_n == markers[0]["n"]
+
+        # The unsafe composed text NEVER reaches the shared note on disk.
+        on_disk = note.read_text()
+        assert token not in on_disk
+
+        # A quarantine entry holds the full composed text privately.
+        entries = quarantine.list_entries(lore_root=tmp_path)
+        assert len(entries) == 1
+        assert entries[0].id == outcome.entry_id
+        assert entries[0].composed_text == composed
+        assert token in entries[0].composed_text  # held for review
+        assert entries[0].category == pg.CATEGORY_SECRET
+        assert entries[0].from_turn == 10
+        assert entries[0].to_turn == 20
+
+    def test_marker_reason_does_not_leak_the_secret(self, tmp_path: Path):
+        note = _fixture_note(tmp_path)
+        token = _secrets.token_urlsafe(40)
+        composed = f"**Leak** \n\nkey sk-{token}. @11"
+        result = pg.evaluate(composed)
+        pg.apply_withhold(
+            note,
+            result=result,
+            composed_text=composed,
+            slice_from_turn=10,
+            slice_to_turn=20,
+            lore_root=tmp_path,
+        )
+        view = nd.read_note(note)
+        marker = next(c for c in view.chapters if c.get("kind") == "marker")
+        assert token not in str(marker.get("reason", ""))
+        assert token not in view.body
+
+
+class TestPhrasingGiveUpPath:
+    def test_phrasing_hit_produces_withheld_with_feedback(self, tmp_path: Path):
+        # First compose attempt: a lint hit yields WITHHELD-with-feedback,
+        # which #125 injects into the retry prompt.
+        result = pg.evaluate("**Fix the flush race**\n\ndetail. @1")
+        assert result.passed is False
+        assert result.category == pg.CATEGORY_PHRASING
+        assert result.feedback
+
+    def test_give_up_withhold_side_effects(self, tmp_path: Path):
+        # Second attempt also hits: the give-up path runs the terminal
+        # withhold side-effects (marker + quarantine).
+        note = _fixture_note(tmp_path)
+        composed = "**Fix the flush race**\n\nstill imperative. @1"
+        result = pg.evaluate(composed)
+        outcome = pg.apply_withhold(
+            note,
+            result=result,
+            composed_text=composed,
+            slice_from_turn=1,
+            slice_to_turn=5,
+            lore_root=tmp_path,
+        )
+        view = nd.read_note(note)
+        marker = next(c for c in view.chapters if c.get("kind") == "marker")
+        assert marker["marker"] == nd.MARKER_WITHHELD
+        (entry,) = quarantine.list_entries(lore_root=tmp_path)
+        assert entry.id == outcome.entry_id
+        assert entry.category == pg.CATEGORY_PHRASING
+
+
+class TestGateIsTheOnlyDoor:
+    def test_passing_chapter_is_not_quarantined(self, tmp_path: Path):
+        # A clean chapter produces no quarantine side-effect; the caller
+        # appends it normally (that path is #125/#127, not the gate).
+        result = pg.evaluate("**Traced the flush race**\n\nprose. @1")
+        assert result.passed is True
+        assert quarantine.list_entries(lore_root=tmp_path) == []

--- a/tests/test_publish_gate_withhold.py
+++ b/tests/test_publish_gate_withhold.py
@@ -1,10 +1,10 @@
 """End-to-end withhold side-effects for the publish gate.
 
 On a terminal WITHHELD verdict the gate owns two side-effects, testable
-without the real compose loop (#125): a deterministic withheld-marker
-chapter is appended to the note, and the composed text is stored in the
-private quarantine sidecar. The shared note never carries the unsafe
-content — only a safe marker and the turn range.
+without the real compose loop: a deterministic withheld-marker chapter is
+appended to the note, and the composed text is stored in the private
+quarantine sidecar. The shared note never carries the unsafe content —
+only a safe marker and the turn range.
 """
 
 from __future__ import annotations
@@ -94,7 +94,7 @@ class TestPlantedSecretEndToEnd:
 class TestPhrasingGiveUpPath:
     def test_phrasing_hit_produces_withheld_with_feedback(self, tmp_path: Path):
         # First compose attempt: a lint hit yields WITHHELD-with-feedback,
-        # which #125 injects into the retry prompt.
+        # which the retry loop injects into the next compose prompt.
         result = pg.evaluate("**Fix the flush race**\n\ndetail. @1")
         assert result.passed is False
         assert result.category == pg.CATEGORY_PHRASING
@@ -125,7 +125,7 @@ class TestPhrasingGiveUpPath:
 class TestGateIsTheOnlyDoor:
     def test_passing_chapter_is_not_quarantined(self, tmp_path: Path):
         # A clean chapter produces no quarantine side-effect; the caller
-        # appends it normally (that path is #125/#127, not the gate).
+        # appends it normally (the compose/integration layer, not the gate).
         result = pg.evaluate("**Traced the flush race**\n\nprose. @1")
         assert result.passed is True
         assert quarantine.list_entries(lore_root=tmp_path) == []

--- a/tests/test_quarantine.py
+++ b/tests/test_quarantine.py
@@ -1,0 +1,111 @@
+"""Tests for ``lore_core.quarantine`` — the private quarantine sidecar.
+
+Withheld chapter text is held here (never in the shared wiki) for the
+reviewer to inspect and dispose of. Storage is one JSON file per entry
+under ``<lore_root>/.lore/quarantine/`` so parallel sessions never race
+on a shared index.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_core import quarantine
+
+
+def _add(lore_root: Path, **overrides) -> quarantine.QuarantineEntry:
+    kwargs = {
+        "lore_root": lore_root,
+        "category": "secret",
+        "note_path": "sessions/2026/07/03-demo.md",
+        "from_turn": 10,
+        "to_turn": 20,
+        "composed_text": "a chapter mentioning sk-secret-value",
+    }
+    kwargs.update(overrides)
+    return quarantine.add_entry(**kwargs)
+
+
+class TestLocation:
+    def test_quarantine_dir_is_private_lore_dir(self, tmp_path: Path):
+        d = quarantine.quarantine_dir_for(tmp_path)
+        # Must live under the private .lore/ area, never under wiki/.
+        assert d == tmp_path / ".lore" / "quarantine"
+        assert "wiki" not in d.parts
+
+
+class TestAddEntry:
+    def test_add_returns_entry_with_id_and_fields(self, tmp_path: Path):
+        entry = _add(tmp_path, category="email", composed_text="secret body")
+        assert entry.id
+        assert entry.category == "email"
+        assert entry.note_path == "sessions/2026/07/03-demo.md"
+        assert entry.from_turn == 10
+        assert entry.to_turn == 20
+        assert entry.composed_text == "secret body"
+        assert entry.created  # ISO timestamp
+
+    def test_add_persists_file_on_disk(self, tmp_path: Path):
+        entry = _add(tmp_path)
+        f = quarantine.quarantine_dir_for(tmp_path) / f"{entry.id}.json"
+        assert f.exists()
+
+    def test_ids_are_unique(self, tmp_path: Path):
+        a = _add(tmp_path)
+        b = _add(tmp_path)
+        assert a.id != b.id
+
+
+class TestListEntries:
+    def test_empty_when_no_quarantine(self, tmp_path: Path):
+        assert quarantine.list_entries(lore_root=tmp_path) == []
+
+    def test_lists_all_added(self, tmp_path: Path):
+        _add(tmp_path, composed_text="one")
+        _add(tmp_path, composed_text="two")
+        entries = quarantine.list_entries(lore_root=tmp_path)
+        assert len(entries) == 2
+        assert {e.composed_text for e in entries} == {"one", "two"}
+
+    def test_full_composed_text_round_trips(self, tmp_path: Path):
+        planted = "chapter body with sk-ant-api03-PLANTEDSECRETVALUE inside"
+        _add(tmp_path, composed_text=planted)
+        (entry,) = quarantine.list_entries(lore_root=tmp_path)
+        assert entry.composed_text == planted
+
+
+class TestGetEntry:
+    def test_get_returns_matching(self, tmp_path: Path):
+        e = _add(tmp_path)
+        got = quarantine.get_entry(e.id, lore_root=tmp_path)
+        assert got is not None
+        assert got.id == e.id
+
+    def test_get_missing_returns_none(self, tmp_path: Path):
+        assert quarantine.get_entry("does-not-exist", lore_root=tmp_path) is None
+
+
+class TestClearEntry:
+    def test_clear_removes_one(self, tmp_path: Path):
+        a = _add(tmp_path, composed_text="one")
+        _add(tmp_path, composed_text="two")
+        assert quarantine.clear_entry(a.id, lore_root=tmp_path) is True
+        remaining = quarantine.list_entries(lore_root=tmp_path)
+        assert len(remaining) == 1
+        assert remaining[0].composed_text == "two"
+
+    def test_clear_missing_returns_false(self, tmp_path: Path):
+        assert quarantine.clear_entry("nope", lore_root=tmp_path) is False
+
+
+class TestKillAll:
+    def test_kill_removes_everything_and_returns_count(self, tmp_path: Path):
+        _add(tmp_path)
+        _add(tmp_path)
+        _add(tmp_path)
+        n = quarantine.kill_all(lore_root=tmp_path)
+        assert n == 3
+        assert quarantine.list_entries(lore_root=tmp_path) == []
+
+    def test_kill_empty_returns_zero(self, tmp_path: Path):
+        assert quarantine.kill_all(lore_root=tmp_path) == 0

--- a/tests/test_quarantine_cli.py
+++ b/tests/test_quarantine_cli.py
@@ -1,0 +1,97 @@
+"""`lore quarantine ...` CLI review flow — list / show / clear / kill."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lore_cli.__main__ import app
+from lore_core import quarantine
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def lore_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    (tmp_path / "wiki").mkdir()
+    return tmp_path
+
+
+def _seed(lore_root: Path, **overrides) -> quarantine.QuarantineEntry:
+    kwargs = {
+        "lore_root": lore_root,
+        "category": "secret",
+        "note_path": "sessions/2026/07/03-demo.md",
+        "from_turn": 10,
+        "to_turn": 20,
+        "composed_text": "withheld chapter body",
+    }
+    kwargs.update(overrides)
+    return quarantine.add_entry(**kwargs)
+
+
+class TestList:
+    def test_list_empty(self, lore_root: Path):
+        result = runner.invoke(app, ["quarantine", "list"])
+        assert result.exit_code == 0, result.output
+
+    def test_list_shows_entries(self, lore_root: Path):
+        e = _seed(lore_root, category="email")
+        result = runner.invoke(app, ["quarantine", "list"])
+        assert result.exit_code == 0, result.output
+        assert e.id in result.output
+        assert "email" in result.output
+
+    def test_list_does_not_dump_full_body(self, lore_root: Path):
+        # `list` is a terse index; the full (possibly secret) body is only
+        # revealed by `show`.
+        _seed(lore_root, composed_text="THE-SECRET-BODY-MARKER")
+        result = runner.invoke(app, ["quarantine", "list"])
+        assert "THE-SECRET-BODY-MARKER" not in result.output
+
+
+class TestShow:
+    def test_show_reveals_body(self, lore_root: Path):
+        e = _seed(lore_root, composed_text="THE-SECRET-BODY-MARKER")
+        result = runner.invoke(app, ["quarantine", "show", e.id])
+        assert result.exit_code == 0, result.output
+        assert "THE-SECRET-BODY-MARKER" in result.output
+
+    def test_show_missing_errors(self, lore_root: Path):
+        result = runner.invoke(app, ["quarantine", "show", "nope"])
+        assert result.exit_code != 0
+
+
+class TestClear:
+    def test_clear_removes_one(self, lore_root: Path):
+        a = _seed(lore_root, composed_text="one")
+        _seed(lore_root, composed_text="two")
+        result = runner.invoke(app, ["quarantine", "clear", a.id])
+        assert result.exit_code == 0, result.output
+        remaining = quarantine.list_entries(lore_root=lore_root)
+        assert len(remaining) == 1
+        assert remaining[0].composed_text == "two"
+
+    def test_clear_missing_errors(self, lore_root: Path):
+        result = runner.invoke(app, ["quarantine", "clear", "nope"])
+        assert result.exit_code != 0
+
+
+class TestKill:
+    def test_kill_all_purges(self, lore_root: Path):
+        _seed(lore_root)
+        _seed(lore_root)
+        result = runner.invoke(app, ["quarantine", "kill", "--all", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert quarantine.list_entries(lore_root=lore_root) == []
+
+    def test_kill_one_by_id(self, lore_root: Path):
+        a = _seed(lore_root, composed_text="one")
+        _seed(lore_root, composed_text="two")
+        result = runner.invoke(app, ["quarantine", "kill", a.id, "--yes"])
+        assert result.exit_code == 0, result.output
+        remaining = quarantine.list_entries(lore_root=lore_root)
+        assert len(remaining) == 1
+        assert remaining[0].composed_text == "two"


### PR DESCRIPTION
Implements #126 (epic #131) — the blocking **publish gate** between compose and append.

## What this adds
- **`lore_core.publish_gate`** — `evaluate(chapter_text, *, detector=None) -> GateResult`. Cheapest-first, short-circuiting on the first hit:
  1. **Deterministic scanners** — secrets (reusing `lore_core.redaction`), emails, phone numbers.
  2. **Deterministic phrasing lint** — TODO/FIXME, imperative bold leads, must/should task language. A hit is a compose failure surfaced as **WITHHELD-with-feedback**.
  3. **One small-model detection call** for fuzzy PII/secrets — an injectable `Detector` seam (`LlmPiiDetector` provided; stubbed in tests, never live). Documented as a **tripwire, not a guarantee**.
- **Fail closed**: any scanner/lint error, or a detection-call error, withholds — never a silent pass.
- **Withhold side-effects** (`apply_withhold`) — appends a deterministic withheld-marker chapter (via `note_document`'s marker seam, safe value-free reason) and stores the composed text in a **private quarantine sidecar** under `.lore/quarantine/` (never the shared wiki).
- **`lore_core.quarantine`** — per-entry JSON store (parallel-session safe), atomic writes.
- **`lore quarantine` CLI** — `list` (metadata only, no body leak) / `show` / `clear` / `kill [--all]`.

## Gate interface (for #125 retry loop + #127 integration)
```
evaluate(chapter_text, *, detector=None) -> GateResult(passed: bool, category: str, feedback: str)
apply_withhold(note_path, *, result, composed_text, slice_from_turn, slice_to_turn,
               lore_root=None | quarantine_dir=None, wiki_root=None) -> WithholdOutcome(chapter_n, entry_id)
```
`feedback` is the retry-prompt injection string and **never echoes the matched value** (so a retry can't re-plant the secret). #125 owns the retry loop and calls `evaluate`; on terminal give-up it (or #127) calls `apply_withhold`. Categories: `secret | email | phone | phrasing | pii | gate-error`.

## Acceptance criteria → tests
1. No chapter reaches the note without the gate — `evaluate` is the sole verdict; `TestGateIsTheOnlyDoor`.
2. Planted secret/PII → withheld marker + quarantine entry, **end-to-end** — `test_publish_gate_withhold.py::TestPlantedSecretEndToEnd` (asserts the secret is absent from the note on disk and present only in quarantine).
3. Phrasing lint → WITHHELD-with-feedback (first hit) + give-up withhold side-effects (second) — `TestPhrasingGiveUpPath`.
4. CLI lists / clears / kills — `test_quarantine_cli.py`.
5. Fixture corpus of hits AND near-misses for scanners + lint — `test_publish_gate.py` (version strings, issue refs, commit SHAs, ISO dates, byte counts vs real phones; `@handle` vs real email; past-tense vs imperative leads).

## Red → green
Strict TDD; RED captured at `.worktrees/feat-126-publish-gate/RED.txt` (all 4 test modules failed to import the missing modules). After implementation: **63 new tests pass**; full suite **2665 passed**, only the **3 known baseline failures** remain (no new failures). Detection LLM call is stubbed (call-contract asserted); no LLM-as-judge anywhere. Ruff-clean on new files; the pre-existing `__main__.py` I001/format debt is untouched.

## Scope
Gate + withhold side-effects + quarantine + CLI + the seam. Does **not** build the compose loop (#125) or give-up/sweep semantics (#127). No version bump.