### PR TITLE
ci: pytest + ruff pipeline on push/PR (#163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci
+
+# The prerequisite gate for every PR into epic/161 and main. Keep pytest
+# green. ruff is advisory (continue-on-error) until the repo-wide
+# lint/format cleanup lands — see #196 — so it reports without blocking.
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dev dependencies
+        run: pip install -e .[dev]
+
+      - name: pytest
+        run: pytest -q
+
+      # advisory until repo is ruff-clean — see #196
+      - name: ruff check
+        continue-on-error: true
+        run: ruff check .
+
+      # advisory until repo is ruff-clean — see #196
+      - name: ruff format --check
+        continue-on-error: true
+        run: ruff format --check .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,23 @@ python -m pytest          # full suite
 python -m pytest tests/test_install_*.py -v   # installer-only
 ```
 
+## CI
+
+`.github/workflows/ci.yml` runs on every push and pull request. It
+mirrors the local dev commands exactly — no separate CI-only config:
+
+```bash
+pip install -e .[dev]
+pytest -q
+ruff check .
+ruff format --check .
+```
+
+`pytest` is a blocking gate. `ruff check` / `ruff format --check` run
+as advisory (`continue-on-error: true`) until the repo-wide lint and
+formatting cleanup tracked in #196 lands — new code you write should
+still pass both locally before you push.
+
 For end-to-end testing on a clean container, the canonical checklist
 lives in the PR description that lands a release (or in
 `docs/REVIEW-*.md` when one is written). If you're cutting a release,

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,39 @@
+"""CI workflow shape — issue #163.
+
+Keeps the workflow file honest without re-implementing a YAML linter:
+asserts the three required gates (pytest, ruff check, ruff format
+--check) are present and wired to run on push and pull_request.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "ci.yml"
+
+
+def _load_workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def test_workflow_file_exists():
+    assert WORKFLOW_PATH.is_file(), f"missing {WORKFLOW_PATH}"
+
+
+def test_workflow_runs_on_push_and_pull_request():
+    workflow = _load_workflow()
+    # YAML parses the bare `on:` key as boolean True, not string "on".
+    triggers = workflow.get(True, workflow.get("on", {}))
+    assert "push" in triggers
+    assert "pull_request" in triggers
+
+
+def test_workflow_runs_pytest_ruff_check_and_ruff_format():
+    workflow = _load_workflow()
+    steps = [step for job in workflow["jobs"].values() for step in job["steps"] if "run" in step]
+    run_commands = " ".join(step["run"] for step in steps)
+    assert "pytest" in run_commands
+    assert "ruff check" in run_commands
+    assert "ruff format --check" in run_commands

--- a/tests/test_lore_verify_skill.py
+++ b/tests/test_lore_verify_skill.py
@@ -63,12 +63,17 @@ def test_skill_calls_lore_verdict_mcp():
 
 def test_plugin_version_bumped_for_skill_addition():
     """Per the lore-plugin-cache-stale memory: any plugin.json change
-    needs a version bump or installed caches never re-fetch."""
-    import json
+    needs a version bump or installed caches never re-fetch.
 
-    plugin = json.loads(
-        (SKILL_PATH.parent.parent.parent / ".claude-plugin" / "plugin.json").read_text()
-    )
-    # 0.50.0 bump: `/lore:verify` rewritten to use the new
-    # `lore_pending_verdicts` MCP tool — zero bash.
-    assert plugin["version"] == "0.50.0"
+    Cross-checked against pyproject.toml's version rather than a
+    hardcoded literal — the release process bumps both in lockstep
+    (see test_version_sync.py), so a hardcoded string here just rots
+    on every release.
+    """
+    import json
+    import tomllib
+
+    repo_root = SKILL_PATH.parent.parent.parent
+    plugin = json.loads((repo_root / ".claude-plugin" / "plugin.json").read_text())
+    pyproject = tomllib.loads((repo_root / "pyproject.toml").read_text())
+    assert plugin["version"] == pyproject["project"]["version"]

--- a/tests/test_openai_backend.py
+++ b/tests/test_openai_backend.py
@@ -583,6 +583,13 @@ def test_make_llm_client_openai_missing_api_key_raises(monkeypatch):
 
     monkeypatch.setenv("LORE_OPENAI_BASE_URL", "https://example.local/v1")
     monkeypatch.delenv("LORE_OPENAI_API_KEY", raising=False)
+    # make_llm_client(lore_root=None) hydrates os.environ from
+    # $LORE_ROOT/.lore/secrets.env (see _resolve_openai_settings). On a
+    # dev machine with $LORE_ROOT pointed at a real vault that has a
+    # secrets.env with LORE_OPENAI_API_KEY set, that hydration silently
+    # re-populates the key this test just deleted. Clear LORE_ROOT so the
+    # "missing key" scenario is actually exercised regardless of host env.
+    monkeypatch.delenv("LORE_ROOT", raising=False)
 
     with pytest.raises(LlmClientError, match="LORE_OPENAI_API_KEY"):
         make_llm_client(backend="openai")

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -8,10 +8,19 @@ scope-aggregation logic was extracted from `lore_cli.resume_cmd` into
 
 from __future__ import annotations
 
+from datetime import date, timedelta
 from textwrap import dedent
 
 import pytest
 from lore_cli import resume_cmd
+
+# Fixture dates are relative to "today" (5/6 days back) rather than
+# hardcoded literals — a fixed date eventually falls outside the
+# default 30-day recent-session window and the fixture silently stops
+# exercising what it's meant to test (see test_resume_recent_finds_sharded_sessions
+# for the same pattern applied to the sharded-layout fixture below).
+_MATCHING_DATE = (date.today() - timedelta(days=5)).isoformat()
+_UNRELATED_DATE = (date.today() - timedelta(days=6)).isoformat()
 
 
 @pytest.fixture
@@ -36,14 +45,14 @@ def vault(tmp_path, monkeypatch):
         )
     )
     # A matching v2 session note
-    (wiki / "sessions" / "2026-04-10-retry-fix.md").write_text(
+    (wiki / "sessions" / f"{_MATCHING_DATE}-retry-fix.md").write_text(
         dedent(
-            """\
+            f"""\
             ---
             schema_version: 2
             type: session
-            created: 2026-04-10
-            last_reviewed: 2026-04-10
+            created: {_MATCHING_DATE}
+            last_reviewed: {_MATCHING_DATE}
             status: stable
             description: "retry fix session"
             scope: ccat:data-center:data-transfer
@@ -54,14 +63,14 @@ def vault(tmp_path, monkeypatch):
         )
     )
     # A non-matching one (different scope)
-    (wiki / "sessions" / "2026-04-09-unrelated.md").write_text(
+    (wiki / "sessions" / f"{_UNRELATED_DATE}-unrelated.md").write_text(
         dedent(
-            """\
+            f"""\
             ---
             schema_version: 2
             type: session
-            created: 2026-04-09
-            last_reviewed: 2026-04-09
+            created: {_UNRELATED_DATE}
+            last_reviewed: {_UNRELATED_DATE}
             status: stable
             description: "unrelated"
             scope: ccat:instrument:atm
@@ -111,9 +120,9 @@ def test_resume_subtree_aggregates_issues(vault, monkeypatch, capsys):
     assert "#10 trust CA" in out
     assert "#31 [draft] wip" in out
     # Session note matching by scope
-    assert "2026-04-10" in out
+    assert _MATCHING_DATE in out
     # Non-matching session excluded
-    assert "2026-04-09" not in out
+    assert _UNRELATED_DATE not in out
 
 
 def test_resume_no_wiki_matches_emits_error(vault, monkeypatch, capsys):
@@ -180,8 +189,8 @@ def test_resume_recent_no_args(vault, monkeypatch, capsys):
     assert "Resume: all wikis" in out
     assert "Recent sessions" in out
     # Both fixture sessions should appear
-    assert "2026-04-10" in out
-    assert "2026-04-09" in out
+    assert _MATCHING_DATE in out
+    assert _UNRELATED_DATE in out
 
 
 def test_resume_wiki_scoped_no_keyword(vault, monkeypatch, capsys):


### PR DESCRIPTION
Closes #163

## Summary
- `.github/workflows/ci.yml`: pytest (blocking) + `ruff check` / `ruff format --check` (advisory, `continue-on-error: true`) on every push and PR — the prerequisite gate for epic/161.
- `ruff` is advisory rather than blocking because the repo has ~740 pre-existing `ruff check` violations and 263 files needing `ruff format` — a large, opinionated cleanup that's out of scope for a CI ticket. Tracked as a follow-up: **buchbend/lore#196**. Each ruff step has an inline comment pointing at #196.
- `CONTRIBUTING.md` documents the CI section — the workflow runs the exact same `pip install -e .[dev]`, `pytest -q`, `ruff check .`, `ruff format --check .` you'd run locally.
- `tests/test_ci_workflow.py`: small red→green test asserting the workflow exists, triggers on push/PR, and names the three gates.

## Baseline investigation (before writing the workflow)
Ran all three gates locally first per the TDD discipline. First pass surfaced 16 pytest failures, but 13 were artifacts of my dev shell (`FORCE_COLOR`/`COLORTERM` making rich emit ANSI codes that break string-equality assertions, plus a leaked `OPENAI_API_KEY`) — none of that applies to a GitHub Actions runner. Re-running with a scrubbed env left 3 real failures, which I root-caused and fixed (product code untouched):

1. `test_lore_verify_skill.py::test_plugin_version_bumped_for_skill_addition` — hardcoded `plugin["version"] == "0.50.0"`, stale since 0.57.0 shipped. Now reads `pyproject.toml`'s version dynamically so it can't rot again.
2. `test_resume.py::test_resume_subtree_aggregates_issues` — fixture session note hardcoded to `2026-04-10`; the "recent sessions" default window is 30 days, so the fixture aged out. Dates are now relative to `date.today()`.
3. `test_openai_backend.py::test_make_llm_client_openai_missing_api_key_raises` — root-caused: `make_llm_client(lore_root=None)` hydrates `os.environ` from `$LORE_ROOT/.lore/secrets.env`. On a machine with `LORE_ROOT` pointed at a real vault containing a `secrets.env` with `LORE_OPENAI_API_KEY` set, that hydration silently re-populated the key the test had just `monkeypatch.delenv`'d. This is a test-isolation gap, not a product bug — fixed by also clearing `LORE_ROOT` in the test.

Also found (not fixed, out of scope): `tests/test_redaction.py::TestGoogleApiKey::test_redaction_catches_aiza_key` uses `secrets.choice` to generate a random 35-char test string with no seed, making it a rare, non-deterministic flake unrelated to this PR — flagging for a separate follow-up.

## Evidence

**Red before the workflow existed:**
```
FAILED tests/test_ci_workflow.py::test_workflow_file_exists - AssertionError: missing .../.github/workflows/ci.yml
FAILED tests/test_ci_workflow.py::test_workflow_runs_on_push_and_pull_request - FileNotFoundError
FAILED tests/test_ci_workflow.py::test_workflow_runs_pytest_ruff_check_and_ruff_format - FileNotFoundError
3 failed in 0.41s
```

**Green after, in a fresh venv simulating the CI runner exactly** (`python3 -m venv`, `pip install -e .[dev]`, scrubbed env — no `FORCE_COLOR`/`LORE_ROOT`/leaked keys):
```
2410 passed, 7 skipped, 1 warning in 68.15s
```
(7 skips are optional-extra-gated tests — `[search]`/`[sinks]` deps aren't part of `[dev]`, matching what the workflow installs.)

**ruff on the touched files only** (new/changed test files, not the pre-existing repo-wide debt):
```
ruff check tests/test_ci_workflow.py tests/test_lore_verify_skill.py tests/test_resume.py tests/test_openai_backend.py
ruff format --check tests/test_ci_workflow.py
→ clean
```

## Test plan
- [x] `.github/workflows/ci.yml` present, triggers on push + pull_request, runs pytest + ruff check + ruff format --check
- [x] Full suite green at branch point (fresh venv, scrubbed env)
- [x] CONTRIBUTING.md documents CI mirrors local commands
- [x] New/changed test files pass ruff check + ruff format --check