### PR TITLE
fix(reaper): same-host pid-gone is uncertain, not dead

### DIFF
--- a/lib/lore_curator/reaper.py
+++ b/lib/lore_curator/reaper.py
@@ -8,18 +8,23 @@ time.
 
 Liveness verdict:
 
-* If the owner PID is unambiguously **dead** (host mismatch,
-  ``ProcessLookupError`` from ``os.kill(pid, 0)``, or
-  ``/proc/<pid>/stat`` start-ts mismatch indicating PID reuse) →
-  **reap immediately**, regardless of heartbeat freshness. Waiting on
-  a confirmed-dead owner buys nothing; short Claude sessions that die
-  without SessionEnd would otherwise leave stub notes pending for the
-  full staleness window.
-* If the owner is unambiguously **alive** → keep waiting.
-* If liveness is **uncertain** (no ``/proc`` access — macOS, network
-  fs, sandbox) → fall back on the staleness threshold
+* If the owner PID is unambiguously **dead** — the recorded owner
+  ``host`` differs from this host — → **reap immediately**, regardless
+  of heartbeat freshness. Waiting on a confirmed-dead owner buys
+  nothing; short Claude sessions that die without SessionEnd would
+  otherwise leave stub notes pending for the full staleness window.
+* If the owner is unambiguously **alive** (same host, PID signalable,
+  ``/proc`` start-ts matches) → keep waiting.
+* If liveness is **uncertain** → fall back on the staleness threshold
   (``liveness_stale_threshold_s``, default 30 min, per-wiki
-  configurable; doubled on macOS).
+  configurable; doubled on macOS). This covers no ``/proc`` access
+  (macOS, network fs, sandbox) *and* a same-host owner whose PID is
+  simply gone (``ProcessLookupError``) or whose ``/proc`` start-ts no
+  longer matches (PID reuse). In the buffer-and-flush architecture the
+  owner pid is re-stamped every heartbeat to the hook subprocess, which
+  exits within milliseconds — "pid gone, same host" is the normal
+  steady state, not a death signal, so it must not short-circuit past
+  the staleness floor the way a genuine cross-host mismatch does.
 
 Concurrency:
 
@@ -41,6 +46,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lore_core.wiki_config import load_wiki_config
+
 from lore_curator.buffer_store import Buffer, Sidecar, iter_all
 from lore_curator.synthesis import spawn_detached_flush
 
@@ -66,7 +72,7 @@ class ReaperReport:
 def _read_proc_start_ticks(pid: int) -> float | None:
     """Return ``/proc/<pid>/stat`` field 22, or ``None`` on macOS / missing."""
     try:
-        with open(f"/proc/{pid}/stat", "r") as fh:
+        with open(f"/proc/{pid}/stat") as fh:
             content = fh.read()
     except (FileNotFoundError, PermissionError, OSError):
         return None
@@ -85,14 +91,17 @@ def _read_proc_start_ticks(pid: int) -> float | None:
 def is_owner_alive(sidecar: Sidecar, *, host: str | None = None) -> bool | None:
     """Return True (alive), False (dead), or None (can't tell — keep waiting).
 
-    Encapsulates the AND-condition liveness check. Returns:
+    Encapsulates the liveness check. Returns:
 
     * ``True`` if the owner is local AND PID is alive AND start_ts matches.
-    * ``False`` if the owner is local AND PID is gone, OR start_ts mismatch.
     * ``False`` if owner host differs from this host (definitely not us).
-    * ``None`` if we can't read /proc and the host matches — the
-      caller should treat this as "uncertain, fall back on staleness
-      threshold".
+    * ``None`` if the owner is local but the PID is gone, or the
+      ``/proc`` start-ts no longer matches (PID reuse), or we can't
+      read ``/proc`` at all — a same-host PID going missing is the
+      normal buffer-and-flush steady state (the owner pid is
+      re-stamped every heartbeat to a hook subprocess that exits
+      within milliseconds), not evidence of death, so the caller falls
+      back on the staleness threshold instead of reaping immediately.
     """
     host = host or socket.gethostname()
     if not sidecar.owner.pid:
@@ -103,7 +112,7 @@ def is_owner_alive(sidecar: Sidecar, *, host: str | None = None) -> bool | None:
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
-        return False
+        return None
     except PermissionError:
         # Pid exists but we can't signal; treat as alive.
         return True
@@ -116,7 +125,9 @@ def is_owner_alive(sidecar: Sidecar, *, host: str | None = None) -> bool | None:
         # No /proc access — caller falls back on staleness threshold.
         return None
     if abs(actual - expected) > _START_TS_TOLERANCE:
-        return False
+        # PID reuse: the process answering to this pid isn't the one
+        # that recorded it — uncertain, not proof of death.
+        return None
     return True
 
 
