### PR TITLE
feat: lore workflow — roadmap validator, PRD scaffolding (#169)

### DIFF
--- a/lib/lore_cli/__main__.py
+++ b/lib/lore_cli/__main__.py
@@ -71,8 +71,8 @@ def _build_app() -> typer.Typer:
         inbox_cmd,
         ingest_cmd,
         init_cmd,
-        journal_cmd,
         install_cmd,
+        journal_cmd,
         lint_cmd,
         log_cmd,
         mcp_cmd,
@@ -92,6 +92,7 @@ def _build_app() -> typer.Typer:
         status_cmd,
         transcripts_cmd,
         wiki_cmd,
+        workflow_cmd,
     )
 
     app = typer.Typer(
@@ -145,6 +146,7 @@ def _build_app() -> typer.Typer:
     app.add_typer(runs_cmd.app, name="runs", rich_help_panel=_ADV)
     app.add_typer(scopes_cmd.app, name="scopes", rich_help_panel=_ADV)
     app.add_typer(transcripts_cmd.app, name="transcripts", rich_help_panel=_ADV)
+    app.add_typer(workflow_cmd.app, name="workflow", rich_help_panel=_ADV)
 
     app.command(
         "uninstall",

--- a/lib/lore_cli/workflow_cmd.py
+++ b/lib/lore_cli/workflow_cmd.py
@@ -1,0 +1,75 @@
+"""`lore workflow` — deterministic epic-workflow substrate (PRD 0003).
+
+Thin Typer wrapper over `lore_workflow`: skills that used to embed this
+mechanic as prose now call these subcommands and gate on their exit code.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+from lore_workflow.prd_docs import create_prd
+from lore_workflow.roadmap_validator import validate_roadmap
+from rich.console import Console
+
+from lore_cli._argv_compat import argv_main
+
+console = Console()
+
+app = typer.Typer(
+    add_completion=False,
+    help="Deterministic epic-workflow gates: roadmap validation, PRD scaffolding.",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+
+
+@app.command("validate-roadmap")
+def validate_roadmap_cmd(
+    path: str = typer.Argument(
+        "-", help="Path to the epic body Markdown, or '-' to read stdin."
+    ),
+) -> None:
+    """Validate an epic's roadmap table: required columns, fully-qualified
+    `owner/repo#n` issue refs, resolvable blocked-by edges, acyclic DAG.
+    """
+    text = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    result = validate_roadmap(text)
+    if result.ok:
+        console.print(
+            f"[green]roadmap OK[/green]: {len(result.rows)} feature(s), "
+            "dependency DAG is acyclic"
+        )
+        return
+    console.print("[red]roadmap INVALID[/red]:")
+    for problem in result.problems:
+        console.print(f"  - {problem.kind}: {problem.message}")
+    raise typer.Exit(code=1)
+
+
+@app.command("create-prd")
+def create_prd_cmd(
+    slug: str = typer.Option(..., "--slug", help="Kebab-case PRD slug."),
+    title: str = typer.Option(..., "--title", help="PRD title."),
+    epic_url: str = typer.Option(..., "--epic-url", help="URL of the tracking epic."),
+    repo: list[str] = typer.Option(
+        None, "--repo", help="Involved repo (owner/repo). Repeat for multiple."
+    ),
+    target: Path | None = typer.Option(
+        None, "--target", help="Repo root under which docs/prd/ is created (default: cwd)."
+    ),
+) -> None:
+    """Write `docs/prd/NNNN-<slug>.md` and wire it into `docs/prd/index.md`."""
+    path = create_prd(
+        target or Path("."), slug=slug, title=title, epic_url=epic_url, repos=repo or []
+    )
+    console.print(f"[green]wrote[/green] {path}")
+
+
+main = argv_main(app)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/lore_workflow/__init__.py
+++ b/lib/lore_workflow/__init__.py
@@ -1,0 +1,10 @@
+"""Deterministic workflow-script substrate for `lore workflow` (PRD 0003).
+
+Ported near-verbatim from the ccat-agent-workflow plugin's `to-epic` and
+`document-epic` skill helpers: no third-party dependencies, no GitHub I/O —
+callers supply text/paths they already have. Skills built on these become
+thin prose calling into a `lore workflow` subcommand instead of embedding
+the mechanic.
+"""
+
+from __future__ import annotations

--- a/lib/lore_workflow/diataxis.py
+++ b/lib/lore_workflow/diataxis.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Diátaxis quadrant-classification heuristic for the document-epic skill.
+
+The `document-epic` skill body is LLM-driven prose, but the part that decides
+*which Diátaxis quadrant a given change belongs to* must be deterministic so it
+can be tested and so two runs of the skill agree. That decision lives here as a
+pure helper with no I/O and no third-party dependency (stdlib only, so it runs
+in CI without an install step).
+
+The four Diátaxis quadrants (https://diataxis.fr/):
+
+  - tutorial    — learning-oriented; a guided first-time walkthrough.
+  - how-to      — task-oriented; a recipe to accomplish a specific goal.
+  - reference   — information-oriented; for us that means docstrings + the
+                  autosummary/toctree wiring that surfaces them, NOT prose.
+  - explanation — understanding-oriented; background, the "why", trade-offs.
+
+Hard rule encoded here and relied on by the skill: `docs/prd/` and `docs/adr/`
+are the canonical, human-owned record. `document-epic` reads them for intent but
+NEVER edits them, so they are excluded from every quadrant — `classify()`
+returns None for them regardless of where they sit under `docs/`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# The canonical Diátaxis four. Anything the skill writes maps to one of these.
+QUADRANTS = ("tutorial", "how-to", "reference", "explanation")
+
+# Documentation directory names mapped to their quadrant. Keys are the directory
+# segment as it appears under a docs root. We accept the canonical Diátaxis
+# names plus the synonyms commonly used across repos so the heuristic works on a
+# target repo's existing layout without forcing a rename.
+_DOC_DIR_QUADRANT = {
+    # tutorial
+    "tutorial": "tutorial",
+    "tutorials": "tutorial",
+    "getting-started": "tutorial",
+    # how-to
+    "how-to": "how-to",
+    "howto": "how-to",
+    "how-to-guides": "how-to",
+    "guide": "how-to",
+    "guides": "how-to",
+    "recipes": "how-to",
+    # reference
+    "reference": "reference",
+    "api": "reference",
+    # explanation
+    "explanation": "explanation",
+    "explanations": "explanation",
+    "concepts": "explanation",
+    "discussion": "explanation",
+    "background": "explanation",
+}
+
+# Path segments that mark the canonical, human-owned record. Never edited.
+_EXCLUDED_DOC_DIRS = ("prd", "adr")
+
+
+def _segments(path: str) -> list[str]:
+    """Split a repo-relative path into normalised segments."""
+    return [seg for seg in path.replace("\\", "/").split("/") if seg]
+
+
+def is_excluded(path: str) -> bool:
+    """True if the path lives under a `docs/prd/` or `docs/adr/` tree.
+
+    These are the canonical PRD/ADR record. The skill reads them but must never
+    write them, so they are excluded from classification entirely. Matches the
+    `prd`/`adr` segment only when it sits directly under a `docs` segment, so a
+    source file that merely happens to be named `adr.py` is not caught.
+    """
+    segs = _segments(path)
+    for i, seg in enumerate(segs[:-1]):
+        if seg == "docs" and segs[i + 1] in _EXCLUDED_DOC_DIRS:
+            return True
+    return False
+
+
+def _doc_quadrant(path: str) -> str | None:
+    """Quadrant for a path that lives under a docs tree, else None."""
+    segs = _segments(path)
+    if "docs" not in segs:
+        return None
+    # Look at the segment immediately following the docs root.
+    idx = segs.index("docs")
+    for seg in segs[idx + 1 :]:
+        if seg in _DOC_DIR_QUADRANT:
+            return _DOC_DIR_QUADRANT[seg]
+    return None
+
+
+def _is_source(path: str) -> bool:
+    """True for a code source file (something that can carry docstrings)."""
+    return path.endswith((".py", ".pyi"))
+
+
+def classify(path: str, *, public_api: bool = False) -> str | None:
+    """Map a changed path to the Diátaxis quadrant whose docs it should update.
+
+    Returns one of QUADRANTS, or None when the change warrants no docs edit.
+
+    Rules, in order:
+      1. PRD/ADR paths are excluded — always None (never edited).
+      2. A path under a recognised docs directory maps to that directory's
+         quadrant (canonical names + common synonyms).
+      3. A *public* source file maps to `reference`: a public API change means
+         its docstring and autosummary/toctree wiring need attention, not prose.
+      4. Everything else (private source, tests, build/config) maps to None.
+
+    `public_api` flags whether a source change touches the public surface; the
+    caller (the skill) determines this from the diff (e.g. a non-underscore
+    symbol exported from the package).
+    """
+    if is_excluded(path):
+        return None
+
+    doc_q = _doc_quadrant(path)
+    if doc_q is not None:
+        return doc_q
+
+    if _is_source(path) and public_api:
+        return "reference"
+
+    return None
+
+
+def classify_changeset(changes: Iterable[dict]) -> list[dict]:
+    """Classify a whole cumulative epic diff into an edit plan.
+
+    `changes` is an iterable of dicts with at least a `path` key and optionally
+    `public_api`. Returns one dict per change with the resolved `quadrant`
+    (None = no docs edit) and an `excluded` flag for prd/adr paths. Excluded
+    paths are guaranteed to carry `quadrant=None`, so the edit plan (the subset
+    with a non-None quadrant) can never contain a prd/adr file.
+    """
+    plan: list[dict] = []
+    for change in changes:
+        path = change["path"]
+        excluded = is_excluded(path)
+        quadrant = (
+            None
+            if excluded
+            else classify(path, public_api=bool(change.get("public_api", False)))
+        )
+        plan.append(
+            {
+                "path": path,
+                "quadrant": quadrant,
+                "excluded": excluded,
+            }
+        )
+    return plan

--- a/lib/lore_workflow/prd_docs.py
+++ b/lib/lore_workflow/prd_docs.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""PRD-file mechanics for the to-epic skill (sub-issue #4).
+
+The `to-epic` skill body is LLM-driven prose, but the part that turns the
+condensed PRD into a *file* under `docs/prd/` and wires it into the docs toctree
+must be deterministic so it can be tested and so two runs agree. That mechanic
+lives here as a small, self-contained helper: no third-party dependencies
+(stdlib only, so it runs in CI without an install step) and no GitHub I/O — the
+skill supplies the epic URL and involved-repo list it already knows.
+
+What it guarantees, matching CONVENTIONS.md and the scaffold layout
+(`scripts/ccat_workflow_init.py`):
+
+  - the PRD is a file at `docs/prd/NNNN-kebab.md` (zero-padded sequence per
+    directory), MyST Markdown with YAML front-matter that links its epic and
+    lists every involved repo — the PRD is the source of truth, the GitHub epic
+    merely links it;
+  - the PRD is wired into `docs/prd/index.md`'s first `{toctree}` block,
+    idempotently, using the single-brace MyST directive form the scaffold uses;
+  - an absent `docs/prd/index.md` is created with the same toctree stub the
+    scaffold writes, so a repo that never ran the scaffold is still wired.
+
+The toctree-wiring approach mirrors `scripts/ccat_workflow_init.py` (single
+source of truth for the convention) but is reimplemented locally so this helper
+stays self-contained and the scaffold script is never imported or modified.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Single-brace MyST toctree stub, matching scripts/ccat_workflow_init.py so a
+# PRD index this helper creates is indistinguishable from a scaffolded one.
+_PRD_INDEX_STUB = """\
+# Product Requirements Documents
+
+PRDs are the source of truth for decisions. Each PRD lives at
+`docs/prd/NNNN-kebab.md` (MyST Markdown) and is linked from its GitHub epic.
+
+```{toctree}
+:maxdepth: 1
+
+```
+"""
+
+# Matches a PRD's leading zero-padded sequence: 0001-foo(.md) → 1.
+_SEQ_RE = re.compile(r"(\d{4})-")
+
+
+def next_sequence(prd_dir: Path) -> int:
+    """Return the next zero-padded PRD number for *prd_dir* (1 if empty).
+
+    Counts both PRD files on disk and `NNNN-` toctree entries already wired into
+    `index.md`, so the next number never collides with a PRD that is referenced
+    in the index but whose file has not yet been written.
+    """
+    highest = 0
+    if prd_dir.is_dir():
+        for child in prd_dir.glob("[0-9][0-9][0-9][0-9]-*.md"):
+            match = _SEQ_RE.match(child.name)
+            if match:
+                highest = max(highest, int(match.group(1)))
+    index_path = prd_dir / "index.md"
+    if index_path.exists():
+        for match in _SEQ_RE.finditer(index_path.read_text(encoding="utf-8")):
+            highest = max(highest, int(match.group(1)))
+    return highest + 1
+
+
+def _frontmatter(title: str, epic_url: str, repos: list[str]) -> str:
+    """Build the PRD's YAML front-matter block.
+
+    Carries the epic link (the back-reference that makes the PRD reachable from
+    its tracker) and the involved-repos list (a cross-repo epic touches more
+    than one), so the PRD front-matter alone documents what the epic spans.
+    """
+    repo_lines = "\n".join(f"  - {repo}" for repo in repos)
+    return (
+        "---\n"
+        f"title: {title}\n"
+        "status: draft\n"
+        f"epic: {epic_url}\n"
+        "repos:\n"
+        f"{repo_lines}\n"
+        "---\n"
+    )
+
+
+def _body(seq: int, title: str, epic_url: str) -> str:
+    """Build the PRD body skeleton (the condensed-PRD sections to-epic fills)."""
+    return (
+        f"# PRD {seq:04d}: {title}\n"
+        "\n"
+        f"> Source of truth for this epic. Tracker: [epic issue]({epic_url}).\n"
+        "> The epic links here; this file is not embedded in the issue body.\n"
+        "\n"
+        "## Problem\n"
+        "The problem, from the user's perspective.\n"
+        "\n"
+        "## Solution\n"
+        "The solution, from the user's perspective.\n"
+        "\n"
+        "## Implementation decisions\n"
+        "Modules to build/modify and their interfaces, schema/API contracts,\n"
+        "architectural decisions.\n"
+        "\n"
+        "## Testing decisions\n"
+        "What makes a good test here, which modules are tested, prior art.\n"
+        "\n"
+        "## Out of scope\n"
+        "What this epic deliberately does not cover.\n"
+    )
+
+
+def wire_toctree(index_path: Path, entry: str) -> None:
+    """Add *entry* into *index_path*'s first toctree block, idempotently.
+
+    Creates the index from the stub when absent, then inserts the entry before
+    the closing fence of the first `{toctree}` block. Does nothing if the entry
+    is already present anywhere in the file. Mirrors the wiring contract in
+    scripts/ccat_workflow_init.py (single-brace MyST directive).
+    """
+    if not index_path.exists():
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text(_PRD_INDEX_STUB, encoding="utf-8")
+
+    text = index_path.read_text(encoding="utf-8")
+    if entry in text:
+        return  # Already present; idempotent.
+
+    lines = text.splitlines(keepends=True)
+    in_toctree = False
+    insert_at = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not in_toctree and (
+            "```{toctree}" in stripped or "``` {toctree}" in stripped
+        ):
+            in_toctree = True
+            continue
+        if in_toctree and stripped == "```":
+            insert_at = i  # Closing fence: insert entry before it.
+            break
+
+    if insert_at is not None:
+        lines.insert(insert_at, entry + "\n")
+        index_path.write_text("".join(lines), encoding="utf-8")
+
+
+def create_prd(
+    target: Path,
+    *,
+    slug: str,
+    title: str,
+    epic_url: str,
+    repos: list[str],
+) -> Path:
+    """Create docs/prd/NNNN-<slug>.md and wire it into docs/prd/index.md.
+
+    *target* is the repo root. *slug* is the kebab-case PRD slug; the helper
+    prefixes the next zero-padded sequence number for that repo. *epic_url* and
+    *repos* go into the PRD front-matter (epic back-link + involved repos).
+
+    Returns the path to the created PRD file. Never overwrites an existing PRD
+    at the resolved path — the sequence number guarantees a fresh name.
+    """
+    prd_dir = Path(target) / "docs" / "prd"
+    prd_dir.mkdir(parents=True, exist_ok=True)
+
+    seq = next_sequence(prd_dir)
+    name = f"{seq:04d}-{slug}"
+    prd_path = prd_dir / f"{name}.md"
+
+    content = _frontmatter(title, epic_url, repos) + "\n" + _body(seq, title, epic_url)
+    prd_path.write_text(content, encoding="utf-8")
+
+    wire_toctree(prd_dir / "index.md", name)
+    return prd_path

--- a/lib/lore_workflow/roadmap_validator.py
+++ b/lib/lore_workflow/roadmap_validator.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Roadmap-DAG validator for the epic workflow (peer of ``prd_docs.py``).
+
+The ``/to-epic`` skill emits, and ``/orchestrate-epic`` consumes, a Markdown
+*roadmap table* in the epic issue body: the canonical dependency DAG, one row
+per feature/sub-issue. That table drives autonomous dispatch, so a malformed
+table is not a cosmetic problem — it derails the orchestrator. This module is
+the deterministic gate both skills run: ``/to-epic`` before publishing the epic,
+``/orchestrate-epic`` before dispatching any teammate.
+
+Like the ``prd_docs`` peer it is self-contained — standard library only, so it
+runs in CI with no install step — and does no GitHub I/O: the caller supplies the
+epic body text it already has (``gh issue view <epic> --json body``).
+
+The roadmap table's columns are exactly, in order::
+
+    | # | Feature | Issue | Repo | Type | Blocked by |
+
+and the validator checks the four dimensions that make the table a usable DAG:
+
+  1. **columns** — the header is exactly the required columns, in order;
+  2. **fully-qualified Issue refs** — every ``Issue`` cell is ``owner/repo#n``
+     (a bare ``#n`` or ``repo#n`` is rejected), so cross-repo refs are
+     unambiguous;
+  3. **resolvable edges** — every ``Blocked by`` reference resolves to a row in
+     the table (a fully-qualified ref matches that row's Issue; a bare ``#n``
+     matches by number). An em-dash, a hyphen, or an empty cell means "no
+     blocker";
+  4. **acyclic** — the blocked-by graph has no cycle.
+
+``validate_roadmap`` returns a structured :class:`ValidationResult` (never
+raises on invalid input); ``validate_roadmap_or_raise`` raises
+:class:`RoadmapError` carrying the same problems, for callers that prefer
+exceptions. ``main`` is a thin CLI so a skill can run the file as a script and
+gate on its exit code.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# The roadmap table's required columns, in canonical order. This is the single
+# source of truth for both the header check and the column->cell mapping the
+# deeper checks rely on.
+REQUIRED_COLUMNS: tuple[str, ...] = (
+    "#",
+    "Feature",
+    "Issue",
+    "Repo",
+    "Type",
+    "Blocked by",
+)
+
+# A fully-qualified issue ref: owner/repo#number. owner and repo use the
+# GitHub-name character set (letters, digits, dot, underscore, hyphen). A ref
+# without the owner/repo prefix (bare "#12" or "repo#12") is deliberately not
+# matched — cross-repo edges must be unambiguous.
+_FQ_REF = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#\d+$")
+
+# A short blocked-by token referencing a row by number: "#12" or "12".
+_SHORT_REF = re.compile(r"^#?(\d+)$")
+
+# The trailing "#number" of an issue ref, used to index rows by number so a
+# short blocked-by token can resolve to a row.
+_TRAILING_NUM = re.compile(r"#(\d+)\s*$")
+
+# A Markdown table separator cell: dashes with optional alignment colons.
+_SEP_CELL = re.compile(r"^:?-+:?$")
+
+# Cell values that mean "no blocker": empty, hyphen, en-dash, em-dash.
+_NO_BLOCKER = {"", "-", "–", "—"}
+
+
+@dataclass(frozen=True)
+class RoadmapRow:
+    """One parsed feature row of the roadmap table."""
+
+    number: str
+    feature: str
+    issue: str
+    repo: str
+    type: str
+    blocked_by: tuple[str, ...]
+    lineno: int
+
+
+@dataclass(frozen=True)
+class Problem:
+    """A single validation failure.
+
+    ``kind`` is a stable machine token (``missing_table``, ``columns``,
+    ``non_fq_ref``, ``dangling_edge``, ``cycle``); ``message`` is human-facing.
+    """
+
+    kind: str
+    message: str
+
+
+@dataclass
+class ValidationResult:
+    """The outcome of validating a roadmap table.
+
+    ``ok`` is true only when ``problems`` is empty. ``rows`` holds the parsed
+    feature rows (empty when no table was found or the columns were wrong).
+    """
+
+    ok: bool
+    problems: list[Problem] = field(default_factory=list)
+    rows: list[RoadmapRow] = field(default_factory=list)
+
+
+class RoadmapError(ValueError):
+    """Raised by :func:`validate_roadmap_or_raise` for an invalid roadmap.
+
+    Carries the full :class:`ValidationResult` (``.result``) and its
+    ``.problems`` so a caller catching the exception still gets structured
+    detail.
+    """
+
+    def __init__(self, result: ValidationResult) -> None:
+        self.result = result
+        self.problems = result.problems
+        summary = "; ".join(f"{p.kind}: {p.message}" for p in result.problems)
+        super().__init__(summary or "roadmap is invalid")
+
+
+def _split_cells(line: str) -> list[str]:
+    """Split a Markdown table row into stripped cell values.
+
+    Leading/trailing pipes are optional (GitHub-flavoured Markdown). Escaped
+    pipes are not handled — roadmap cells never contain them.
+    """
+    s = line.strip()
+    if s.startswith("|"):
+        s = s[1:]
+    if s.endswith("|"):
+        s = s[:-1]
+    return [cell.strip() for cell in s.split("|")]
+
+
+def _is_separator(line: str) -> bool:
+    """True if *line* is a Markdown table separator (``|---|---|``)."""
+    if "|" not in line:
+        return False
+    cells = _split_cells(line)
+    return bool(cells) and all(_SEP_CELL.match(cell) for cell in cells)
+
+
+def _parse_blockers(cell: str) -> tuple[str, ...]:
+    """Parse a ``Blocked by`` cell into blocker tokens.
+
+    Splits on commas; an em-dash, hyphen, en-dash, or empty part means "no
+    blocker" and contributes nothing.
+    """
+    tokens: list[str] = []
+    for part in cell.split(","):
+        token = part.strip()
+        if token in _NO_BLOCKER:
+            continue
+        tokens.append(token)
+    return tuple(tokens)
+
+
+def _find_table(markdown: str) -> tuple[list[str], list[tuple[int, str]]] | None:
+    """Locate the first Markdown table and return (header cells, data rows).
+
+    A table is a pipe row immediately followed by a separator row; data rows are
+    the pipe rows that follow, up to the first blank or non-pipe line. Returns
+    ``None`` when no table is present. Data rows are ``(1-based lineno, raw)``.
+    """
+    lines = markdown.splitlines()
+    for i in range(len(lines) - 1):
+        if "|" not in lines[i] or _is_separator(lines[i]):
+            continue
+        if not _is_separator(lines[i + 1]):
+            continue
+        header = _split_cells(lines[i])
+        data: list[tuple[int, str]] = []
+        j = i + 2
+        while j < len(lines) and lines[j].strip() and "|" in lines[j]:
+            if _is_separator(lines[j]):
+                break
+            data.append((j + 1, lines[j]))
+            j += 1
+        return header, data
+    return None
+
+
+def _check_columns(header: list[str]) -> Problem | None:
+    """Return a columns Problem if *header* is not the required column set."""
+    got = [cell.lower() for cell in header]
+    want = [cell.lower() for cell in REQUIRED_COLUMNS]
+    if got != want:
+        return Problem(
+            "columns",
+            "roadmap columns must be exactly "
+            f"'{' | '.join(REQUIRED_COLUMNS)}'; got '{' | '.join(header)}'",
+        )
+    return None
+
+
+def _build_indexes(
+    rows: list[RoadmapRow],
+) -> tuple[dict[str, RoadmapRow], dict[int, list[RoadmapRow]]]:
+    """Index rows by full Issue ref and by trailing issue number.
+
+    ``by_full`` maps ``owner/repo#n`` to its row (first occurrence wins).
+    ``by_number`` maps the bare number to every row carrying it — a list,
+    because cross-repo roadmaps can reuse a number across repos.
+    """
+    by_full: dict[str, RoadmapRow] = {}
+    by_number: dict[int, list[RoadmapRow]] = {}
+    for row in rows:
+        by_full.setdefault(row.issue, row)
+        match = _TRAILING_NUM.search(row.issue)
+        if match:
+            by_number.setdefault(int(match.group(1)), []).append(row)
+    return by_full, by_number
+
+
+def _resolve(
+    token: str,
+    by_full: dict[str, RoadmapRow],
+    by_number: dict[int, list[RoadmapRow]],
+) -> list[RoadmapRow]:
+    """Return the rows a single blocked-by *token* resolves to (empty if none).
+
+    A fully-qualified token matches one row by exact Issue ref; a short ``#n``
+    token matches by number (possibly several rows across repos).
+    """
+    token = token.strip()
+    if _FQ_REF.match(token):
+        row = by_full.get(token)
+        return [row] if row is not None else []
+    match = _SHORT_REF.match(token)
+    if match:
+        return list(by_number.get(int(match.group(1)), ()))
+    return []
+
+
+def _find_cycle(
+    rows: list[RoadmapRow],
+    by_full: dict[str, RoadmapRow],
+    by_number: dict[int, list[RoadmapRow]],
+) -> list[str] | None:
+    """Return a blocked-by cycle as a list of Issue refs, or ``None`` if acyclic.
+
+    Builds the directed graph (row -> each row it is blocked by) over resolvable
+    edges only, then does a depth-first search marking nodes on the active path;
+    a back edge to a node still on the path closes a cycle.
+    """
+    position = {id(row): idx for idx, row in enumerate(rows)}
+    adjacency: dict[int, list[int]] = {idx: [] for idx in range(len(rows))}
+    for idx, row in enumerate(rows):
+        seen: set[int] = set()
+        for token in row.blocked_by:
+            for blocker in _resolve(token, by_full, by_number):
+                target = position[id(blocker)]
+                if target not in seen:
+                    seen.add(target)
+                    adjacency[idx].append(target)
+
+    white, grey, black = 0, 1, 2
+    color = [white] * len(rows)
+    path: list[int] = []
+
+    def visit(node: int) -> list[int] | None:
+        color[node] = grey
+        path.append(node)
+        for nxt in adjacency[node]:
+            if color[nxt] == grey:
+                start = path.index(nxt)
+                return path[start:] + [nxt]
+            if color[nxt] == white:
+                found = visit(nxt)
+                if found is not None:
+                    return found
+        path.pop()
+        color[node] = black
+        return None
+
+    for start_node in range(len(rows)):
+        if color[start_node] == white:
+            cycle = visit(start_node)
+            if cycle is not None:
+                return [rows[idx].issue or rows[idx].number for idx in cycle]
+    return None
+
+
+def validate_roadmap(markdown: str) -> ValidationResult:
+    """Validate the roadmap table in *markdown* and return a structured result.
+
+    Never raises on invalid input — every failure is a :class:`Problem` on the
+    returned :class:`ValidationResult`. When the header columns are wrong the
+    column->cell mapping is untrustworthy, so only the column problem is
+    reported (the deeper checks are skipped).
+    """
+    parsed = _find_table(markdown)
+    if parsed is None:
+        return ValidationResult(
+            ok=False,
+            problems=[Problem("missing_table", "no roadmap table found in the text")],
+        )
+
+    header, data_lines = parsed
+    column_problem = _check_columns(header)
+    if column_problem is not None:
+        return ValidationResult(ok=False, problems=[column_problem])
+
+    problems: list[Problem] = []
+    rows: list[RoadmapRow] = []
+    width = len(REQUIRED_COLUMNS)
+    for lineno, raw in data_lines:
+        cells = _split_cells(raw)
+        if len(cells) != width:
+            problems.append(
+                Problem(
+                    "columns",
+                    f"roadmap row at line {lineno} has {len(cells)} cells, "
+                    f"expected {width}",
+                )
+            )
+            continue
+        rows.append(
+            RoadmapRow(
+                number=cells[0],
+                feature=cells[1],
+                issue=cells[2],
+                repo=cells[3],
+                type=cells[4],
+                blocked_by=_parse_blockers(cells[5]),
+                lineno=lineno,
+            )
+        )
+
+    for row in rows:
+        if not _FQ_REF.match(row.issue):
+            problems.append(
+                Problem(
+                    "non_fq_ref",
+                    f"row {row.number}: Issue ref '{row.issue}' is not "
+                    "fully-qualified (expected owner/repo#n)",
+                )
+            )
+
+    by_full, by_number = _build_indexes(rows)
+    for row in rows:
+        for token in row.blocked_by:
+            if not _resolve(token, by_full, by_number):
+                problems.append(
+                    Problem(
+                        "dangling_edge",
+                        f"row {row.number}: blocked-by '{token}' does not "
+                        "resolve to any roadmap row",
+                    )
+                )
+
+    cycle = _find_cycle(rows, by_full, by_number)
+    if cycle is not None:
+        problems.append(
+            Problem("cycle", "cyclic blocked-by chain: " + " -> ".join(cycle))
+        )
+
+    return ValidationResult(ok=not problems, problems=problems, rows=rows)
+
+
+def validate_roadmap_or_raise(markdown: str) -> ValidationResult:
+    """Validate *markdown*, raising :class:`RoadmapError` if it is invalid.
+
+    Returns the passing :class:`ValidationResult` on success.
+    """
+    result = validate_roadmap(markdown)
+    if not result.ok:
+        raise RoadmapError(result)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: validate a roadmap table, printing problems and returning an exit code.
+
+    Reads the epic body from a file path argument, or from stdin when the path
+    is omitted or ``-``. Returns 0 when the roadmap is valid, 1 otherwise, so a
+    skill can gate on the exit code.
+    """
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate an epic roadmap table: required columns, fully-qualified "
+            "owner/repo#n refs, resolvable blocked-by edges, acyclic DAG."
+        )
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        help="Markdown file to read (the epic body); omit or '-' to read stdin.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.path and args.path != "-":
+        text = Path(args.path).read_text(encoding="utf-8")
+    else:
+        text = sys.stdin.read()
+
+    result = validate_roadmap(text)
+    if result.ok:
+        print(f"roadmap OK: {len(result.rows)} feature(s), dependency DAG is acyclic")
+        return 0
+    print("roadmap INVALID:", file=sys.stderr)
+    for problem in result.problems:
+        print(f"  - {problem.kind}: {problem.message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/merged-epic/changeset.json
+++ b/tests/fixtures/merged-epic/changeset.json
@@ -1,0 +1,75 @@
+{
+  "epic": "ccatobs/widgetlib#8",
+  "comment": "Cumulative epic diff: every path the merged sub-issue PRs touched, with the kind of change. This is the input to the document-epic classification heuristic. 'expected_quadrant' is the assertion target for the unit tests (null = no docs edit / excluded).",
+  "changes": [
+    {
+      "path": "src/widgetlib/export.py",
+      "kind": "added",
+      "summary": "New public export_widget() API with full docstring.",
+      "public_api": true,
+      "expected_quadrant": "reference"
+    },
+    {
+      "path": "src/widgetlib/_internal/serialize.py",
+      "kind": "added",
+      "summary": "Private serialisation helper (leading underscore package).",
+      "public_api": false,
+      "expected_quadrant": null
+    },
+    {
+      "path": "src/widgetlib/cli.py",
+      "kind": "modified",
+      "summary": "Added the widget-export subcommand.",
+      "public_api": true,
+      "expected_quadrant": "reference"
+    },
+    {
+      "path": "docs/how-to/export-a-widget.md",
+      "kind": "added",
+      "summary": "Task recipe: export a widget from the terminal.",
+      "expected_quadrant": "how-to"
+    },
+    {
+      "path": "docs/tutorials/getting-started.md",
+      "kind": "modified",
+      "summary": "Walkthrough now ends by exporting the toy widget.",
+      "expected_quadrant": "tutorial"
+    },
+    {
+      "path": "docs/explanation/export-format.md",
+      "kind": "added",
+      "summary": "Why JSON, size trade-offs; cites ADR 0002.",
+      "expected_quadrant": "explanation"
+    },
+    {
+      "path": "docs/reference/api.md",
+      "kind": "modified",
+      "summary": "autosummary/toctree entry wiring export_widget into the API ref.",
+      "expected_quadrant": "reference"
+    },
+    {
+      "path": "docs/prd/0001-widget-export.md",
+      "kind": "modified",
+      "summary": "PRD marked implemented. document-epic MUST NOT touch this.",
+      "expected_quadrant": null
+    },
+    {
+      "path": "docs/adr/0002-export-format.md",
+      "kind": "added",
+      "summary": "ADR for the format decision. document-epic MUST NOT touch this.",
+      "expected_quadrant": null
+    },
+    {
+      "path": "tests/test_export.py",
+      "kind": "added",
+      "summary": "Unit tests for the export API.",
+      "expected_quadrant": null
+    },
+    {
+      "path": "pyproject.toml",
+      "kind": "modified",
+      "summary": "Registered the widget-export console script.",
+      "expected_quadrant": null
+    }
+  ]
+}

--- a/tests/fixtures/roadmaps/cross-repo.md
+++ b/tests/fixtures/roadmaps/cross-repo.md
@@ -1,0 +1,9 @@
+## Roadmap
+A cross-repo epic. Blocked-by uses fully-qualified refs because the same issue
+number (#5) exists in two different repos, so a bare `#5` would be ambiguous.
+
+| # | Feature | Issue | Repo | Type | Blocked by |
+|---|---------|-------|------|------|------------|
+| 1 | Producer API | ccatobs/producer#5 | producer | AFK | — |
+| 2 | Consumer client | ccatobs/consumer#5 | consumer | AFK | ccatobs/producer#5 |
+| 3 | Consumer UI | ccatobs/consumer#6 | consumer | HITL | ccatobs/consumer#5 |

--- a/tests/fixtures/roadmaps/cyclic.md
+++ b/tests/fixtures/roadmaps/cyclic.md
@@ -1,0 +1,9 @@
+## Roadmap
+Cyclic: 1 → 3 → 2 → 1. Columns are valid, refs are fully-qualified, and every
+edge resolves, but the blocked-by graph has a cycle.
+
+| # | Feature | Issue | Repo | Type | Blocked by |
+|---|---------|-------|------|------|------------|
+| 1 | Feature A | ccatobs/widget#12 | widget | AFK | #14 |
+| 2 | Feature B | ccatobs/widget#13 | widget | AFK | #12 |
+| 3 | Feature C | ccatobs/widget#14 | widget | AFK | #13 |

--- a/tests/fixtures/roadmaps/malformed-columns.md
+++ b/tests/fixtures/roadmaps/malformed-columns.md
@@ -1,0 +1,8 @@
+## Roadmap
+Malformed: the required `Issue` column is missing, so the header does not match
+the canonical column set.
+
+| # | Feature | Repo | Type | Blocked by |
+|---|---------|------|------|------------|
+| 1 | Load the config | widget | AFK | — |
+| 2 | Parse the manifest | widget | AFK | #1 |

--- a/tests/fixtures/roadmaps/malformed-dangling.md
+++ b/tests/fixtures/roadmaps/malformed-dangling.md
@@ -1,0 +1,8 @@
+## Roadmap
+Malformed: row 2 is blocked by #99, which is not a row in the table, so the edge
+does not resolve.
+
+| # | Feature | Issue | Repo | Type | Blocked by |
+|---|---------|-------|------|------|------------|
+| 1 | Load the config | ccatobs/widget#12 | widget | AFK | — |
+| 2 | Parse the manifest | ccatobs/widget#13 | widget | AFK | #99 |

--- a/tests/fixtures/roadmaps/malformed-non-fq.md
+++ b/tests/fixtures/roadmaps/malformed-non-fq.md
@@ -1,0 +1,8 @@
+## Roadmap
+Malformed: the Issue column holds refs that are not fully-qualified
+`owner/repo#n` (no owner/repo on the ref).
+
+| # | Feature | Issue | Repo | Type | Blocked by |
+|---|---------|-------|------|------|------------|
+| 1 | Load the config | #12 | widget | AFK | — |
+| 2 | Parse the manifest | widget#13 | widget | AFK | #12 |

--- a/tests/fixtures/roadmaps/well-formed.md
+++ b/tests/fixtures/roadmaps/well-formed.md
@@ -1,0 +1,15 @@
+## Summary
+A small, well-formed epic used as the happy-path fixture.
+
+## Roadmap
+Canonical DAG for `/orchestrate-epic` — one row per feature/sub-issue.
+
+| # | Feature | Issue | Repo | Type | Blocked by |
+|---|---------|-------|------|------|------------|
+| 1 | Load the config | ccatobs/widget#12 | widget | AFK | — |
+| 2 | Parse the manifest | ccatobs/widget#13 | widget | AFK | #12 |
+| 3 | Export the report | ccatobs/widget#14 | widget | AFK | #12, #13 |
+
+- [ ] ccatobs/widget#12 — Load the config
+- [ ] ccatobs/widget#13 — Parse the manifest
+- [ ] ccatobs/widget#14 — Export the report

--- a/tests/test_workflow_cmd.py
+++ b/tests/test_workflow_cmd.py
@@ -1,0 +1,42 @@
+"""Tests for the `lore workflow` Typer subcommands (CLI wrapper over
+`lore_workflow`)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_cli import workflow_cmd
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "roadmaps"
+
+
+def test_validate_roadmap_ok(capsys) -> None:
+    rc = workflow_cmd.main(["validate-roadmap", str(FIXTURES / "well-formed.md")])
+    assert rc == 0
+    assert "roadmap OK" in capsys.readouterr().out
+
+
+def test_validate_roadmap_invalid(capsys) -> None:
+    rc = workflow_cmd.main(["validate-roadmap", str(FIXTURES / "cyclic.md")])
+    assert rc != 0
+    assert "roadmap INVALID" in capsys.readouterr().out
+
+
+def test_create_prd_writes_file(tmp_path: Path) -> None:
+    rc = workflow_cmd.main(
+        [
+            "create-prd",
+            "--slug",
+            "foo",
+            "--title",
+            "Foo",
+            "--epic-url",
+            "https://github.com/o/r/issues/8",
+            "--repo",
+            "o/r",
+            "--target",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    assert (tmp_path / "docs" / "prd" / "0001-foo.md").exists()

--- a/tests/test_workflow_diataxis.py
+++ b/tests/test_workflow_diataxis.py
@@ -1,0 +1,129 @@
+"""Unit tests for `lore_workflow.diataxis` — the document-epic classification
+heuristic.
+
+Ported near-verbatim from ccat-agent-workflow's `tests/test_diataxis.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from lore_workflow import diataxis
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "merged-epic"
+
+
+def _load_changeset() -> list[dict]:
+    data = json.loads((FIXTURE / "changeset.json").read_text())
+    return data["changes"]
+
+
+class TestQuadrantConstants(unittest.TestCase):
+    def test_exactly_the_diataxis_four(self):
+        self.assertEqual(
+            set(diataxis.QUADRANTS),
+            {"tutorial", "how-to", "reference", "explanation"},
+        )
+
+
+class TestExclusion(unittest.TestCase):
+    def test_prd_is_excluded(self):
+        self.assertTrue(diataxis.is_excluded("docs/prd/0001-widget-export.md"))
+
+    def test_adr_is_excluded(self):
+        self.assertTrue(diataxis.is_excluded("docs/adr/0002-export-format.md"))
+
+    def test_nested_prd_adr_excluded(self):
+        self.assertTrue(diataxis.is_excluded("project/docs/prd/x.md"))
+        self.assertTrue(diataxis.is_excluded("project/docs/adr/y.md"))
+
+    def test_normal_docs_not_excluded(self):
+        self.assertFalse(diataxis.is_excluded("docs/how-to/export-a-widget.md"))
+        self.assertFalse(diataxis.is_excluded("docs/reference/api.md"))
+
+    def test_excluded_paths_never_get_a_quadrant(self):
+        self.assertIsNone(diataxis.classify("docs/prd/0001-widget-export.md"))
+        self.assertIsNone(diataxis.classify("docs/adr/0002-export-format.md"))
+
+
+class TestClassifyDocPaths(unittest.TestCase):
+    def test_tutorials_dir(self):
+        self.assertEqual(
+            diataxis.classify("docs/tutorials/getting-started.md"), "tutorial"
+        )
+
+    def test_howto_dir(self):
+        self.assertEqual(diataxis.classify("docs/how-to/export-a-widget.md"), "how-to")
+
+    def test_reference_dir(self):
+        self.assertEqual(diataxis.classify("docs/reference/api.md"), "reference")
+
+    def test_explanation_dir(self):
+        self.assertEqual(
+            diataxis.classify("docs/explanation/export-format.md"), "explanation"
+        )
+
+    def test_directory_synonyms(self):
+        self.assertEqual(diataxis.classify("docs/guide/x.md"), "how-to")
+        self.assertEqual(diataxis.classify("docs/guides/x.md"), "how-to")
+        self.assertEqual(diataxis.classify("docs/api/x.md"), "reference")
+        self.assertEqual(diataxis.classify("docs/concepts/x.md"), "explanation")
+
+
+class TestClassifySource(unittest.TestCase):
+    def test_public_source_routes_to_reference(self):
+        self.assertEqual(
+            diataxis.classify("src/widgetlib/export.py", public_api=True),
+            "reference",
+        )
+
+    def test_private_source_is_not_documented(self):
+        self.assertIsNone(
+            diataxis.classify("src/widgetlib/_internal/serialize.py", public_api=False)
+        )
+
+    def test_non_doc_non_source_is_ignored(self):
+        self.assertIsNone(diataxis.classify("tests/test_export.py"))
+        self.assertIsNone(diataxis.classify("pyproject.toml"))
+
+
+class TestClassifyChangesetAgainstFixture(unittest.TestCase):
+    """End-to-end: classify the fixture changeset and match expected_quadrant."""
+
+    def setUp(self):
+        self.changes = _load_changeset()
+
+    def test_every_change_classified_as_expected(self):
+        for change in self.changes:
+            with self.subTest(path=change["path"]):
+                got = diataxis.classify(
+                    change["path"],
+                    public_api=change.get("public_api", False),
+                )
+                self.assertEqual(got, change["expected_quadrant"])
+
+    def test_classify_changeset_helper_matches(self):
+        results = diataxis.classify_changeset(self.changes)
+        by_path = {r["path"]: r for r in results}
+        for change in self.changes:
+            r = by_path[change["path"]]
+            self.assertEqual(r["quadrant"], change["expected_quadrant"])
+            if diataxis.is_excluded(change["path"]):
+                self.assertIsNone(r["quadrant"])
+                self.assertTrue(r["excluded"])
+
+    def test_no_excluded_path_in_edit_plan(self):
+        results = diataxis.classify_changeset(self.changes)
+        edit_plan = [r for r in results if r["quadrant"] is not None]
+        for r in edit_plan:
+            self.assertFalse(
+                diataxis.is_excluded(r["path"]),
+                f"excluded path leaked into edit plan: {r['path']}",
+            )
+        quadrants_touched = {r["quadrant"] for r in edit_plan}
+        self.assertEqual(
+            quadrants_touched,
+            {"tutorial", "how-to", "reference", "explanation"},
+        )

--- a/tests/test_workflow_prd_docs.py
+++ b/tests/test_workflow_prd_docs.py
@@ -1,0 +1,140 @@
+"""Tests for `lore_workflow.prd_docs` — the PRD-file creation mechanic.
+
+Ported from ccat-agent-workflow's `tests/test_to_epic_prd.py`. Only the
+helper's behavioural half is ported; that repo's structural SKILL.md
+prose-gate checks are skill-specific and out of scope here (skills are
+ported separately, #172).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from lore_workflow import prd_docs as mod
+
+
+def _parse_frontmatter(text: str) -> str | None:
+    """Return the raw YAML frontmatter block, or None if absent."""
+    if not text.startswith("---"):
+        return None
+    match = re.match(r"^---\s*\n(.*?)\n---\s*(\n|$)", text, re.DOTALL)
+    return match.group(1) if match else None
+
+
+def test_create_prd_writes_file(tmp_path: Path) -> None:
+    path = mod.create_prd(
+        tmp_path,
+        slug="foo",
+        title="Foo",
+        epic_url="https://github.com/o/r/issues/8",
+        repos=["o/r"],
+    )
+    assert Path(path).exists()
+    assert (tmp_path / "docs" / "prd" / "0001-foo.md").exists()
+
+
+def test_create_prd_path_is_nnnn_kebab(tmp_path: Path) -> None:
+    """The PRD file must be docs/prd/NNNN-kebab.md (zero-padded sequence)."""
+    path = mod.create_prd(
+        tmp_path,
+        slug="foo",
+        title="Foo",
+        epic_url="https://github.com/o/r/issues/8",
+        repos=["o/r"],
+    )
+    assert Path(path).name == "0001-foo.md"
+
+
+def test_create_prd_frontmatter_links_epic(tmp_path: Path) -> None:
+    """The PRD front-matter must carry an epic: link."""
+    epic_url = "https://github.com/o/r/issues/8"
+    mod.create_prd(tmp_path, slug="foo", title="Foo", epic_url=epic_url, repos=["o/r"])
+    text = (tmp_path / "docs" / "prd" / "0001-foo.md").read_text(encoding="utf-8")
+    fm = _parse_frontmatter(text)
+    assert fm is not None, "PRD must open with MyST/YAML front-matter"
+    assert "epic:" in fm, "PRD front-matter must carry an epic: key"
+    assert epic_url in fm, "PRD front-matter epic: must hold the epic URL"
+
+
+def test_create_prd_frontmatter_lists_repos(tmp_path: Path) -> None:
+    """The PRD front-matter must list every involved repo."""
+    mod.create_prd(
+        tmp_path,
+        slug="foo",
+        title="Foo",
+        epic_url="https://github.com/o/r/issues/8",
+        repos=["o/r", "o/other"],
+    )
+    text = (tmp_path / "docs" / "prd" / "0001-foo.md").read_text(encoding="utf-8")
+    fm = _parse_frontmatter(text)
+    assert fm is not None
+    assert "repos:" in fm, "PRD front-matter must carry a repos: list"
+    assert "o/r" in fm and "o/other" in fm, "all involved repos must be listed"
+
+
+def test_create_prd_has_title_and_problem(tmp_path: Path) -> None:
+    """The PRD body must carry the title and the PRD skeleton sections."""
+    mod.create_prd(
+        tmp_path,
+        slug="widget-export",
+        title="Widget export",
+        epic_url="https://github.com/o/r/issues/8",
+        repos=["o/r"],
+    )
+    text = (tmp_path / "docs" / "prd" / "0001-widget-export.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Widget export" in text
+    assert "## Problem" in text
+
+
+def test_create_prd_sequence_increments(tmp_path: Path) -> None:
+    """A second PRD in the same repo gets the next zero-padded number."""
+    mod.create_prd(tmp_path, slug="first", title="First", epic_url="u", repos=["o/r"])
+    second = mod.create_prd(
+        tmp_path, slug="second", title="Second", epic_url="u", repos=["o/r"]
+    )
+    assert Path(second).name == "0002-second.md"
+
+
+# ---------------------------------------------------------------------------
+# Toctree wiring
+# ---------------------------------------------------------------------------
+
+
+def test_create_prd_wires_toctree(tmp_path: Path) -> None:
+    """Creating 0001-foo.md wires 0001-foo into docs/prd/index.md's toctree."""
+    mod.create_prd(tmp_path, slug="foo", title="Foo", epic_url="u", repos=["o/r"])
+    index = (tmp_path / "docs" / "prd" / "index.md").read_text(encoding="utf-8")
+    assert "```{toctree}" in index, "prd index must use single-brace ```{toctree}"
+    assert "{{" not in index, "prd index must not contain double braces"
+    assert "0001-foo" in index, "the PRD must be wired into the toctree"
+
+
+def test_create_prd_wiring_idempotent(tmp_path: Path) -> None:
+    """Wiring the same PRD twice must not duplicate its toctree entry."""
+    mod.create_prd(tmp_path, slug="foo", title="Foo", epic_url="u", repos=["o/r"])
+    mod.wire_toctree(tmp_path / "docs" / "prd" / "index.md", "0001-foo")
+    index = (tmp_path / "docs" / "prd" / "index.md").read_text(encoding="utf-8")
+    assert index.count("0001-foo") == 1, "PRD entry must appear exactly once"
+
+
+def test_create_prd_preserves_existing_index_content(tmp_path: Path) -> None:
+    """An existing docs/prd/index.md (with entries) is preserved, not clobbered."""
+    prd_dir = tmp_path / "docs" / "prd"
+    prd_dir.mkdir(parents=True)
+    existing = "# PRDs\n\n```{toctree}\n:maxdepth: 1\n\n0001-existing\n```\n"
+    (prd_dir / "index.md").write_text(existing, encoding="utf-8")
+    mod.create_prd(tmp_path, slug="new", title="New", epic_url="u", repos=["o/r"])
+    index = (prd_dir / "index.md").read_text(encoding="utf-8")
+    assert "0001-existing" in index, "existing toctree entries must survive"
+    assert "0002-new" in index, "new PRD must be wired in and numbered next"
+
+
+def test_create_prd_creates_index_when_absent(tmp_path: Path) -> None:
+    """When docs/prd/index.md is missing, the helper creates a wired one."""
+    mod.create_prd(tmp_path, slug="foo", title="Foo", epic_url="u", repos=["o/r"])
+    index = tmp_path / "docs" / "prd" / "index.md"
+    assert index.exists(), "helper must create docs/prd/index.md when absent"
+    assert "0001-foo" in index.read_text(encoding="utf-8")

--- a/tests/test_workflow_roadmap_validator.py
+++ b/tests/test_workflow_roadmap_validator.py
@@ -1,0 +1,141 @@
+"""Tests for `lore_workflow.roadmap_validator` — the roadmap-DAG gate.
+
+Ported from ccat-agent-workflow's `tests/test_roadmap_validator.py`. Only the
+behavioural half is ported: that repo's prose-gate checks against its own
+`SKILL.md` files don't apply here — skills are ported separately (#172).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lore_workflow import roadmap_validator as mod
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "roadmaps"
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _kinds(result: mod.ValidationResult) -> set[str]:
+    return {p.kind for p in result.problems}
+
+
+# ---------------------------------------------------------------------------
+# Well-formed
+# ---------------------------------------------------------------------------
+
+
+def test_well_formed_passes() -> None:
+    result = mod.validate_roadmap(_fixture("well-formed.md"))
+    assert result.ok, f"well-formed roadmap must pass; problems={result.problems}"
+    assert not result.problems
+
+
+def test_well_formed_rows_parsed() -> None:
+    result = mod.validate_roadmap(_fixture("well-formed.md"))
+    assert len(result.rows) == 3
+    first = result.rows[0]
+    assert first.issue == "ccatobs/widget#12"
+    assert first.blocked_by == ()  # em-dash means no blocker
+    third = result.rows[2]
+    assert third.blocked_by == ("#12", "#13"), "multiple blockers split on comma"
+
+
+def test_or_raise_returns_on_valid() -> None:
+    result = mod.validate_roadmap_or_raise(_fixture("well-formed.md"))
+    assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo roadmap (fully-qualified edges resolve across repos)
+# ---------------------------------------------------------------------------
+
+
+def test_cross_repo_passes() -> None:
+    result = mod.validate_roadmap(_fixture("cross-repo.md"))
+    assert result.ok, f"cross-repo roadmap must pass; problems={result.problems}"
+    repos = {row.repo for row in result.rows}
+    assert repos == {"producer", "consumer"}, "cross-repo rows span >1 repo"
+
+
+def test_cross_repo_full_ref_edges_resolve() -> None:
+    """A fully-qualified blocked-by resolves even with a number shared across
+    repos (producer#5 vs consumer#5)."""
+    result = mod.validate_roadmap(_fixture("cross-repo.md"))
+    assert "dangling_edge" not in _kinds(result)
+
+
+# ---------------------------------------------------------------------------
+# Malformed cases
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_columns_fails() -> None:
+    result = mod.validate_roadmap(_fixture("malformed-columns.md"))
+    assert not result.ok
+    assert "columns" in _kinds(result), "missing required column must be reported"
+
+
+def test_non_fq_ref_fails() -> None:
+    result = mod.validate_roadmap(_fixture("malformed-non-fq.md"))
+    assert not result.ok
+    assert "non_fq_ref" in _kinds(result), (
+        "an Issue ref lacking owner/repo must be rejected"
+    )
+
+
+def test_dangling_edge_fails() -> None:
+    result = mod.validate_roadmap(_fixture("malformed-dangling.md"))
+    assert not result.ok
+    assert "dangling_edge" in _kinds(result)
+
+
+def test_cyclic_fails() -> None:
+    result = mod.validate_roadmap(_fixture("cyclic.md"))
+    assert not result.ok
+    assert "cycle" in _kinds(result)
+
+
+def test_or_raise_raises_on_invalid() -> None:
+    with pytest.raises(mod.RoadmapError) as exc:
+        mod.validate_roadmap_or_raise(_fixture("cyclic.md"))
+    assert exc.value.problems
+
+
+def test_missing_table_returns_no_rows() -> None:
+    result = mod.validate_roadmap("# no table here")
+    assert not result.ok
+    assert result.rows == []
+
+
+# ---------------------------------------------------------------------------
+# Structured result API
+# ---------------------------------------------------------------------------
+
+
+def test_result_and_problem_shape() -> None:
+    result = mod.validate_roadmap(_fixture("cyclic.md"))
+    assert hasattr(result, "ok")
+    assert hasattr(result, "problems")
+    assert hasattr(result, "rows")
+    problem = result.problems[0]
+    assert hasattr(problem, "kind")
+    assert hasattr(problem, "message")
+    assert isinstance(problem.kind, str)
+    assert isinstance(problem.message, str)
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def test_cli_returns_zero_on_valid() -> None:
+    assert mod.main([str(FIXTURES / "well-formed.md")]) == 0
+
+
+def test_cli_returns_nonzero_on_invalid() -> None:
+    assert mod.main([str(FIXTURES / "cyclic.md")]) != 0


### PR DESCRIPTION
Closes #169

## Summary
- New package `lib/lore_workflow/`: `roadmap_validator.py` (DAG gate: required columns, fully-qualified `owner/repo#n` refs, resolvable blocked-by edges, acyclic), `prd_docs.py` (`docs/prd/NNNN-kebab.md` scaffolding + idempotent toctree wiring), `diataxis.py` (document-epic quadrant classifier, ported now for the later skill port in #172). All ported near-verbatim from `ccat-agent-workflow` — stdlib-only, no host-path assumptions.
- New `lore workflow` Typer subcommand group (`lib/lore_cli/workflow_cmd.py`): `lore workflow validate-roadmap <path|->` and `lore workflow create-prd --slug --title --epic-url --repo ... [--target]`.
- `lib/lore_cli/__main__.py`: two-line addition (import + `add_typer` in the Advanced group) per the shared-touchpoint contract.

## Test plan (TDD: red → green)
- Ported behavioural unit tests first (red — `ModuleNotFoundError: lore_workflow`), then ported the modules + reinstalled editable (green).
- `pytest tests/test_workflow_roadmap_validator.py tests/test_workflow_prd_docs.py tests/test_workflow_diataxis.py tests/test_workflow_cmd.py -q` → 44 passed (incl. 11 subtests).
- Full suite: `pytest -q` → 2470 passed.
- `mypy lib/lore_workflow/ lib/lore_cli/workflow_cmd.py` → no issues.
- `ruff check` on touched files clean except two pre-existing-pattern `B008` hits on `list[str]`/`Path`-typed `typer.Option(...)` params — same shape already present unaddressed in `briefing_cmd.py`; ruff is repo-wide advisory (`continue-on-error`, tracked in #196), not a regression I introduced.
- [x] Manual: `python -m lore_cli.__main__ workflow --help` and `workflow validate-roadmap`/`create-prd --help` render correctly.