### PR TITLE
Model-tier host-keyed data + lore tier resolve

### DIFF
--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -118,6 +118,10 @@ Vault-wide policy. Schema lives in
 - `observability.proc.keep_generations`
 - `curator.backend` — `auto` | `subscription` | `api` | `openai`
 - `curator.openai.{base_url, api_key_env, model_simple, model_middle, model_high, reasoning_effort_simple, reasoning_effort_middle, reasoning_effort_high}`
+- `journal.enabled`
+- `tiers.overrides.<host>.<tier>` — override the shipped model-tier table
+  (`lib/lore_core/tiers/table.py`) for one host/tier cell; see
+  `docs/model-tiers.md`.
 
 Loader: `load_root_config(lore_root) -> RootConfig`. Missing file →
 all defaults. Unknown keys → `warnings.warn` (not fatal). Malformed

--- a/docs/model-tiers.md
+++ b/docs/model-tiers.md
@@ -1,0 +1,67 @@
+# Model tiers
+
+Skills and subagent spawns delegate work by **semantic tier**, never by
+concrete model name: a tier says how much capability a step needs, and
+`lore tier resolve <tier>` maps that to a concrete model for the host
+currently running. That indirection is what lets a plugin move from
+Claude Code to another host without editing every prompt — only the
+table in `lib/lore_core/tiers/table.py` changes.
+
+Ported from `ccat-agent-workflow`'s `MODEL-TIERS.md`; see that repo for
+the CI/enforcement side (no skill may name a concrete model — not yet
+ported here, tracked separately).
+
+## Tiers
+
+Four tiers, ordered strongest -> cheapest:
+
+| Tier | Semantic role | Claude Code model |
+|------|----------------|--------------------|
+| `frontier` | Strongest reasoning: orchestration, grilling / synthesis. | `claude-opus-4-8` (the session's driving model) |
+| `strong` | Crosscheck / review; architectural or cross-cutting implementation. | `claude-opus-4-8` |
+| `mid` | Exploration / gathering; mechanical implementation. | `claude-sonnet-5` |
+| `cheap` | Bulk-mechanical sub-tasks only — never a stage's default. | `claude-haiku-4-5` |
+
+**Cursor's column is PROVISIONAL** — a best guess seeded ahead of any
+real mileage on that host. Treat it as a starting point, not ground
+truth; update `lib/lore_core/tiers/table.py` once the plugin actually
+runs there.
+
+## Rules (carried over from the source table)
+
+- **Ordinal / collapse.** `frontier` > `strong` > `mid` > `cheap`. A
+  host with no distinct model for two adjacent tiers collapses them
+  onto the same model (Claude Code: `frontier` and `strong` both
+  resolve to Opus).
+- **Fallback.** An unregistered host or tier is never silently
+  guessed — `resolve_tier` / `lore tier resolve` raise
+  `TierResolutionError` loudly instead.
+- **Cheap reservation.** `cheap` is reserved for explicitly
+  bulk-mechanical work (large volumes of rote, low-judgement edits).
+  It is no stage's default.
+
+## Resolving a tier
+
+```
+lore tier resolve mid
+lore tier resolve frontier --host cursor
+```
+
+Also exposed as the `lore_tier_resolve` MCP tool (`tier`, optional
+`host`) — same resolution, for callers that can't shell out.
+
+## User overrides
+
+Any table cell can be overridden per vault, without touching the
+shipped table, via `$LORE_ROOT/.lore/config.yml`:
+
+```yaml
+tiers:
+  overrides:
+    claude:
+      frontier: claude-opus-4-9
+```
+
+Only the tiers you list are overridden; everything else falls through
+to `lib/lore_core/tiers/table.py`. See `lib/lore_core/root_config.py:TierConfig`
+and `tests/test_tiers.py::test_config_override_wins_over_table_default`.

--- a/lib/lore_cli/__main__.py
+++ b/lib/lore_cli/__main__.py
@@ -90,6 +90,7 @@ def _build_app() -> typer.Typer:
         search_cmd,
         session_cmd,
         status_cmd,
+        tier_cmd,
         transcripts_cmd,
         wiki_cmd,
     )
