### PR TITLE
CONTEXT.md hard reset and stale-doc trim (#129)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,386 +1,247 @@
 # Lore — domain context
 
-Glossary of terms with tight, shared meanings. Add a term here the
-first time it gets sharpened in a grill or design discussion. If a
-term is being used loosely, sharpen it before adding.
+An AI-navigation map of Lore's domain: the terms below have one tight
+meaning each, matched against shipped code. Cross-check any claim here
+against the modules it points to before relying on it — if a term or
+behavior isn't grounded in a real symbol, it doesn't belong here.
 
-## Curators
+## Vault, wiki, scope
 
-- **Curator A** — the *session-note composer*. Runs per session (buffer
-  + flush). Reads transcript turns; writes session notes under
-  `sessions/<handle>/YYYY/MM/`. Per-session granularity.
-- **Curator B** — the *daily abstractor*. Lifted concepts / decisions /
-  papers from session notes into the wiki proper. Per-day granularity.
-  **Dormant as of v1.0.** Removed from the codebase entirely (not just
-  gated): module + tests deleted.
-- **Curator C** — the *defrag / converge pass*. Adjacent-merge,
-  auto-supersede, cross-scope hoist, orphan-link repair. Weekly
-  granularity. **Dormant as of v1.0.** Removed from the codebase
-  entirely.
+- **Vault** — the directory `$LORE_ROOT` points at. Contains one
+  `wiki/` subdirectory plus `.lore/` for derived, host-local state.
+- **Wiki** — a mounted knowledge store at `<vault>/wiki/<name>/`. Each
+  wiki is its own git repo; a vault can host several. A fresh wiki
+  (`lore wiki new`) is scaffolded with `projects/`, `concepts/`,
+  `decisions/`, `sessions/`, `inbox/` — session notes are the only one
+  of these Lore writes automatically; the rest are written directly
+  (by hand, or via `/lore:inbox`) when there's something worth a
+  standalone note.
+- **Scope** — a colon-separated namespace inside a wiki
+  (`ccat:data-center:data-transfer`), resolved from a working
+  directory by longest-prefix match against `.lore/attachments.json`.
 
-## Trust scopes — what stays vs. what goes in v1.0
+Full model (three state files, resolution order, failure modes):
+`docs/architecture/state.md`. Config precedence across CLI flag / env
+var / wiki config / root config / code default: `docs/architecture/config.md`.
 
-- **Substrate (kept):** adapters (turn extraction), `transcript_sync`
-  (gitignored per-wiki mirror), `identity` + team-mode, `.lore.yml` +
-  scope, SessionStart + turn hooks, Curator A (buffer/flush +
-  Phase-2 narration), `lore_mcp` server, `lore_search` (FTS),
-  `freshness` + verdicts, `drain` + run_log, `git_sync`, inbox.
-- **Journals (kept):** `lore_core/journal.py` + `lore_journal_*`
-  MCP handlers. Reason: pure user/AI scratch — no LLM abstraction,
-  no propagation, no trust claim. Survives the trim risk-free.
-- **Removed:** Curator B, Curator C, surfaces, briefings. Code + tests
-  deleted; user-facing skill entries removed.
+## The session note
 
-### Removal is not a clean delete — entanglements (mapped 2026-05-20)
+Every Claude Code session that does real work gets **one session
+note** — a markdown file under `<wiki>/sessions/[<handle>/]YYYY/MM/`.
+It is a **lab notebook**, not a source of truth: git owns what
+happened to the code, the connected repo's ADRs and PRDs own what was
+decided and why. The note records what a session discussed and tried,
+nothing more.
 
-Six consumer sites in KEEP code reference REMOVE code; each is
-rewired or its dependency salvaged:
-1. `lore_curator/__init__.py:27` exports `run_curator_c` → drop export.
-2. `lore_cli/curator_cmd.py` imports B + C runners → drop those subcommands.
-3. `lore_cli/briefing_cmd.py` → delete the command.
-4. `lore_mcp/server.py` dispatch → drop `handle_briefing_gather`,
-   `handle_surface_context`, `handle_surface_validate`. **Keep**
-   `handle_journal_write/read` (journals stay).
-5. `lore_core/lint.py:967` imports `find_orphan_links` from
-   `c_orphan_links` — **load-bearing for PRD #65 freshness** (orphan
-   set feeds the read-time staleness check). **Salvage:** relocate
-   `find_orphan_links` into lint/freshness; do NOT delete with C.
-6. `lore_core/schema.py`, `git_sync.py`, `scopes_cmd.py` import from
-   `lore_core/surfaces.py`. Decompose surfaces.py:
-   - **Salvage** `rewrite_scopes_in_frontmatter` (scope rewriting is a
-     KEEP primitive) → relocate to a scope module.
-   - **Remove** surface-aware schema validation (`required_fields_for`
-     via SURFACES.md) — moot once v3 notes have fixed schema fields
-     and surface-typed notes are gone.
+Core module: `lore_core/note_document.py`. Vocabulary, all defined
+there:
 
-The deletion set is ~80% clean; the salvage list is small and
-determined (orphan-link detection + scope rewriting).
+- **Disclaimer** — a fixed, machine-written paragraph (`DISCLAIMER` in
+  `note_document.py`) that opens every note and travels with every
+  MCP pull. It states the note's genre in one place so no reader — human
+  or agent — mistakes a lab record for a directive.
+- **Chapter** — one chunk of the note, corresponding to one *flush*
+  (see below). Chapters are strictly chronological and never edited
+  once appended; the note is append-only until it closes.
+- **Topic block** — one topic within a chapter: a bold, one-sentence,
+  self-sufficient **lead** (must stand alone — no pronoun reaching into
+  the body), an optional short prose **body**, and exactly one `@N`
+  **anchor** at the end pointing at the transcript turn where the topic
+  started.
+- **Continuation block** — a topic block that resumes or corrects a
+  topic raised in an earlier chapter. Renders as `**Continued: <topic>**`
+  instead of a fresh lead. Earlier blocks are never rewritten; a
+  correction always arrives as a new block later in the note.
+- **Skim layer** — the sequence of bold leads read top-to-bottom,
+  ignoring the bodies. Because every lead is self-sufficient, the skim
+  layer alone is a legible, boom-boom-boom summary of the whole
+  session; the bodies are there for whoever wants the detail.
+- **Marker chapter** — a chapter written by the *system*, not an LLM:
+  deterministic text recording that a chapter was **withheld** (gate
+  rejected it) or **failed** (composition never produced anything
+  anchor-clean). See `MARKER_WITHHELD` / `MARKER_FAILED` and
+  `append_marker_chapter` in `note_document.py`.
 
-### Implementation ordering — decouple early, delete late (decided 2026-05-20)
+Frontmatter is machine-first and deterministic: `note_status`
+(`open`/`closed`), the `chapters` list (each entry's turn range and
+kind), and a cumulative `SessionFacts` snapshot (commits, PRs,
+files touched/read, duration) that only ever grows. Nothing in
+frontmatter is re-narrated in the body.
 
