### PR TITLE
feat(capture): topic-derived note slug — rename after the first chapter

### DIFF
--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -68,7 +68,9 @@ from lore_curator.buffer_store import (
     iter_all,
 )
 from lore_curator.chapter_compose import ComposeStatus, Gate, compose_chapter
+from lore_curator.session_filer import _slug
 from lore_curator.session_note import ensure_note_from_sidecar, facts_from_replay
+from lore_curator.stub_note import _lead_for_rename, _resolve_renamed_path
 
 if TYPE_CHECKING:
     from lore_core.run_log import RunLogger
@@ -470,6 +472,31 @@ def _read_note_body(note_path: Path) -> str:
         return ""
 
 
+def _rename_to_topic_slug(buffer: Buffer, note_path: Path, chapter: nd.Chapter) -> Path:
+    """Rename a note to its first chapter's topic, once that topic exists.
+
+    The note is created (and first named) at the first heartbeat, well
+    before any chapter — so its filename starts as an incidental guess (a
+    commit subject, a touched file's basename, or a bare timestamp). Once
+    the first chapter composes, its opening lead names the session's
+    actual topic; this makes the filename match. A chapter with no usable
+    lead text (shouldn't happen for a COMPOSED result, but defensive)
+    leaves the filename untouched rather than risk an empty slug.
+    """
+    lead = _lead_for_rename(chapter)
+    if not lead:
+        return note_path
+    slug = _slug(lead)
+    if not slug or slug == "session":
+        return note_path
+    new_path = _resolve_renamed_path(note_path, slug)
+    if new_path == note_path:
+        return note_path
+    note_path.replace(new_path)
+    buffer.patch(stub_path=str(new_path))
+    return new_path
+
+
 def _apply_outcome(
     *,
     buffer: Buffer,
@@ -515,6 +542,10 @@ def _apply_outcome(
             facts=facts,
             wiki_root=wiki_root,
         )
+        if out.chapter_n == 1:
+            note_path = _rename_to_topic_slug(buffer, note_path, compose_result.chapter)
+            out.note_path = note_path
+            out.wikilink = f"[[{note_path.stem}]]"
         out.status = "composed"
         _clear_after_progress(buffer, close=close)
     elif status is ComposeStatus.EMPTY:

--- a/lib/lore_curator/stub_note.py
+++ b/lib/lore_curator/stub_note.py
@@ -54,6 +54,7 @@ from lore_curator.buffer_store import Buffer, ReplayedBuffer, Sidecar
 from lore_curator.session_filer import _slug
 
 if TYPE_CHECKING:
+    from lore_core.note_document import Chapter
     from lore_core.run_log import RunLogger
 
 
@@ -132,6 +133,53 @@ def _derive_slug(
 
     scope_label = scope.scope.replace(":", "-")
     return _slug(f"session-{scope_label}-{work_time.strftime('%H%M')}")
+
+
+def _lead_for_rename(chapter: Chapter) -> str:
+    """First block's topic text, for renaming a note after its first chapter.
+
+    A composed note's file is created (and first named) at the first
+    heartbeat — well before any chapter exists, so the initial filename is
+    always the heuristic guess above. Once the first chapter composes, its
+    opening block names the session's actual topic and the file is renamed
+    to match (see ``chapter_flush._rename_to_topic_slug``). Returns ``""``
+    when the chapter has no blocks or the first one carries no usable text
+    (a continuation block's topic lives in ``continued_topic``) — the
+    caller must treat that as "keep the current filename", never invent an
+    empty slug.
+    """
+    if not chapter.blocks:
+        return ""
+    block = chapter.blocks[0]
+    lead = (block.continued_topic if block.continued else block.lead) or ""
+    return lead.strip()
+
+
+def _resolve_renamed_path(note_path: Path, slug: str) -> Path:
+    """Return the rename target for ``note_path`` once ``slug`` is known.
+
+    Preserves the ``<DD>-<HHMM>-`` prefix and probes the same directory for
+    a free filename exactly like :func:`_resolve_first_write_path`'s
+    same-minute collision handling (numeric ``-2``, ``-3`` ... suffix) —
+    two notes composed in the same minute must never collide. Returns
+    ``note_path`` unchanged when its stem isn't the canonical
+    ``<DD>-<HHMM>-<slug>`` shape, or when ``slug`` already matches the
+    current one (nothing to rename).
+    """
+    parts = note_path.stem.split("-", 2)
+    if len(parts) < 3:
+        return note_path
+    day, hhmm, current_slug = parts
+    if current_slug == slug:
+        return note_path
+    prefix = f"{day}-{hhmm}-"
+    parent = note_path.parent
+    candidate = parent / f"{prefix}{slug}.md"
+    counter = 1
+    while candidate.exists() and candidate != note_path:
+        counter += 1
+        candidate = parent / f"{prefix}{slug}-{counter}.md"
+    return candidate
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chapter_flush.py
+++ b/tests/test_chapter_flush.py
@@ -274,6 +274,117 @@ def test_planted_secret_withholds_marker_and_quarantines(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Topic-derived slug — rename the note once its first chapter composes
+# ---------------------------------------------------------------------------
+
+
+def test_first_chapter_rename_reflects_topic_lead(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    all_turns = _turns(0, 4)
+    buf = _append(lore_root, all_turns)
+    client = _Client([_chapter_payload("Traced the flush race", "prose.", 2)])
+
+    outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+        auto_commit=False,
+    )
+    assert outcome.status == "composed"
+    assert outcome.note_path.name.endswith("-traced-the-flush-race.md")
+    assert outcome.wikilink == f"[[{outcome.note_path.stem}]]"
+
+    # Renamed in place — no orphaned file left at the old heuristic name.
+    notes = list((wiki_root / "sessions").rglob("*.md"))
+    assert notes == [outcome.note_path]
+
+    reopened = Buffer.open(lore_root, transcript_id="abc", local_date="2026-05-01")
+    assert reopened.read_sidecar().stub_path == str(outcome.note_path)
+
+
+def test_second_chapter_does_not_rename_again(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    adapter = _Adapter(_turns(0, 5))
+
+    _append(lore_root, _turns(0, 2))
+    buf = Buffer.open(lore_root, transcript_id="abc", local_date="2026-05-01")
+    c1 = _Client([_chapter_payload("Recorded the buffer store design", "Prose about buffers.", 1)])
+    first_outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=c1,
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    assert first_outcome.note_path.name.endswith("-recorded-the-buffer-store-design.md")
+
+    _append(lore_root, _turns(3, 5))
+    c2 = _Client([_chapter_payload("Discussed the flush lifecycle", "More prose.", 4)])
+    second_outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=c2,
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    # The filename stays pinned to the first chapter's topic.
+    assert second_outcome.note_path == first_outcome.note_path
+    notes = list((wiki_root / "sessions").rglob("*.md"))
+    assert notes == [first_outcome.note_path]
+
+
+def test_same_minute_rename_collision_gets_numeric_suffix(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    # Force both buffers into the same minute so their rename targets collide.
+    monkeypatch.setattr(
+        "lore_curator.buffer_store._now_iso",
+        lambda: "2026-05-01T14:32:00+00:00",
+    )
+
+    turns_a = _turns(0, 2)
+    buf_a = _append(lore_root, turns_a, tid="abc")
+    client_a = _Client([_chapter_payload("Shared Topic", "prose a.", 1)])
+    outcome_a = synth_in_place(
+        buf_a.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client_a,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(turns_a)),
+        auto_commit=False,
+    )
+
+    turns_b = _turns(0, 2)
+    buf_b = _append(lore_root, turns_b, tid="def")
+    client_b = _Client([_chapter_payload("Shared Topic", "prose b.", 1)])
+    outcome_b = synth_in_place(
+        buf_b.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client_b,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(turns_b)),
+        auto_commit=False,
+    )
+
+    assert outcome_a.note_path != outcome_b.note_path
+    assert outcome_a.note_path.name.endswith("-shared-topic.md")
+    assert outcome_b.note_path.name.endswith("-shared-topic-2.md")
+    assert outcome_a.note_path.exists()
+    assert outcome_b.note_path.exists()
+
+
+# ---------------------------------------------------------------------------
 # Failure semantics
 # ---------------------------------------------------------------------------
 

--- a/tests/test_stub_note.py
+++ b/tests/test_stub_note.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from lore_core.note_document import Chapter, TopicBlock
 from lore_core.schema import parse_frontmatter
 from lore_core.types import Scope, TranscriptHandle, Turn
 from lore_core.wiki_config import WikiConfig
@@ -14,6 +15,8 @@ from lore_curator.buffer_append import append_chunk
 from lore_curator.stub_note import (
     STUB_DESCRIPTION_PLACEHOLDER,
     STUB_SUMMARY_PLACEHOLDER,
+    _lead_for_rename,
+    _resolve_renamed_path,
     write_or_update,
 )
 
@@ -609,3 +612,63 @@ def test_preview_singular_plural_and_no_extras(
     # No commits / issues seeded → those segments must not appear.
     assert "commits" not in text.lower().split("_so far:", 1)[1].split("_._", 1)[0]
     assert "issue" not in text.lower().split("_so far:", 1)[1].split("_._", 1)[0]
+
+
+# ---------------------------------------------------------------------------
+# Topic-derived rename — the note's filename after its first chapter composes
+# ---------------------------------------------------------------------------
+
+
+def test_lead_for_rename_picks_first_block_lead():
+    chapter = Chapter(blocks=[
+        TopicBlock(lead="Traced the flush race", body="prose", anchor_turn=2),
+    ])
+    assert _lead_for_rename(chapter) == "Traced the flush race"
+
+
+def test_lead_for_rename_uses_continued_topic_for_continuation_block():
+    chapter = Chapter(blocks=[
+        TopicBlock(
+            lead="", body="prose", anchor_turn=2, continued=True, continued_topic="Flush race",
+        ),
+    ])
+    assert _lead_for_rename(chapter) == "Flush race"
+
+
+def test_lead_for_rename_empty_when_no_blocks():
+    assert _lead_for_rename(Chapter(blocks=[])) == ""
+
+
+def test_lead_for_rename_empty_when_first_block_blank():
+    chapter = Chapter(blocks=[TopicBlock(lead="   ", body="prose", anchor_turn=1)])
+    assert _lead_for_rename(chapter) == ""
+
+
+def test_resolve_renamed_path_swaps_slug_keeps_prefix(tmp_path: Path):
+    old = tmp_path / "01-1432-session-proj-x-1432.md"
+    old.write_text("stub")
+    new = _resolve_renamed_path(old, "traced-the-flush-race")
+    assert new.name == "01-1432-traced-the-flush-race.md"
+    assert new.parent == old.parent
+
+
+def test_resolve_renamed_path_noop_when_slug_unchanged(tmp_path: Path):
+    old = tmp_path / "01-1432-traced-the-flush-race.md"
+    old.write_text("stub")
+    new = _resolve_renamed_path(old, "traced-the-flush-race")
+    assert new == old
+
+
+def test_resolve_renamed_path_avoids_collision(tmp_path: Path):
+    old = tmp_path / "01-1432-session-proj-x-1432.md"
+    old.write_text("stub")
+    (tmp_path / "01-1432-traced-the-flush-race.md").write_text("someone else's note")
+    new = _resolve_renamed_path(old, "traced-the-flush-race")
+    assert new.name == "01-1432-traced-the-flush-race-2.md"
+
+
+def test_resolve_renamed_path_leaves_malformed_stem_untouched(tmp_path: Path):
+    old = tmp_path / "weird-name.md"
+    old.write_text("stub")
+    new = _resolve_renamed_path(old, "traced-the-flush-race")
+    assert new == old


### PR DESCRIPTION
## Summary

Closes #150. Part of epic #151 (PRD 0002).

A session note's file is created — and first named — at the first heartbeat, well before any chapter exists (`ensure_note` / `ensure_note_from_sidecar` write the disclaimer + zero-chapter frontmatter immediately). So the initial slug can only ever be the existing heuristic (`_derive_slug`: first commit subject → first `files_touched` basename → `session-<scope>-<HHMM>`), which is exactly the failure mode the PRD calls out: a note about a note-design discussion filed as `publish-gate.md` because a touched file happened to be named that.

Since no chapter exists at note-creation time, "derive the slug from the first composed lead" necessarily means **renaming the file once the first chapter composes**, not changing the initial heuristic. This PR:

- Adds `stub_note._lead_for_rename(chapter)` — the first chapter block's topic text (its `lead`, or `continued_topic` for a continuation block), `""` if unusable.
- Adds `stub_note._resolve_renamed_path(note_path, slug)` — a rename target that preserves the `<DD>-<HHMM>-` prefix and probes for a free filename exactly like the existing first-write collision handling (`-2`, `-3` ... suffix), so two notes composed in the same minute never collide.
- Adds `chapter_flush._rename_to_topic_slug(buffer, note_path, chapter)`, wired into `_apply_outcome`'s `COMPOSED` branch **only when `out.chapter_n == 1`** — the note is renamed the moment its first real topic chapter lands; later chapters never touch the filename again. The rename updates `FlushOutcome.note_path` / `.wikilink` and the buffer's `stub_path` before any downstream auto-commit / drain-emit, so nothing else needed to change.
- A chapter with no usable lead text (defensive; shouldn't happen for a `COMPOSED` result) or a stub/trivial note with no chapter yet keeps its current/heuristic filename — no crash, no empty slug.

**`backfill_slugs.py` is intentionally untouched.** It targets the pre-epic `state: stub` + Phase-2-written-`title` architecture. In the new chapter-based model, frontmatter `title` never advances past its placeholder (`<scope> session — <date>`), so `plan_rename`'s title-based rule can never fire for these notes anyway — the two mechanisms are already non-overlapping. Extending backfill to retroactively re-slug already-filed historical notes is "fixes forward" territory the PRD explicitly puts out of scope.

## Red → green

```
$ PYTHONPATH=.../lib pytest tests/test_stub_note.py tests/test_chapter_flush.py -k "rename or lead_for or resolve_renamed or same_minute" -q
ImportError: cannot import name '_lead_for_rename' from 'lore_curator.stub_note'
... (collection error — red)

# after implementation:
$ PYTHONPATH=.../lib pytest tests/test_chapter_flush.py tests/test_stub_note.py tests/test_session_note.py tests/test_backfill_slugs.py tests/test_slug.py tests/test_slug_index.py -q
64 passed
```

New tests:
- `test_stub_note.py`: pure unit tests for `_lead_for_rename` (first block, continuation block, no blocks, blank lead) and `_resolve_renamed_path` (swap slug / no-op when unchanged / collision suffix / malformed stem left alone).
- `test_chapter_flush.py`: end-to-end via `synth_in_place` — first chapter compose renames the note (old name vacated, no orphan file); second chapter never renames again; two buffers forced into the same minute (`buffer_store._now_iso` patched) get `-shared-topic.md` / `-shared-topic-2.md`.

## Test plan

- [x] `ruff check` on touched files — 0 new violations (7 pre-existing, unrelated, confirmed via baseline diff; matches sibling PRs' fingerprinted debt)
- [x] `ruff format --check` — not a repo-wide clean gate today (104/156 files in `lib/` already fail it pre-existing, no CI enforces it); didn't reformat unrelated pre-existing lines to keep the diff scoped
- [x] Full suite: `2390 passed, 16 failed, 8 skipped` — the 16 failures are the known pre-existing set from #152–#155 (rich ANSI color-code assertions, missing optional `openai` dep, stale hardcoded dates/version); none touch stub_note/chapter_flush/session_note/backfill_slugs/slug