### PR TITLE
Briefings on new-shape notes: drop regions, gather full bodies (#128)

### DIFF
--- a/lib/lore_core/briefing/compose.py
+++ b/lib/lore_core/briefing/compose.py
@@ -64,6 +64,10 @@ _PROMPT_HEADER = (
 
 _MAX_SESSIONS_IN_PROMPT = 60
 _SUMMARY_CAP = 600
+# Full note bodies are the primary input now (no more pre-extracted
+# "what we worked on" / "decisions made" sections to lean on), so they get
+# a generous cap of their own rather than the short one-liner cap above.
+_BODY_CAP = 2000
 
 
 def _shorten(text: str, cap: int) -> str:
@@ -71,6 +75,10 @@ def _shorten(text: str, cap: int) -> str:
     if len(text) <= cap:
         return text
     return text[:cap].rstrip() + "…"
+
+
+def _indent(text: str, prefix: str = "  ") -> str:
+    return "\n".join(prefix + line if line else line for line in text.splitlines())
 
 
 def _build_prompt(gather_result: dict[str, Any]) -> str:
@@ -98,16 +106,13 @@ def _build_prompt(gather_result: dict[str, Any]) -> str:
         slug = s.get("slug", "")
         fm = s.get("frontmatter") or {}
         summary = fm.get("summary") or fm.get("description") or ""
-        sections = s.get("sections") or {}
-        worked = sections.get("what we worked on", "")
-        decisions = sections.get("decisions made", "")
+        body = s.get("body") or ""
         lines.append(f"- {d} · {slug}")
         if summary:
             lines.append(f"  summary: {_shorten(str(summary), _SUMMARY_CAP)}")
-        if worked:
-            lines.append(f"  what: {_shorten(worked, _SUMMARY_CAP)}")
-        if decisions and decisions.strip().lower() not in {"_none_", "none", ""}:
-            lines.append(f"  decisions: {_shorten(decisions, _SUMMARY_CAP)}")
+        if body:
+            lines.append("  body:")
+            lines.append(_indent(_shorten(body, _BODY_CAP)))
     if len(sessions) > _MAX_SESSIONS_IN_PROMPT:
         lines.append(
             f"(+{len(sessions) - _MAX_SESSIONS_IN_PROMPT} older sessions omitted)"

--- a/lib/lore_core/briefing/format.py
+++ b/lib/lore_core/briefing/format.py
@@ -18,9 +18,13 @@ Shape:
 
 Per-session ``<summary>`` resolution order:
     1. ``frontmatter.summary`` (curator-written)
-    2. first non-empty bullet of the "what we worked on" section
-    3. ``frontmatter.description``
-    4. ``""`` (slug alone)
+    2. ``frontmatter.description``
+    3. ``""`` (slug alone)
+
+The new note shape has no H2 structure to mine a fallback bullet from —
+a session's full body (disclaimer + chapters of topic blocks) is
+available via ``session["body"]`` for the LLM composer, but this
+deterministic fallback formatter stays frontmatter-only.
 """
 
 from __future__ import annotations
@@ -28,32 +32,12 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any
 
-_BULLET_PREFIXES = ("- ", "* ", "+ ")
-
-
-def _first_bullet(text: str) -> str:
-    """Return the first non-empty bullet body from ``text``, or ""."""
-    for raw in text.splitlines():
-        line = raw.strip()
-        for prefix in _BULLET_PREFIXES:
-            if line.startswith(prefix):
-                body = line[len(prefix) :].strip()
-                if body:
-                    return body
-                break
-    return ""
-
 
 def _session_summary(session: dict[str, Any]) -> str:
     fm = session.get("frontmatter") or {}
     summary = fm.get("summary")
     if isinstance(summary, str) and summary.strip():
         return summary.strip()
-    sections = session.get("sections") or {}
-    worked_on = sections.get("what we worked on", "")
-    bullet = _first_bullet(worked_on)
-    if bullet:
-        return bullet
     description = fm.get("description")
     if isinstance(description, str) and description.strip():
         return description.strip()

--- a/lib/lore_core/briefing/gather.py
+++ b/lib/lore_core/briefing/gather.py
@@ -15,19 +15,16 @@ sink-side write and `lore briefing mark` for the ledger commit.
 from __future__ import annotations
 
 import json
-import re
 from datetime import date
 from pathlib import Path
 from typing import Any
 
 from lore_core.config import get_wiki_root
 from lore_core.errors import NO_VAULT, WIKI_NOT_FOUND, mcp_error
-from lore_core.schema import parse_frontmatter
+from lore_core.schema import parse_frontmatter, strip_frontmatter
 
 _LEDGER_FILE = ".briefing-ledger.json"
 _CONFIG_FILE = ".lore-briefing.yml"
-
-_SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
 
 
 def _parse_session_path(
@@ -107,18 +104,6 @@ def _read_sink_config(wiki_path: Path) -> dict[str, Any] | None:
         return None
 
 
-def _extract_sections(text: str) -> dict[str, str]:
-    """Map H2 heading → body text up to the next H2."""
-    out: dict[str, str] = {}
-    matches = list(_SECTION_RE.finditer(text))
-    for i, m in enumerate(matches):
-        title = m.group(1).strip().lower()
-        body_start = m.end()
-        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
-        out[title] = text[body_start:body_end].strip()
-    return out
-
-
 def gather(
     *,
     wiki: str,
@@ -144,7 +129,7 @@ def gather(
             "date": str,
             "slug": str,
             "frontmatter": dict,
-            "sections": {h2_title_lower: body_text}  (when include_body_sections)
+            "body": str  (when include_body_sections)
           },
           ...
         ],
@@ -187,10 +172,6 @@ def gather(
             if md.name in incorporated or stem + ".md" in incorporated:
                 continue
             text = md.read_text(errors="replace")
-            # Session notes carry no human-only region: the note is
-            # machine-written and cleared by the publish gate, so the
-            # whole body feeds the briefing composer. (Chapter-aware
-            # gather over the new note shape is a separate slice.)
             entry: dict[str, Any] = {
                 "path": rel,
                 "date": d.isoformat(),
@@ -200,7 +181,12 @@ def gather(
             if user and entry["frontmatter"].get("user") != user:
                 continue
             if include_body_sections:
-                entry["sections"] = _extract_sections(text)
+                # Session notes carry no human-only region — machine-written
+                # and cleared by the publish gate before they land here — so
+                # the whole body (disclaimer + chronological chapters of
+                # topic blocks) feeds the briefing composer. There is no H2
+                # structure left to split on in the new note shape.
+                entry["body"] = strip_frontmatter(text).strip()
             new_sessions.append(entry)
 
     return {

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 import pytest
 from lore_cli import briefing_cmd
 from lore_core.briefing import gather, mark_incorporated, render_briefing
+from lore_core.note_document import Chapter, TopicBlock, append_chapter, close_note, create_note
 
 
 @pytest.fixture
@@ -17,31 +18,27 @@ def briefing_vault(tmp_path, monkeypatch):
     wiki = vault_root / "wiki" / "ccat"
     (wiki / "sessions").mkdir(parents=True)
 
-    def write_session(name: str, what: str, decisions: str = "") -> None:
-        body = dedent(
-            f"""\
-            ---
-            schema_version: 2
-            type: session
-            created: {name[:10]}
-            last_reviewed: {name[:10]}
-            description: "session {name}"
-            ---
-
-            ## What we worked on
-
-            {what}
-
-            ## Decisions made
-
-            {decisions or "_None_"}
-            """
+    def write_session(name: str, lead: str, decision: str = "") -> None:
+        """Write a real new-shape note: disclaimer + one chapter + one block."""
+        path = wiki / "sessions" / f"{name}.md"
+        create_note(
+            path,
+            title=name[11:],
+            description=f"session {name}",
+            scope="lore:test",
+            created=name[:10],
         )
-        (wiki / "sessions" / f"{name}.md").write_text(body)
+        append_chapter(
+            path,
+            Chapter(blocks=[TopicBlock(lead=lead, body=decision, anchor_turn=12)]),
+            slice_from_turn=1,
+            slice_to_turn=12,
+        )
+        close_note(path)
 
-    write_session("2026-04-15-fix-a", "- did the A thing")
-    write_session("2026-04-16-fix-b", "- did the B thing", "- chose option Z because Y")
-    write_session("2026-04-17-fix-c", "- did the C thing")
+    write_session("2026-04-15-fix-a", "Did the A thing.")
+    write_session("2026-04-16-fix-b", "Did the B thing.", "Chose option Z because Y.")
+    write_session("2026-04-17-fix-c", "Did the C thing.")
 
     monkeypatch.setenv("LORE_ROOT", str(vault_root))
     return vault_root, wiki
@@ -75,19 +72,22 @@ def test_gather_filters_by_since_date(briefing_vault):
     assert result["new_sessions"][0]["slug"] == "fix-c"
 
 
-def test_gather_extracts_sections(briefing_vault):
+def test_gather_includes_full_body(briefing_vault):
+    """Chapter-aware gather: the whole note body (disclaimer + chapters +
+    topic blocks) is handed over — there is no H2 structure to split on
+    in the new note shape, so full text is the only faithful extraction."""
     result = gather(wiki="ccat")
     s = next(s for s in result["new_sessions"] if s["slug"] == "fix-b")
-    assert "what we worked on" in s["sections"]
-    assert "B thing" in s["sections"]["what we worked on"]
-    assert "decisions made" in s["sections"]
-    assert "option Z" in s["sections"]["decisions made"]
+    assert "Lab-notebook session note" in s["body"]  # disclaimer travels too
+    assert "lore:chapter 1" in s["body"]
+    assert "Did the B thing." in s["body"]
+    assert "Chose option Z because Y." in s["body"]
 
 
-def test_gather_no_sections_when_disabled(briefing_vault):
+def test_gather_no_body_when_disabled(briefing_vault):
     result = gather(wiki="ccat", include_body_sections=False)
     s = result["new_sessions"][0]
-    assert "sections" not in s
+    assert "body" not in s
 
 
 def test_gather_unknown_wiki(briefing_vault):
@@ -178,7 +178,7 @@ def test_render_briefing_uses_summary_frontmatter():
                 "date": "2026-04-29",
                 "slug": "thing",
                 "frontmatter": {"summary": "shipped the thing"},
-                "sections": {},
+                "body": "**Shipped the thing.**\n\n@12",
             }
         ],
     }
@@ -189,27 +189,10 @@ def test_render_briefing_uses_summary_frontmatter():
     assert "- **thing** — shipped the thing" in out
 
 
-def test_render_briefing_falls_back_to_first_bullet():
-    result = {
-        "wiki": "ccat",
-        "today": "2026-04-29",
-        "ledger": {"last_briefing": None, "incorporated_count": 0},
-        "new_sessions": [
-            {
-                "path": "p",
-                "date": "2026-04-29",
-                "slug": "thing",
-                "frontmatter": {},
-                "sections": {"what we worked on": "- did the A thing\n- and B"},
-            }
-        ],
-    }
-    out = render_briefing(result)
-    assert "- **thing** — did the A thing" in out
-    assert "since the start" in out
-
-
 def test_render_briefing_falls_back_to_description():
+    """No `summary` frontmatter: falls straight to `description` — the new
+    note shape has no H2 sections to mine a bullet from, so there is no
+    intermediate tier between summary and description."""
     result = {
         "wiki": "ccat",
         "today": "2026-04-29",
@@ -220,12 +203,13 @@ def test_render_briefing_falls_back_to_description():
                 "date": "2026-04-29",
                 "slug": "thing",
                 "frontmatter": {"description": "fallback line"},
-                "sections": {},
+                "body": "**Did the thing.**\n\n@12",
             }
         ],
     }
     out = render_briefing(result)
     assert "- **thing** — fallback line" in out
+    assert "since the start" in out
 
 
 def test_render_briefing_groups_by_date_descending():
@@ -239,14 +223,14 @@ def test_render_briefing_groups_by_date_descending():
                 "date": "2026-04-15",
                 "slug": "older",
                 "frontmatter": {"summary": "older work"},
-                "sections": {},
+                "body": "",
             },
             {
                 "path": "p2",
                 "date": "2026-04-29",
                 "slug": "newer",
                 "frontmatter": {"summary": "newer work"},
-                "sections": {},
+                "body": "",
             },
         ],
     }
@@ -374,20 +358,20 @@ def sharded_briefing_vault(tmp_path, monkeypatch):
     sessions.mkdir(parents=True)
 
     def write(name: str, summary: str) -> None:
-        body = dedent(
-            f"""\
-            ---
-            schema_version: 2
-            type: session
-            summary: "{summary}"
-            ---
-
-            ## What we worked on
-
-            - did things
-            """
+        path = sessions / f"{name}.md"
+        create_note(
+            path,
+            title=summary,
+            description=summary,
+            scope="lore:test",
+            extra_frontmatter={"summary": summary},
         )
-        (sessions / f"{name}.md").write_text(body)
+        append_chapter(
+            path,
+            Chapter(blocks=[TopicBlock(lead="Did things.", anchor_turn=5)]),
+            slice_from_turn=1,
+            slice_to_turn=5,
+        )
 
     write("15-0900-fix-a", "fixed A")
     write("16-1200-fix-b", "fixed B")
@@ -434,20 +418,19 @@ def test_gather_sharded_without_handle(tmp_path, monkeypatch):
     wiki = vault_root / "wiki" / "demo"
     sessions = wiki / "sessions" / "2026" / "04"
     sessions.mkdir(parents=True)
-    (sessions / "29-1100-thing.md").write_text(
-        dedent(
-            """\
-            ---
-            schema_version: 2
-            type: session
-            summary: "did the thing"
-            ---
-
-            ## What we worked on
-
-            - thing
-            """
-        )
+    path = sessions / "29-1100-thing.md"
+    create_note(
+        path,
+        title="thing",
+        description="did the thing",
+        scope="lore:test",
+        extra_frontmatter={"summary": "did the thing"},
+    )
+    append_chapter(
+        path,
+        Chapter(blocks=[TopicBlock(lead="Did the thing.", anchor_turn=3)]),
+        slice_from_turn=1,
+        slice_to_turn=3,
     )
     monkeypatch.setenv("LORE_ROOT", str(vault_root))
     result = gather(wiki="demo")
@@ -506,7 +489,7 @@ def test_compose_briefing_prose_returns_llm_text():
                     "date": "2026-04-29",
                     "slug": "thing",
                     "frontmatter": {"summary": "shipped the thing"},
-                    "sections": {},
+                    "body": "**Shipped the thing.**\n\nWired up the last piece.\n\n@12",
                 }
             ],
         },
@@ -518,6 +501,8 @@ def test_compose_briefing_prose_returns_llm_text():
     prompt = fake.messages.calls[0]["messages"][0]["content"]
     assert "shipped the thing" in prompt
     assert "ccat" in prompt
+    # Full body text (not a section extract) reaches the composer prompt.
+    assert "Wired up the last piece." in prompt
 
 
 def test_compose_briefing_prose_empty_input_short_circuits():


### PR DESCRIPTION
Implements #128 (epic #131).

## Summary
Adapts briefing gather to the new note shape (disclaimer + chronological chapters of topic blocks). The two-region redaction dependency was already removed upstream (#125); this closes the remaining gap: gather's H2-heading section extraction was dead code against new-shape notes (which have no `##` headings — chapters are delimited by HTML comments, topics by bold leads), so it's replaced with a direct full-body read that feeds the briefing composer.

- `gather()`: per-session `"sections": {h2_title: text}` → `"body": str` (full text after frontmatter — disclaimer + chapters + blocks). Same `include_body_sections` flag controls whether it's populated (CLI/MCP call sites unchanged). Ledger/filtering semantics untouched.
- `compose.py`: prompt builder now includes the full body (own truncation cap, `_BODY_CAP=2000`, since bodies are the primary signal now rather than a pre-digested "what/decisions" pair) alongside `frontmatter.summary`/`description`.
- `format.py`: deterministic fallback drops the now-unreachable bullet-mining tier (there's no bullet list to mine in the new shape) and resolves `summary → description → ""`.
- No import of / reference to the deleted `regions` module anywhere in the briefing package or its tests (verified via grep).
- Publish, mark, sinks (markdown + matrix), CLI, and the MCP surface are byte-for-byte untouched (`git diff --stat` over those paths is empty).

## Red → green
Started from a green baseline (48 briefing tests passing on old-shape fixtures). Rewrote `tests/test_briefing.py`'s fixtures to build **real** new-shape notes via `lore_core.note_document.create_note`/`append_chapter` instead of hand-rolled H2 markdown, then:

- RED: `test_gather_includes_full_body` (renamed from `test_gather_extracts_sections`) failed with `KeyError: 'body'`; `test_compose_briefing_prose_returns_llm_text` failed asserting the full body reaches the LLM prompt (old code only forwarded pre-extracted sections). 2 failed / 31 passed.
- GREEN: after the gather/compose/format changes above, same file: 33 passed (net one test removed — see below).
- Full `test_briefing.py` + `test_briefing_git_coordination.py` + `test_curator_b_briefing_integration.py`: 47 passed (was 48; `test_render_briefing_falls_back_to_first_bullet` removed since the bullet-mining feature it covered no longer exists in the new note shape — `test_render_briefing_falls_back_to_description` still covers the meaningful part of the fallback chain).

Full repo suite: ran 3× (with and without this diff, via `git stash`) to characterize a pre-existing, order-dependent flakiness in the wider suite (a shifting set of ~15 unrelated tests — `test_drain_prune`, `test_log_cmd`, `test_proc_cmd`, `test_install_dispatcher`, etc. — none touching briefing/gather/compose/format/note_document). This reproduces identically on the base branch with my diff stashed out, so it predates and is independent of this change. The three baseline node IDs (`test_plugin_version_bumped_for_skill_addition`, `test_make_llm_client_openai_missing_api_key_raises`, `test_resume_subtree_aggregates_issues`) are present in every run as expected; no briefing-related test ever failed across ~4 full-suite runs.

## Lint
`ruff check` on changed files: one pre-existing UP035 hit in `compose.py` (unrelated `Callable` import, confirmed present on the base branch, not touched by this diff). `ruff format --diff`: every reported hunk is on lines this diff does not touch (confirmed identical on base branch via `git show HEAD:<file> | ruff format --diff`); no new format debt introduced, no mass reformatting.

## Test plan
- [x] `tests/test_briefing.py` (33/33)
- [x] `tests/test_briefing_git_coordination.py` (7/7)
- [x] `tests/test_curator_b_briefing_integration.py` (7/7)
- [x] Full suite: no new failures beyond baseline + pre-existing unrelated flakiness (verified via stash comparison)
- [x] `ruff check` / `ruff format --diff`: no new hits on changed lines