### PR TITLE
feat: two-plugin monorepo — lore-workflow marketplace entry (#164)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,18 @@
     "name": "Christof Buchbender"
   },
   "metadata": {
-    "description": "Lore — knowledge graph for AI-coding teams."
+    "description": "Lore \u2014 knowledge graph for AI-coding teams."
   },
   "plugins": [
     {
       "name": "lore",
       "source": "./",
       "description": "LLM-optimized knowledge graph: session notes, auto-extracted knowledge, pluggable briefings, magic context injection."
+    },
+    {
+      "name": "lore-workflow",
+      "source": "./lore-workflow",
+      "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams (depends on lore; ships no skills yet)."
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,8 @@ github-source plugins, the plugin manifest's version always wins
 silently and a duplicate in the marketplace is ignored (per the
 Claude Code plugin docs' explicit warning).
 
+The repo also ships `lore-workflow`, a second plugin with its own manifest at `lore-workflow/.claude-plugin/plugin.json` and an independent version axis — bumping `lore` does not require bumping `lore-workflow`, and vice versa. `tests/test_version_sync.py` checks both manifests are present and marketplace-wired; it does not force them to agree. Dependency direction is one-way: `lore-workflow` may depend on `lore`'s CLI/MCP surface, `lore` never depends on `lore-workflow`.
+
 The `_lore_schema_version` field inside `mcpServers.lore`
 (installed into `~/.cursor/mcp.json` etc.) is a separate concern —
 bump that only when the *managed-block shape* changes, not on every

--- a/lore-workflow/.claude-plugin/plugin.json
+++ b/lore-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "lore-workflow",
+  "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams. Depends on lore; ships no skills yet.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Christof Buchbender"
+  },
+  "homepage": "https://github.com/buchbend/lore",
+  "license": "MIT",
+  "keywords": [
+    "workflow",
+    "tdd",
+    "epic",
+    "prd"
+  ]
+}

--- a/lore-workflow/README.md
+++ b/lore-workflow/README.md
@@ -1,0 +1,16 @@
+# lore-workflow
+
+Companion plugin to [`lore`](../README.md): deterministic epic/PRD/TDD
+workflow skills (orient, grill, to-epic, orchestrate-epic, tdd, debug,
+document-epic, implement-issue, seed-epic, domain-modeling).
+
+Empty for now — skills migrate in from `ccatobs/ccat-agent-workflow` in a
+later slice (see PRD 0003).
+
+**Dependency direction: `lore-workflow` depends on `lore`; `lore` never
+depends on `lore-workflow`.** Workflow skills call `lore`'s CLI/MCP surface
+(code map, tier resolver, workflow subcommands); nothing in `lore` core
+imports or requires this plugin. This keeps `lore` installable standalone
+and lets `lore-workflow` stay opt-in.
+
+Versioned independently from `lore` — see `.claude-plugin/plugin.json`.

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -7,6 +7,11 @@ drift between sources means installed clients keep running cached code.
 
 This test fails fast if the three sources disagree, and is the canonical
 "CI guard" referenced by the release process in `CONTRIBUTING.md`.
+
+The repo also ships a second plugin, `lore-workflow` (its own manifest at
+`lore-workflow/.claude-plugin/plugin.json`), on an independent version
+axis — it has no pyproject/CHANGELOG counterpart yet, so it's checked
+only for internal validity and marketplace wiring, not cross-file sync.
 """
 
 from __future__ import annotations
@@ -20,7 +25,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 PLUGIN_MANIFEST = REPO_ROOT / ".claude-plugin" / "plugin.json"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+MARKETPLACE = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+WORKFLOW_MANIFEST = REPO_ROOT / "lore-workflow" / ".claude-plugin" / "plugin.json"
 
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 CHANGELOG_HEADING_RE = re.compile(r"^##\s+\[(?P<version>\d+\.\d+\.\d+)\]")
 
 
@@ -58,4 +66,40 @@ def test_changelog_has_entry_for_current_version():
         f"CHANGELOG.md latest release heading is {latest!r} but "
         f"pyproject.toml is {py!r}. Add a `## [{py}] — YYYY-MM-DD` "
         f"section under `## [Unreleased]`."
+    )
+
+
+def _marketplace_plugins() -> dict:
+    data = json.loads(MARKETPLACE.read_text())
+    return {entry["name"]: entry for entry in data["plugins"]}
+
+
+def test_marketplace_lists_both_plugins():
+    plugins = _marketplace_plugins()
+    assert set(plugins) == {"lore", "lore-workflow"}, (
+        f"marketplace.json plugins are {sorted(plugins)!r}; expected both "
+        f"'lore' and 'lore-workflow' entries (PRD 0003 two-plugin monorepo)."
+    )
+
+
+def test_marketplace_sources_resolve_to_a_plugin_manifest():
+    for name, entry in _marketplace_plugins().items():
+        source_dir = (REPO_ROOT / entry["source"]).resolve()
+        manifest = source_dir / ".claude-plugin" / "plugin.json"
+        assert manifest.is_file(), (
+            f"marketplace entry {name!r} has source={entry['source']!r}, "
+            f"but no manifest at {manifest} — plugin isn't installable."
+        )
+
+
+def test_lore_workflow_manifest_has_independent_version():
+    assert WORKFLOW_MANIFEST.is_file(), (
+        f"expected a lore-workflow plugin manifest at {WORKFLOW_MANIFEST}"
+    )
+    manifest = json.loads(WORKFLOW_MANIFEST.read_text())
+    assert manifest["name"] == "lore-workflow"
+    version = manifest.get("version")
+    assert version and SEMVER_RE.match(version), (
+        f"lore-workflow plugin.json version={version!r} must be a "
+        f"standalone X.Y.Z, independent of the lore plugin's version."
     )


### PR DESCRIPTION
Closes #164

## Summary
- `.claude-plugin/marketplace.json` now lists two plugins: `lore` (unchanged) and `lore-workflow` (new), each with its own manifest.
- `lore-workflow/.claude-plugin/plugin.json` is a standalone manifest on its own version axis (`0.1.0`), independent of `lore`'s `0.57.0`. No skills yet — those land in #172.
- `tests/test_version_sync.py` extended with three tests: marketplace lists both plugin names, each entry's `source` resolves to a real `.claude-plugin/plugin.json`, and the `lore-workflow` manifest has a valid standalone semver version. The original pyproject/plugin.json/CHANGELOG sync test for `lore` is untouched — the two plugins are intentionally not forced to share a version.
- Dependency direction documented in `lore-workflow/README.md` and `CONTRIBUTING.md`'s release section: `lore-workflow` may depend on `lore`'s CLI/MCP surface; `lore` never depends on `lore-workflow`.

## Red -> Green
Red (before manifest/marketplace changes):
```
FAILED tests/test_version_sync.py::test_marketplace_lists_both_plugins
FAILED tests/test_version_sync.py::test_lore_workflow_manifest_has_independent_version
2 failed, 3 passed in 0.19s
```
Green (after):
```
5 passed in 0.19s
```
Full suite: `2428 passed, 1 warning in 78.27s` (pre-existing, unrelated warning about a temp-file permission fixture).
`ruff check` / `ruff format --check` clean on touched files.

## Test plan
- [x] `pytest tests/test_version_sync.py -q` green
- [x] `pytest -q` (full suite) green, 2428 passed
- [x] `ruff check` / `ruff format --check` clean on touched files
- [x] Did not bump `lore`'s existing version (per scope fence)