### PR TITLE
feat(capture): reopen + continue — one session, one note (#148)

### DIFF
--- a/docs/adr/0001-session-note-reopen-relaxes-close-immutability.md
+++ b/docs/adr/0001-session-note-reopen-relaxes-close-immutability.md
@@ -1,0 +1,105 @@
+# ADR 0001: Session-note reopen relaxes close-immutability (one file per session)
+
+- Status: Accepted
+- Date: 2026-07-06
+- Context: epic [#151](https://github.com/buchbend/lore/issues/151),
+  PRD [0002](../prd/0002-useful-session-notes.md), sub-issue
+  [#148](https://github.com/buchbend/lore/issues/148)
+
+## Context
+
+A session note is the deterministic core's one-note-per-session record: a
+fixed disclaimer followed by chronological chapters, one per flush. PRD 0001
+established the lifecycle *create → append → (marker) → close*, where **close**
+sets `note_status: closed` and the file becomes immutable — no further chapter
+may be appended (`append_chapter` raises `NoteClosedError`).
+
+That invariant assumed close is terminal for a session. It is not. A session's
+buffer can be closed and archived to `_done/` while the session is still live
+or about to resume:
+
+- a **false liveness reap** — the owner `pid` is re-stamped every heartbeat to
+  the ephemeral hook subprocess, which exits within milliseconds, so
+  "pid gone" is the steady state, not death (fixed for the instant-reap case in
+  #146, but a genuinely idle-then-resumed session still closes via staleness);
+- a **genuine close followed by a resume** — an editor restart, a `/compact`,
+  or an idle-then-return.
+
+On resume the next heartbeat finds no live sidecar (it was archived), mints a
+fresh one with an empty `stub_path`, and `ensure_note` creates a **second**
+note file that re-narrates the first from an empty note-so-far. The pilot
+(transcript `a737ff12`, 2026-07-04) split one session into `04-0605` (turns
+1095–1383) and `04-0608` (turns 1384–1430): two unlinked files, the second
+repeating the first. This defeats the product promise of one faithful,
+skimmable record per session.
+
+The fix requires appending a new chapter to the already-closed note — which the
+immutability invariant forbids.
+
+## Decision
+
+Introduce a `reopen_note` primitive in the deterministic core
+(`lore_core/note_document.py`) that flips a closed note's `note_status` back to
+`open` (idempotent on an already-open note) and **deliberately relaxes the
+close-immutability invariant for session notes only**, under a *one file per
+session (reopen)* model:
+
+- When a resumed session's heartbeat finds no live buffer for its stem
+  (`<transcript_id>__<local_date>`), it first looks in `_done/` for its own
+  archived buffer. If found, it **restores** that buffer (moves it back to the
+  live dir, resets it to a fresh accumulation cycle preserving the note
+  pointer), **reopens** the note, and continues appending chapters to the same
+  file — seeding note-so-far from the existing body so the composer does not
+  duplicate earlier content.
+- The archive is *moved*, not copied, preserving the "one buffer per stem"
+  invariant: a later close archives cleanly with no `_done/` collision.
+- Reopen is unconditional for a closed session note. The note records **no
+  close reason**, so there is no basis to distinguish "closed at a session
+  boundary" from any other close; we do not invent one (YAGNI). Only a
+  session's own continuing heartbeat, keyed on the identical stem, ever reopens
+  its own note.
+
+Immutability is preserved everywhere else: derived and curated artifacts
+(concepts, decisions, threads) remain immutable, and no cross-session or
+curator writer may reopen a session note. The carve-out is narrow — a session
+may reopen *its own* note, nothing more.
+
+## Consequences / Trade-offs
+
+- **Positive.** One session yields exactly one note across false reaps and
+  resumes; no duplicated sibling files; the continuation is seeded with the
+  prior body so it reads as a single coherent record. The `04-0605`/`04-0608`
+  split no longer occurs.
+- **Negative — a closed note is no longer a hard-frozen artifact.** A reader or
+  downstream consumer can no longer assume `note_status: closed` is permanent;
+  the same file may gain chapters later if its session resumes. This is
+  acceptable because a session note is explicitly a lab-notebook record (per
+  its own disclaimer), not a source of truth, and the reopen only ever *appends*
+  — earlier chapters are never edited, matching the existing append-only-until-
+  close contract within a session.
+- **Concurrency.** Two heartbeats racing to reattach the same archived buffer
+  serialise on the per-stem flock (its `.lock` file is never archived, so the
+  lock path is stable across archive/restore). The first restores and reopens;
+  the second re-reads the now-live sidecar and takes the normal accumulate path.
+  This reuses the exact serialisation the existing fresh-mint path already
+  relies on.
+- **Discarded prior note.** If the prior session was trivial/empty and its note
+  file was deleted, the archived `stub_path` dangles. Restore detects the
+  missing file, clears `stub_path`, and lets a fresh note be created for the
+  resumed session rather than crashing on a reopen of a deleted file.
+
+## Alternatives considered
+
+- **A linked chain of sibling notes** (keep immutability; link `04-0608` back to
+  `04-0605` via frontmatter). Rejected: it still fragments one session across
+  files, still risks cross-file duplication, and complicates every reader and
+  briefing-gather with chain-following. One file is simpler and matches the
+  product promise directly.
+- **A stable session-level owner id** replacing the ephemeral pid, so the buffer
+  is never closed for a live session in the first place. Deferred (out of scope
+  for this epic, PRD 0002): it is a deeper owner-identity redesign; routing
+  pid-gone through the staleness path (#146) plus reopen-on-resume is sufficient
+  now.
+- **A close-reason gate on reopen** (only reopen notes closed "at a boundary").
+  Rejected: no close reason is recorded today, so the distinction does not
+  exist; inventing one would be speculative complexity.

--- a/docs/prd/0001-trim-to-lab-notebook-notes.md
+++ b/docs/prd/0001-trim-to-lab-notebook-notes.md
@@ -50,7 +50,13 @@ decisions); absorbing the plugin into lore is a follow-up epic.
 ## Implementation decisions
 
 **Note document (deterministic core).** One note per session; the file is append-only until
-close, then immutable (Part-N splitting is removed). Structure: fixed machine-written genre
+close, then immutable (Part-N splitting is removed) — with one carve-out added by epic #151
+(PRD 0002): a resumed session (same transcript + local date) whose note was closed early may
+**reopen** its own note and continue appending, so one session still yields exactly one note
+instead of a duplicated sibling. Immutability still holds for every derived/curated artifact
+and for any other writer; only a session's own continuing heartbeat reopens its own session
+note. See [ADR 0001](../adr/0001-session-note-reopen-relaxes-close-immutability.md).
+Structure: fixed machine-written genre
 disclaimer, then chronological chapters — one per flush. A chapter is a set of topic blocks:
 bold one-sentence self-sufficient lead (no pronouns into the body), short prose body, one
 `@turn` anchor at block end marking where the topic starts. No kinds, no lead prefixes;

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -47,6 +47,7 @@ __all__ = [
     "append_chapter",
     "append_marker_chapter",
     "close_note",
+    "reopen_note",
     "is_closed",
     "read_note",
     "render_chapter_body",
@@ -397,6 +398,36 @@ def close_note(
     _apply_facts(fm, facts)
     fm["last_reviewed"] = _today()
     _write(path, fm, body, wiki_root=wiki_root)
+
+
+def reopen_note(
+    path: Path,
+    *,
+    wiki_root: Path | None = None,
+) -> bool:
+    """Reopen a closed session note so its own continuing session can append.
+
+    Flips ``note_status`` from ``closed`` back to ``open`` and returns
+    ``True`` when a reopen happened; a no-op returning ``False`` when the
+    note is already open (idempotent). No content is touched — only the
+    status flag and ``last_reviewed`` move, and the next
+    :func:`append_chapter` resumes numbering from the existing chapters.
+
+    This deliberately relaxes the "a closed session note is immutable"
+    invariant, and *only* for session notes under the one-file-per-session
+    (reopen) model: a session that was closed early (a false liveness reap)
+    or resumes after a genuine close reattaches to its own note rather than
+    minting a duplicate sibling. Immutability still holds for derived /
+    curated artifacts; there is no close-reason gate because the note
+    records no close reason to gate on. See ``docs/adr/0001``.
+    """
+    fm, body = _load(path)
+    if fm.get("note_status") != _CLOSED:
+        return False
+    fm["note_status"] = _OPEN
+    fm["last_reviewed"] = _today()
+    _write(path, fm, body, wiki_root=wiki_root)
+    return True
 
 
 def is_closed(path: Path) -> bool:

--- a/lib/lore_curator/buffer_append.py
+++ b/lib/lore_curator/buffer_append.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from lore_core import note_document as nd
 from lore_core.types import Turn
 from lore_core.wiki_config import WikiConfig
 from lore_curator.buffer_store import (
@@ -274,30 +275,56 @@ def append_chunk(
         existing = buffer.read_sidecar()
 
         if existing is None:
-            owner = _build_owner(
-                run_id=owner_run_id,
-                claude_session_id=owner_claude_session_id,
-            )
-            sidecar = _build_initial_sidecar(
-                transcript_id=transcript_id,
-                local_date=local_date,
-                integration=integration,
-                wiki=wiki,
-                scope=scope,
-                cwd=cwd,
-                handle_label=handle_label,
-                owner=owner,
-            )
-            buffer.init_sidecar(sidecar)
-            is_new = True
-            existing = buffer.read_sidecar()
-            if logger is not None:
-                logger.emit(
-                    "buffer-opened",
+            restored = buffer.reopen_from_done()
+            if restored is not None:
+                # Resumed session: a prior close (a false liveness reap, or a
+                # genuine close followed by an editor restart / /compact /
+                # idle-then-return) archived this stem's buffer. Reattach to
+                # it and reopen its note so the continuation appends to the
+                # SAME file instead of minting a duplicate, partly-duplicated
+                # sibling — one session, one note. See docs/adr/0001.
+                existing = restored
+                note_path = Path(restored.stub_path) if restored.stub_path else None
+                if note_path is not None and note_path.exists():
+                    nd.reopen_note(note_path, wiki_root=wiki_root)
+                else:
+                    # The prior note was discarded (trivial / empty) or never
+                    # written; drop the dangling pointer so a fresh note is
+                    # created for the resumed session.
+                    existing = buffer.patch(stub_path="")
+                if logger is not None:
+                    logger.emit(
+                        "buffer-reopened",
+                        transcript_id=transcript_id,
+                        local_date=local_date,
+                        stem=buffer.stem,
+                        note_path=existing.stub_path,
+                    )
+            else:
+                owner = _build_owner(
+                    run_id=owner_run_id,
+                    claude_session_id=owner_claude_session_id,
+                )
+                sidecar = _build_initial_sidecar(
                     transcript_id=transcript_id,
                     local_date=local_date,
-                    stem=buffer.stem,
+                    integration=integration,
+                    wiki=wiki,
+                    scope=scope,
+                    cwd=cwd,
+                    handle_label=handle_label,
+                    owner=owner,
                 )
+                buffer.init_sidecar(sidecar)
+                is_new = True
+                existing = buffer.read_sidecar()
+                if logger is not None:
+                    logger.emit(
+                        "buffer-opened",
+                        transcript_id=transcript_id,
+                        local_date=local_date,
+                        stem=buffer.stem,
+                    )
 
         # State guard: if a flush worker has already taken ownership
         # (state in {flushing, closed}), the heartbeat must NOT mutate

--- a/lib/lore_curator/buffer_store.py
+++ b/lib/lore_curator/buffer_store.py
@@ -601,6 +601,46 @@ class Buffer:
             os.replace(self._log_path, new_log)
         return new_sidecar, new_log
 
+    def reopen_from_done(self) -> Sidecar | None:
+        """Restore this stem's archived buffer from ``_done/`` for continuation.
+
+        Moves ``_done/<stem>.state.json`` (and ``.jsonl`` if present) back to
+        the live buffers dir, then resets the sidecar to a fresh accumulation
+        cycle — state ``accumulating``, counters zeroed, event log truncated,
+        flush bookkeeping cleared — while preserving the note pointer
+        (``stub_path``), session identity, and the transcript watermark
+        (``last_seen``). Returns the restored :class:`Sidecar`, or ``None``
+        when no archived buffer exists for this stem. Caller must hold
+        :meth:`with_lock`.
+
+        This is the buffer half of the reopen-and-continue path: a session
+        that was closed — a false liveness reap, or a genuine close followed
+        by a resume — reattaches to its own buffer instead of minting a
+        duplicate. The archive is *moved* (not copied) so the "one buffer per
+        stem" invariant holds: a later :meth:`close` archives cleanly with no
+        ``_done/`` collision. The event log is truncated because the note
+        already carries every flushed chapter; only new turns accumulate now.
+        """
+        done = done_dir(self._lore_root)
+        archived_sidecar = done / self._sidecar_path.name
+        archived_log = done / self._log_path.name
+        if not archived_sidecar.exists():
+            return None
+        os.replace(archived_sidecar, self._sidecar_path)
+        if archived_log.exists():
+            os.replace(archived_log, self._log_path)
+        sidecar = self.read_sidecar()
+        if sidecar is None:
+            return None
+        sidecar.state = "accumulating"
+        sidecar.counters = Counters()
+        sidecar.flush_attempts = 0
+        sidecar.last_error = None
+        sidecar.flush_requested = None
+        self._write_sidecar(sidecar)
+        self._log_path.write_text("")
+        return sidecar
+
 
 # ---------------------------------------------------------------------------
 # Cross-buffer iteration (used by reaper / SessionEnd / status)

--- a/tests/test_reopen_continue.py
+++ b/tests/test_reopen_continue.py
@@ -1,0 +1,421 @@
+"""Reopen + continue: a resumed session continues its existing note.
+
+One session, one note. When a session is closed — a false liveness reap, or a
+genuine close followed by an editor restart / ``/compact`` / idle-then-return —
+its buffer sidecar is archived to ``_done/``. The next heartbeat on the same
+stem must reattach to that archived buffer, reopen its (closed) note, and
+append the new chapter to the **same** file instead of minting an unlinked,
+partly-duplicated sibling.
+
+Every LLM interaction is faked with the stub-replay harness; no test asserts
+prose quality and no LLM-as-judge appears.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from lore_core import note_document as nd
+from lore_core.note_document import Chapter, TopicBlock
+from lore_core.types import Turn
+from lore_core.wiki_config import WikiConfig
+from lore_curator.buffer_append import append_chunk
+from lore_curator.buffer_store import (
+    Buffer,
+    Counters,
+    LastSeen,
+    Sidecar,
+    _stem_for,
+    done_dir,
+)
+from lore_curator.chapter_flush import synth_and_close
+
+# ---------------------------------------------------------------------------
+# Fakes (stub-replay compose harness)
+# ---------------------------------------------------------------------------
+
+
+class _Adapter:
+    integration = "fake"
+
+    def __init__(self, turns: list[Turn]) -> None:
+        self._turns = turns
+
+    def transcript_path_for_id(self, transcript_id: str, cwd: Path) -> Path:
+        return cwd / f"{transcript_id}.jsonl"
+
+    def read_slice(self, handle, from_index: int = 0):
+        yield from (t for t in self._turns if t.index >= from_index)
+
+
+def _lookup(adapter: _Adapter):
+    def _l(integration: str):
+        return adapter
+
+    return _l
+
+
+class _Block:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.type = "tool_use"
+        self.input = payload
+
+
+class _Resp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.content = [_Block(payload)]
+        self.model = "m"
+
+
+class _Messages:
+    def __init__(self, payloads: list[dict | None]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> _Resp:
+        self.calls.append(kwargs)
+        payload = self._payloads.pop(0) if self._payloads else {}
+        if payload is None:
+            raise RuntimeError("simulated LLM failure")
+        return _Resp(payload)
+
+
+class _Client:
+    def __init__(self, payloads: list[dict | None]) -> None:
+        self.messages = _Messages(payloads)
+
+
+def _chapter_payload(lead: str, body: str, anchor: int) -> dict[str, Any]:
+    return {"blocks": [{"lead": lead, "body": body, "anchor": anchor}]}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / seeding
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_collectors(monkeypatch):
+    monkeypatch.setattr("lore_curator.session_activity.collect_commits_by_sha", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_issues_in_window",
+        lambda *a, **k: ([], []),
+    )
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_projects_for_session",
+        lambda **k: [],
+    )
+    monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
+    monkeypatch.setattr("lore_core.git.current_repo", lambda cwd: "")
+
+
+# The concrete pilot fixture: transcript a737ff12, 2026-07-04, split at a
+# /compact into 04-0605 (turns 1095-1383) and 04-0608 (turns 1384-1430).
+TID = "a737ff12"
+DATE = "2026-07-04"
+
+
+def _turns(lo: int, hi: int) -> list[Turn]:
+    return [
+        Turn(index=i, timestamp=None, role="user" if i % 2 == 0 else "assistant", text=f"line {i}")
+        for i in range(lo, hi + 1)
+    ]
+
+
+def _lore_root(tmp_path: Path) -> Path:
+    (tmp_path / ".lore" / "buffers").mkdir(parents=True)
+    (tmp_path / "wiki" / "private" / "sessions").mkdir(parents=True)
+    return tmp_path
+
+
+def _append(lore_root: Path, turns: list[Turn], *, tid: str = TID, date: str = DATE):
+    return append_chunk(
+        lore_root=lore_root,
+        chunk_turns=turns,
+        local_date=date,
+        transcript_id=tid,
+        integration="fake",
+        wiki="private",
+        scope="proj:x",
+        cwd=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        cfg=WikiConfig(),
+    )
+
+
+def _seed_archived_closed_note(
+    lore_root: Path,
+    *,
+    tid: str,
+    date: str,
+    chapter_lead: str,
+    from_turn: int,
+    to_turn: int,
+    stub_path: Path | None = None,
+    write_note: bool = True,
+) -> tuple[Path, str]:
+    """Seed a closed session note plus its archived (``_done/``) buffer.
+
+    Mirrors the on-disk state left by a session that already composed one
+    chapter and closed: a ``note_status: closed`` note file and a
+    ``_done/<stem>.state.json`` sidecar (state ``closed``) pointing at it.
+    """
+    wiki_root = lore_root / "wiki" / "private"
+    stem = _stem_for(tid, date)
+    note_path = stub_path or (wiki_root / "sessions" / f"{tid}-first.md")
+    if write_note:
+        nd.create_note(
+            note_path,
+            title="Session note",
+            description="Lab-notebook session note.",
+            scope="proj:x",
+            extra_frontmatter={"transcript_id": tid, "integration": "fake", "buffer_stem": stem},
+        )
+        nd.append_chapter(
+            note_path,
+            Chapter(blocks=[TopicBlock(lead=chapter_lead, body="prose.", anchor_turn=from_turn)]),
+            slice_from_turn=from_turn,
+            slice_to_turn=to_turn,
+        )
+        nd.close_note(note_path)
+    sc = Sidecar(
+        transcript_id=tid,
+        local_date=date,
+        integration="fake",
+        wiki="private",
+        scope="proj:x",
+        cwd=str(lore_root),
+        handle="",
+        state="closed",
+        stub_path=str(note_path),
+        counters=Counters(),
+        last_seen=LastSeen(content_hash="h", index_hint=to_turn),
+    )
+    done = done_dir(lore_root)
+    (done / f"{stem}.state.json").write_text(json.dumps(sc.to_dict(), default=str))
+    (done / f"{stem}.jsonl").write_text("")
+    return note_path, stem
+
+
+# ---------------------------------------------------------------------------
+# reopen_note primitive (unit)
+# ---------------------------------------------------------------------------
+
+
+def test_reopen_note_flips_closed_to_open_and_allows_append(tmp_path):
+    path = tmp_path / "note.md"
+    nd.create_note(path, title="t", description="d", scope="proj:x")
+    nd.append_chapter(
+        path,
+        Chapter(blocks=[TopicBlock(lead="First finding", body="a", anchor_turn=1)]),
+        slice_from_turn=0,
+        slice_to_turn=2,
+    )
+    nd.close_note(path)
+    assert nd.is_closed(path) is True
+    # A closed note refuses appends today.
+    with pytest.raises(nd.NoteClosedError):
+        nd.append_chapter(
+            path,
+            Chapter(blocks=[TopicBlock(lead="blocked", body="x", anchor_turn=3)]),
+            slice_from_turn=3,
+            slice_to_turn=4,
+        )
+
+    nd.reopen_note(path)
+    assert nd.is_closed(path) is False
+
+    n = nd.append_chapter(
+        path,
+        Chapter(blocks=[TopicBlock(lead="Second finding", body="b", anchor_turn=3)]),
+        slice_from_turn=3,
+        slice_to_turn=4,
+    )
+    assert n == 2
+    view = nd.read_note(path)
+    assert len([c for c in view.chapters if c.get("kind") == "topic"]) == 2
+    assert "First finding" in view.body and "Second finding" in view.body
+
+
+def test_reopen_note_idempotent_on_open_note(tmp_path):
+    path = tmp_path / "note.md"
+    nd.create_note(path, title="t", description="d", scope="proj:x")
+    nd.append_chapter(
+        path,
+        Chapter(blocks=[TopicBlock(lead="Only finding", body="a", anchor_turn=1)]),
+        slice_from_turn=0,
+        slice_to_turn=2,
+    )
+    before = path.read_text()
+    # Reopening an already-open note is a no-op — no raise, byte-identical file.
+    nd.reopen_note(path)
+    assert nd.is_closed(path) is False
+    assert path.read_text() == before
+
+
+# ---------------------------------------------------------------------------
+# Reattach: a resumed session continues the existing note (one file)
+# ---------------------------------------------------------------------------
+
+
+def test_resumed_session_reattaches_and_appends_to_same_note(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    adapter = _Adapter(_turns(0, 20))
+
+    # Session 1: accumulate, compose one chapter, close (archives the buffer).
+    _append(lore_root, _turns(0, 12))
+    buf = Buffer.open(lore_root, transcript_id=TID, local_date=DATE)
+    stem = buf.stem
+    out1 = synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client([_chapter_payload("Recorded the publish gate", "gate prose.", 4)]),
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    note_path = out1.note_path
+    assert nd.is_closed(note_path) is True
+    assert list((wiki_root / "sessions").rglob("*.md")) == [note_path]
+    assert not buf.sidecar_path.exists()
+    assert (done_dir(lore_root) / f"{stem}.state.json").exists()
+
+    # Session 2 resumes on the same stem after the close.
+    out2 = _append(lore_root, _turns(13, 20))
+    assert out2.is_new_buffer is False  # reattached, not a fresh buffer
+    assert buf.sidecar_path.exists()  # buffer restored out of _done/
+    assert buf.read_sidecar().stub_path == str(note_path)  # same note pointer
+    assert nd.is_closed(note_path) is False  # note reopened
+    assert not (done_dir(lore_root) / f"{stem}.state.json").exists()  # archive moved back
+
+    # Flush the continuation and close again.
+    out3 = synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client(
+            [_chapter_payload("Recorded the essence rewrite", "essence prose.", 15)]
+        ),
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    assert out3.status == "composed"
+    # Still exactly one note file — no sibling minted.
+    assert list((wiki_root / "sessions").rglob("*.md")) == [note_path]
+    view = nd.read_note(note_path)
+    topic = [c for c in view.chapters if c.get("kind") == "topic"]
+    assert len(topic) == 2
+    assert topic[0]["from_turn"] == 0 and topic[0]["to_turn"] == 12
+    assert topic[1]["from_turn"] == 13 and topic[1]["to_turn"] == 20
+    assert view.closed is True
+
+
+def test_continued_compose_receives_existing_body_as_note_so_far(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    adapter = _Adapter(_turns(0, 20))
+
+    _append(lore_root, _turns(0, 12))
+    buf = Buffer.open(lore_root, transcript_id=TID, local_date=DATE)
+    out1 = synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client(
+            [_chapter_payload("Recorded the publish gate design", "unique-marker-alpha.", 4)]
+        ),
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    assert out1.note_path is not None
+
+    _append(lore_root, _turns(13, 20))
+    c2 = _Client([_chapter_payload("Recorded the continuation", "beta prose.", 15)])
+    synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=c2,
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    # The continuation compose was seeded with the existing body, so the
+    # first chapter is present in note-so-far and never re-narrated.
+    prompt = c2.messages.calls[0]["messages"][0]["content"]
+    assert "Recorded the publish gate design" in prompt
+    assert "unique-marker-alpha" in prompt
+
+
+def test_0605_0608_split_reproduced_as_single_note(tmp_path):
+    # The concrete pilot failure: transcript a737ff12 filed 04-0605 (turns
+    # 1095-1383) then, after a /compact, an unlinked 04-0608 (turns
+    # 1384-1430). With reopen+continue the resume reattaches — one note.
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    note_path, stem = _seed_archived_closed_note(
+        lore_root,
+        tid=TID,
+        date=DATE,
+        chapter_lead="Recorded the publish gate",
+        from_turn=1095,
+        to_turn=1383,
+    )
+    assert list((wiki_root / "sessions").rglob("*.md")) == [note_path]
+
+    out = _append(lore_root, _turns(1384, 1430))
+    assert out.is_new_buffer is False
+    assert nd.is_closed(note_path) is False  # reopened, not a new file
+
+    buf = Buffer.open(lore_root, transcript_id=TID, local_date=DATE)
+    synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client(
+            [_chapter_payload("Recorded record-the-work-not-the-working", "essence prose.", 1400)]
+        ),
+        model="m",
+        adapter_lookup=_lookup(_Adapter(_turns(1384, 1430))),
+        auto_commit=False,
+    )
+    # The split is healed: still exactly one note file, now two chapters.
+    assert list((wiki_root / "sessions").rglob("*.md")) == [note_path]
+    view = nd.read_note(note_path)
+    topic = [c for c in view.chapters if c.get("kind") == "topic"]
+    assert len(topic) == 2
+    assert topic[0]["to_turn"] == 1383
+    assert topic[1]["from_turn"] == 1384 and topic[1]["to_turn"] == 1430
+
+
+def test_resume_after_discarded_note_starts_fresh(tmp_path):
+    # A prior session was discarded (trivial / empty): its note file was
+    # removed but the buffer archived with a dangling stub_path. Resuming
+    # must not crash on the missing file; it clears the pointer so a fresh
+    # note is created for the continuing session.
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    missing = wiki_root / "sessions" / "gone.md"
+    _seed_archived_closed_note(
+        lore_root,
+        tid=TID,
+        date=DATE,
+        chapter_lead="unused",
+        from_turn=0,
+        to_turn=1,
+        stub_path=missing,
+        write_note=False,  # note file never exists on disk
+    )
+
+    out = _append(lore_root, _turns(0, 4))
+    assert out.is_new_buffer is False
+    buf = Buffer.open(lore_root, transcript_id=TID, local_date=DATE)
+    assert buf.sidecar_path.exists()  # buffer restored, no crash
+    assert buf.read_sidecar().stub_path == ""  # dangling pointer cleared


### PR DESCRIPTION
Closes #148. Part of epic #151 (PRD 0002). Targets `epic/151`.

## What

A resumed session now continues its **existing** note instead of minting an
unlinked, partly-duplicated sibling. When a session is closed — a false
liveness reap, or a genuine close followed by an editor restart / `/compact` /
idle-then-return — its buffer sidecar is archived to `_done/`, so the next
heartbeat's `read_sidecar()` returned `None`, a fresh sidecar with an empty
`stub_path` was minted, and a second note file was filed that re-narrated the
first (the concrete `04-0605` / `04-0608` pilot split).

Now, at the `existing is None` branch of `append_chunk`, the code first looks
in `_done/` for an archived buffer of the same stem (`<transcript_id>__<local_date>`),
restores it, reopens its note, and continues appending chapters to the **same
file** — seeding note-so-far from the existing body so the compose does not
duplicate earlier content.

## Changes

- **`lore_core/note_document.py`** — new `reopen_note` primitive: flips a
  closed note's `note_status` back to `open`, idempotent on an already-open
  note (returns whether a reopen happened). Exported in `__all__`.
- **`lore_curator/buffer_store.py`** — new `Buffer.reopen_from_done()`:
  *moves* `_done/<stem>.state.json` (+ `.jsonl`) back to the live dir and
  resets the sidecar to a fresh accumulation cycle (state `accumulating`,
  counters zeroed, log truncated, flush bookkeeping cleared) while preserving
  `stub_path`, identity, and the `last_seen` watermark. Moving (not copying)
  keeps the "one buffer per stem" invariant so a later `close()` archives with
  no `_done/` collision.
- **`lore_curator/buffer_append.py`** — reattach path: try `reopen_from_done()`
  first; on success reopen the note (if its file still exists) and continue;
  otherwise mint fresh as before. Emits a `buffer-reopened` log event.
- **ADR** `docs/adr/0001-session-note-reopen-relaxes-close-immutability.md`
  (first ADR in the repo) records the immutability carve-out; **PRD 0001**
  prose amended to note the session-note reopen exception and cross-reference
  the ADR.
- **`tests/test_reopen_continue.py`** — 6 new tests.

## Red → green (TDD)

Failing first (implementation stashed), all 6 red:

```
FAILED test_reopen_note_flips_closed_to_open_and_allows_append - AttributeError: module 'lore_core.note_document' has no attribute 'reopen_note'
FAILED test_reopen_note_idempotent_on_open_note                - AttributeError: ... no attribute 'reopen_note'
FAILED test_resumed_session_reattaches_and_appends_to_same_note - AssertionError: assert True is False  (is_new_buffer)
FAILED test_continued_compose_receives_existing_body_as_note_so_far - IndexError: list index out of range  (no 2nd compose call)
FAILED test_0605_0608_split_reproduced_as_single_note          - AssertionError: assert True is False  (note not reopened)
FAILED test_resume_after_discarded_note_starts_fresh           - AssertionError: assert True is False
6 failed in 0.61s
```

Green after implementation:

```
tests/test_reopen_continue.py ......  6 passed
```

Full suite: **2373 passed, 8 skipped, 16 failed** — the 16 are the pre-existing
unrelated failures already fingerprinted by #152/#153 (rich ANSI color-code
assertions, missing optional `openai` dep, stale hardcoded dates/version). No
new failures; none touch the modules changed here. `ruff check` and
`ruff format --check` are clean on the new test file, and the changes to the
lib files introduce **zero** new ruff findings (the pre-existing ruff/format
debt in `buffer_store.py` / `buffer_append.py` is left untouched per the scope
fence — the base branch fails those identically).

## Decisions / judgment calls

- **Reattach race.** Two heartbeats racing to reattach the same archived buffer
  serialise on the per-stem flock — the `.lock` file is never archived, so the
  lock path is stable across archive/restore. The first restores + reopens; the
  second re-reads the now-live sidecar and takes the normal accumulate path.
  This reuses the exact serialisation the existing fresh-mint path already
  relies on; the restore happens inside the same `with buffer.with_lock()`.
- **Close-reason gate.** The note records no close reason, so there is no basis
  to distinguish a boundary close from any other. Per the task guidance I did
  **not** invent one — `reopen_note` reopens any closed session note
  unconditionally (only a session's own continuing heartbeat, keyed on the
  identical stem, ever calls it).
- **Discarded prior note.** A trivial/empty prior session deletes its note file
  but archives its buffer with a dangling `stub_path`. Restore detects the
  missing file, clears `stub_path`, and lets a fresh note be created rather than
  crashing on a reopen of a deleted file (covered by
  `test_resume_after_discarded_note_starts_fresh`).