@@ -127,6 +128,7 @@ def _build_app() -> typer.Typer:
     app.add_typer(off_cmd.app, name="off", rich_help_panel=_KN)
 
     app.add_typer(backfill_cmd.app, name="backfill", rich_help_panel=_ADV)
+    app.add_typer(tier_cmd.app, name="tier", rich_help_panel=_ADV)
     app.add_typer(attachments_cmd.app, name="attachments", rich_help_panel=_ADV)
     app.add_typer(briefing_cmd.app, name="briefing", rich_help_panel=_ADV)
     app.add_typer(completions_cmd.app, name="completions", rich_help_panel=_ADV)

--- a/lib/lore_cli/tier_cmd.py
+++ b/lib/lore_cli/tier_cmd.py
@@ -1,0 +1,46 @@
+"""`lore tier resolve <tier>` — resolve a semantic model tier for this host.
+
+    lore tier resolve mid
+    lore tier resolve frontier --host cursor
+
+See ``docs/model-tiers.md`` and :mod:`lore_core.tiers`.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import typer
+from lore_core.tiers import TierResolutionError, resolve_tier
+from rich.console import Console
+
+from lore_cli._argv_compat import argv_main
+
+console = Console()
+
+app = typer.Typer(
+    add_completion=False,
+    help=__doc__,
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+
+
+@app.command("resolve")
+def resolve(
+    tier: str = typer.Argument(..., help="Semantic tier: frontier | strong | mid | cheap."),
+    host: str = typer.Option(None, "--host", help="Override host detection (e.g. cursor)."),
+) -> None:
+    """Print the concrete model resolved for TIER on the current (or given) host."""
+    try:
+        console.print(resolve_tier(tier, host=host))
+    except TierResolutionError as e:
+        console.print(f"[red]error:[/red] {e}")
+        raise typer.Exit(code=1) from None
+
+
+main = argv_main(app)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/lore_core/root_config.py
+++ b/lib/lore_core/root_config.py
@@ -101,10 +101,23 @@ class JournalConfig:
 
 
 @dataclass
+class TierConfig:
+    """Model-tier overrides -- user escape hatch over the shipped tier table.
+
+    Keyed by host then tier, e.g. ``claude: {frontier: claude-opus-4-9}``.
+    Only present keys override; everything else falls through to
+    ``lore_core.tiers.table.TABLE``. See :func:`lore_core.tiers.resolve_tier`.
+    """
+
+    overrides: dict[str, dict[str, str]] = field(default_factory=dict)
+
+
+@dataclass
 class RootConfig:
     observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
     curator: CuratorBackendConfig = field(default_factory=CuratorBackendConfig)
     journal: JournalConfig = field(default_factory=JournalConfig)
+    tiers: TierConfig = field(default_factory=TierConfig)
 
 
 def _merge(target: Any, raw: dict[str, Any], path: str, source: Path) -> None:

--- a/lib/lore_core/tiers/__init__.py
+++ b/lib/lore_core/tiers/__init__.py
@@ -1,0 +1,74 @@
+"""Model-tier resolution: semantic tier -> concrete model, per host.
+
+Skills/prompts should never name a concrete model — they name a
+*semantic* tier (how much capability a step needs) and the harness
+maps that to whatever model actually runs. See ``docs/model-tiers.md``
+for the full rules (ordinal/collapse, fallback, cheap reservation),
+ported from ccat-agent-workflow's ``MODEL-TIERS.md``.
+
+``resolve_tier`` is the single entry point: detect the current host
+(unless given), look up the tier in ``TABLE`` for that host, and let a
+user config override (``.lore/config.yml`` -> ``tiers.overrides``) win
+if present. Unknown tier or unknown host raises ``TierResolutionError``
+loudly rather than silently falling back.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from lore_core.tiers.table import TABLE, TIER_ORDER
+
+
+class TierResolutionError(Exception):
+    """Raised when a tier or host can't be resolved — never silent-fallback."""
+
+
+def detect_host() -> str:
+    """Detect which host is currently running lore, via env-var signals.
+
+    Mirrors the CWD-resolution precedence already used elsewhere in lore
+    (``$CLAUDE_PROJECT_DIR`` / ``$CURSOR_PROJECT_DIR``, see
+    ``lore_cli.hooks``). Raises loudly rather than guessing when no
+    known host announces itself — silent defaulting would resolve
+    tiers to the wrong model without any signal that happened.
+    """
+    if any(
+        os.environ.get(var)
+        for var in ("CLAUDECODE", "CLAUDE_PROJECT_DIR", "CLAUDE_SESSION_ID", "CLAUDE_CODE_EXECPATH")
+    ):
+        return "claude"
+    if os.environ.get("CURSOR_PROJECT_DIR"):
+        return "cursor"
+    raise TierResolutionError(
+        "unable to detect host: no known host env var is set "
+        "(CLAUDECODE, CLAUDE_PROJECT_DIR, CURSOR_PROJECT_DIR, ...)"
+    )
+
+
+def resolve_tier(tier: str, host: str | None = None, lore_root: Path | None = None) -> str:
+    """Resolve a semantic tier to a concrete model for the given/detected host.
+
+    ``lore_root`` lets callers pin the vault to read overrides from
+    (mainly for tests); defaults to :func:`lore_core.config.get_lore_root`.
+    """
+    if tier not in TIER_ORDER:
+        raise TierResolutionError(
+            f"unknown tier {tier!r}; known tiers: {', '.join(TIER_ORDER)}"
+        )
+    resolved_host = host or detect_host()
+    if resolved_host not in TABLE:
+        raise TierResolutionError(
+            f"unknown host {resolved_host!r}; known hosts: {', '.join(sorted(TABLE))}"
+        )
+
+    from lore_core.config import get_lore_root
+    from lore_core.root_config import load_root_config
+
+    root = lore_root if lore_root is not None else get_lore_root()
+    cfg = load_root_config(root)
+    override = cfg.tiers.overrides.get(resolved_host, {}).get(tier)
+    if override:
+        return override
+    return TABLE[resolved_host][tier]