@@ -165,7 +176,7 @@ def reap_once(
     *,
     dry_run: bool = False,
     max_per_pass: int | None = None,
-    logger: "RunLogger | None" = None,
+    logger: RunLogger | None = None,
     now: datetime | None = None,
 ) -> ReaperReport:
     """One reaper pass over live buffers under ``<lore_root>/.lore/buffers``.
@@ -236,7 +247,7 @@ def _judge(
     *,
     host: str,
     now: datetime,
-    logger: "RunLogger | None",
+    logger: RunLogger | None,
 ) -> tuple[str, str]:
     """Return ``(verdict, reason)`` for a single buffer.
 
@@ -265,14 +276,16 @@ def _judge(
             return "alive", "owner-alive"
 
         if alive_verdict is False:
-            # Owner is unambiguously dead — reap regardless of staleness.
-            # Why: short Claude sessions that die without SessionEnd leave
-            # stub notes "synthesis pending" for the full staleness window
-            # (30+ min); waiting buys nothing once the PID is provably gone.
+            # Owner is on a different host — unambiguously not us, reap
+            # regardless of staleness. Why: short Claude sessions that die
+            # without SessionEnd leave stub notes "synthesis pending" for
+            # the full staleness window (30+ min); waiting buys nothing
+            # once the owner is provably not this machine.
             return "reap", "owner-dead"
 
-        # alive_verdict is None: uncertain (no /proc / network-fs / macOS).
-        # Fall back on staleness threshold to avoid false-positive reaps.
+        # alive_verdict is None: uncertain (no /proc / network-fs / macOS /
+        # same-host pid-gone / pid-reused). Fall back on staleness
+        # threshold to avoid false-positive reaps.
         if not _is_stale(sidecar, threshold_s=threshold, now=now):
             return "alive", "fresh-heartbeat"
         return "reap", "stale+owner-uncertain"

--- a/tests/test_reaper_force_flush.py
+++ b/tests/test_reaper_force_flush.py
@@ -6,13 +6,11 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
-
 from lore_core.types import Turn
 from lore_core.wiki_config import WikiConfig
 from lore_curator.buffer_append import append_chunk
 from lore_curator.buffer_store import OwnerInfo, Sidecar
 from lore_curator.reaper import (
-    ReaperReport,
     is_owner_alive,
     reap_once,
 )
@@ -33,9 +31,15 @@ def lore_root(tmp_path: Path) -> Path:
 
 @pytest.fixture(autouse=True)
 def patch_collectors(monkeypatch):
-    monkeypatch.setattr("lore_curator.session_activity.collect_commits_by_sha", lambda *a, **kw: [])
-    monkeypatch.setattr("lore_curator.session_activity.collect_issues_in_window", lambda *a, **kw: ([], []))
-    monkeypatch.setattr("lore_curator.session_activity.collect_projects_for_session", lambda **kw: [])
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_commits_by_sha", lambda *a, **kw: []
+    )
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_issues_in_window", lambda *a, **kw: ([], [])
+    )
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_projects_for_session", lambda **kw: []
+    )
     monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
     monkeypatch.setattr("lore_core.git.current_repo", lambda cwd: "")
 
@@ -72,12 +76,28 @@ def test_owner_alive_local_pid_returns_true_or_none():
     assert verdict in (True, None)  # depends on /proc availability
 
 
-def test_owner_dead_pid_returns_false():
-    """Use a pid that's almost certainly free (very high)."""
+def test_owner_gone_same_host_returns_none():
+    """A same-host owner whose pid is absent is uncertain, not dead.
+
+    The buffer's owner pid is re-stamped every heartbeat to the hook
+    subprocess, which exits within milliseconds -- "pid gone" is the
+    normal steady state, not a death signal, so long as the host still
+    matches."""
     sidecar = Sidecar(owner=OwnerInfo(pid=2**31 - 1, host="", start_ts=0.0))
     import socket
+
     sidecar.owner.host = socket.gethostname()
-    assert is_owner_alive(sidecar) is False
+    assert is_owner_alive(sidecar) is None
+
+
+def test_owner_pid_reused_start_ts_mismatch_returns_none():
+    """A live pid whose start-tick doesn't match the recorded value means
+    the pid was reused by an unrelated process -- uncertain, not dead."""
+    sidecar = Sidecar(owner=OwnerInfo(pid=os.getpid(), host="", start_ts=999999999.0))
+    import socket
+
+    sidecar.owner.host = socket.gethostname()
+    assert is_owner_alive(sidecar) is None
 
 
 def test_owner_different_host_returns_false():
@@ -103,7 +123,6 @@ def test_alive_owner_not_reaped(lore_root, monkeypatch):
 def test_dead_owner_and_stale_is_reaped(lore_root, monkeypatch):
     buf, _ = _seed(lore_root)
     # Backdate last_heartbeat past the staleness threshold.
-    sidecar = buf.read_sidecar()
     stale = (datetime.now(UTC) - timedelta(hours=3)).isoformat().replace("+00:00", "Z")
     with buf.with_lock():
         buf.patch(last_heartbeat=stale, last_appended_at=stale)
@@ -179,6 +198,48 @@ def test_closed_buffers_skipped(lore_root, monkeypatch):
     report = reap_once(lore_root)
     assert report.already_done == 1
     assert report.force_flushed == 0
