### PR TITLE
docs(architecture): session-note lifecycle for epic #151

### DIFF
--- a/docs/architecture/session-note-lifecycle.md
+++ b/docs/architecture/session-note-lifecycle.md
@@ -1,0 +1,178 @@
+# Session-note lifecycle — one session, one note
+
+**Audience:** contributors who open a note whose frontmatter says
+`note_status: closed`, watch it gain another chapter an hour later, and
+wonder how a "closed" note is still being written to — or who need to
+know why a resumed session no longer leaves two half-duplicated notes
+behind.
+
+The session note is the deterministic core's one-record-per-session
+artifact: a fixed disclaimer followed by chronological chapters, one per
+flush. `CONTEXT.md` is the vocabulary (buffer, flush, chapter, block,
+anchor, marker); this document explains the **lifecycle** that vocabulary
+moves through — `create → append → close → reopen` — and the guarantee
+that lifecycle exists to keep: **one session produces exactly one note.**
+
+---
+
+## The promise, and how it used to break
+
+A session note should be a faithful, skimmable, navigable record of what
+*one* session figured out. Two failure classes broke that promise even
+after the note *voice* was fixed:
+
+- **One session, several notes.** A session closed early (a false
+  liveness reap) or resumed after a `/compact`, an editor restart, or an
+  idle-then-return would mint a *second* note file that re-narrated the
+  first from an empty note-so-far. The vault accumulated sibling notes
+  that each told part of the story and repeated the rest.
+- **Notes reporting work the session never did.** Material the user
+  pasted only as a formatting exemplar or a reference was read by the
+  composer and reported as the session's own findings — with every block
+  collapsing onto the single turn that held the pasted blob, so the
+  anchors were useless for navigation.
+
+The lifecycle below closes both. The full problem statement and the
+per-decision rationale live in
+[PRD 0002](../prd/0002-useful-session-notes.md); the immutability
+trade-off is recorded in
+[ADR 0001](../adr/0001-session-note-reopen-relaxes-close-immutability.md).
+
+---
+
+## Keeping one session to one note
+
+Two mechanisms cooperate: a session is not closed while it is merely
+quiet, and if it *is* closed and then resumes, it reattaches to its own
+note instead of starting a new one.
+
+### 1. Liveness — "pid gone, same host" is uncertain, not dead
+
+The buffer records an owner `pid`, re-stamped every heartbeat to the
+current hook subprocess — which exits within milliseconds. So "the owner
+pid is gone" is the **normal steady state of a live session**, not a
+death signal. `lore_curator/reaper.py::is_owner_alive` returns:
+
+| Owner state | Verdict | Consequence |
+|---|---|---|
+| Same host, pid signalable, `/proc` start-ts matches | `True` (alive) | keep waiting |
+| Owner `host` differs from this host | `False` (dead) | reap immediately |
+| Same host, pid gone / start-ts mismatch / no `/proc` access | `None` (uncertain) | fall back on the staleness threshold |
+
+The critical case is the last row. A same-host pid-gone owner is
+**uncertain**, so the reaper and the SessionStart sweep defer to
+`liveness_stale_threshold_s` (default 30 min, doubled on macOS) instead
+of closing instantly. A genuinely dead session still closes — just via
+staleness, a little later — so no buffer leaks. Only an *unambiguously*
+dead owner (a different host) is reaped on sight. This alone stops most
+of the duplicate-note churn, because the live session that was being
+reaped mid-flight now survives.
+
+### 2. Reopen + continue — a resume reattaches to its own note
+
+Staleness still closes a session that goes genuinely idle and later
+comes back. When it comes back, the next heartbeat finds no live buffer
+(it was archived to `_done/`) and would, historically, mint a fresh
+sidecar with an empty note pointer and thus a **second** file.
+
+Instead, at the `existing is None` branch of
+`buffer_append.py::append_chunk`, the code first calls
+`buffer.reopen_from_done()`: it looks in `_done/` for an archived buffer
+of the **same stem** (`<transcript_id>__<local_date>`) and, if found,
+*moves* it back to the live directory and continues appending chapters
+to the same note. The archived note is reopened with
+`lore_core/note_document.py::reopen_note`, and note-so-far is seeded from
+the existing body so the next compose does not repeat earlier content.
+The drain emits `buffer-reopened` rather than a second `note-filed`.
+
+If the prior note was discarded (a trivial/empty session whose file was
+deleted), the restored pointer dangles; the restore detects the missing
+file, clears the pointer, and lets a fresh note be created — it never
+crashes trying to reopen a deleted file.
+
+**This deliberately relaxes one invariant.** Before this epic, `close`
+was terminal: a note with `note_status: closed` was immutable and
+`append_chapter` raised `NoteClosedError`. `reopen_note` flips that
+status back to `open` so a resumed session can append. The carve-out is
+narrow and its trade-offs are the subject of
+[ADR 0001](../adr/0001-session-note-reopen-relaxes-close-immutability.md):
+
+- Only a session's **own** continuing heartbeat, keyed on the identical
+  stem, ever reopens its own note. No cross-session or curator writer can.
+- Immutability still holds for every derived/curated artifact (concepts,
+  decisions, threads).
+- Reopen only ever *appends* — earlier chapters are never edited, so the
+  append-only-within-a-session contract is intact. What changes is that
+  `note_status: closed` is no longer a guarantee of *permanence* for a
+  session note; the same file may gain chapters if its session resumes.
+
+---
+
+## Recording only what the session worked on
+
+One session, one note is worthless if that one note reports the wrong
+work. Two compose-side checks keep the record faithful. Both live in
+`lore_curator/chapter_compose.py` and both are written explicitly
+because the compose model is a ~120B open model, weak at implicit
+pragmatics.
+
+### Quoted and reference material is not the session's work
+
+`_build_prompt` carries an explicit clause: content the user pastes or
+quotes as an **exemplar, reference, or comparison** — signalled by
+framing ("this is a form I'd like", "for example", "an older version
+of"), by a fenced code block, or by a block that carries its **own**
+`@N`-anchored bold leads (the shape of an earlier note) — is *about* that
+pasted material and does **not** describe what this session did. Its
+claims, tools, paths, and config are never reported as the session's
+findings. The one exception: when working on that material *was* the
+topic (the user asked to review, fix, or reason about it), that work is
+the session's work and is recorded. The chapter tool schema's `body`
+description reinforces the same rule.
+
+### Same-anchor soft lint — nudge honest anchors
+
+`chapter_same_anchor_lint` flags a chapter with **more than two** blocks
+all citing one turn — the tell of several "findings" derived from a
+single pasted passage. Two blocks sharing a turn is common and
+unremarkable; more than two is usually a collapse that makes the anchors
+useless for navigation. On a hit, the compose loop issues **exactly one**
+corrective retry (`_same_anchor_feedback`: "confirm these are distinct
+findings … re-anchor each block to the turn where its own topic actually
+started"). It is a **soft** signal: it never hard-rejects and never
+fabricates anchor diversity — after the single nudge the chapter
+publishes regardless of whether the anchors changed. This sits beside the
+existing hard `chapter_anchor_lint` (which rejects out-of-range anchors),
+reusing the same retry plumbing.
+
+---
+
+## Naming the file after its topic
+
+The note file is created — and first named — at the first heartbeat,
+before any chapter exists, so its initial slug is an incidental guess (a
+commit subject, a touched file's basename, or a bare timestamp). Once the
+first chapter composes, its opening lead names the session's actual
+topic, and `chapter_flush.py::_rename_to_topic_slug` renames the file to
+match (only on chapter 1). A chapter with no usable lead, or a lead that
+slugs to nothing or to the bare fallback `session`, leaves the filename
+untouched rather than risk an empty slug; same-minute collisions still
+get a numeric suffix. Stub notes that never compose a chapter keep their
+fallback name.
+
+---
+
+## See also
+
+- `CONTEXT.md` — the note vocabulary (buffer, flush, chapter, block,
+  anchor, marker) and the buffer/flush/compose write path.
+- [ADR 0001](../adr/0001-session-note-reopen-relaxes-close-immutability.md)
+  — the close-immutability carve-out, its alternatives, and its
+  concurrency and trade-off analysis.
+- [PRD 0002](../prd/0002-useful-session-notes.md) — the problem
+  statement, the pilot transcript that exposed both failure classes, and
+  the per-decision rationale.
+- Source: `lore_curator/reaper.py` (liveness),
+  `lore_curator/buffer_append.py` + `lore_core/note_document.py`
+  (reopen + continue), `lore_curator/chapter_compose.py` (compose
+  fidelity), `lore_curator/chapter_flush.py` (topic slug).


### PR DESCRIPTION
## What

Documentation catch-up for epic #151 (**PRD 0002 — session notes that carry
the essence, one per session**), merged to `main` via #159.

Adds one **explanation** doc, `docs/architecture/session-note-lifecycle.md`,
describing the shipped `create → append → close → reopen` lifecycle and the
one-session-one-note guarantee the epic established:

- **Liveness** — a same-host, pid-gone owner is now *uncertain*, not dead, so
  the reaper/sweep no longer close a live session mid-flight (#146).
- **Reopen + continue** — a resumed session reattaches to its own archived
  note and appends to the same file instead of minting a duplicate sibling;
  this relaxes close-immutability for session notes only (#148, ADR 0001).
- **Compose fidelity** — quoted/reference material the user only pasted is not
  reported as the session's work (#147); a soft same-anchor lint nudges honest
  anchors without ever blocking publication (#149).
- **Topic slug** — the note file is renamed to its first chapter's topic once
  that chapter composes (#150).

## Diátaxis scope

- **Explanation** quadrant only (the repo's `docs/architecture/` tree).
- **Reference** needs no edit: the new public symbols (`reopen_note`,
  `chapter_same_anchor_lint`) already carry complete docstrings and there is no
  Sphinx/autosummary site to wire.
- No tutorial or how-to warranted — the epic changed automatic behavior and
  added no new command or first-time user task.
- **Does not touch `docs/prd/` or `docs/adr/`** (canonical, human-owned).

## Verification

No CI is configured on this repo, so the local suite is the gate:
`PYTHONPATH=lib python -m pytest` → **2390 passed, 8 skipped, 16 failed**. All
16 failures are the pre-existing, unrelated fingerprint carried across this
epic's PRs (rich ANSI color-code assertions, the missing optional `openai`
dep, and a stale hardcoded date/version); none touch the note-lifecycle
subsystem, and this PR changes only a Markdown file.

## Links

- Epic: #151
- Merge: #159
- Sub-issues: #146, #147, #148, #149, #150
- ADR 0001, PRD 0002 (read-only references)

_Docs land autonomously and are reviewed post-hoc, per the document-epic
workflow._