--- a/lib/lore_core/tiers/__init__.py
+++ b/lib/lore_core/tiers/__init__.py
@@ -54,9 +54,7 @@ def resolve_tier(tier: str, host: str | None = None, lore_root: Path | None = No
     (mainly for tests); defaults to :func:`lore_core.config.get_lore_root`.
     """
     if tier not in TIER_ORDER:
-        raise TierResolutionError(
-            f"unknown tier {tier!r}; known tiers: {', '.join(TIER_ORDER)}"
-        )
+        raise TierResolutionError(f"unknown tier {tier!r}; known tiers: {', '.join(TIER_ORDER)}")
     resolved_host = host or detect_host()
     if resolved_host not in TABLE:
         raise TierResolutionError(

--- a/lib/lore_core/tiers/table.py
+++ b/lib/lore_core/tiers/table.py
@@ -1,0 +1,27 @@
+"""The tier table itself — one column per registered host.
+
+Claude Code's column is authoritative (ported from ccat-agent-workflow's
+MODEL-TIERS.md). Other hosts are PROVISIONAL best-guess seeds — nobody
+has exercised the plugin there yet; update as each host gets real
+mileage. See ``docs/model-tiers.md``.
+"""
+
+from __future__ import annotations
+
+TIER_ORDER: tuple[str, ...] = ("frontier", "strong", "mid", "cheap")
+
+TABLE: dict[str, dict[str, str]] = {
+    "claude": {
+        "frontier": "claude-opus-4-8",
+        "strong": "claude-opus-4-8",
+        "mid": "claude-sonnet-5",
+        "cheap": "claude-haiku-4-5",
+    },
+    # provisional — no mileage on this host yet, best guess only.
+    "cursor": {
+        "frontier": "claude-opus-4-8",
+        "strong": "claude-opus-4-8",
+        "mid": "claude-sonnet-5",
+        "cheap": "claude-haiku-4-5",
+    },
+}

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -979,6 +979,18 @@ def _resolve_repo_root(repo_path: str | None) -> Path | None:
     return git_repo_root(Path.cwd())
 
 
+def handle_tier_resolve(tier: str, host: str | None = None) -> dict[str, Any]:
+    """Resolve a semantic model tier to a concrete model for the current host."""
+    from lore_core.tiers import TierResolutionError, detect_host, resolve_tier
+
+    try:
+        resolved_host = host or detect_host()
+        model = resolve_tier(tier, host=resolved_host)
+    except TierResolutionError as e:
+        return _mcp_error("tier_resolution_failed", str(e))
+    return {"tier": tier, "host": resolved_host, "model": model}
+
+
 def handle_repo_docs_list(kind: str, repo_path: str | None = None) -> dict[str, Any]:
     """List ADR/PRD entries from a connected repo's conventional home.
 