-Interleaved (c):
-- **Now:** disable B/C/surfaces/briefing entry points (no runs, no MCP
-  exposure, no skill entries) AND do the salvage relocations
-  (orphan-links → freshness, scope-rewrite → scope module) so KEEP
-  code no longer imports REMOVE code. Leave the dormant module *files*
-  on disk.
-- **After pilot green:** delete the dormant files + tests in one sweep.
+## Writing a note — buffer, flush, compose
 
-Principle: decouple early (safe, reversible — moving functions, not
-deleting capability); delete late (irreversible — gate behind proof).
-Pure remove-first is rejected: it deletes the only working note-
-abstraction machinery before the v3 replacement is proven.
+A session's turns accumulate in a per-transcript **buffer**
+(`lore_curator/buffer_store.py`), driven by Curator A's heartbeat
+(`lore_curator/session_curator.py`, `run_curator_a`) on ordinary
+Claude Code hook activity — there is no cron. The first heartbeat for
+a session creates the note (disclaimer + frontmatter, zero chapters:
+`lore_curator/session_note.py:ensure_note`); later heartbeats just
+grow the buffer.
 
-## The trustworthy-note substrate (from `lore-experiments`)
+A **flush** turns the buffer's not-yet-composed slice into one
+chapter (`lore_curator/chapter_flush.py`):
 
-The session-note model that the experiments converged on (and the
-v1.0 candidate substrate) is **P1 — structured claims with
-`evidence_turns`**, deterministically rendered to markdown. The LLM
-never writes markdown; it emits structured data and a pure renderer
-produces the body.
+```
+read note-so-far + slice → compose_chapter (1 LLM call, ≤2 attempts)
+                          → publish gate
+                          → append_chapter | withheld marker + quarantine | failed marker
+```
 
-- **Composer schema** (`lore-experiments/005/schemas/claims_v1.json`):
-  - `title` — 6–10 words, content-named
-  - `summary_lede` — one sentence (≤220 chars), names what the
-    session worked on and what changed/landed/was decided
-  - `claims[]` — atomic propositions; required fields:
-    - `text` — one-sentence claim (10–30 words), self-explaining
-    - `kind` — one of: `decision | tried | leaning | open | done | context`
-    - `evidence_turns: int[]` — non-empty list of turn indices that
-      support the claim (`minItems: 1`, `maxItems: 4`)
-- **Deterministic renderer** (`render_claims.py`): groups by `kind`
-  in a fixed section order (Decisions / Tried / Leaning / Done /
-  Open / Context), one bullet per claim with `[@<turn>, @<turn>]`
-  appended verbatim. No inline weaving, no LLM-authored markdown.
+`lore_curator/chapter_compose.py:compose_chapter` is **one LLM call**
+per chapter — every turn is read by an LLM exactly once, no separate
+outline pass. The prompt includes the complete note-so-far (so a topic
+left open earlier and resolved now becomes a continuation block) and
+the unflushed transcript slice. Between the (at most two) attempts, a
+deterministic **anchor lint** (`chapter_anchor_lint`) rejects any `@N`
+outside the slice's turn range, and the publish gate may withhold the
+result — either verdict feeds corrective text into the retry.
 
-### Two axes: `kind` vs. `status` (decided 2026-05-20)
+Flush triggers (unchanged, buffer cap 120 turns / 240K chars,
+pre-compact, session-end) fire either an **in-place** flush (buffer
+stays open, note keeps growing — cap-trip, pre-compact) or a
+**close** flush (buffer archives, note closes — session-end, reaper,
+sweep). See `FLUSH_DEFAULT_CAP_TURNS` / `FLUSH_DEFAULT_CAP_CHARS` in
+`chapter_flush.py`; per-wiki overrides live in `.lore-wiki.yml` under
+`curator.synthesis_buffer_cap_*`.
 
-A claim carries two orthogonal labels:
-- **`kind`** — what kind of statement this is *at its cited moment*:
-  `decision | tried | leaning | open | done | context`. Set at Stage 1.
-- **`status`** — whether it survived to session end:
-  `active | superseded | tentative`. Set at Stage 3.
+### Failure and give-up semantics
 
-`{kind: decision, status: superseded}` is coherent: "decided Haiku at
-@47, later superseded by the Sonnet decision at @153." The two never
-collapse into each other.
+- **Mid-session failure is silent.** No marker while a retry chance
+  remains — the buffer keeps accumulating and the next trigger retries
+  with the grown slice (`flush_attempts` counts the misses).
+- **Give-up bound.** A buffer with a prior failed attempt that grows to
+  2x the cap gets a deterministic *failed* marker chapter for that span
+  and a fresh buffer — the note stays open, one session stays one note.
+- **Session-end failure** writes the failed marker and closes the note
+  regardless.
+- **Startup sweep.** Lore acts as a singleton at start (global lock,
+  `lore_core.lockfile.curator_lock`): `chapter_flush.startup_sweep`
+  finds buffers whose owning process is provably dead, gives each one
+  compose attempt, and closes its note either way (composed, withheld,
+  or failed marker) — a crashed session never leaves an open note
+  behind. `lore curator sweep` runs this by hand.
 
-### The `decision` kind — kind-aware verification (decided 2026-05-20)
+## The publish gate + quarantine
 
-`decision` is the schema's footgun (005: Mistral over-tags proposals
-as decisions; this is a *kind* error that passes ordinary Stage 2
-because the quote still supports the text). We keep `decision`
-(it is the highest-value signal for a knowledge graph) but harden it:
-- Stage 2's semantic judge is **kind-aware**. For `kind=decision` the
-  test is stricter: "Does the quote show a *ratified choice* (X
-  conclusively picked over Y), not a proposal or a leaning?"
-- A failed `decision` may be **demoted** `decision`→`leaning` as a
-  repair outcome — a controlled exception to the no-rewrite rule.
-  Rationale: demotion lowers a claim's *certainty* to match the
-  evidence (honest), unlike text-weakening which hides *content*.
-  The allowed repair ladder is certainty-lowering only.
+Every composed chapter passes `lore_core/publish_gate.py:evaluate`
+before it can join the shared note — this is the last check between an
+LLM's output and the shared vault, and it **fails closed**: any error
+anywhere in the gate withholds rather than passes.
 
-### What the experiments establish about this substrate
+Cheapest-first, short-circuiting on the first hit:
 
-- **Structural grounding works.** 005-P1 achieved 0/88 `from_example`
-  and 2/88 (2.3%) `unsupported` claims across both local models —
-  on the harder discussion-shape input.
-- **Local-judge is dead.** 006a closed the door at 0%
-  `contradicted`-recall, even with `reasoning_effort=high`. Locals
-  cannot critique their own narration.
-- **Ship lever for local models: `reasoning_effort=high` at narrate
-  time.** 007 baseline at GPT-OSS-120B reasoning=high hit 0.89 mean,
-  2 contradicted, 0 unsupported. Every probe regressed against it.
-- **The `decision` kind is the schema's weak spot.** Mistral over-
-  applies it to proposed-but-not-ratified items. Mitigation pending
-  in v1.0 (drop / tighten / move to a separate field).
+1. **Deterministic scanners** — high-entropy secrets (via
+   `lore_core.redaction`), email addresses, phone numbers.
+2. **Deterministic phrasing lint** — TODO/FIXME, an imperative-verb
+   bold lead, or must/should task language. The note is a past-tense
+   lab record, never a directive; a lint hit counts as a compose
+   failure and its feedback drives the retry.
+3. **One small-model detection call** (`LlmPiiDetector`, cheapest
+   tier) for fuzzy PII/secrets that slip the first two layers. This is
+   pattern recognition, not truth verification, so it's exempt from
+   the no-LLM-judges-LLM rule — but it's a tripwire, not a guarantee,
+   and is documented as such here and in the module docstring.
 
