### PR TITLE
Epic: Session notes that carry the essence, one per session (PRD 0002)

### DIFF
--- a/docs/adr/0001-session-note-reopen-relaxes-close-immutability.md
+++ b/docs/adr/0001-session-note-reopen-relaxes-close-immutability.md
@@ -1,0 +1,105 @@
+# ADR 0001: Session-note reopen relaxes close-immutability (one file per session)
+
+- Status: Accepted
+- Date: 2026-07-06
+- Context: epic [#151](https://github.com/buchbend/lore/issues/151),
+  PRD [0002](../prd/0002-useful-session-notes.md), sub-issue
+  [#148](https://github.com/buchbend/lore/issues/148)
+
+## Context
+
+A session note is the deterministic core's one-note-per-session record: a
+fixed disclaimer followed by chronological chapters, one per flush. PRD 0001
+established the lifecycle *create → append → (marker) → close*, where **close**
+sets `note_status: closed` and the file becomes immutable — no further chapter
+may be appended (`append_chapter` raises `NoteClosedError`).
+
+That invariant assumed close is terminal for a session. It is not. A session's
+buffer can be closed and archived to `_done/` while the session is still live
+or about to resume:
+
+- a **false liveness reap** — the owner `pid` is re-stamped every heartbeat to
+  the ephemeral hook subprocess, which exits within milliseconds, so
+  "pid gone" is the steady state, not death (fixed for the instant-reap case in
+  #146, but a genuinely idle-then-resumed session still closes via staleness);
+- a **genuine close followed by a resume** — an editor restart, a `/compact`,
+  or an idle-then-return.
+
+On resume the next heartbeat finds no live sidecar (it was archived), mints a
+fresh one with an empty `stub_path`, and `ensure_note` creates a **second**
+note file that re-narrates the first from an empty note-so-far. The pilot
+(transcript `a737ff12`, 2026-07-04) split one session into `04-0605` (turns
+1095–1383) and `04-0608` (turns 1384–1430): two unlinked files, the second
+repeating the first. This defeats the product promise of one faithful,
+skimmable record per session.
+
+The fix requires appending a new chapter to the already-closed note — which the
+immutability invariant forbids.
+
+## Decision
+
+Introduce a `reopen_note` primitive in the deterministic core
+(`lore_core/note_document.py`) that flips a closed note's `note_status` back to
+`open` (idempotent on an already-open note) and **deliberately relaxes the
+close-immutability invariant for session notes only**, under a *one file per
+session (reopen)* model:
+
+- When a resumed session's heartbeat finds no live buffer for its stem
+  (`<transcript_id>__<local_date>`), it first looks in `_done/` for its own
+  archived buffer. If found, it **restores** that buffer (moves it back to the
+  live dir, resets it to a fresh accumulation cycle preserving the note
+  pointer), **reopens** the note, and continues appending chapters to the same
+  file — seeding note-so-far from the existing body so the composer does not
+  duplicate earlier content.
+- The archive is *moved*, not copied, preserving the "one buffer per stem"
+  invariant: a later close archives cleanly with no `_done/` collision.
+- Reopen is unconditional for a closed session note. The note records **no
+  close reason**, so there is no basis to distinguish "closed at a session
+  boundary" from any other close; we do not invent one (YAGNI). Only a
+  session's own continuing heartbeat, keyed on the identical stem, ever reopens
+  its own note.
+
+Immutability is preserved everywhere else: derived and curated artifacts
+(concepts, decisions, threads) remain immutable, and no cross-session or
+curator writer may reopen a session note. The carve-out is narrow — a session
+may reopen *its own* note, nothing more.
+
+## Consequences / Trade-offs
+
+- **Positive.** One session yields exactly one note across false reaps and
+  resumes; no duplicated sibling files; the continuation is seeded with the
+  prior body so it reads as a single coherent record. The `04-0605`/`04-0608`
+  split no longer occurs.
+- **Negative — a closed note is no longer a hard-frozen artifact.** A reader or
+  downstream consumer can no longer assume `note_status: closed` is permanent;
+  the same file may gain chapters later if its session resumes. This is
+  acceptable because a session note is explicitly a lab-notebook record (per
+  its own disclaimer), not a source of truth, and the reopen only ever *appends*
+  — earlier chapters are never edited, matching the existing append-only-until-
+  close contract within a session.
+- **Concurrency.** Two heartbeats racing to reattach the same archived buffer
+  serialise on the per-stem flock (its `.lock` file is never archived, so the
+  lock path is stable across archive/restore). The first restores and reopens;
+  the second re-reads the now-live sidecar and takes the normal accumulate path.
+  This reuses the exact serialisation the existing fresh-mint path already
+  relies on.
+- **Discarded prior note.** If the prior session was trivial/empty and its note
+  file was deleted, the archived `stub_path` dangles. Restore detects the
+  missing file, clears `stub_path`, and lets a fresh note be created for the
+  resumed session rather than crashing on a reopen of a deleted file.
+
+## Alternatives considered
+
+- **A linked chain of sibling notes** (keep immutability; link `04-0608` back to
+  `04-0605` via frontmatter). Rejected: it still fragments one session across
+  files, still risks cross-file duplication, and complicates every reader and
+  briefing-gather with chain-following. One file is simpler and matches the
+  product promise directly.
+- **A stable session-level owner id** replacing the ephemeral pid, so the buffer
+  is never closed for a live session in the first place. Deferred (out of scope
+  for this epic, PRD 0002): it is a deeper owner-identity redesign; routing
+  pid-gone through the staleness path (#146) plus reopen-on-resume is sufficient
+  now.
+- **A close-reason gate on reopen** (only reopen notes closed "at a boundary").
+  Rejected: no close reason is recorded today, so the distinction does not
+  exist; inventing one would be speculative complexity.

--- a/docs/prd/0001-trim-to-lab-notebook-notes.md
+++ b/docs/prd/0001-trim-to-lab-notebook-notes.md
@@ -50,7 +50,13 @@ decisions); absorbing the plugin into lore is a follow-up epic.
 ## Implementation decisions
 
 **Note document (deterministic core).** One note per session; the file is append-only until
-close, then immutable (Part-N splitting is removed). Structure: fixed machine-written genre
+close, then immutable (Part-N splitting is removed) — with one carve-out added by epic #151
+(PRD 0002): a resumed session (same transcript + local date) whose note was closed early may
+**reopen** its own note and continue appending, so one session still yields exactly one note
+instead of a duplicated sibling. Immutability still holds for every derived/curated artifact
+and for any other writer; only a session's own continuing heartbeat reopens its own session
+note. See [ADR 0001](../adr/0001-session-note-reopen-relaxes-close-immutability.md).
+Structure: fixed machine-written genre
 disclaimer, then chronological chapters — one per flush. A chapter is a set of topic blocks:
 bold one-sentence self-sufficient lead (no pronouns into the body), short prose body, one
 `@turn` anchor at block end marking where the topic starts. No kinds, no lead prefixes;

--- a/docs/prd/0002-useful-session-notes.md
+++ b/docs/prd/0002-useful-session-notes.md
@@ -1,0 +1,146 @@
+---
+title: Session notes that carry the essence, one per session
+status: draft
+epic: https://github.com/buchbend/lore/issues/PENDING
+repos:
+  - buchbend/lore
+---
+
+# PRD 0002: Session notes that carry the essence, one per session
+
+> Source of truth for this epic. Tracker: [epic issue](https://github.com/buchbend/lore/issues/PENDING).
+> The epic links here; this file is not embedded in the issue body.
+
+## Problem
+
+The 0.56.0 essence-first rewrite improved the *voice* of session notes but a
+pilot against real transcripts exposed two failure classes that still make the
+notes unhelpful when a colleague returns to them months later.
+
+**One session produces several unlinked, partly-duplicated notes.** A single
+work session (transcript `a737ff12`, 2026-07-04) filed as two separate note
+files — `04-0605-publish-gate.md` (turns 1095–1383) and
+`04-0608-...-record-the-work-not-the.md` (turns 1384–1430) — split at a
+`/compact`. The second note re-narrated facts the first already carried,
+because it started from an empty note-so-far. The vault accumulates sibling
+notes that each tell part of the story and repeat the rest.
+
+**Notes report material the user never worked on.** `04-0605-publish-gate.md`
+presents SOPS / `age` / `.env` / `tmpfs` security *findings* as the session's
+work. The session was about Lore's own note-compose quality; the user merely
+**pasted an old SOPS note as a formatting exemplar**. The composer read the
+pasted, self-anchored example blocks and attributed their claims to the
+session. A related tell: every block in that note cites the same `@1095`
+anchor — the single turn holding the pasted blob — so the anchors are
+worthless as navigation.
+
+Both classes defeat the product promise: a note should be a faithful,
+skimmable, navigable record of *what this session figured out*.
+
+## Solution
+
+From the user's perspective, after this epic:
+
+- **One session is one note.** A session that is closed early (a false
+  liveness reap) or resumes after a genuine close (editor restart, a
+  `/compact`, an idle-then-return) continues its **existing** note instead of
+  spawning a duplicate sibling. Notes never repeat content across files.
+- **Notes describe only what the session worked on.** Material the user pastes
+  or quotes as an exemplar, reference, or comparison is never reported as the
+  session's own findings.
+- **Anchors point somewhere useful.** When several findings all cite one turn,
+  the composer is nudged to anchor them to where each actually arose, or to
+  confirm they are genuinely one finding.
+- **Note filenames name their topic**, derived from the first composed lead
+  rather than an incidental heuristic.
+
+## Implementation decisions
+
+Work is confined to `buchbend/lore`, across two subsystems.
+
+### Buffer lifecycle — one session, one note
+
+- **Liveness (`lore_curator/reaper.py::is_owner_alive`).** In the
+  buffer-and-flush architecture the owner `pid` is re-stamped every heartbeat
+  to the *current hook subprocess*, which exits within milliseconds — so
+  "pid gone" is the normal steady state, not death. Today a same-host,
+  pid-absent owner returns `False` (dead), letting the reaper and startup
+  sweep `synth_and_close` a **live** session. It must return `None`
+  (uncertain) instead, deferring to the existing staleness threshold. A
+  genuinely dead session still closes — via staleness, just not instantly.
+  A cross-host owner stays `False` (unchanged).
+- **Reopen + continuation (`lore_core/note_document.py`,
+  `lore_curator/buffer_append.py`, `session_note.py`, `buffer_store.py`).** A
+  new `reopen_note` primitive flips a closed note's `note_status` back to
+  `open`. In `append_chunk`'s `existing is None` branch — the point where a
+  resumed session currently mints a fresh sidecar with an empty `stub_path`
+  and thus a new file — the code first looks in `_done/` for an archived
+  sidecar of the same stem (`<transcript_id>__<local_date>`); if found it
+  restores that buffer, reopens its note, and continues appending chapters to
+  the **same file**, seeding note-so-far from the existing body so the compose
+  does not duplicate.
+
+  **ADR-worthy decision:** this deliberately relaxes the invariant "a closed
+  session note is immutable" for **session notes**. The chosen model is *one
+  file per session* (reopen), not a linked chain of sibling notes. Immutability
+  still holds for derived/curated artifacts; only a session's own note may be
+  reopened by its own continuing session. This is recorded as an ADR and the
+  vault-edit-policy is updated to carve out the exception.
+
+### Compose quality
+
+- **Quoted-vs-worked distinction (`lore_curator/chapter_compose.py::_build_prompt`).**
+  An explicit clause tells the composer that content the user pastes or quotes
+  as an exemplar / reference / comparison (signalled by framing like "this is a
+  form I'd like", fenced blocks, or blocks that carry their own `@N`-anchored
+  bold leads) is **not** this session's work; its claims are never attributed
+  to the session unless working on that material was itself the topic. Written
+  explicitly because the compose model is a ~120B open model, weaker at
+  implicit pragmatics.
+- **Same-anchor soft lint (`lore_curator/chapter_compose.py`).** The existing
+  anchor-lint / retry-feedback plumbing gains a *soft* check: when a chapter
+  has more than two blocks all citing one anchor, one corrective retry is
+  issued ("these all cite the same turn — confirm they are distinct findings
+  from session progression, not restatements of one quoted passage"). It never
+  hard-rejects and never fabricates anchor diversity; after the retry the
+  chapter publishes regardless.
+- **Topic slug (`lore_curator/session_note.py::_derive_slug`).** Derive the
+  note filename slug from the first composed lead; fall back to the current
+  heuristic for stubs that have no chapter yet.
+
+## Testing decisions
+
+Tests assert external behavior, not internals, and use the stub-LLM replay
+harness already established in `test_chapter_compose.py` /
+`test_chapter_flush.py` (no LLM-as-judge; every model call is faked).
+
+- **Liveness:** a regression test reproducing the false reap — a heartbeat pid
+  exits, the reaper runs, and the session must survive; plus the boundary that
+  a truly stale pid-gone buffer still closes. Prior art:
+  `test_startup_sweep.py`, `test_reaper.py`.
+- **Continuation:** seed an archived buffer (`_done/`) with a closed note, feed
+  a new chunk on the same stem, assert a **single** note file results with the
+  new chapter appended and no duplicated body; a `reopen_note` unit test for
+  the open/append/close cycle. Reproduce the concrete `04-0605`/`04-0608`
+  split as the acceptance fixture.
+- **Quoted material:** replay transcript `a737ff12` turns 1095–1383 and assert
+  the SOPS/tmpfs claims are absent from the composed output, while a session
+  that genuinely works on pasted content still reports it.
+- **Same-anchor lint:** deterministic unit tests — >2 blocks one anchor →
+  exactly one corrective retry then publish; distinct anchors untouched.
+- **Slug:** a composed note's slug reflects its first lead; stubs keep a safe
+  fallback; no same-minute collision.
+
+## Out of scope
+
+- **Re-composing the notes already filed under the broken rules** (the existing
+  duplicate/misattributed notes). Tracked separately under the spirit of #49
+  (re-flush pre-existing notes); this epic fixes forward.
+- **A redesigned owner-identity scheme** (e.g. a stable session-level owner id
+  replacing the ephemeral pid). Slice 1 routes pid-gone through the existing
+  staleness path, which is sufficient; a deeper owner model is a possible
+  follow-up.
+- **Mid-session cap-trip flush (#145)** as an independent defect. It is
+  plausibly the same false-reap root; the epic links it and it is closed if
+  slice 1 resolves it, but no separate slice is committed to it.
+- **The curator lock 1-hour lockout (#144).**

--- a/docs/prd/0002-useful-session-notes.md
+++ b/docs/prd/0002-useful-session-notes.md
@@ -1,14 +1,14 @@
 ---
 title: Session notes that carry the essence, one per session
 status: draft
-epic: https://github.com/buchbend/lore/issues/PENDING
+epic: https://github.com/buchbend/lore/issues/151
 repos:
   - buchbend/lore
 ---
 
 # PRD 0002: Session notes that carry the essence, one per session
 
-> Source of truth for this epic. Tracker: [epic issue](https://github.com/buchbend/lore/issues/PENDING).
+> Source of truth for this epic. Tracker: [epic issue](https://github.com/buchbend/lore/issues/151).
 > The epic links here; this file is not embedded in the issue body.
 
 ## Problem

--- a/docs/prd/0002-useful-session-notes.md
+++ b/docs/prd/0002-useful-session-notes.md
@@ -104,9 +104,12 @@ Work is confined to `buchbend/lore`, across two subsystems.
   from session progression, not restatements of one quoted passage"). It never
   hard-rejects and never fabricates anchor diversity; after the retry the
   chapter publishes regardless.
-- **Topic slug (`lore_curator/session_note.py::_derive_slug`).** Derive the
-  note filename slug from the first composed lead; fall back to the current
-  heuristic for stubs that have no chapter yet.
+- **Topic slug (`lore_curator/chapter_flush.py::_rename_to_topic_slug`).** The
+  note file is created (and first named via the existing
+  `stub_note.py::_derive_slug` heuristic) before any chapter exists, so the
+  topic-accurate name is applied as a rename once the first chapter composes
+  — not a change to the initial-creation heuristic. Stubs with no chapter yet
+  keep the fallback name; same-minute collisions still get a numeric suffix.
 
 ## Testing decisions
 

--- a/docs/prd/index.md
+++ b/docs/prd/index.md
@@ -7,4 +7,5 @@ PRDs are the source of truth for decisions. Each PRD lives at
 :maxdepth: 1
 
 0001-trim-to-lab-notebook-notes
+0002-useful-session-notes
 ```

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -47,6 +47,7 @@ __all__ = [
     "append_chapter",
     "append_marker_chapter",
     "close_note",
+    "reopen_note",
     "is_closed",
     "read_note",
     "render_chapter_body",
@@ -397,6 +398,36 @@ def close_note(
     _apply_facts(fm, facts)
     fm["last_reviewed"] = _today()
     _write(path, fm, body, wiki_root=wiki_root)
+
+
+def reopen_note(
+    path: Path,
+    *,
+    wiki_root: Path | None = None,
+) -> bool:
+    """Reopen a closed session note so its own continuing session can append.
+
+    Flips ``note_status`` from ``closed`` back to ``open`` and returns
+    ``True`` when a reopen happened; a no-op returning ``False`` when the
+    note is already open (idempotent). No content is touched — only the
+    status flag and ``last_reviewed`` move, and the next
+    :func:`append_chapter` resumes numbering from the existing chapters.
+
+    This deliberately relaxes the "a closed session note is immutable"
+    invariant, and *only* for session notes under the one-file-per-session
+    (reopen) model: a session that was closed early (a false liveness reap)
+    or resumes after a genuine close reattaches to its own note rather than
+    minting a duplicate sibling. Immutability still holds for derived /
+    curated artifacts; there is no close-reason gate because the note
+    records no close reason to gate on. See ``docs/adr/0001``.
+    """
+    fm, body = _load(path)
+    if fm.get("note_status") != _CLOSED:
+        return False
+    fm["note_status"] = _OPEN
+    fm["last_reviewed"] = _today()
+    _write(path, fm, body, wiki_root=wiki_root)
+    return True
 
 
 def is_closed(path: Path) -> bool:

--- a/lib/lore_curator/buffer_append.py
+++ b/lib/lore_curator/buffer_append.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from lore_core import note_document as nd
 from lore_core.types import Turn
 from lore_core.wiki_config import WikiConfig
 from lore_curator.buffer_store import (
@@ -274,30 +275,56 @@ def append_chunk(
         existing = buffer.read_sidecar()
 
         if existing is None:
-            owner = _build_owner(
-                run_id=owner_run_id,
-                claude_session_id=owner_claude_session_id,
-            )
-            sidecar = _build_initial_sidecar(
-                transcript_id=transcript_id,
-                local_date=local_date,
-                integration=integration,
-                wiki=wiki,
-                scope=scope,
-                cwd=cwd,
-                handle_label=handle_label,
-                owner=owner,
-            )
-            buffer.init_sidecar(sidecar)
-            is_new = True
-            existing = buffer.read_sidecar()
-            if logger is not None:
-                logger.emit(
-                    "buffer-opened",
+            restored = buffer.reopen_from_done()
+            if restored is not None:
+                # Resumed session: a prior close (a false liveness reap, or a
+                # genuine close followed by an editor restart / /compact /
+                # idle-then-return) archived this stem's buffer. Reattach to
+                # it and reopen its note so the continuation appends to the
+                # SAME file instead of minting a duplicate, partly-duplicated
+                # sibling — one session, one note. See docs/adr/0001.
+                existing = restored
+                note_path = Path(restored.stub_path) if restored.stub_path else None
+                if note_path is not None and note_path.exists():
+                    nd.reopen_note(note_path, wiki_root=wiki_root)
+                else:
+                    # The prior note was discarded (trivial / empty) or never
+                    # written; drop the dangling pointer so a fresh note is
+                    # created for the resumed session.
+                    existing = buffer.patch(stub_path="")
+                if logger is not None:
+                    logger.emit(
+                        "buffer-reopened",
+                        transcript_id=transcript_id,
+                        local_date=local_date,
+                        stem=buffer.stem,
+                        note_path=existing.stub_path,
+                    )
+            else:
+                owner = _build_owner(
+                    run_id=owner_run_id,
+                    claude_session_id=owner_claude_session_id,
+                )
+                sidecar = _build_initial_sidecar(
                     transcript_id=transcript_id,
                     local_date=local_date,
-                    stem=buffer.stem,
+                    integration=integration,
+                    wiki=wiki,
+                    scope=scope,
+                    cwd=cwd,
+                    handle_label=handle_label,
+                    owner=owner,
                 )
+                buffer.init_sidecar(sidecar)
+                is_new = True
+                existing = buffer.read_sidecar()
+                if logger is not None:
+                    logger.emit(
+                        "buffer-opened",
+                        transcript_id=transcript_id,
+                        local_date=local_date,
+                        stem=buffer.stem,
+                    )
 
         # State guard: if a flush worker has already taken ownership
         # (state in {flushing, closed}), the heartbeat must NOT mutate

--- a/lib/lore_curator/buffer_store.py
+++ b/lib/lore_curator/buffer_store.py
@@ -601,6 +601,46 @@ class Buffer:
             os.replace(self._log_path, new_log)
         return new_sidecar, new_log
 
+    def reopen_from_done(self) -> Sidecar | None:
+        """Restore this stem's archived buffer from ``_done/`` for continuation.
+
+        Moves ``_done/<stem>.state.json`` (and ``.jsonl`` if present) back to
+        the live buffers dir, then resets the sidecar to a fresh accumulation
+        cycle — state ``accumulating``, counters zeroed, event log truncated,
+        flush bookkeeping cleared — while preserving the note pointer
+        (``stub_path``), session identity, and the transcript watermark
+        (``last_seen``). Returns the restored :class:`Sidecar`, or ``None``
+        when no archived buffer exists for this stem. Caller must hold
+        :meth:`with_lock`.
+
+        This is the buffer half of the reopen-and-continue path: a session
+        that was closed — a false liveness reap, or a genuine close followed
+        by a resume — reattaches to its own buffer instead of minting a
+        duplicate. The archive is *moved* (not copied) so the "one buffer per
+        stem" invariant holds: a later :meth:`close` archives cleanly with no
+        ``_done/`` collision. The event log is truncated because the note
+        already carries every flushed chapter; only new turns accumulate now.
+        """
+        done = done_dir(self._lore_root)
+        archived_sidecar = done / self._sidecar_path.name
+        archived_log = done / self._log_path.name
+        if not archived_sidecar.exists():
+            return None
+        os.replace(archived_sidecar, self._sidecar_path)
+        if archived_log.exists():
+            os.replace(archived_log, self._log_path)
+        sidecar = self.read_sidecar()
+        if sidecar is None:
+            return None
+        sidecar.state = "accumulating"
+        sidecar.counters = Counters()
+        sidecar.flush_attempts = 0
+        sidecar.last_error = None
+        sidecar.flush_requested = None
+        self._write_sidecar(sidecar)
+        self._log_path.write_text("")
+        return sidecar
+
 
 # ---------------------------------------------------------------------------
 # Cross-buffer iteration (used by reaper / SessionEnd / status)

--- a/lib/lore_curator/chapter_compose.py
+++ b/lib/lore_curator/chapter_compose.py
@@ -54,6 +54,7 @@ __all__ = [
     "ComposeResult",
     "compose_chapter",
     "chapter_anchor_lint",
+    "chapter_same_anchor_lint",
     "chapter_tool_schema",
     "render_chapter_body",
     "CHAPTER_MAX_ATTEMPTS",
@@ -153,6 +154,25 @@ def chapter_anchor_lint(chapter: Chapter, *, from_turn: int, to_turn: int) -> li
     return offenders
 
 
+def chapter_same_anchor_lint(chapter: Chapter) -> int | None:
+    """Return the anchor turn shared by more than two blocks, else ``None``.
+
+    Two blocks citing the same turn is common and unremarkable — two
+    closely related findings surfacing together. More than two is usually
+    a tell that every block was derived from one quoted or pasted passage
+    rather than distinct moments in the session, which collapses the
+    anchors and makes them useless for navigation. This is a soft signal:
+    callers retry once for a nudge, never reject on it.
+    """
+    counts: dict[int, int] = {}
+    for block in chapter.blocks:
+        counts[block.anchor_turn] = counts.get(block.anchor_turn, 0) + 1
+    for anchor, count in counts.items():
+        if count > 2:
+            return anchor
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Compose loop
 # ---------------------------------------------------------------------------
@@ -175,8 +195,12 @@ def compose_chapter(
 
     Attempt 1 composes; a deterministic anchor lint and the injected
     gate then judge the result. An anchor-lint miss or a gate withhold
-    feeds corrective text into a second attempt. After
-    :data:`CHAPTER_MAX_ATTEMPTS` the outcome is returned:
+    feeds corrective text into a second attempt. A softer same-anchor
+    lint (more than two blocks citing one turn) earns at most one
+    corrective retry of its own but never blocks publication — after
+    that single nudge the chapter is composed regardless of whether the
+    anchors changed. After :data:`CHAPTER_MAX_ATTEMPTS` the outcome is
+    returned:
 
     * PASS → ``COMPOSED`` with the chapter.
     * zero blocks on any attempt → ``EMPTY`` immediately (the model
@@ -195,6 +219,7 @@ def compose_chapter(
     last_withheld: GateResult | None = None
     last_withheld_text = ""
     attempts = 0
+    same_anchor_retried = False
 
     while attempts < CHAPTER_MAX_ATTEMPTS:
         attempts += 1
@@ -227,6 +252,20 @@ def compose_chapter(
                     call="chapter-anchor-lint",
                     transcript_id=transcript_id,
                     offenders=offenders,
+                )
+            continue
+
+        shared_anchor = chapter_same_anchor_lint(chapter)
+        retry_left = attempts < CHAPTER_MAX_ATTEMPTS
+        if shared_anchor is not None and not same_anchor_retried and retry_left:
+            same_anchor_retried = True
+            retry_feedback = _same_anchor_feedback(shared_anchor)
+            if logger is not None:
+                logger.emit(
+                    "warning",
+                    call="chapter-same-anchor-lint",
+                    transcript_id=transcript_id,
+                    anchor=shared_anchor,
                 )
             continue
 
@@ -268,6 +307,15 @@ def _anchor_feedback(offenders: list[tuple[int, int]], from_turn: int, to_turn: 
         f"The previous attempt cited a turn outside it (block(s) {bad}). "
         f"Every @N anchor must be a turn index shown in the slice, within "
         f"{lo}-{hi}."
+    )
+
+
+def _same_anchor_feedback(anchor: int) -> str:
+    return (
+        f"Several blocks all cite the same turn (@{anchor}). Confirm these "
+        "are distinct findings from the session's progression, not "
+        "restatements of one quoted or pasted passage — re-anchor each "
+        "block to the turn where its own topic actually started."
     )
 
 

--- a/lib/lore_curator/chapter_compose.py
+++ b/lib/lore_curator/chapter_compose.py
@@ -446,6 +446,23 @@ def _build_prompt(
             "permission chatter. Leave them out entirely, unless diagnosing "
             "the tooling was itself the session's purpose.",
             "",
+            "Quoted and reference material is NOT the session's work. "
+            "Sometimes the user pastes or quotes a block as an exemplar, a "
+            "reference, or a comparison, not as something to act on: a "
+            'formatting sample ("this is a form I\'d like the notes to have", '
+            '"here is the shape I want"), an example ("for example", "like '
+            'this one"), or another / older artefact of their own ("an older '
+            'version of", "the previous note", "a note I wrote earlier"). Its '
+            "content is ABOUT that pasted material and does not describe what "
+            "this session did. Spot it by the exemplar framing in the "
+            "surrounding turns, by a fenced code block, or by a block that "
+            "carries its OWN @N-anchored bold leads (the shape of an earlier "
+            "note). NEVER report the claims, tools, paths, or config inside "
+            "such material as this session's findings. The ONLY exception is "
+            "when working on that material was itself the topic: the user asks "
+            "you to review, fix, or reason about the pasted content, in which "
+            "case that work IS the session's work and you record it.",
+            "",
             "Each topic is ONE block:",
             "- The lead is one bold sentence carrying the takeaway: a "
             "SELF-SUFFICIENT declarative claim a reader understands with no "
@@ -537,7 +554,10 @@ def chapter_tool_schema() -> dict[str, Any]:
                                 "description": (
                                     "Short prose body: the reasoning and "
                                     "specifics behind the lead, in the "
-                                    "active voice. No event narration."
+                                    "active voice. No event narration. "
+                                    "Never restate claims from material "
+                                    "the user only pasted or quoted as an "
+                                    "exemplar or reference."
                                 ),
                             },
                             "anchor": {

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -68,7 +68,9 @@ from lore_curator.buffer_store import (
     iter_all,
 )
 from lore_curator.chapter_compose import ComposeStatus, Gate, compose_chapter
+from lore_curator.session_filer import _slug
 from lore_curator.session_note import ensure_note_from_sidecar, facts_from_replay
+from lore_curator.stub_note import _lead_for_rename, _resolve_renamed_path
 
 if TYPE_CHECKING:
     from lore_core.run_log import RunLogger
@@ -470,6 +472,31 @@ def _read_note_body(note_path: Path) -> str:
         return ""
 
 
+def _rename_to_topic_slug(buffer: Buffer, note_path: Path, chapter: nd.Chapter) -> Path:
+    """Rename a note to its first chapter's topic, once that topic exists.
+
+    The note is created (and first named) at the first heartbeat, well
+    before any chapter — so its filename starts as an incidental guess (a
+    commit subject, a touched file's basename, or a bare timestamp). Once
+    the first chapter composes, its opening lead names the session's
+    actual topic; this makes the filename match. A chapter with no usable
+    lead text (shouldn't happen for a COMPOSED result, but defensive)
+    leaves the filename untouched rather than risk an empty slug.
+    """
+    lead = _lead_for_rename(chapter)
+    if not lead:
+        return note_path
+    slug = _slug(lead)
+    if not slug or slug == "session":
+        return note_path
+    new_path = _resolve_renamed_path(note_path, slug)
+    if new_path == note_path:
+        return note_path
+    note_path.replace(new_path)
+    buffer.patch(stub_path=str(new_path))
+    return new_path
+
+
 def _apply_outcome(
     *,
     buffer: Buffer,
@@ -515,6 +542,10 @@ def _apply_outcome(
             facts=facts,
             wiki_root=wiki_root,
         )
+        if out.chapter_n == 1:
+            note_path = _rename_to_topic_slug(buffer, note_path, compose_result.chapter)
+            out.note_path = note_path
+            out.wikilink = f"[[{note_path.stem}]]"
         out.status = "composed"
         _clear_after_progress(buffer, close=close)
     elif status is ComposeStatus.EMPTY:

--- a/lib/lore_curator/reaper.py
+++ b/lib/lore_curator/reaper.py
@@ -8,18 +8,23 @@ time.
 
 Liveness verdict:
 
-* If the owner PID is unambiguously **dead** (host mismatch,
-  ``ProcessLookupError`` from ``os.kill(pid, 0)``, or
-  ``/proc/<pid>/stat`` start-ts mismatch indicating PID reuse) →
-  **reap immediately**, regardless of heartbeat freshness. Waiting on
-  a confirmed-dead owner buys nothing; short Claude sessions that die
-  without SessionEnd would otherwise leave stub notes pending for the
-  full staleness window.
-* If the owner is unambiguously **alive** → keep waiting.
-* If liveness is **uncertain** (no ``/proc`` access — macOS, network
-  fs, sandbox) → fall back on the staleness threshold
+* If the owner PID is unambiguously **dead** — the recorded owner
+  ``host`` differs from this host — → **reap immediately**, regardless
+  of heartbeat freshness. Waiting on a confirmed-dead owner buys
+  nothing; short Claude sessions that die without SessionEnd would
+  otherwise leave stub notes pending for the full staleness window.
+* If the owner is unambiguously **alive** (same host, PID signalable,
+  ``/proc`` start-ts matches) → keep waiting.
+* If liveness is **uncertain** → fall back on the staleness threshold
   (``liveness_stale_threshold_s``, default 30 min, per-wiki
-  configurable; doubled on macOS).
+  configurable; doubled on macOS). This covers no ``/proc`` access
+  (macOS, network fs, sandbox) *and* a same-host owner whose PID is
+  simply gone (``ProcessLookupError``) or whose ``/proc`` start-ts no
+  longer matches (PID reuse). In the buffer-and-flush architecture the
+  owner pid is re-stamped every heartbeat to the hook subprocess, which
+  exits within milliseconds — "pid gone, same host" is the normal
+  steady state, not a death signal, so it must not short-circuit past
+  the staleness floor the way a genuine cross-host mismatch does.
 
 Concurrency:
 
@@ -41,6 +46,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lore_core.wiki_config import load_wiki_config
+
 from lore_curator.buffer_store import Buffer, Sidecar, iter_all
 from lore_curator.synthesis import spawn_detached_flush
 
@@ -66,7 +72,7 @@ class ReaperReport:
 def _read_proc_start_ticks(pid: int) -> float | None:
     """Return ``/proc/<pid>/stat`` field 22, or ``None`` on macOS / missing."""
     try:
-        with open(f"/proc/{pid}/stat", "r") as fh:
+        with open(f"/proc/{pid}/stat") as fh:
             content = fh.read()
     except (FileNotFoundError, PermissionError, OSError):
         return None
@@ -85,14 +91,17 @@ def _read_proc_start_ticks(pid: int) -> float | None:
 def is_owner_alive(sidecar: Sidecar, *, host: str | None = None) -> bool | None:
     """Return True (alive), False (dead), or None (can't tell — keep waiting).
 
-    Encapsulates the AND-condition liveness check. Returns:
+    Encapsulates the liveness check. Returns:
 
     * ``True`` if the owner is local AND PID is alive AND start_ts matches.
-    * ``False`` if the owner is local AND PID is gone, OR start_ts mismatch.
     * ``False`` if owner host differs from this host (definitely not us).
-    * ``None`` if we can't read /proc and the host matches — the
-      caller should treat this as "uncertain, fall back on staleness
-      threshold".
+    * ``None`` if the owner is local but the PID is gone, or the
+      ``/proc`` start-ts no longer matches (PID reuse), or we can't
+      read ``/proc`` at all — a same-host PID going missing is the
+      normal buffer-and-flush steady state (the owner pid is
+      re-stamped every heartbeat to a hook subprocess that exits
+      within milliseconds), not evidence of death, so the caller falls
+      back on the staleness threshold instead of reaping immediately.
     """
     host = host or socket.gethostname()
     if not sidecar.owner.pid:
@@ -103,7 +112,7 @@ def is_owner_alive(sidecar: Sidecar, *, host: str | None = None) -> bool | None:
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
-        return False
+        return None
     except PermissionError:
         # Pid exists but we can't signal; treat as alive.
         return True
@@ -116,7 +125,9 @@ def is_owner_alive(sidecar: Sidecar, *, host: str | None = None) -> bool | None:
         # No /proc access — caller falls back on staleness threshold.
         return None
     if abs(actual - expected) > _START_TS_TOLERANCE:
-        return False
+        # PID reuse: the process answering to this pid isn't the one
+        # that recorded it — uncertain, not proof of death.
+        return None
     return True
 
 
@@ -165,7 +176,7 @@ def reap_once(
     *,
     dry_run: bool = False,
     max_per_pass: int | None = None,
-    logger: "RunLogger | None" = None,
+    logger: RunLogger | None = None,
     now: datetime | None = None,
 ) -> ReaperReport:
     """One reaper pass over live buffers under ``<lore_root>/.lore/buffers``.
@@ -236,7 +247,7 @@ def _judge(
     *,
     host: str,
     now: datetime,
-    logger: "RunLogger | None",
+    logger: RunLogger | None,
 ) -> tuple[str, str]:
     """Return ``(verdict, reason)`` for a single buffer.
 
@@ -265,14 +276,16 @@ def _judge(
             return "alive", "owner-alive"
 
         if alive_verdict is False:
-            # Owner is unambiguously dead — reap regardless of staleness.
-            # Why: short Claude sessions that die without SessionEnd leave
-            # stub notes "synthesis pending" for the full staleness window
-            # (30+ min); waiting buys nothing once the PID is provably gone.
+            # Owner is on a different host — unambiguously not us, reap
+            # regardless of staleness. Why: short Claude sessions that die
+            # without SessionEnd leave stub notes "synthesis pending" for
+            # the full staleness window (30+ min); waiting buys nothing
+            # once the owner is provably not this machine.
             return "reap", "owner-dead"
 
-        # alive_verdict is None: uncertain (no /proc / network-fs / macOS).
-        # Fall back on staleness threshold to avoid false-positive reaps.
+        # alive_verdict is None: uncertain (no /proc / network-fs / macOS /
+        # same-host pid-gone / pid-reused). Fall back on staleness
+        # threshold to avoid false-positive reaps.
         if not _is_stale(sidecar, threshold_s=threshold, now=now):
             return "alive", "fresh-heartbeat"
         return "reap", "stale+owner-uncertain"

--- a/lib/lore_curator/stub_note.py
+++ b/lib/lore_curator/stub_note.py
@@ -54,6 +54,7 @@ from lore_curator.buffer_store import Buffer, ReplayedBuffer, Sidecar
 from lore_curator.session_filer import _slug
 
 if TYPE_CHECKING:
+    from lore_core.note_document import Chapter
     from lore_core.run_log import RunLogger
 
 
@@ -132,6 +133,53 @@ def _derive_slug(
 
     scope_label = scope.scope.replace(":", "-")
     return _slug(f"session-{scope_label}-{work_time.strftime('%H%M')}")
+
+
+def _lead_for_rename(chapter: Chapter) -> str:
+    """First block's topic text, for renaming a note after its first chapter.
+
+    A composed note's file is created (and first named) at the first
+    heartbeat — well before any chapter exists, so the initial filename is
+    always the heuristic guess above. Once the first chapter composes, its
+    opening block names the session's actual topic and the file is renamed
+    to match (see ``chapter_flush._rename_to_topic_slug``). Returns ``""``
+    when the chapter has no blocks or the first one carries no usable text
+    (a continuation block's topic lives in ``continued_topic``) — the
+    caller must treat that as "keep the current filename", never invent an
+    empty slug.
+    """
+    if not chapter.blocks:
+        return ""
+    block = chapter.blocks[0]
+    lead = (block.continued_topic if block.continued else block.lead) or ""
+    return lead.strip()
+
+
+def _resolve_renamed_path(note_path: Path, slug: str) -> Path:
+    """Return the rename target for ``note_path`` once ``slug`` is known.
+
+    Preserves the ``<DD>-<HHMM>-`` prefix and probes the same directory for
+    a free filename exactly like :func:`_resolve_first_write_path`'s
+    same-minute collision handling (numeric ``-2``, ``-3`` ... suffix) —
+    two notes composed in the same minute must never collide. Returns
+    ``note_path`` unchanged when its stem isn't the canonical
+    ``<DD>-<HHMM>-<slug>`` shape, or when ``slug`` already matches the
+    current one (nothing to rename).
+    """
+    parts = note_path.stem.split("-", 2)
+    if len(parts) < 3:
+        return note_path
+    day, hhmm, current_slug = parts
+    if current_slug == slug:
+        return note_path
+    prefix = f"{day}-{hhmm}-"
+    parent = note_path.parent
+    candidate = parent / f"{prefix}{slug}.md"
+    counter = 1
+    while candidate.exists() and candidate != note_path:
+        counter += 1
+        candidate = parent / f"{prefix}{slug}-{counter}.md"
+    return candidate
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/prompts/quoted_exemplar_paste.txt
+++ b/tests/fixtures/prompts/quoted_exemplar_paste.txt
@@ -1,0 +1,13 @@
+[user@1095] Before we touch the session-note voice, look at this — this is a form I'd like the notes to have. It's an older version of a note I wrote by hand about secret management, pasted here only as a formatting example:
+[user@1096] ```
+[user@1097] > **Lab-notebook session note.**
+[user@1098]
+[user@1099] **Secrets are encrypted at rest with SOPS and age.** The repo keeps `secrets.env` encrypted with `sops`; the `age` identity lives outside the repo and decrypts into a `tmpfs` mount at deploy time so the plaintext `.env` never touches disk. @12
+[user@1100]
+[user@1101] **The deploy script sources the decrypted .env into the systemd unit.** `systemd` `EnvironmentFile=` points at the tmpfs path; on stop the tmpfs is unmounted and the plaintext is gone. @14
+[user@1102] ```
+[user@1103] See how each point leads with a bold claim and ends with an @-anchor? That is the shape I want for our notes — I am not asking you to do anything with SOPS or age, it is purely an exemplar.
+[assistant@1120] Understood — bold self-sufficient lead, short body, exactly one @-anchor per point. That is the lab-notebook chapter shape we are building toward.
+[user@1140] Right. For THIS session the thing I actually care about is the note voice: I keep getting notes that narrate the session ("the user asked...", "a command was run...") instead of recording what was figured out.
+[assistant@1160] The fix is essence-first: the lead carries the takeaway as a self-sufficient claim, and session mechanics (greetings, tool hiccups) are omitted entirely.
+[user@1383] Exactly. Let's make the composer record the work, not the working.

--- a/tests/test_chapter_compose.py
+++ b/tests/test_chapter_compose.py
@@ -12,6 +12,7 @@ prompt experiments.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -431,7 +432,11 @@ def test_lead_markdown_bold_is_stripped():
     # Models sometimes bold the lead themselves; the renderer adds the
     # bold, so embedded ** would double up ("****lead****"). Parsing
     # normalizes it away.
-    payload = {"blocks": [{"lead": "**The cache was stale**, so skills never loaded.", "body": "x", "anchor": 0}]}
+    payload = {
+        "blocks": [
+            {"lead": "**The cache was stale**, so skills never loaded.", "body": "x", "anchor": 0}
+        ]
+    }
     msgs = _RecordingMessages([payload])
     client = _FakeClient(msgs)
     result = compose_chapter(
@@ -506,3 +511,81 @@ def test_synthesis_no_longer_imports_render_regions():
     import lore_curator.synthesis as synthesis
 
     assert not hasattr(synthesis, "render_regions")
+
+
+# ---------------------------------------------------------------------------
+# Quoted / reference material is not the session's work (#147)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_carries_quoted_material_distinction():
+    # The compose model (a weak-pragmatics ~120B open model) must be told
+    # concretely that pasted exemplar / reference material is not the
+    # session's own work, with the signals spelled out — not inferred.
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+    compose_chapter(
+        slice_text="[user@0] hi",
+        slice_from_turn=0,
+        slice_to_turn=0,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    prompt = _prompt_text(msgs.calls[0]).lower()
+    assert "quoted and reference material" in prompt
+    assert "not the session's work" in prompt
+    # Concrete exemplar-framing signals are named verbatim.
+    assert "this is a form i'd like" in prompt
+    assert "for example" in prompt
+    assert "an older version of" in prompt
+    # Structural signals: fenced blocks and self-anchored bold leads.
+    assert "fenced" in prompt
+    assert "anchored bold lead" in prompt
+
+
+def test_prompt_keeps_worked_pasted_content_attributable():
+    # True-positive exception: when the session actually works ON the
+    # pasted content (reviews / fixes it), that work IS reported. The
+    # prompt must carry the exception so the clause does not over-suppress.
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+    compose_chapter(
+        slice_text="[user@0] hi",
+        slice_from_turn=0,
+        slice_to_turn=0,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    prompt = _prompt_text(msgs.calls[0]).lower()
+    assert "exception" in prompt
+    assert "working on that material was itself the topic" in prompt
+    assert "review" in prompt
+    assert "pasted content" in prompt
+
+
+def test_prompt_from_exemplar_paste_fixture_carries_clause():
+    # A realistic slice matching the SOPS-paste regression (transcript
+    # a737ff12): a long block pasted purely as a formatting exemplar,
+    # followed by the genuine session topic (note voice). The clause that
+    # keeps the pasted block's SOPS/.env/tmpfs claims out of the note must
+    # ride the prompt built from that exact input.
+    fixture = Path(__file__).parent / "fixtures" / "prompts" / "quoted_exemplar_paste.txt"
+    slice_text = fixture.read_text()
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+    compose_chapter(
+        slice_text=slice_text,
+        slice_from_turn=1095,
+        slice_to_turn=1383,
+        note_so_far="(empty)",
+        llm_client=client,
+        model="m",
+    )
+    prompt = _prompt_text(msgs.calls[0]).lower()
+    # The exemplar framing from the paste is present in the slice ...
+    assert "this is a form i'd like the notes to have" in prompt
+    # ... and the guarding clause is present in the same prompt.
+    assert "quoted and reference material" in prompt
+    assert "never report the claims" in prompt

--- a/tests/test_chapter_compose.py
+++ b/tests/test_chapter_compose.py
@@ -24,6 +24,7 @@ from lore_curator.chapter_compose import (
     GateResult,
     PassThroughGate,
     chapter_anchor_lint,
+    chapter_same_anchor_lint,
     chapter_tool_schema,
     compose_chapter,
     render_chapter_body,
@@ -292,6 +293,107 @@ def test_persistent_out_of_slice_anchor_fails():
     )
     assert result.status is ComposeStatus.FAILED
     assert result.attempts == CHAPTER_MAX_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# Same-anchor lint (deterministic) — soft: nudges once, never blocks publish
+# ---------------------------------------------------------------------------
+
+
+def test_same_anchor_lint_flags_more_than_two_shared():
+    chapter = Chapter(
+        blocks=[
+            TopicBlock(lead="a", body="", anchor_turn=34),
+            TopicBlock(lead="b", body="", anchor_turn=34),
+            TopicBlock(lead="c", body="", anchor_turn=34),
+        ]
+    )
+    assert chapter_same_anchor_lint(chapter) == 34
+
+
+def test_same_anchor_lint_allows_two_shared():
+    chapter = Chapter(
+        blocks=[
+            TopicBlock(lead="a", body="", anchor_turn=5),
+            TopicBlock(lead="b", body="", anchor_turn=5),
+        ]
+    )
+    assert chapter_same_anchor_lint(chapter) is None
+
+
+def test_same_anchor_lint_allows_distinct_anchors():
+    chapter = Chapter(
+        blocks=[
+            TopicBlock(lead="a", body="", anchor_turn=1),
+            TopicBlock(lead="b", body="", anchor_turn=2),
+            TopicBlock(lead="c", body="", anchor_turn=3),
+        ]
+    )
+    assert chapter_same_anchor_lint(chapter) is None
+
+
+def _same_anchor_payload(anchor: int, count: int) -> dict[str, Any]:
+    blocks = [{"lead": f"lead {i}", "body": f"body {i}", "anchor": anchor} for i in range(count)]
+    return {"blocks": blocks}
+
+
+def test_more_than_two_shared_anchors_triggers_one_retry_then_composes():
+    bad = _same_anchor_payload(34, 3)
+    good = _valid_payload()
+    msgs = _RecordingMessages([bad, good])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@0] x\n[assistant@34] y",
+        slice_from_turn=0,
+        slice_to_turn=100,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    assert result.status is ComposeStatus.COMPOSED
+    assert result.attempts == 2
+    assert len(msgs.calls) == 2
+    retry_prompt = _prompt_text(msgs.calls[1])
+    assert "34" in retry_prompt
+    assert "same turn" in retry_prompt.lower()
+
+
+def test_distinct_anchors_untouched_by_same_anchor_lint():
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@2] x\n[assistant@4] y",
+        slice_from_turn=2,
+        slice_to_turn=4,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    assert result.status is ComposeStatus.COMPOSED
+    assert result.attempts == 1
+    assert len(msgs.calls) == 1
+
+
+def test_persistent_same_anchor_still_publishes():
+    bad = _same_anchor_payload(34, 3)
+    msgs = _RecordingMessages([bad, dict(bad)])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@0] x\n[assistant@34] y",
+        slice_from_turn=0,
+        slice_to_turn=100,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    assert result.status is ComposeStatus.COMPOSED
+    assert result.attempts == 2
+    assert len(msgs.calls) == 2
+    assert result.chapter is not None
+    assert len(result.chapter.blocks) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chapter_flush.py
+++ b/tests/test_chapter_flush.py
@@ -274,6 +274,117 @@ def test_planted_secret_withholds_marker_and_quarantines(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Topic-derived slug — rename the note once its first chapter composes
+# ---------------------------------------------------------------------------
+
+
+def test_first_chapter_rename_reflects_topic_lead(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    all_turns = _turns(0, 4)
+    buf = _append(lore_root, all_turns)
+    client = _Client([_chapter_payload("Traced the flush race", "prose.", 2)])
+
+    outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+        auto_commit=False,
+    )
+    assert outcome.status == "composed"
+    assert outcome.note_path.name.endswith("-traced-the-flush-race.md")
+    assert outcome.wikilink == f"[[{outcome.note_path.stem}]]"
+
+    # Renamed in place — no orphaned file left at the old heuristic name.
+    notes = list((wiki_root / "sessions").rglob("*.md"))
+    assert notes == [outcome.note_path]
+
+    reopened = Buffer.open(lore_root, transcript_id="abc", local_date="2026-05-01")
+    assert reopened.read_sidecar().stub_path == str(outcome.note_path)
+
+
+def test_second_chapter_does_not_rename_again(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    adapter = _Adapter(_turns(0, 5))
+
+    _append(lore_root, _turns(0, 2))
+    buf = Buffer.open(lore_root, transcript_id="abc", local_date="2026-05-01")
+    c1 = _Client([_chapter_payload("Recorded the buffer store design", "Prose about buffers.", 1)])
+    first_outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=c1,
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    assert first_outcome.note_path.name.endswith("-recorded-the-buffer-store-design.md")
+
+    _append(lore_root, _turns(3, 5))
+    c2 = _Client([_chapter_payload("Discussed the flush lifecycle", "More prose.", 4)])
+    second_outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=c2,
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    # The filename stays pinned to the first chapter's topic.
+    assert second_outcome.note_path == first_outcome.note_path
+    notes = list((wiki_root / "sessions").rglob("*.md"))
+    assert notes == [first_outcome.note_path]
+
+
+def test_same_minute_rename_collision_gets_numeric_suffix(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    # Force both buffers into the same minute so their rename targets collide.
+    monkeypatch.setattr(
+        "lore_curator.buffer_store._now_iso",
+        lambda: "2026-05-01T14:32:00+00:00",
+    )
+
+    turns_a = _turns(0, 2)
+    buf_a = _append(lore_root, turns_a, tid="abc")
+    client_a = _Client([_chapter_payload("Shared Topic", "prose a.", 1)])
+    outcome_a = synth_in_place(
+        buf_a.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client_a,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(turns_a)),
+        auto_commit=False,
+    )
+
+    turns_b = _turns(0, 2)
+    buf_b = _append(lore_root, turns_b, tid="def")
+    client_b = _Client([_chapter_payload("Shared Topic", "prose b.", 1)])
+    outcome_b = synth_in_place(
+        buf_b.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client_b,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(turns_b)),
+        auto_commit=False,
+    )
+
+    assert outcome_a.note_path != outcome_b.note_path
+    assert outcome_a.note_path.name.endswith("-shared-topic.md")
+    assert outcome_b.note_path.name.endswith("-shared-topic-2.md")
+    assert outcome_a.note_path.exists()
+    assert outcome_b.note_path.exists()
+
+
+# ---------------------------------------------------------------------------
 # Failure semantics
 # ---------------------------------------------------------------------------
 

--- a/tests/test_reaper_force_flush.py
+++ b/tests/test_reaper_force_flush.py
@@ -6,13 +6,11 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
-
 from lore_core.types import Turn
 from lore_core.wiki_config import WikiConfig
 from lore_curator.buffer_append import append_chunk
 from lore_curator.buffer_store import OwnerInfo, Sidecar
 from lore_curator.reaper import (
-    ReaperReport,
     is_owner_alive,
     reap_once,
 )
@@ -33,9 +31,15 @@ def lore_root(tmp_path: Path) -> Path:
 
 @pytest.fixture(autouse=True)
 def patch_collectors(monkeypatch):
-    monkeypatch.setattr("lore_curator.session_activity.collect_commits_by_sha", lambda *a, **kw: [])
-    monkeypatch.setattr("lore_curator.session_activity.collect_issues_in_window", lambda *a, **kw: ([], []))
-    monkeypatch.setattr("lore_curator.session_activity.collect_projects_for_session", lambda **kw: [])
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_commits_by_sha", lambda *a, **kw: []
+    )
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_issues_in_window", lambda *a, **kw: ([], [])
+    )
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_projects_for_session", lambda **kw: []
+    )
     monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
     monkeypatch.setattr("lore_core.git.current_repo", lambda cwd: "")
 
@@ -72,12 +76,28 @@ def test_owner_alive_local_pid_returns_true_or_none():
     assert verdict in (True, None)  # depends on /proc availability
 
 
-def test_owner_dead_pid_returns_false():
-    """Use a pid that's almost certainly free (very high)."""
+def test_owner_gone_same_host_returns_none():
+    """A same-host owner whose pid is absent is uncertain, not dead.
+
+    The buffer's owner pid is re-stamped every heartbeat to the hook
+    subprocess, which exits within milliseconds -- "pid gone" is the
+    normal steady state, not a death signal, so long as the host still
+    matches."""
     sidecar = Sidecar(owner=OwnerInfo(pid=2**31 - 1, host="", start_ts=0.0))
     import socket
+
     sidecar.owner.host = socket.gethostname()
-    assert is_owner_alive(sidecar) is False
+    assert is_owner_alive(sidecar) is None
+
+
+def test_owner_pid_reused_start_ts_mismatch_returns_none():
+    """A live pid whose start-tick doesn't match the recorded value means
+    the pid was reused by an unrelated process -- uncertain, not dead."""
+    sidecar = Sidecar(owner=OwnerInfo(pid=os.getpid(), host="", start_ts=999999999.0))
+    import socket
+
+    sidecar.owner.host = socket.gethostname()
+    assert is_owner_alive(sidecar) is None
 
 
 def test_owner_different_host_returns_false():
@@ -103,7 +123,6 @@ def test_alive_owner_not_reaped(lore_root, monkeypatch):
 def test_dead_owner_and_stale_is_reaped(lore_root, monkeypatch):
     buf, _ = _seed(lore_root)
     # Backdate last_heartbeat past the staleness threshold.
-    sidecar = buf.read_sidecar()
     stale = (datetime.now(UTC) - timedelta(hours=3)).isoformat().replace("+00:00", "Z")
     with buf.with_lock():
         buf.patch(last_heartbeat=stale, last_appended_at=stale)
@@ -179,6 +198,48 @@ def test_closed_buffers_skipped(lore_root, monkeypatch):
     report = reap_once(lore_root)
     assert report.already_done == 1
     assert report.force_flushed == 0
+
+
+def test_pid_gone_same_host_not_reaped_within_staleness(lore_root):
+    """Regression for the mid-session false reap: a heartbeat stamps a
+    pid that then exits (the normal buffer-and-flush steady state) --
+    the reaper must not treat pid-gone alone as death while the
+    heartbeat is still fresh. The buffer must survive as-is."""
+    import socket
+
+    buf, _ = _seed(lore_root)
+    with buf.with_lock():
+        buf.patch(owner=OwnerInfo(pid=2**31 - 1, host=socket.gethostname(), start_ts=0.0))
+
+    report = reap_once(lore_root)
+    assert report.force_flushed == 0
+    assert report.alive == 1
+    assert buf.read_sidecar().state == "accumulating"
+
+
+def test_pid_gone_same_host_reaped_after_staleness(lore_root, monkeypatch):
+    """A same-host pid-gone owner is still eventually reaped once the
+    heartbeat goes stale -- uncertainty defers to the staleness floor,
+    it doesn't suppress reaping forever."""
+    import socket
+
+    buf, _ = _seed(lore_root)
+    stale = (datetime.now(UTC) - timedelta(hours=3)).isoformat().replace("+00:00", "Z")
+    with buf.with_lock():
+        buf.patch(
+            owner=OwnerInfo(pid=2**31 - 1, host=socket.gethostname(), start_ts=0.0),
+            last_heartbeat=stale,
+            last_appended_at=stale,
+        )
+
+    spawned: list = []
+    monkeypatch.setattr(
+        "lore_curator.reaper.spawn_detached_flush",
+        lambda buffer_path, lore_root: spawned.append(buffer_path) or True,
+    )
+    report = reap_once(lore_root)
+    assert report.force_flushed == 1
+    assert spawned == [buf.sidecar_path]
 
 
 def test_max_per_pass_bounds_scan(lore_root, monkeypatch):

--- a/tests/test_reopen_continue.py
+++ b/tests/test_reopen_continue.py
@@ -1,0 +1,421 @@
+"""Reopen + continue: a resumed session continues its existing note.
+
+One session, one note. When a session is closed — a false liveness reap, or a
+genuine close followed by an editor restart / ``/compact`` / idle-then-return —
+its buffer sidecar is archived to ``_done/``. The next heartbeat on the same
+stem must reattach to that archived buffer, reopen its (closed) note, and
+append the new chapter to the **same** file instead of minting an unlinked,
+partly-duplicated sibling.
+
+Every LLM interaction is faked with the stub-replay harness; no test asserts
+prose quality and no LLM-as-judge appears.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from lore_core import note_document as nd
+from lore_core.note_document import Chapter, TopicBlock
+from lore_core.types import Turn
+from lore_core.wiki_config import WikiConfig
+from lore_curator.buffer_append import append_chunk
+from lore_curator.buffer_store import (
+    Buffer,
+    Counters,
+    LastSeen,
+    Sidecar,
+    _stem_for,
+    done_dir,
+)
+from lore_curator.chapter_flush import synth_and_close
+
+# ---------------------------------------------------------------------------
+# Fakes (stub-replay compose harness)
+# ---------------------------------------------------------------------------
+
+
+class _Adapter:
+    integration = "fake"
+
+    def __init__(self, turns: list[Turn]) -> None:
+        self._turns = turns
+
+    def transcript_path_for_id(self, transcript_id: str, cwd: Path) -> Path:
+        return cwd / f"{transcript_id}.jsonl"
+
+    def read_slice(self, handle, from_index: int = 0):
+        yield from (t for t in self._turns if t.index >= from_index)
+
+
+def _lookup(adapter: _Adapter):
+    def _l(integration: str):
+        return adapter
+
+    return _l
+
+
+class _Block:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.type = "tool_use"
+        self.input = payload
+
+
+class _Resp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.content = [_Block(payload)]
+        self.model = "m"
+
+
+class _Messages:
+    def __init__(self, payloads: list[dict | None]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> _Resp:
+        self.calls.append(kwargs)
+        payload = self._payloads.pop(0) if self._payloads else {}
+        if payload is None:
+            raise RuntimeError("simulated LLM failure")
+        return _Resp(payload)
+
+
+class _Client:
+    def __init__(self, payloads: list[dict | None]) -> None:
+        self.messages = _Messages(payloads)
+
+
+def _chapter_payload(lead: str, body: str, anchor: int) -> dict[str, Any]:
+    return {"blocks": [{"lead": lead, "body": body, "anchor": anchor}]}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / seeding
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_collectors(monkeypatch):
+    monkeypatch.setattr("lore_curator.session_activity.collect_commits_by_sha", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_issues_in_window",
+        lambda *a, **k: ([], []),
+    )
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_projects_for_session",
+        lambda **k: [],
+    )
+    monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
+    monkeypatch.setattr("lore_core.git.current_repo", lambda cwd: "")
+
+
+# The concrete pilot fixture: transcript a737ff12, 2026-07-04, split at a
+# /compact into 04-0605 (turns 1095-1383) and 04-0608 (turns 1384-1430).
+TID = "a737ff12"
+DATE = "2026-07-04"
+
+
+def _turns(lo: int, hi: int) -> list[Turn]:
+    return [
+        Turn(index=i, timestamp=None, role="user" if i % 2 == 0 else "assistant", text=f"line {i}")
+        for i in range(lo, hi + 1)
+    ]
+
+
+def _lore_root(tmp_path: Path) -> Path:
+    (tmp_path / ".lore" / "buffers").mkdir(parents=True)
+    (tmp_path / "wiki" / "private" / "sessions").mkdir(parents=True)
+    return tmp_path
+
+
+def _append(lore_root: Path, turns: list[Turn], *, tid: str = TID, date: str = DATE):
+    return append_chunk(
+        lore_root=lore_root,
+        chunk_turns=turns,
+        local_date=date,
+        transcript_id=tid,
+        integration="fake",
+        wiki="private",
+        scope="proj:x",
+        cwd=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        cfg=WikiConfig(),
+    )
+
+
+def _seed_archived_closed_note(
+    lore_root: Path,
+    *,
+    tid: str,
+    date: str,
+    chapter_lead: str,
+    from_turn: int,
+    to_turn: int,
+    stub_path: Path | None = None,
+    write_note: bool = True,
+) -> tuple[Path, str]:
+    """Seed a closed session note plus its archived (``_done/``) buffer.
+
+    Mirrors the on-disk state left by a session that already composed one
+    chapter and closed: a ``note_status: closed`` note file and a
+    ``_done/<stem>.state.json`` sidecar (state ``closed``) pointing at it.
+    """
+    wiki_root = lore_root / "wiki" / "private"
+    stem = _stem_for(tid, date)
+    note_path = stub_path or (wiki_root / "sessions" / f"{tid}-first.md")
+    if write_note:
+        nd.create_note(
+            note_path,
+            title="Session note",
+            description="Lab-notebook session note.",
+            scope="proj:x",
+            extra_frontmatter={"transcript_id": tid, "integration": "fake", "buffer_stem": stem},
+        )
+        nd.append_chapter(
+            note_path,
+            Chapter(blocks=[TopicBlock(lead=chapter_lead, body="prose.", anchor_turn=from_turn)]),
+            slice_from_turn=from_turn,
+            slice_to_turn=to_turn,
+        )
+        nd.close_note(note_path)
+    sc = Sidecar(
+        transcript_id=tid,
+        local_date=date,
+        integration="fake",
+        wiki="private",
+        scope="proj:x",
+        cwd=str(lore_root),
+        handle="",
+        state="closed",
+        stub_path=str(note_path),
+        counters=Counters(),
+        last_seen=LastSeen(content_hash="h", index_hint=to_turn),
+    )
+    done = done_dir(lore_root)
+    (done / f"{stem}.state.json").write_text(json.dumps(sc.to_dict(), default=str))
+    (done / f"{stem}.jsonl").write_text("")
+    return note_path, stem
+
+
+# ---------------------------------------------------------------------------
+# reopen_note primitive (unit)
+# ---------------------------------------------------------------------------
+
+
+def test_reopen_note_flips_closed_to_open_and_allows_append(tmp_path):
+    path = tmp_path / "note.md"
+    nd.create_note(path, title="t", description="d", scope="proj:x")
+    nd.append_chapter(
+        path,
+        Chapter(blocks=[TopicBlock(lead="First finding", body="a", anchor_turn=1)]),
+        slice_from_turn=0,
+        slice_to_turn=2,
+    )
+    nd.close_note(path)
+    assert nd.is_closed(path) is True
+    # A closed note refuses appends today.
+    with pytest.raises(nd.NoteClosedError):
+        nd.append_chapter(
+            path,
+            Chapter(blocks=[TopicBlock(lead="blocked", body="x", anchor_turn=3)]),
+            slice_from_turn=3,
+            slice_to_turn=4,
+        )
+
+    nd.reopen_note(path)
+    assert nd.is_closed(path) is False
+
+    n = nd.append_chapter(
+        path,
+        Chapter(blocks=[TopicBlock(lead="Second finding", body="b", anchor_turn=3)]),
+        slice_from_turn=3,
+        slice_to_turn=4,
+    )
+    assert n == 2
+    view = nd.read_note(path)
+    assert len([c for c in view.chapters if c.get("kind") == "topic"]) == 2
+    assert "First finding" in view.body and "Second finding" in view.body
+
+
+def test_reopen_note_idempotent_on_open_note(tmp_path):
+    path = tmp_path / "note.md"
+    nd.create_note(path, title="t", description="d", scope="proj:x")
+    nd.append_chapter(
+        path,
+        Chapter(blocks=[TopicBlock(lead="Only finding", body="a", anchor_turn=1)]),
+        slice_from_turn=0,
+        slice_to_turn=2,
+    )
+    before = path.read_text()
+    # Reopening an already-open note is a no-op — no raise, byte-identical file.
+    nd.reopen_note(path)
+    assert nd.is_closed(path) is False
+    assert path.read_text() == before
+
+
+# ---------------------------------------------------------------------------
+# Reattach: a resumed session continues the existing note (one file)
+# ---------------------------------------------------------------------------
+
+
+def test_resumed_session_reattaches_and_appends_to_same_note(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    adapter = _Adapter(_turns(0, 20))
+
+    # Session 1: accumulate, compose one chapter, close (archives the buffer).
+    _append(lore_root, _turns(0, 12))
+    buf = Buffer.open(lore_root, transcript_id=TID, local_date=DATE)
+    stem = buf.stem
+    out1 = synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client([_chapter_payload("Recorded the publish gate", "gate prose.", 4)]),
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    note_path = out1.note_path
+    assert nd.is_closed(note_path) is True
+    assert list((wiki_root / "sessions").rglob("*.md")) == [note_path]
+    assert not buf.sidecar_path.exists()
+    assert (done_dir(lore_root) / f"{stem}.state.json").exists()
+
+    # Session 2 resumes on the same stem after the close.
+    out2 = _append(lore_root, _turns(13, 20))
+    assert out2.is_new_buffer is False  # reattached, not a fresh buffer
+    assert buf.sidecar_path.exists()  # buffer restored out of _done/
+    assert buf.read_sidecar().stub_path == str(note_path)  # same note pointer
+    assert nd.is_closed(note_path) is False  # note reopened
+    assert not (done_dir(lore_root) / f"{stem}.state.json").exists()  # archive moved back
+
+    # Flush the continuation and close again.
+    out3 = synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client(
+            [_chapter_payload("Recorded the essence rewrite", "essence prose.", 15)]
+        ),
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    assert out3.status == "composed"
+    # Still exactly one note file — no sibling minted.
+    assert list((wiki_root / "sessions").rglob("*.md")) == [note_path]
+    view = nd.read_note(note_path)
+    topic = [c for c in view.chapters if c.get("kind") == "topic"]
+    assert len(topic) == 2
+    assert topic[0]["from_turn"] == 0 and topic[0]["to_turn"] == 12
+    assert topic[1]["from_turn"] == 13 and topic[1]["to_turn"] == 20
+    assert view.closed is True
+
+
+def test_continued_compose_receives_existing_body_as_note_so_far(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    adapter = _Adapter(_turns(0, 20))
+
+    _append(lore_root, _turns(0, 12))
+    buf = Buffer.open(lore_root, transcript_id=TID, local_date=DATE)
+    out1 = synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client(
+            [_chapter_payload("Recorded the publish gate design", "unique-marker-alpha.", 4)]
+        ),
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    assert out1.note_path is not None
+
+    _append(lore_root, _turns(13, 20))
+    c2 = _Client([_chapter_payload("Recorded the continuation", "beta prose.", 15)])
+    synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=c2,
+        model="m",
+        adapter_lookup=_lookup(adapter),
+        auto_commit=False,
+    )
+    # The continuation compose was seeded with the existing body, so the
+    # first chapter is present in note-so-far and never re-narrated.
+    prompt = c2.messages.calls[0]["messages"][0]["content"]
+    assert "Recorded the publish gate design" in prompt
+    assert "unique-marker-alpha" in prompt
+
+
+def test_0605_0608_split_reproduced_as_single_note(tmp_path):
+    # The concrete pilot failure: transcript a737ff12 filed 04-0605 (turns
+    # 1095-1383) then, after a /compact, an unlinked 04-0608 (turns
+    # 1384-1430). With reopen+continue the resume reattaches — one note.
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    note_path, stem = _seed_archived_closed_note(
+        lore_root,
+        tid=TID,
+        date=DATE,
+        chapter_lead="Recorded the publish gate",
+        from_turn=1095,
+        to_turn=1383,
+    )
+    assert list((wiki_root / "sessions").rglob("*.md")) == [note_path]
+
+    out = _append(lore_root, _turns(1384, 1430))
+    assert out.is_new_buffer is False
+    assert nd.is_closed(note_path) is False  # reopened, not a new file
+
+    buf = Buffer.open(lore_root, transcript_id=TID, local_date=DATE)
+    synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client(
+            [_chapter_payload("Recorded record-the-work-not-the-working", "essence prose.", 1400)]
+        ),
+        model="m",
+        adapter_lookup=_lookup(_Adapter(_turns(1384, 1430))),
+        auto_commit=False,
+    )
+    # The split is healed: still exactly one note file, now two chapters.
+    assert list((wiki_root / "sessions").rglob("*.md")) == [note_path]
+    view = nd.read_note(note_path)
+    topic = [c for c in view.chapters if c.get("kind") == "topic"]
+    assert len(topic) == 2
+    assert topic[0]["to_turn"] == 1383
+    assert topic[1]["from_turn"] == 1384 and topic[1]["to_turn"] == 1430
+
+
+def test_resume_after_discarded_note_starts_fresh(tmp_path):
+    # A prior session was discarded (trivial / empty): its note file was
+    # removed but the buffer archived with a dangling stub_path. Resuming
+    # must not crash on the missing file; it clears the pointer so a fresh
+    # note is created for the continuing session.
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    missing = wiki_root / "sessions" / "gone.md"
+    _seed_archived_closed_note(
+        lore_root,
+        tid=TID,
+        date=DATE,
+        chapter_lead="unused",
+        from_turn=0,
+        to_turn=1,
+        stub_path=missing,
+        write_note=False,  # note file never exists on disk
+    )
+
+    out = _append(lore_root, _turns(0, 4))
+    assert out.is_new_buffer is False
+    buf = Buffer.open(lore_root, transcript_id=TID, local_date=DATE)
+    assert buf.sidecar_path.exists()  # buffer restored, no crash
+    assert buf.read_sidecar().stub_path == ""  # dangling pointer cleared

--- a/tests/test_stub_note.py
+++ b/tests/test_stub_note.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from lore_core.note_document import Chapter, TopicBlock
 from lore_core.schema import parse_frontmatter
 from lore_core.types import Scope, TranscriptHandle, Turn
 from lore_core.wiki_config import WikiConfig
@@ -14,6 +15,8 @@ from lore_curator.buffer_append import append_chunk
 from lore_curator.stub_note import (
     STUB_DESCRIPTION_PLACEHOLDER,
     STUB_SUMMARY_PLACEHOLDER,
+    _lead_for_rename,
+    _resolve_renamed_path,
     write_or_update,
 )
 
@@ -609,3 +612,63 @@ def test_preview_singular_plural_and_no_extras(
     # No commits / issues seeded → those segments must not appear.
     assert "commits" not in text.lower().split("_so far:", 1)[1].split("_._", 1)[0]
     assert "issue" not in text.lower().split("_so far:", 1)[1].split("_._", 1)[0]
+
+
+# ---------------------------------------------------------------------------
+# Topic-derived rename — the note's filename after its first chapter composes
+# ---------------------------------------------------------------------------
+
+
+def test_lead_for_rename_picks_first_block_lead():
+    chapter = Chapter(blocks=[
+        TopicBlock(lead="Traced the flush race", body="prose", anchor_turn=2),
+    ])
+    assert _lead_for_rename(chapter) == "Traced the flush race"
+
+
+def test_lead_for_rename_uses_continued_topic_for_continuation_block():
+    chapter = Chapter(blocks=[
+        TopicBlock(
+            lead="", body="prose", anchor_turn=2, continued=True, continued_topic="Flush race",
+        ),
+    ])
+    assert _lead_for_rename(chapter) == "Flush race"
+
+
+def test_lead_for_rename_empty_when_no_blocks():
+    assert _lead_for_rename(Chapter(blocks=[])) == ""
+
+
+def test_lead_for_rename_empty_when_first_block_blank():
+    chapter = Chapter(blocks=[TopicBlock(lead="   ", body="prose", anchor_turn=1)])
+    assert _lead_for_rename(chapter) == ""
+
+
+def test_resolve_renamed_path_swaps_slug_keeps_prefix(tmp_path: Path):
+    old = tmp_path / "01-1432-session-proj-x-1432.md"
+    old.write_text("stub")
+    new = _resolve_renamed_path(old, "traced-the-flush-race")
+    assert new.name == "01-1432-traced-the-flush-race.md"
+    assert new.parent == old.parent
+
+
+def test_resolve_renamed_path_noop_when_slug_unchanged(tmp_path: Path):
+    old = tmp_path / "01-1432-traced-the-flush-race.md"
+    old.write_text("stub")
+    new = _resolve_renamed_path(old, "traced-the-flush-race")
+    assert new == old
+
+
+def test_resolve_renamed_path_avoids_collision(tmp_path: Path):
+    old = tmp_path / "01-1432-session-proj-x-1432.md"
+    old.write_text("stub")
+    (tmp_path / "01-1432-traced-the-flush-race.md").write_text("someone else's note")
+    new = _resolve_renamed_path(old, "traced-the-flush-race")
+    assert new.name == "01-1432-traced-the-flush-race-2.md"
+
+
+def test_resolve_renamed_path_leaves_malformed_stem_untouched(tmp_path: Path):
+    old = tmp_path / "weird-name.md"
+    old.write_text("stub")
+    new = _resolve_renamed_path(old, "traced-the-flush-race")
+    assert new == old


### PR DESCRIPTION
## Summary

Fixes the two failure classes a pilot exposed in the 0.55.0 essence-first session-note rewrite: one session filing several unlinked, partly-duplicated notes, and the composer reporting material the user only pasted as an exemplar as if it were the session's own work. Closes epic #151 (PRD [`docs/prd/0002-useful-session-notes.md`](docs/prd/0002-useful-session-notes.md), now included on this branch).

## Delivered roadmap

- #146 — Liveness: same-host pid-gone is uncertain, not dead (PR #152)
- #147 — Compose: quoted/reference material is not the session's work (PR #153)
- #149 — Compose: soft same-anchor retry lint (PR #154)
- #148 — Reopen + continue: a resumed session continues its existing note (PR #155) — includes ADR [`docs/adr/0001-session-note-reopen-relaxes-close-immutability.md`](docs/adr/0001-session-note-reopen-relaxes-close-immutability.md)
- #150 — Topic-derived note slug (PR #158)

Each PR passed an independent strong-tier crosscheck before merging into this branch; a whole-epic strong-tier review then verified cross-feature composition (naming consistency, no duplicated helpers, `chapter_flush.py`'s shared touchpoints, the #146×#148 reaper/reopen interaction, and PRD/ADR consistency) — verdict posted below.

Two non-blocking follow-ups surfaced during crosscheck were filed separately rather than gating this epic: #156 (drain telemetry double-counts `note-filed` on a reopened note's later close) and #157 (`reopen_from_done` should guard a malformed archived sidecar).

## Test plan

- [x] Every feature's own tests pass on this branch
- [x] Post-merge invariant re-verified after each batch: full suite green modulo 16 pre-existing, unrelated failures (rich ANSI color-code assertions, missing optional `openai` dependency, stale hardcoded dates/version) — fingerprinted identical to base by every reviewer across all 5 PRs
- [x] Whole-epic review re-ran the full suite on the merged tree: 2390 passed, 16 pre-existing failures, 8 skipped — no new failures