@@ -1381,6 +1393,26 @@ def _tool_schema() -> list[dict]:
             },
         },
         {
+            "name": "lore_tier_resolve",
+            "description": (
+                "Resolve a semantic model tier (frontier | strong | mid | "
+                "cheap) to the concrete model for the current host. Use "
+                "before spawning a subagent so its model param reflects "
+                "the tier the task needs, not a guess."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "tier": {"type": "string"},
+                    "host": {
+                        "type": "string",
+                        "description": "Override host detection (optional).",
+                    },
+                },
+                "required": ["tier"],
+            },
+        },
+        {
             "name": "lore_repo_docs_fetch",
             "description": (
                 "Fetch one ADR or PRD's full content from a connected repo. "
@@ -1450,6 +1482,8 @@ def _dispatch(tool_name: str, args: dict) -> Any:
             return handle_repo_docs_list(**args)
         case "lore_repo_docs_fetch":
             return handle_repo_docs_fetch(**args)
+        case "lore_tier_resolve":
+            return handle_tier_resolve(**args)
         case _:
             return _mcp_error("unknown_tool", f"unknown tool: {tool_name}")
 

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -48,10 +48,7 @@ def test_resolve_unknown_host_fails_loudly(tmp_path):
 def test_config_override_wins_over_table_default(tmp_path):
     root = _mk_root(tmp_path)
     (root / ".lore" / "config.yml").write_text(
-        "tiers:\n"
-        "  overrides:\n"
-        "    claude:\n"
-        "      frontier: claude-opus-4-9\n"
+        "tiers:\n  overrides:\n    claude:\n      frontier: claude-opus-4-9\n"
     )
     assert resolve_tier("frontier", host="claude", lore_root=root) == "claude-opus-4-9"
     # untouched tier still falls through to the shipped table

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -1,0 +1,86 @@
+"""Model-tier resolution: table lookup, host detection, config overrides.
+
+Ports the semantics of MODEL-TIERS.md from ccat-agent-workflow: four
+ordinal tiers (frontier > strong > mid > cheap), one column per host,
+unknown tier/host fails loudly, user config overrides win.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lore_core.tiers import TABLE, TIER_ORDER, TierResolutionError, resolve_tier
+
+
+def _mk_root(tmp_path: Path) -> Path:
+    (tmp_path / ".lore").mkdir()
+    return tmp_path
+
+
+def test_tier_order_is_the_four_semantic_tiers():
+    assert TIER_ORDER == ("frontier", "strong", "mid", "cheap")
+
+
+def test_table_has_an_entry_for_every_tier_on_every_host():
+    for host, tiers in TABLE.items():
+        for tier in TIER_ORDER:
+            assert tier in tiers, f"host {host!r} missing tier {tier!r}"
+
+
+def test_resolve_known_tier_on_claude(tmp_path):
+    root = _mk_root(tmp_path)
+    assert resolve_tier("mid", host="claude", lore_root=root) == TABLE["claude"]["mid"]
+
+
+def test_resolve_unknown_tier_fails_loudly(tmp_path):
+    root = _mk_root(tmp_path)
+    with pytest.raises(TierResolutionError, match="unknown tier"):
+        resolve_tier("premium", host="claude", lore_root=root)
+
+
+def test_resolve_unknown_host_fails_loudly(tmp_path):
+    root = _mk_root(tmp_path)
+    with pytest.raises(TierResolutionError, match="unknown host"):
+        resolve_tier("mid", host="nonexistent-ide", lore_root=root)
+
+
+def test_config_override_wins_over_table_default(tmp_path):
+    root = _mk_root(tmp_path)
+    (root / ".lore" / "config.yml").write_text(
+        "tiers:\n"
+        "  overrides:\n"
+        "    claude:\n"
+        "      frontier: claude-opus-4-9\n"
+    )
+    assert resolve_tier("frontier", host="claude", lore_root=root) == "claude-opus-4-9"
+    # untouched tier still falls through to the shipped table
+    assert resolve_tier("mid", host="claude", lore_root=root) == TABLE["claude"]["mid"]
+
+
+def test_detect_host_recognizes_claude_env(monkeypatch):
+    from lore_core.tiers import detect_host
+
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.delenv("CURSOR_PROJECT_DIR", raising=False)
+    assert detect_host() == "claude"
+
+
+def test_detect_host_recognizes_cursor_env(monkeypatch):
+    from lore_core.tiers import detect_host
+
+    for var in ("CLAUDECODE", "CLAUDE_PROJECT_DIR", "CLAUDE_SESSION_ID", "CLAUDE_CODE_EXECPATH"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CURSOR_PROJECT_DIR", "/some/project")
+    assert detect_host() == "cursor"
+
+
+def test_detect_host_unknown_fails_loudly(monkeypatch):
+    from lore_core.tiers import detect_host
+
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CURSOR_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_EXECPATH", raising=False)
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    with pytest.raises(TierResolutionError, match="unable to detect"):
+        detect_host()


### PR DESCRIPTION
## Summary
- Tier table (`lib/lore_core/tiers/table.py`): four semantic tiers (frontier > strong > mid > cheap), one column per host (`claude`, `cursor` — cursor marked provisional). Ordinal-collapse and fallback semantics ported from `MODEL-TIERS.md` in ccat-agent-workflow.
- Resolver (`lib/lore_core/tiers/__init__.py`): `detect_host()` via env-var signals (mirrors the `$CLAUDE_PROJECT_DIR`/`$CURSOR_PROJECT_DIR` precedence already used in `lore_cli.hooks`); `resolve_tier(tier, host=None, lore_root=None)` looks up the table, applies `.lore/config.yml` overrides, raises `TierResolutionError` loudly on unknown tier/host (no silent fallback).
- `lore tier resolve <tier> [--host]` CLI (`lib/lore_cli/tier_cmd.py`), non-zero exit on failure.
- `lore_tier_resolve` MCP tool mirrored in `lib/lore_mcp/server.py` (schema + dispatch + handler).
- User override support: `RootConfig.tiers.overrides` (`lib/lore_core/root_config.py`), documented in `docs/model-tiers.md` and `docs/architecture/config.md`, tested for override-wins-over-default precedence.

## Test plan
- [x] Red: `tests/test_tiers.py` fails before implementation (`ModuleNotFoundError: lore_core.tiers`)
- [x] Green: `tests/test_tiers.py` — 9/9 passing (table completeness, known/unknown tier & host, config override precedence, host detection incl. unknown-host failure)
- [x] Full suite: `2435 passed` (`PYTHONPATH=lib pytest -q`, env matching CI: `env -u FORCE_COLOR -u COLORTERM -u OPENAI_API_KEY NO_COLOR=1`)
- [x] `ruff check` clean on all touched files
- [x] Manual: `lore tier resolve mid --host claude` → `claude-sonnet-5`; `lore tier resolve bogus --host claude` → error, exit 1

Closes #168