### PR TITLE
feat(compose): soft same-anchor retry lint (#149)

### DIFF
--- a/lib/lore_curator/chapter_compose.py
+++ b/lib/lore_curator/chapter_compose.py
@@ -54,6 +54,7 @@ __all__ = [
     "ComposeResult",
     "compose_chapter",
     "chapter_anchor_lint",
+    "chapter_same_anchor_lint",
     "chapter_tool_schema",
     "render_chapter_body",
     "CHAPTER_MAX_ATTEMPTS",
@@ -153,6 +154,25 @@ def chapter_anchor_lint(chapter: Chapter, *, from_turn: int, to_turn: int) -> li
     return offenders
 
 
+def chapter_same_anchor_lint(chapter: Chapter) -> int | None:
+    """Return the anchor turn shared by more than two blocks, else ``None``.
+
+    Two blocks citing the same turn is common and unremarkable — two
+    closely related findings surfacing together. More than two is usually
+    a tell that every block was derived from one quoted or pasted passage
+    rather than distinct moments in the session, which collapses the
+    anchors and makes them useless for navigation. This is a soft signal:
+    callers retry once for a nudge, never reject on it.
+    """
+    counts: dict[int, int] = {}
+    for block in chapter.blocks:
+        counts[block.anchor_turn] = counts.get(block.anchor_turn, 0) + 1
+    for anchor, count in counts.items():
+        if count > 2:
+            return anchor
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Compose loop
 # ---------------------------------------------------------------------------
@@ -175,8 +195,12 @@ def compose_chapter(
 
     Attempt 1 composes; a deterministic anchor lint and the injected
     gate then judge the result. An anchor-lint miss or a gate withhold
-    feeds corrective text into a second attempt. After
-    :data:`CHAPTER_MAX_ATTEMPTS` the outcome is returned:
+    feeds corrective text into a second attempt. A softer same-anchor
+    lint (more than two blocks citing one turn) earns at most one
+    corrective retry of its own but never blocks publication — after
+    that single nudge the chapter is composed regardless of whether the
+    anchors changed. After :data:`CHAPTER_MAX_ATTEMPTS` the outcome is
+    returned:
 
     * PASS → ``COMPOSED`` with the chapter.
     * zero blocks on any attempt → ``EMPTY`` immediately (the model
@@ -195,6 +219,7 @@ def compose_chapter(
     last_withheld: GateResult | None = None
     last_withheld_text = ""
     attempts = 0
+    same_anchor_retried = False
 
     while attempts < CHAPTER_MAX_ATTEMPTS:
         attempts += 1
@@ -227,6 +252,20 @@ def compose_chapter(
                     call="chapter-anchor-lint",
                     transcript_id=transcript_id,
                     offenders=offenders,
+                )
+            continue
+
+        shared_anchor = chapter_same_anchor_lint(chapter)
+        retry_left = attempts < CHAPTER_MAX_ATTEMPTS
+        if shared_anchor is not None and not same_anchor_retried and retry_left:
+            same_anchor_retried = True
+            retry_feedback = _same_anchor_feedback(shared_anchor)
+            if logger is not None:
+                logger.emit(
+                    "warning",
+                    call="chapter-same-anchor-lint",
+                    transcript_id=transcript_id,
+                    anchor=shared_anchor,
                 )
             continue
 
@@ -268,6 +307,15 @@ def _anchor_feedback(offenders: list[tuple[int, int]], from_turn: int, to_turn: 
         f"The previous attempt cited a turn outside it (block(s) {bad}). "
         f"Every @N anchor must be a turn index shown in the slice, within "
         f"{lo}-{hi}."
+    )
+
+
+def _same_anchor_feedback(anchor: int) -> str:
+    return (
+        f"Several blocks all cite the same turn (@{anchor}). Confirm these "
+        "are distinct findings from the session's progression, not "
+        "restatements of one quoted or pasted passage — re-anchor each "
+        "block to the turn where its own topic actually started."
     )
 
 

--- a/tests/test_chapter_compose.py
+++ b/tests/test_chapter_compose.py
@@ -24,6 +24,7 @@ from lore_curator.chapter_compose import (
     GateResult,
     PassThroughGate,
     chapter_anchor_lint,
+    chapter_same_anchor_lint,
     chapter_tool_schema,
     compose_chapter,
     render_chapter_body,
@@ -292,6 +293,107 @@ def test_persistent_out_of_slice_anchor_fails():
     )
     assert result.status is ComposeStatus.FAILED
     assert result.attempts == CHAPTER_MAX_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# Same-anchor lint (deterministic) — soft: nudges once, never blocks publish
+# ---------------------------------------------------------------------------
+
+
+def test_same_anchor_lint_flags_more_than_two_shared():
+    chapter = Chapter(
+        blocks=[
+            TopicBlock(lead="a", body="", anchor_turn=34),
+            TopicBlock(lead="b", body="", anchor_turn=34),
+            TopicBlock(lead="c", body="", anchor_turn=34),
+        ]
+    )
+    assert chapter_same_anchor_lint(chapter) == 34
+
+
+def test_same_anchor_lint_allows_two_shared():
+    chapter = Chapter(
+        blocks=[
+            TopicBlock(lead="a", body="", anchor_turn=5),
+            TopicBlock(lead="b", body="", anchor_turn=5),
+        ]
+    )
+    assert chapter_same_anchor_lint(chapter) is None
+
+
+def test_same_anchor_lint_allows_distinct_anchors():
+    chapter = Chapter(
+        blocks=[
+            TopicBlock(lead="a", body="", anchor_turn=1),
+            TopicBlock(lead="b", body="", anchor_turn=2),
+            TopicBlock(lead="c", body="", anchor_turn=3),
+        ]
+    )
+    assert chapter_same_anchor_lint(chapter) is None
+
+
+def _same_anchor_payload(anchor: int, count: int) -> dict[str, Any]:
+    blocks = [{"lead": f"lead {i}", "body": f"body {i}", "anchor": anchor} for i in range(count)]
+    return {"blocks": blocks}
+
+
+def test_more_than_two_shared_anchors_triggers_one_retry_then_composes():
+    bad = _same_anchor_payload(34, 3)
+    good = _valid_payload()
+    msgs = _RecordingMessages([bad, good])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@0] x\n[assistant@34] y",
+        slice_from_turn=0,
+        slice_to_turn=100,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    assert result.status is ComposeStatus.COMPOSED
+    assert result.attempts == 2
+    assert len(msgs.calls) == 2
+    retry_prompt = _prompt_text(msgs.calls[1])
+    assert "34" in retry_prompt
+    assert "same turn" in retry_prompt.lower()
+
+
+def test_distinct_anchors_untouched_by_same_anchor_lint():
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@2] x\n[assistant@4] y",
+        slice_from_turn=2,
+        slice_to_turn=4,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    assert result.status is ComposeStatus.COMPOSED
+    assert result.attempts == 1
+    assert len(msgs.calls) == 1
+
+
+def test_persistent_same_anchor_still_publishes():
+    bad = _same_anchor_payload(34, 3)
+    msgs = _RecordingMessages([bad, dict(bad)])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@0] x\n[assistant@34] y",
+        slice_from_turn=0,
+        slice_to_turn=100,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    assert result.status is ComposeStatus.COMPOSED
+    assert result.attempts == 2
+    assert len(msgs.calls) == 2
+    assert result.chapter is not None
+    assert len(result.chapter.blocks) == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `chapter_same_anchor_lint(chapter) -> int | None`, a deterministic check that flags when more than two blocks in a chapter all cite the same `@N` anchor — the tell that every block was derived from one quoted/pasted passage instead of distinct moments in the session.
- `compose_chapter` spends at most one retry on this signal: on the first hit it injects corrective feedback ("Several blocks all cite the same turn (@N)... re-anchor each block to the turn where its own topic actually started") and retries once. Whether or not the retry changes the anchors, the chapter still publishes — this check never withholds and never fails a chapter.
- The one-retry cap is enforced by a dedicated `same_anchor_retried` flag (independent of `CHAPTER_MAX_ATTEMPTS`), so the soft/never-hard-reject guarantee holds even if the attempt budget changes later.

Closes #149.

## Design notes
- Two blocks sharing an anchor is left alone — that's normal (two closely related findings from the same turn). Only >2 triggers the nudge.
- Sits after the existing hard `chapter_anchor_lint` (out-of-slice/missing anchors) and before the gate evaluation in the retry loop, so a genuinely invalid anchor is still corrected first; the same-anchor nudge only looks at anchors already known to be in-slice.
- Did not touch the #147 quoted-material prompt clause or the buffer/reopen logic (#148) — scope stayed to `chapter_compose.py`'s lint/retry path and its tests.

## Test plan (TDD, red → green)
Failing-test output before implementation (import error for the not-yet-defined `chapter_same_anchor_lint`):
```
ImportError while importing test module '.../tests/test_chapter_compose.py'.
tests/test_chapter_compose.py:20: in <module>
    from lore_curator.chapter_compose import (
E   ImportError: cannot import name 'chapter_same_anchor_lint' from 'lore_curator.chapter_compose'
```

After implementation, full green:
- [x] `test_same_anchor_lint_flags_more_than_two_shared` / `..._allows_two_shared` / `..._allows_distinct_anchors` — lint unit tests, no LLM
- [x] `test_more_than_two_shared_anchors_triggers_one_retry_then_composes` — one retry, feedback carries the anchor and "same turn" text
- [x] `test_distinct_anchors_untouched_by_same_anchor_lint` — no extra call when anchors already distinct
- [x] `test_persistent_same_anchor_still_publishes` — retry doesn't fix it, chapter still `COMPOSED` (soft, never withheld/failed)
- `tests/test_chapter_compose.py`: 32 passed
- `ruff check` / `ruff format --check`: clean
- Full suite: 2373 passed, 16 failed (pre-existing, unrelated — rich ANSI color assertions, missing optional `openai` dep, stale hardcoded dates/version; same fingerprint as sibling PRs #152/#153), 8 skipped