-### What "trustworthy" means here
+On a withhold, `apply_withhold` runs the two terminal side-effects:
+a deterministic withheld-marker chapter goes into the note (safe,
+value-free reason text — the category, never the matched string), and
+the full composed text goes into the private **quarantine** sidecar
+(`lore_core/quarantine.py`, one JSON file per entry under
+`.lore/quarantine/`, inside the already-private `.lore/` area — it
+never reaches the shared wiki). `lore quarantine list/show/clear/kill`
+is the reviewer's flow over that sidecar; `list` never prints body
+content, since an entry may hold the very secret that tripped the
+gate.
 
-A claim is **structurally grounded** when its `evidence_turns` resolve
-to existing turns in a stored transcript. The current bar is
-**existence-only** — the validator can prove "these turn indices
-exist," not "these turns *support* the claim text."
+## Hygiene — the retained frontmatter-only curator
 
-**Four candidate bars** (in order of strength + cost):
-- **(a) Existence-only** — turn indices resolve.
-- **(b) Verbatim-quote** — schema adds `quote`; substring check.
-- **(c) Fuzzy-quote** — quote near-match (n-gram / Levenshtein).
-- **(d) Supports-by-judge** — second LLM call decides semantic support.
+`lore curator [--wiki] [--apply]` (bare, no subcommand — distinct from
+`lore curator run`, which is the Curator A pass above) runs
+deterministic, frontmatter-only passes over every wiki
+(`lore_curator/hygiene.py`): supersession propagation
+(`supersedes [[B]]` → `superseded_by: [[A]]` on B), `implements:`
+back-link processing, git-log date backfill, and a team-mode hint once
+a solo wiki's git log shows multiple authors. Staleness is a deliberate
+no-op here — see `lore_core/freshness.py` below. Findings land in
+`wiki/<name>/_review.md`; writes are mtime-guarded so a note open in
+Obsidian is skipped rather than clobbered. `--apply` is required to
+write; the default is a dry-run.
 
-**(d) splits into two sub-bars:**
-- **(d-batch)** — atomize-and-judge whole narrative at once. What
-  006a tested. Locals: 0% contradicted-recall. Dead.
-- **(d-narrow)** — per-claim binary: "Does turn N support claim X
-  given quote Q?" *Not yet tested.* Hypothesis: locals can do narrow
-  yes/no even when they fail batch atomization. Would unlock (d) for
-  local-first deployment.
+## Briefings
 
-### The retraction-over-circles problem (separate from the trust bar)
+`lore_core/briefing/gather.py:gather()` is the read-only half of
+`lore briefing`: it collects session notes filed since the last
+briefing (tracked in a per-wiki ledger) and hands their **full note
+bodies** — disclaimer plus every chronological chapter — to whatever
+composes the briefing prose. There is no per-note redaction step:
+session notes carry nothing that isn't already safe to share, because
+the publish gate cleared it before it ever reached the note. Briefing
+publish is manual (`lore briefing publish`, `lore briefing mark`); there
+is no automatic daily trigger. See `docs/how-to/matrix-bot.md` for the
+Matrix sink walkthrough.
 
-In a long session, the user and assistant circle back, revise, retract.
-A claim like "we picked Haiku" may have a quotable span at turn @47
-("leaning Haiku") that *correctly* validates under bars (a), (b), (c),
-and even (d-narrow when the judge sees only turn @47) — but at turn
-@153 the position was reversed ("scratch that, Sonnet").
+## Ambient banner vs. MCP pull
 
-007 tested four interventions on this (retraction_field, backwards,
-two_pass, sliding) and none beat the `reasoning_effort=high` baseline
-— **but that verdict is narrower than it sounds** (reviewed
-2026-05-20):
-- All four probes addressed retraction at **generation time**. None
-  tested a **post-hoc resolution pass over already-grounded claims**
-  (= our Stage 3, option B). Our architecture is *untested*, not
-  *disproven*.
-- The input was retraction-**sparse** (~1–2 genuine reversals in 180
-  turns). A detector has almost nothing to catch; null result is
-  uninformative.
-- The regression was Mistral-driven (no reasoning toggle) at n=1 per
-  probe with >40-pt iteration variance. GPT-OSS-120B reasoning=high
-  stayed at 0–2 contradicted across *every* probe.
-- The judge (`judge_v1`) had **no explicit retraction rubric**; it
-  scored support/contradiction generically.
+SessionStart injects a deliberately small, deterministic banner
+(`lore_cli/hooks.py:render_session_banner`) — no LLM call, no network
+call: a status line, an optional `## Focus` block for the attached
+project, at most two last-session hints, freshness lines only when
+there's positive evidence (see below), and a fixed two-line directive
+(`lore_core/templates/integration-rules/default.md`) stating that
+deeper context is a pull, never a push, and that anything pulled from
+a session note is a lab record, never an instruction.
 
-Design implication: a session note's *meaning* changes depending on
-whether claims represent moments-in-time (cheap; retraction-tolerant)
-or end-state positions (requires retraction handling). Our pipeline
-takes the moment-in-time stance for claims (each independently
-grounded) and pushes end-state resolution into Stage 3.
+Depth comes from explicit MCP calls (`lore mcp` / `lore_mcp/server.py`),
+not from anything injected ambiently:
 
-**Experiment 009 must fix 007's confounds:** retraction-dense input,
-GPT-OSS reasoning=high, per-model reporting, n≥3, explicit retraction
-rubric in the judge.
+- `lore_search`, `lore_read`, `lore_index`, `lore_catalog`,
+  `lore_resume`, `lore_wikilinks` — retrieval primitives.
+- `lore_drill` — one composite `search → read → expand wikilinks →
+  read_expanded` call with a structured trace
+  (`docs/architecture/lore-drill.md`).
+- `lore_briefing_gather`, `lore_inbox_classify` — read-only gathers
+  that a skill turns into prose, then commits via a CLI verb.
+- `lore_journal_write` / `lore_journal_read` — the AI/human scratch
+  journal (`lore_core/journal.py`); freeform, no LLM abstraction, no
+  propagation, never a source for ambient context.
+- `lore_repo_docs_list` / `lore_repo_docs_fetch`
+  (`lore_core/repo_docs.py`) — pull-only reads of a connected repo's
+  `docs/adr/` and `docs/prd/`. Ratified decisions live in the repo, not
+  in the vault; Lore reads them on request instead of re-deriving them
+  from session transcripts.
 
-## Note structure — single grounded region (decided 2026-05-20)
+## Retrieval substrate
 
