### PR TITLE
feat(compose): quoted/reference material is not the session's work (#147)

### DIFF
--- a/lib/lore_curator/chapter_compose.py
+++ b/lib/lore_curator/chapter_compose.py
@@ -446,6 +446,23 @@ def _build_prompt(
             "permission chatter. Leave them out entirely, unless diagnosing "
             "the tooling was itself the session's purpose.",
             "",
+            "Quoted and reference material is NOT the session's work. "
+            "Sometimes the user pastes or quotes a block as an exemplar, a "
+            "reference, or a comparison, not as something to act on: a "
+            'formatting sample ("this is a form I\'d like the notes to have", '
+            '"here is the shape I want"), an example ("for example", "like '
+            'this one"), or another / older artefact of their own ("an older '
+            'version of", "the previous note", "a note I wrote earlier"). Its '
+            "content is ABOUT that pasted material and does not describe what "
+            "this session did. Spot it by the exemplar framing in the "
+            "surrounding turns, by a fenced code block, or by a block that "
+            "carries its OWN @N-anchored bold leads (the shape of an earlier "
+            "note). NEVER report the claims, tools, paths, or config inside "
+            "such material as this session's findings. The ONLY exception is "
+            "when working on that material was itself the topic: the user asks "
+            "you to review, fix, or reason about the pasted content, in which "
+            "case that work IS the session's work and you record it.",
+            "",
             "Each topic is ONE block:",
             "- The lead is one bold sentence carrying the takeaway: a "
             "SELF-SUFFICIENT declarative claim a reader understands with no "
@@ -537,7 +554,10 @@ def chapter_tool_schema() -> dict[str, Any]:
                                 "description": (
                                     "Short prose body: the reasoning and "
                                     "specifics behind the lead, in the "
-                                    "active voice. No event narration."
+                                    "active voice. No event narration. "
+                                    "Never restate claims from material "
+                                    "the user only pasted or quoted as an "
+                                    "exemplar or reference."
                                 ),
                             },
                             "anchor": {

--- a/tests/fixtures/prompts/quoted_exemplar_paste.txt
+++ b/tests/fixtures/prompts/quoted_exemplar_paste.txt
@@ -1,0 +1,13 @@
+[user@1095] Before we touch the session-note voice, look at this — this is a form I'd like the notes to have. It's an older version of a note I wrote by hand about secret management, pasted here only as a formatting example:
+[user@1096] ```
+[user@1097] > **Lab-notebook session note.**
+[user@1098]
+[user@1099] **Secrets are encrypted at rest with SOPS and age.** The repo keeps `secrets.env` encrypted with `sops`; the `age` identity lives outside the repo and decrypts into a `tmpfs` mount at deploy time so the plaintext `.env` never touches disk. @12
+[user@1100]
+[user@1101] **The deploy script sources the decrypted .env into the systemd unit.** `systemd` `EnvironmentFile=` points at the tmpfs path; on stop the tmpfs is unmounted and the plaintext is gone. @14
+[user@1102] ```
+[user@1103] See how each point leads with a bold claim and ends with an @-anchor? That is the shape I want for our notes — I am not asking you to do anything with SOPS or age, it is purely an exemplar.
+[assistant@1120] Understood — bold self-sufficient lead, short body, exactly one @-anchor per point. That is the lab-notebook chapter shape we are building toward.
+[user@1140] Right. For THIS session the thing I actually care about is the note voice: I keep getting notes that narrate the session ("the user asked...", "a command was run...") instead of recording what was figured out.
+[assistant@1160] The fix is essence-first: the lead carries the takeaway as a self-sufficient claim, and session mechanics (greetings, tool hiccups) are omitted entirely.
+[user@1383] Exactly. Let's make the composer record the work, not the working.

--- a/tests/test_chapter_compose.py
+++ b/tests/test_chapter_compose.py
@@ -12,6 +12,7 @@ prompt experiments.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -431,7 +432,11 @@ def test_lead_markdown_bold_is_stripped():
     # Models sometimes bold the lead themselves; the renderer adds the
     # bold, so embedded ** would double up ("****lead****"). Parsing
     # normalizes it away.
-    payload = {"blocks": [{"lead": "**The cache was stale**, so skills never loaded.", "body": "x", "anchor": 0}]}
+    payload = {
+        "blocks": [
+            {"lead": "**The cache was stale**, so skills never loaded.", "body": "x", "anchor": 0}
+        ]
+    }
     msgs = _RecordingMessages([payload])
     client = _FakeClient(msgs)
     result = compose_chapter(
@@ -506,3 +511,81 @@ def test_synthesis_no_longer_imports_render_regions():
     import lore_curator.synthesis as synthesis
 
     assert not hasattr(synthesis, "render_regions")
+
+
+# ---------------------------------------------------------------------------
+# Quoted / reference material is not the session's work (#147)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_carries_quoted_material_distinction():
+    # The compose model (a weak-pragmatics ~120B open model) must be told
+    # concretely that pasted exemplar / reference material is not the
+    # session's own work, with the signals spelled out — not inferred.
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+    compose_chapter(
+        slice_text="[user@0] hi",
+        slice_from_turn=0,
+        slice_to_turn=0,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    prompt = _prompt_text(msgs.calls[0]).lower()
+    assert "quoted and reference material" in prompt
+    assert "not the session's work" in prompt
+    # Concrete exemplar-framing signals are named verbatim.
+    assert "this is a form i'd like" in prompt
+    assert "for example" in prompt
+    assert "an older version of" in prompt
+    # Structural signals: fenced blocks and self-anchored bold leads.
+    assert "fenced" in prompt
+    assert "anchored bold lead" in prompt
+
+
+def test_prompt_keeps_worked_pasted_content_attributable():
+    # True-positive exception: when the session actually works ON the
+    # pasted content (reviews / fixes it), that work IS reported. The
+    # prompt must carry the exception so the clause does not over-suppress.
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+    compose_chapter(
+        slice_text="[user@0] hi",
+        slice_from_turn=0,
+        slice_to_turn=0,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    prompt = _prompt_text(msgs.calls[0]).lower()
+    assert "exception" in prompt
+    assert "working on that material was itself the topic" in prompt
+    assert "review" in prompt
+    assert "pasted content" in prompt
+
+
+def test_prompt_from_exemplar_paste_fixture_carries_clause():
+    # A realistic slice matching the SOPS-paste regression (transcript
+    # a737ff12): a long block pasted purely as a formatting exemplar,
+    # followed by the genuine session topic (note voice). The clause that
+    # keeps the pasted block's SOPS/.env/tmpfs claims out of the note must
+    # ride the prompt built from that exact input.
+    fixture = Path(__file__).parent / "fixtures" / "prompts" / "quoted_exemplar_paste.txt"
+    slice_text = fixture.read_text()
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+    compose_chapter(
+        slice_text=slice_text,
+        slice_from_turn=1095,
+        slice_to_turn=1383,
+        note_so_far="(empty)",
+        llm_client=client,
+        model="m",
+    )
+    prompt = _prompt_text(msgs.calls[0]).lower()
+    # The exemplar framing from the paste is present in the slice ...
+    assert "this is a form i'd like the notes to have" in prompt
+    # ... and the guarding clause is present in the same prompt.
+    assert "quoted and reference material" in prompt
+    assert "never report the claims" in prompt


### PR DESCRIPTION
## What

Stops the chapter composer from reporting material the user pasted or quoted **only as an exemplar/reference** as if it were the session's own work. In the motivating transcript (`a737ff12`) the user pasted an old SOPS/`age` note as a *formatting example* ("this is a form I'd like the notes to have"); the composer then reported its SOPS / `.env` / `tmpfs` claims as the session's findings.

Adds an explicit **quoted-vs-worked** clause to the compose prompt in `_build_prompt`, plus a reinforcing sentence in the tool schema's `body`-field description.

## Why spelled out concretely

The compose model is a ~120B open model, weak at implicit pragmatics. The clause therefore names the signals verbatim rather than relying on the model to infer intent:

- **Framing**: `"this is a form I'd like"`, `"for example"`, `"an older version of"`, `"the previous note"`, …
- **Structure**: fenced code blocks; blocks that carry their **own** `@N`-anchored bold leads (the shape of an earlier note).
- **Rule**: never report the claims/tools/paths/config inside such material as this session's findings.
- **Exception (keeps the true-positive intact)**: when *working on that material was itself the topic* — the user asks you to review/fix/reason about the pasted content — that work **is** the session's work and is recorded.

## Tests (TDD, no LLM-as-judge)

Deterministic prompt-contract assertions only (there is no real-LLM replay harness in this repo — "replay" refers to the event-buffer folding and the stub-LLM queue). Three new tests in `tests/test_chapter_compose.py`:

- `test_prompt_carries_quoted_material_distinction` — the clause + concrete signals ride the prompt.
- `test_prompt_keeps_worked_pasted_content_attributable` — the review/fix exception is present so the clause does not over-suppress.
- `test_prompt_from_exemplar_paste_fixture_carries_clause` — builds the prompt from a new fixture (`tests/fixtures/prompts/quoted_exemplar_paste.txt`) reproducing the SOPS-paste shape (exemplar-framed paste with self-`@N`-anchored bold leads carrying SOPS/`.env`/`tmpfs` claims, followed by the genuine session topic) and asserts the guarding clause is present in the built prompt.

The `a737ff12` behavioral acceptance (live compose model no longer emitting SOPS/`.env`/`tmpfs` as findings) is a live-model validation to run separately; it cannot be a deterministic unit assertion without an LLM-as-judge, which the ACs forbid.

### Red → green evidence

Red (clause reverted to HEAD, new tests present, run against worktree source):

```
E  AssertionError: assert 'quoted and reference material' in 'you are distilling one chapter ...'
E  AssertionError: assert 'exception' in 'you are distilling one chapter ...'
E  AssertionError: assert 'quoted and reference material' in 'you are distilling one chapter ...'
3 failed, 23 deselected
```

Green (clause added):

```
3 passed, 23 deselected
```

Full compose file: `26 passed`.

## Gates

- `ruff check` — clean on both changed files (`All checks passed!`).
- `ruff format --check` — clean on both changed files.
- Full suite: `2364 passed`, 16 pre-existing failures unrelated to this change (verified identical on clean HEAD — rich/ANSI CLI rendering, missing `openai` module, plugin-version-bump assertions; none touch compose).

## Notes / decisions

- `tests/test_chapter_compose.py`'s pre-existing over-length line (in `test_lead_markdown_bold_is_stripped`) was split by `ruff format` as an incidental format-only change so `ruff format --check` passes for the file; no logic touched.
- Scope kept to `chapter_compose.py`'s prompt-building + its tests + one fixture.

Closes #147.