+
+
+def test_pid_gone_same_host_not_reaped_within_staleness(lore_root):
+    """Regression for the mid-session false reap: a heartbeat stamps a
+    pid that then exits (the normal buffer-and-flush steady state) --
+    the reaper must not treat pid-gone alone as death while the
+    heartbeat is still fresh. The buffer must survive as-is."""
+    import socket
+
+    buf, _ = _seed(lore_root)
+    with buf.with_lock():
+        buf.patch(owner=OwnerInfo(pid=2**31 - 1, host=socket.gethostname(), start_ts=0.0))
+
+    report = reap_once(lore_root)
+    assert report.force_flushed == 0
+    assert report.alive == 1
+    assert buf.read_sidecar().state == "accumulating"
+
+
+def test_pid_gone_same_host_reaped_after_staleness(lore_root, monkeypatch):
+    """A same-host pid-gone owner is still eventually reaped once the
+    heartbeat goes stale -- uncertainty defers to the staleness floor,
+    it doesn't suppress reaping forever."""
+    import socket
+
+    buf, _ = _seed(lore_root)
+    stale = (datetime.now(UTC) - timedelta(hours=3)).isoformat().replace("+00:00", "Z")
+    with buf.with_lock():
+        buf.patch(
+            owner=OwnerInfo(pid=2**31 - 1, host=socket.gethostname(), start_ts=0.0),
+            last_heartbeat=stale,
+            last_appended_at=stale,
+        )
+
+    spawned: list = []
+    monkeypatch.setattr(
+        "lore_curator.reaper.spawn_detached_flush",
+        lambda buffer_path, lore_root: spawned.append(buffer_path) or True,
+    )
+    report = reap_once(lore_root)
+    assert report.force_flushed == 1
+    assert spawned == [buf.sidecar_path]
 
 
 def test_max_per_pass_bounds_scan(lore_root, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #146. In the buffer-and-flush architecture the buffer's owner `pid` is re-stamped every heartbeat to the current hook subprocess, which exits within milliseconds — so "owner pid is gone" is the normal steady state, not death. `is_owner_alive` was treating a same-host, pid-absent owner as unambiguously **dead**, letting the reaper / startup sweep force-flush (`synth_and_close`) a session that was still running. This is the root cause of one session filing multiple, partly-duplicated notes.

`is_owner_alive` now returns `None` (uncertain) instead of `False` for a same-host owner whose pid is absent (`ProcessLookupError`) or whose `/proc` start-tick no longer matches the recorded value (pid reuse). Both cases defer to the existing staleness-threshold path (already handled correctly by `reap_once`'s `_judge` and by `chapter_flush.sweep_dead_sessions`, so no changes were needed there). A cross-host owner still returns `False` and reaps immediately, unchanged.

- A genuinely dead session still closes — via staleness, just later, not instantly on pid-gone.
- Docstrings in `reaper.py` (module-level liveness verdict summary, `is_owner_alive`, and the `_judge` reap-reason comments) updated to describe the new contract.

## Test plan

Strict TDD: new/updated tests were written first and observed failing against the old code, then made to pass.

Failing (red), before the fix:
```
FAILED tests/test_reaper_force_flush.py::test_owner_gone_same_host_returns_none - AssertionError: assert False is None
FAILED tests/test_reaper_force_flush.py::test_owner_pid_reused_start_ts_mismatch_returns_none - AssertionError: assert False is None
FAILED tests/test_reaper_force_flush.py::test_pid_gone_same_host_not_reaped_within_staleness - assert 1 == 0
3 failed, 10 passed
```

Passing (green), after the fix:
```
13 passed
```

- `test_owner_gone_same_host_returns_none` / `test_owner_pid_reused_start_ts_mismatch_returns_none` — updated/added unit coverage for `is_owner_alive`'s new contract (renamed from the now-incorrect `test_owner_dead_pid_returns_false`; `test_owner_different_host_returns_false` is unchanged and still passes, confirming cross-host behavior is untouched).
- `test_pid_gone_same_host_not_reaped_within_staleness` — regression test for the mid-session false reap: a heartbeat stamps a pid that then exits, `reap_once` runs, and the buffer must survive (`state == "accumulating"`, not reaped).
- `test_pid_gone_same_host_reaped_after_staleness` — confirms no leak: the same scenario past the staleness threshold is still eventually reaped.

Full suite: `ruff check` and `ruff format --check` clean on the changed files (pre-existing `ruff format` drift in untouched lines of these files predates this branch and was left alone per the scope fence); full test suite green modulo 16 pre-existing, unrelated failures confirmed present on `epic/151` before this change (ANSI/rich color-code string matching, missing optional `openai` dependency, stale hardcoded dates/version in unrelated tests) — verified identical via `git stash`.

- [x] `is_owner_alive` returns `None` for same-host pid-absent owner; cross-host owner still returns `False`
- [x] Reaper doesn't close a buffer whose only death signal is pid-gone while within the staleness window
- [x] A buffer past staleness with pid-gone is still eventually closed
- [x] Regression test reproduces the mid-session false reap and passes