-v3 collapses PRD #92's two-region (reload-safe + human-only) split to
-a **single grounded region**. The whole note is retrieval-safe by
-construction:
-- **Title** — model-authored navigational label (ungrounded by design;
-  it's a label, not a claim).
-- **Lede** — grounded (`lede_claims`, Stage-2 verified).
-- **Body** — grounded (`claims`, Stage-2 verified).
-- **Frontmatter** — mechanical/derived (files, projects, dates), not
-  LLM claims.
+Kept, general-purpose, and independent of the note-writing pipeline
+above:
 
-Rationale: the human-only region existed to quarantine ungrounded
-model prose. The new pipeline doesn't *produce* ungrounded prose, so
-there is nothing to quarantine. A "give me flowing prose" instinct is
-served by the grounded resolved lede, not by an ungrounded narrative
-region (which would reintroduce the `18-1526` human-misleading
-failure mode the trim exists to kill). User scratch narrative lives in
-the kept **journal** side-chain, not in the session note.
+- **Freshness** (`lore_core/freshness.py`) — positive-evidence-only
+  staleness: a note is only ever flagged `stale-candidate` because of
+  a named cause (an authored `status: stale` / `superseded_by` /
+  `supersede_candidate*` marker, or membership in the orphan-link set).
+  Age by itself never flags anything.
+- **Search** (`lore_search`) — hybrid ranked full-text search backing
+  `lore_search` / `lore_resume` / `lore_drill`.
+- **Wikilinks** (`lore_core/wikilinks.py`, `schema.py`) — `[[slug]]`
+  parsing/resolution, per-wiki only (a wikilink never resolves across
+  wiki boundaries — wikis are portable units).
 
-## Citation unit
+## Module map
 
-The unit that carries a citation is the **claim** (one entry in the
-`claims[]` array). Not the bullet, not the sentence, not the section.
-The rendered bullet inherits the claim's `evidence_turns`. The
-deterministic renderer is the bridge between the structured form
-(grounded) and the markdown form (read by humans / retrieved by
-agents).
-
-## v1.0 pipeline — three stages
-
-**Stage 1 — Generation (1 LLM call).**
-Curator emits P1-extended schema:
-- `title` — 6–10 words, content-named (as P1).
-- `lede_claims[]` — 1–3 entries, same shape as a body claim:
-  `{text, kind, evidence_turns, quote}`. Renderer concatenates
-  these into the note's top-of-page lede paragraph. They go
-  through Stage 2 verification just like body claims.
-- `claims[]` — body propositions. Each: `{text, kind,
-  evidence_turns, quote}`. The `quote` field is a verbatim substring
-  from at least one of the cited turns. Schema requires non-empty
-  `quote` and non-empty `evidence_turns`.
-
-The most-read part of the note (the lede) is subject to the same
-per-claim verification as the body. No section is exempt.
-
-**Stage 2 — Per-claim verification, two passes (decided 2026-05-20).**
-
-Two checks define pass/fail for any claim:
-- **Mechanical (cheap, runs first):** `claim.quote in turn.content`
-  for at least one cited turn. No LLM call needed.
-- **Semantic (LLM judge, narrow binary):** "Given quote Q from
-  turn N and claim C, does Q support C?"
-
-*Pass 1 — parallel triage.* Verify all candidate claims independently
-and in parallel. Partition into `verified` and `failed`. The bulk
-clears here.
-
-*Pass 2 — sequential repair (accumulating context).* Process `failed`
-claims one at a time, **chronologically by first evidence turn**, so
-the verified set grows in the session's natural order. Each retry
-call sees:
-- the failed claim + the **exact** failure reason + the cited turn's
-  actual text (turns "guess a quote" into "copy a span")
-- the **current `verified` set** (grows as repairs succeed)
-Allowed outcomes: **re-cite** (pick a supporting turn+quote) /
-**drop-as-redundant** (already covered by a verified claim) /
-**drop-as-contradictory** (conflicts with a verified claim) /
-**drop-as-unsupported**. No claim-text weakening.
-On success → claim joins `verified` (visible to the next repair).
-On retry-cap exhaustion (default 2 per claim, tunable) → drop.
-
-Effect: Pass 2 begins doing Stage 3's coherence work — contradictions
-against the trusted core surface during repair, not only at synthesis.
-Costs: Pass 2 is serial (slow if failures are heavy); per-call context
-grows; outcome is order-dependent (mitigated by chronological order).
-
-**Terminal trust outcome (a)+(e) — three tiers:**
-- `trusted`   — all lede claims pass AND ≥80% body claims survive.
-- `degraded`  — all lede claims pass AND ≥50% body claims survive.
-- `failed`    — a lede claim was dropped, OR survival <50%. Note is
-  written to disk for human review but **excluded from retrieval**.
-Thresholds are placeholders; pilot data tunes them.
-
-Open sub-decisions (defaults proposed):
-- Retry granularity: per-claim calls (consistent with the narrow-call
-  architecture) vs. one batched corrective call for all failures.
-  *Default: per-claim.*
-- What retry may change: citation-only (pick a better turn+quote) vs.
-  also allow claim-text refinement. Allowing text-rewrite risks the
-  model weakening claims to pass the check. *Default: citation-only;
-  text-rewrite deferred.*
-- Retry cap shape: per-claim cap vs. per-note global budget.
-  *Default: per-claim cap = 2.*
-
-Surviving claims become inputs to Stage 3.
-
-**Stage 3 — Cross-claim resolution + resolved lede (1 LLM call).**
-Input: the verified-claim set (no transcript re-read). Outputs:
-- A **resolved lede** reflecting the verified end-state.
-- A **claim status map**: per claim, `{status: active | superseded
-  | tentative, superseded_by: <claim_id> | null}`.
-Renderer uses these to hide / move / strike-through superseded claims
-and to put the resolved lede at the top.
-
-**Render — deterministic.** No LLM call. `render_claims.py`-shaped:
-group active claims by `kind`, append `[@N]` citations verbatim,
-render superseded claims to a "Reversed / superseded" section (or
-omit, depending on note-shape design).
-
-Total cost: 1 + N + 1 ≈ 7–17 calls per session for a typical 5–15
-candidate-claim note. Local-friendly if narrow judges calibrate
-(unmeasured — needs experiments 008 + 009).
-
-## When the pipeline runs — two-phase, deferred (decided 2026-05-20)
-
-- **At session boundary (SessionEnd / PreCompact):** write the
-  existing live **stub** immediately (crash-safe, instant). Stub is
-  filtered from retrieval.
-- **Detached afterward:** the full 3-stage pipeline runs as a
-  background job and flushes the stub → verified note when done. The
-  user never waits; the note "ripens" over the following minutes and
-  is ready by next SessionStart.
-- **Self-healing:** on SessionStart, if a pending stub older than X
-  has no verified note, resume its pipeline (rides the existing
-  heartbeat/SessionStart machinery). Survives laptop sleep / closed
-  sessions.
-
-This preserves "capture is automatic, never ask" and keeps latency
-invisible (nothing waits on the note in the session that produced it).
-
-## Existing vault content — operational cleanup, not tooling (decided 2026-05-20)
-
-v1.0 does **not** build a `trust: legacy` quarantine system (no
-retrieval filter for legacy, no in-body banner, no flag migration).
-The maintainer removes untrusted content at the source:
-- **v2 session notes:** mostly already removed manually. Worth-keeping
-  sessions get **re-derived** by re-running the v3 pipeline over the
-  surviving transcript mirror — but **only once the pipeline is
-  earned** (post-pilot), and only where the transcript still exists.
-  This is the eventual answer to "what about old notes," gated on
-  proof, not assumed.
-- **Concepts (ccat wiki):** `git revert` the wiki repo's `concepts/`
-  to the commit just before Curator B began writing into it. Accepts
-  loss of any hand-written concepts since lore started (judged
-  acceptable for ccat).
-- **Concepts (private wiki):** cut back manually (surgical — private
-  has hand-written concepts worth keeping).
-
-Note: `trust: trusted | degraded | failed` (the three-tier outcome
-for *newly produced* v3 notes) is unaffected — it is a different
-mechanism from legacy quarantine, which is dropped.
-
-## The earn-gate — pre-committed thresholds (decided 2026-05-20)
-
-Both the dormant-file deletion (ordering step 2) and old-note
-re-derivation gate on "pilot green." Green = all hard gates pass.
-Pre-committing the numbers is what keeps the verdict honest (per
-006a/007 methodology).
-
-| Metric | Threshold | Gate type |
-|---|---|---|
-| **008** narrow-judge contradicted-recall vs Opus | **≥70%** | **HARD** — no judge = hollow Stage 2 |
-| **009** supersession-recall, retraction-dense input | **≥60%** | **DEGRADE** — miss → ship time-anchored claims, defer Stage 3 cross-claim resolution to 1.x |
-| **Regression** end-to-end published-claim factuality (Opus audit) | **≥0.85 mean** | **HARD** — quote requirement must not tank factuality |
-| **Survival liveness** — ≥1 claim rejected per N pilot sessions | rejection observed | **HARD** — verification must demonstrably bite (replaces a survival-rate ceiling, which would wrongly penalize a genuinely good model) |
-| **Survival floor** — candidate claims passing verification | **≥40%** | **HARD** — below 40% notes are too thin |
-| **Pilot latency** — deferred pipeline completion | **<10 min/session p90** | **HARD** — notes must ripen before next session |
-
-**Halt-vs-degrade:** 008 is load-bearing (the whole verify
-architecture is hollow without a working narrow judge) → hard gate.
-009 is a nice-to-have (time-anchored claims are honest without
-supersession resolution) → a miss degrades scope rather than blocking
-the release.
-
-**Pilot scope:** both `private` (discussion-heavy) AND `ccat`
-(work-grind). The 003/004 input-class finding warns that
-single-class piloting misleads — factuality and selection effects
-reverse across input class.
-
-## Experiments still needed before locking v1.0
-
-- **008 — narrow per-claim verifier calibration.** Does a local model
-  doing the bar-(b)+bar-(d-narrow) per-claim check calibrate against
-  Opus? 006a's failure was on the *batch* version; per-claim has not
-  been measured. Reuse 005's claims + 002's judge as ground truth.
-- **009 — cross-claim contradiction detection.** Does a local model
-  given verified claim-text-only input correctly identify supersession
-  ("leaning Haiku [@47]" superseded by "decided Sonnet [@153]")? Must
-  fix 007's confounds: retraction-dense input, GPT-OSS reasoning=high,
-  per-model reporting, n≥3, explicit retraction rubric in the judge.
-- **regression test** — does forcing a `quote` field at Stage 1 hurt
-  the 005-P1 / 007-baseline factuality numbers (0.89 mean)?
+| Concern | Module |
+|---|---|
+| Session note document (chapters, disclaimer, lifecycle) | `lore_core/note_document.py` |
+| Publish gate (scanners, phrasing lint, detector, withhold) | `lore_core/publish_gate.py` |
+| Private quarantine sidecar | `lore_core/quarantine.py` |
+| One-call chapter composer + anchor lint | `lore_curator/chapter_compose.py` |
+| Flush lifecycle (compose → gate → append/marker), give-up, sweep | `lore_curator/chapter_flush.py` |
+| Buffer-and-flush heartbeat (Curator A pass) | `lore_curator/session_curator.py` |
+| Buffer storage + sidecar state machine | `lore_curator/buffer_store.py` |
+| Note creation from a buffer (heartbeat + flush both call this) | `lore_curator/session_note.py` |
+| Frontmatter-only hygiene passes | `lore_curator/hygiene.py` |
+| Briefing gather (read-only) | `lore_core/briefing/gather.py` |
+| Repo ADR/PRD pull (filesystem side) | `lore_core/repo_docs.py` |
+| MCP server (tool dispatch) | `lore_mcp/server.py` |
+| SessionStart / PreCompact banner + hooks | `lore_cli/hooks.py` |
+| Freshness classification | `lore_core/freshness.py` |
+| Vault/wiki/scope resolution | `lore_core/scope_resolver.py`, `lore_core/state/` |

--- a/README.md
+++ b/README.md
@@ -5,13 +5,9 @@ auto-extracted into durable knowledge, repo-scoped context injected at
 session start, pluggable team briefings. No vector DB needed for small
 vaults; a full hybrid search + MCP server for larger ones.
 
-> ⚠️ **Work in progress — 0.1 alpha.** APIs, hook contracts, skill
-> surfaces, frontmatter schema, and CLI flags are all still changing.
-> Expect breakage. Not recommended for wikis you can't re-linter into
-> shape. Core linter + schema + migration are in place; session
-> pipeline, search, MCP, curator, and the scope/team/identity MVP
-> (tracked in [#3](https://github.com/buchbend/lore/issues/3)) are
-> under active implementation. No stability guarantee until 0.2.
+> ⚠️ **Pre-1.0.** APIs, hook contracts, skill surfaces, frontmatter
+> schema, and CLI flags can still change between minor versions. Not
+> recommended for wikis you can't re-migrate into shape.
 
 ## The pitch
 
@@ -20,18 +16,20 @@ threads live in a chat window that disappears. PRs capture the diff;
 nothing captures *why*. Lore closes the loop:
 
 ```
-Session with AI  →  (auto at SessionEnd / PreCompact)
-                 →  transcript captured, session note filed (draft:true)
-                 →  daily: Curator B abstracts concepts / decisions / results
-                 →  briefing published to configured sinks
-                 →  graph surfaces at next SessionStart, scoped
-                    to the repo you're in
+Session with AI  →  (auto at SessionEnd / PreCompact / cap-trip)
+                 →  transcript captured into a per-session buffer
+                 →  one chapter composed per flush, gated for PII/
+                    secrets/directive phrasing before it's appended
+                 →  one lab-notebook session note per session,
+                    readable via MCP pull at next SessionStart
 ```
 
-The flagship is the **session-note pipeline**. As of the work on `main`
-(Plans 1 + 2 of the passive-capture roadmap), capture is automatic —
+The flagship is the **session-note pipeline**: capture is automatic —
 no explicit capture command needed. See the "Bootstrap" section below.
-Everything else (search, MCP, curator C) serves the same pipeline.
+Everything else (search, MCP, hygiene curator) serves the same
+pipeline. Ratified decisions live in the connected repo's ADRs/PRDs,
+pulled on demand via MCP — Lore does not extract decisions from
+transcripts.
 
 ## Canonical shape
 
@@ -147,13 +145,15 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the editable-from-checkout
 recipe. Same recipe is the path for installs on machines without
 network egress to PyPI / the marketplace.
 
-## Bootstrap: passive capture (new, on `main`)
+## Bootstrap: passive capture
 
-As of the work on `main` (see
-`docs/superpowers/specs/2026-04-19-passive-capture-v1-design.md`),
-session notes auto-extract from Claude Code transcripts; explicit
-capture commands are no longer needed. Surfaces (concepts, decisions,
-results, …) are abstracted daily by Curator B.
+Session notes auto-extract from Claude Code transcripts; explicit
+capture commands are no longer needed. Each session's turns accumulate
+in a buffer and are composed into chapters of a single, per-session
+lab-notebook note (see `CONTEXT.md` for the full model). Anything else
+in a wiki — concepts, decisions, projects, reference notes — is
+written directly, by hand or via `/lore:inbox`; there is no automatic
+daily abstraction pass.
 
 ### Update from an older install
 
@@ -201,59 +201,40 @@ lore attach
 Interactive — asks for wiki + scope, writes the managed block to
 `CLAUDE.md`. Idempotent; safe to re-run.
 
-### Bootstrap a wiki with surfaces
-
-If you're creating a new wiki, declare which surfaces Curator B should
-extract:
-
-```bash
-lore wiki new team-wiki --surfaces standard  # concept + decision + session
-# other templates:
-lore wiki new research --surfaces science    # + paper + result
-lore wiki new product --surfaces design      # + artefact + critique
-lore wiki new scratch --surfaces custom      # skeleton you fill yourself
-```
-
-`SURFACES.md` is human-editable markdown with embedded YAML. Two ways
-to author and maintain it:
-
-- **Interactive, LLM-guided:** `/lore:surface <wiki>` opens with one
-  dispatch question — *add* a new surface or *redesign* the full set —
-  and routes to either flow. Both commit through
-  `lore surface commit <path>`.
-- **Scripted / automation / no-LLM:** write a `draft.json` (schema:
-  `lore.surface.draft/1`) and run `lore surface commit <path>`. This
-  is also how the skill writes under the hood.
-  `lore wiki new <name> --surfaces <template>` (above) remains the
-  fastest way to seed a wiki headlessly.
-
-The interactive flow requires `claude` on PATH. The `commit` primitive
-does not. Run `lore surface lint` anytime to validate the file.
-
-See `docs/superpowers/specs/2026-04-20-surface-authoring-design.md` for
-the full design.
-
 ### What runs automatically
 
 Once attached with a wiki present:
 
-- **Claude Code SessionEnd / PreCompact hooks** update the sidecar
-  transcript ledger. No LLM in the hook itself; Curator A runs in a
-  detached background subprocess when pending work crosses threshold.
-- **First SessionStart of each calendar day** also spawns Curator B
-  for the attached wiki (graph abstraction) and publishes a briefing
-  if configured. All detached — SessionStart never blocks.
-- **Banner at SessionStart** shows pending state:
-  `lore: 3 pending · last curator 2h ago · briefing yesterday`.
-  `lore!:` prefix flags actionable errors (broken SURFACES.md, etc.).
+- **Claude Code SessionEnd / PreCompact hooks**, plus ordinary tool
+  activity, drive a per-session buffer-and-flush heartbeat — no cron.
+  A flush composes one chapter (one LLM call) from the buffered slice
+  and appends it to the session's note, behind the publish gate. No
+  LLM runs inline in the hook itself; the flush is detached.
+- **SessionStart** also sweeps any session whose owning process is
+  provably dead (crash, closed laptop lid) — its note gets one compose
+  attempt and closes, under a global singleton lock. All detached —
+  SessionStart never blocks.
+- **Banner at SessionStart** is deliberately minimal: a status line, an
+  optional Focus block, at most two last-session hints, freshness
+  lines only on positive evidence, and a fixed directive pointing at
+  MCP pull for anything deeper. `lore!:` prefix flags actionable
+  errors.
 
 ### Manual escape hatches
 
 - `lore ingest --from <file.jsonl> --integration cursor --directory <cwd>` —
   ingest a transcript from any integration lore doesn't auto-capture.
-- `lore curator run` — run Curator A now.
-- `lore curator run --abstract [--wiki <name>]` — run A then B.
-- `lore curator run --abstract --dry-run` — see what would happen.
+- `lore curator run` — run the buffer/flush heartbeat now (files
+  session notes from pending transcripts).
+- `lore curator flush <buffer-sidecar>` — run the flush worker for one
+  buffer directly.
+- `lore curator sweep` — close every dead session's note now, under
+  the singleton lock.
+- `lore curator reap` — force-flush buffers whose owning session
+  crashed.
+- `lore curator [--wiki <name>] [--apply]` — the frontmatter-only
+  hygiene pass (supersession, `implements:` back-links, git-date
+  backfill, team-mode hint); dry-run by default.
 - `lore registry ls` / `lore registry doctor` —
   list configured wikis and validate them. (For looking up the
   attachment covering a specific path, use `lore attachments show
@@ -269,18 +250,17 @@ git:
   auto_push: false              # push manually by default
   auto_pull: true
 curator:
-  threshold_pending: 3          # spawn Curator A when ≥ N pending
-  threshold_tokens: 50000       # OR ≥ M tokens accumulated
+  threshold_pending_turns: 30   # spawn the heartbeat when ≥ N buffered turns
+  max_pending_age_s: 600        # OR the oldest pending entry is this old
   a_noteworthy_tier: middle     # middle (default) | simple (cheap, higher false-neg)
-  curator_c:
-    enabled: false              # experimental weekly defrag — off for v1
-    mode: local
+  synthesis_buffer_cap_turns: 120   # flush a chapter at this many turns...
+  synthesis_buffer_cap_chars: 240000 # ...or this many transcript chars
+  synthesis_model_tier: middle  # which `models.*` tier composes chapters
 models:
   simple: claude-haiku-4-5
   middle: claude-sonnet-4-6
-  high:   claude-opus-4-7       # or 'off' — degrades Curator B/C abstract to middle
+  high:   claude-opus-4-7       # or 'off' — degrades synthesis_model_tier: high to middle
 briefing:
-  auto: true
   audience: personal
   sinks:
     - markdown:~/lore-briefing.md
@@ -290,16 +270,8 @@ breadcrumb:
 ```
 
 All fields default to sane values — start without a `.lore-wiki.yml`
-and add knobs only as you need them.
-
-### Roadmap & implementation notes
-
-- [`docs/superpowers/specs/2026-04-19-passive-capture-v1-design.md`](docs/superpowers/specs/2026-04-19-passive-capture-v1-design.md) —
-  architecture spec (all 5 plans).
-- [`docs/superpowers/HANDOVER-2026-04-19.md`](docs/superpowers/HANDOVER-2026-04-19.md) —
-  roadmap status, gotchas, how to resume Plans 3–5.
-- [`docs/superpowers/plans/`](docs/superpowers/plans/) — executed plans
-  (1 + 2) for reference when writing 3–5.
+and add knobs only as you need them. Briefings publish manually
+(`lore briefing publish`) — there is no automatic cadence.
 
 ## Observability
 
@@ -342,8 +314,6 @@ observability:
     max_total_mb: 100
     keep_trace: 30
 ~~~
-
-Full design: [`docs/superpowers/specs/2026-04-20-auto-session-diagnostics-design.md`](docs/superpowers/specs/2026-04-20-auto-session-diagnostics-design.md).
 
 ## Two onboarding recipes
 
@@ -403,8 +373,8 @@ curator:
     base_url: https://chat.kiconnect.nrw/api/v1   # your gateway root
     # api_key_env: LORE_OPENAI_API_KEY            # optional override
     model_simple: gpt-4o-mini                     # cheap tier
-    model_middle: gpt-4o                          # default tier (Curator A noteworthy, Curator B sections)
-    model_high:   gpt-4o                          # heaviest tier (Curator B abstract, Curator C defrag)
+    model_middle: gpt-4o                          # default tier (chapter compose at synthesis_model_tier: middle)
+    model_high:   gpt-4o                          # heaviest tier (synthesis_model_tier: high)
 ```
 
 **`$LORE_ROOT/.lore/secrets.env`** — secrets only, mode `0600`:
@@ -484,9 +454,10 @@ curator:
 
 ## Scheduling the curator — cost-free defaults
 
-The curator (flags stale notes, detects superseded decisions, keeps
-`_index.txt` fresh) can run several ways. The README picks no default for
-you; pick your trade-off:
+The hygiene curator (propagates `supersedes:` / `implements:`
+relations, backfills dates from git, hints at team-mode) can run
+several ways. The README picks no default for you; pick your
+trade-off:
 
 | Pattern | Cost | Cadence | For |
 |---------|------|---------|-----|

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -60,7 +60,7 @@ rather than silently falling back to `~/lore`.
 | Var | Type | Default | Read in | Wins over |
 |-----|------|---------|---------|-----------|
 | `LORE_LLM_BACKEND` | `auto` \| `subscription` \| `api` \| `openai` | `auto` | `lore_curator/llm_client.py:make_llm_client` | `.lore/config.yml:curator.backend` |
-| `LORE_CURATOR_MODE` | `local` \| `central` | `local` | `lore_curator/curator_c.py` | `.lore-wiki.yml:curator.curator_c.mode` |
+| `LORE_CURATOR_MODE` | `1` \| unset | unset | `lore_cli/hooks.py:_in_curator_mode` | (internal — set by the curator's own detached-subprocess spawns, not a user knob) |
 | `LORE_CLAUDE_TIMEOUT_S` | float seconds | `300.0` | `llm_client.py:_resolve_claude_timeout` | constructor arg |
 
 #### OpenAI-compatible backend (when `LORE_LLM_BACKEND=openai`)
@@ -129,11 +129,13 @@ Per-vault-mount policy. Schema lives in
 `lib/lore_core/wiki_config.py:WikiConfig`. Subsections:
 
 - `git.{auto_commit, auto_push, auto_pull}`
-- `curator.{threshold_pending, threshold_tokens, a_noteworthy_tier,
-  curator_a_cooldown_s, curator_b_cooldown_s}`
-- `curator.curator_c.{enabled, mode, defrag_body_writes}`
+- `curator.{threshold_pending_turns, max_pending_age_s, a_noteworthy_tier,
+  curator_a_cooldown_s}`
+- `curator.{synthesis_buffer_cap_turns, synthesis_buffer_cap_chars,
+  synthesis_flush_timeout_s, synthesis_model_tier, reaper_max_per_pass,
+  buffer_done_retention_days, liveness_stale_threshold_s}` — buffer-and-flush knobs
 - `models.{simple, middle, high}` — Claude model IDs per tier
-- `briefing.{auto, audience, sinks}`
+- `briefing.{audience, sinks}`
 - `heartbeat.{enabled, cooldown_s, push_context}`
 - `breadcrumb.{mode, scope_filter}`
 

--- a/docs/architecture/lore-drill.md
+++ b/docs/architecture/lore-drill.md
@@ -4,8 +4,9 @@
 MCP tool and the `lore drill` CLI presenter.
 
 This document settles **P3.2** from the 2026-04-27 multi-agent review.
-`lore drill` does not exist yet — this is the design before the first
-implementation commit.
+`lore drill` is implemented (`lore_mcp/server.py:handle_drill`); this
+is the design it was built against — check the handler for the current
+behavior of any detail this doc doesn't cover.
 
 ## Purpose
 

--- a/docs/architecture/sync.md
+++ b/docs/architecture/sync.md
@@ -36,8 +36,7 @@ produces — without producing temp artifacts or losing content.
 
 | Trigger | Where | What |
 |---|---|---|
-| **Curator A post-commit** | `lib/lore_curator/session_curator.py:_maybe_auto_commit` (existing) | After auto-commit of a freshly filed session note. |
-| **Curator B post-write** | `lib/lore_curator/daily_curator.py` | After surfaces are filed. |
+| **Curator A post-commit** | `lib/lore_curator/session_curator.py:_maybe_auto_commit` (existing) | After auto-commit of a freshly filed session note or appended chapter. |
 | LLM-merge follow-up | `lib/lore_core/git_sync.py:auto_push` | When push fails non-FF, run LLM merge, re-push. |
 
 `auto_push` is `auto_pull` + `git push`, with conflict-resolution baked in.
@@ -69,36 +68,33 @@ tree, network failure), and Host B writes its own day-note that later
 collides with Host A's on push, the LLM-merge resolver kicks in. The
 two notes get merged into one canonical body. No `.host-A.md` siblings.
 
-### 2. Surfaces — LLM-merge on push conflict
+### 2. Manually-authored notes — LLM-merge on push conflict
 
-Surfaces (`<wiki>/<surface_dir>/<slug>.md` — concepts, decisions,
-results, … as defined by each wiki's `SURFACES.md`) are the most
-likely conflict point: Curator B on Host A and Host B both produce
-`concepts/foo.md` independently, abstracting overlapping work.
-
-Resolution at push time:
+Notes in a wiki's typed subdirectories (`concepts/`, `decisions/`,
+`projects/`, …) are written directly — by hand or via `/lore:inbox` —
+there is no automatic abstraction pass that populates them, so this
+conflict class is rarer than session-note conflicts in practice. The
+classifier and merge path still apply to whatever two hosts
+independently write there:
 
 1. `git fetch origin`
 2. `git merge origin/<branch> --no-commit --no-ff`
 3. Enumerate conflicted paths: `git diff --name-only --diff-filter=U`
-4. Classify each path. For surfaces:
+4. Classify each path. For a typed-subdirectory note:
    - Read OURS (HEAD), THEIRS (origin), BASE (merge-base)
    - LLM call (middle tier, ~$0.001) with structured prompt: "merge
-     these two versions of `<surface>`. Preserve all distinct facts,
-     deduplicate restated points, keep wikilinks from both sides.
-     Validate the result still satisfies the `<surface_type>` schema
-     in SURFACES.md."
+     these two versions of `<note>`. Preserve all distinct facts,
+     deduplicate restated points, keep wikilinks from both sides."
    - Write merged result, `git add <path>`
 5. If all conflicts resolved: `git commit -m "merge(auto-llm): N
-   surface(s)"`, `git push`
+   note(s)"`, `git push`
 6. If any unresolved: `git merge --abort`, log via `lore status`,
    surface a `lore curator merge --resolve` action to the user.
 
-**Why LLM and not Curator C's defrag?** Curator C runs on cadence and
-introduces a *temporal* gap where the wiki is in an "I have two notes
-about the same thing" state visible to MCP search. LLM-merge at push
-time is synchronous: by the time Host B's push completes, the wiki
-has one canonical surface. No temp artifacts. No drift window.
+LLM-merge at push time is synchronous: by the time Host B's push
+completes, the wiki has one canonical note. No temp artifacts, no
+drift window where MCP search would see two notes about the same
+thing.
 
 ### 3. Regenerable artifacts — pick either side, lint to truth
 
@@ -111,7 +107,7 @@ on either host's next regen.
 ### 4. Unknown — bail to user
 
 Anything else (CLAUDE.md root files, hand-edited markdown outside
-sessions/surfaces) → `git merge --abort`, log via `lore status` with
+sessions/typed-notes) → `git merge --abort`, log via `lore status` with
 the path list and a `lore curator merge --resolve <path>` hint. Never
 silently overwrite hand-edited content.
 
@@ -132,9 +128,10 @@ regresses to "post-pull, MCP search may be stale for up to 5s." This
 is what 0.10.x ships today, so the optional-dep fallback is not a
 regression.
 
-**Self-edit handling:** Curator A/B/C writes notes — the watcher
-trips on those too. That's fine: the dirty flag just says "next
-query may need fresh data." The throttle prevents a reindex storm.
+**Self-edit handling:** the curator's own writes (session notes,
+chapters, hygiene-pass frontmatter edits) trip the watcher too. That's
+fine: the dirty flag just says "next query may need fresh data." The
+throttle prevents a reindex storm.
 
 ### Future direction (not for 0.11.0)
 
@@ -168,7 +165,7 @@ Per-wiki, in `<wiki>/.lore-wiki.yml`:
 
 ```yaml
 git:
-  auto_commit: true     # Curator A/B commit their writes
+  auto_commit: true     # the curator commits its own writes
   auto_push: true       # push after each commit
   auto_pull: true       # fetch + ff at SessionStart
 ```
@@ -191,7 +188,7 @@ because it's read-only on a clean tree.
 | Clean tree, fast-forwardable | Fetch + ff | `lore status` (silent unless new commits pulled) |
 | Clean tree, diverged (we have local commits, remote has different commits) | Skip pull, surface to user | `lore status` `· wiki diverged — git pull manually` |
 | Push: remote ahead, FF possible | Fetch + ff + push | (silent) |
-| Push: surface conflict | LLM-merge → push | `lore status` shows merge count |
+| Push: typed-note conflict | LLM-merge → push | `lore status` shows merge count |
 | Push: unresolvable conflict | abort merge, surface to user | `lore status` `· merge needed: <paths>` |
 | `watchdog` not installed | Reindex throttle = 5s natural decay | (silent — same as 0.10.x) |
 
@@ -202,7 +199,7 @@ because it's read-only on a clean tree.
 - Bare-repo fixtures for two hosts (`tmp_path/host_a`, `tmp_path/host_b`,
   shared `tmp_path/origin`)
 - `auto_pull`: clean tree → ff; dirty tree → skip + log; diverged → skip + status flag
-- `auto_push`: surface-conflict → LLM-stub merge → assert merged file present, no
+- `auto_push`: typed-note conflict → LLM-stub merge → assert merged file present, no
   `.host-*` siblings, exit code 0
 - `auto_push`: session-conflict → LLM-stub merge → assert one canonical file
 - `auto_push`: regenerable conflict (`_catalog.json`) → ours wins → lint reconciles

--- a/docs/how-to/matrix-bot.md
+++ b/docs/how-to/matrix-bot.md
@@ -101,13 +101,13 @@ thread it through to the matrix sink.
 echo "## test briefing" | lore briefing publish --sink matrix --wiki <wiki>
 ```
 
-### Auto-publish from Curator B
+### Scheduled publish
 
-If the wiki's `.lore/wiki-config.yml` has `briefing.auto: true` with
-`briefing.sinks: ["matrix"]`, Curator B's daily run will publish
-without any further action — it reuses the same `.lore-briefing.yml`
-via `gather`'s `sink_config` field, so no env vars are required for
-the daemon path.
+There is no automatic daily publish — `lore briefing publish` is a
+manual (or externally scheduled, e.g. `cron` / `/schedule`) command.
+Whatever triggers it reuses the same `.lore-briefing.yml` via
+`gather`'s `sink_config` field, so no env vars are required beyond
+the one-time Matrix login above.
 
 ---
 


### PR DESCRIPTION
Implements #129 (epic #131).

## Summary
- Rewrote `CONTEXT.md` from scratch against shipped code only, using the settled vocabulary (session note, chapter, topic block, lead, continuation block, disclaimer, skim layer, gate, quarantine). Every claim is grounded in a real module — `note_document.py`, `publish_gate.py`, `chapter_compose.py`, `chapter_flush.py`, `hygiene.py`, `briefing/gather.py`, `lore_mcp/server.py`, `repo_docs.py`, `hooks.py`'s SessionStart banner.
- Corrected `README.md`: pitch diagram, "Bootstrap" section, "what runs automatically", manual escape hatches, per-wiki config example, and the OpenAI-backend example no longer describe Curator B (daily), Curator C (defrag), surfaces/SURFACES.md, or `--abstract`/`--defrag` as live — none of that ships. Removed dead links into the deleted `docs/superpowers/` tree and the stale "0.1 alpha / no stability until 0.2" framing.
- Corrected `docs/architecture/sync.md` (surfaces → Curator B sync mechanics rewritten to reflect that typed notes are written manually, not auto-abstracted), `docs/architecture/config.md` (`LORE_CURATOR_MODE` row and the `.lore-wiki.yml` schema list referenced a deleted `curator_c.py` module and dead config fields), `docs/how-to/matrix-bot.md` ("Auto-publish from Curator B" → manual/scheduled publish), and `docs/architecture/lore-drill.md` (stale "does not exist yet" framing for a tool that has since shipped).
- `docs/prd/` and `docs/adr/` untouched; no code changed.

## Verification
- `grep -rniE 'curator[ _]?b|curator[ _]?c|daily.curator|defrag|surface|two.region|part-?n|--abstract|--defrag' *.md docs` comes back clean except: `docs/prd/0001-*.md` (protected, describes the trim itself), `CHANGELOG.md` (historical record, untouched by design), and benign generic uses of the verb "surface" (e.g. "surface to user", "Sync surfaces" heading).
- Full suite: `2372 passed, 7 skipped, 3 failed` — the same 3 pre-existing baseline failures (`test_plugin_version_bumped_for_skill_addition`, `test_make_llm_client_openai_missing_api_key_raises`, `test_resume_subtree_aggregates_issues`), no new failures.

## Test plan
- [x] `NO_COLOR=1 FORCE_COLOR= PYTHONPATH=lib python -m pytest -q -p no:cacheprovider` — 3-baseline, no regressions
- [x] Deleted-feature grep clean (see above)
- [x] No code touched; `docs/prd/`, `docs/adr/` untouched