### PR TITLE
feat(mcp): lore_codemap tool — bounded code-map query slices

### DIFF
--- a/lib/lore_core/codemap/query.py
+++ b/lib/lore_core/codemap/query.py
@@ -1,0 +1,122 @@
+"""Bounded queries over the code map — the ``lore_codemap`` MCP tool's backend.
+
+Consumers (planning skills) want ~30 relevant rows, never the full
+``CODEMAP.md``. Three modes:
+
+- ``symbols`` — symbols whose qualname matches a regex/substring pattern.
+- ``directory`` — inventory rows scoped to a directory prefix (or the
+  top-level bounded inventory when no prefix is given).
+- ``top`` — the N highest-referenced symbols.
+
+Each query builds (or reuses) a :class:`~lore_core.codemap.CodeMap` for the
+repo root. Building is the expensive part (a full discovery + AST parse
+pass), so results are cached in-process keyed on the root and the
+generator's own fingerprint (git blob SHAs, or a content hash for non-git
+trees — see :func:`lore_core.codemap.discover`). A cheap ``discover()`` call
+checks whether the cached fingerprint is still current before deciding
+whether to rebuild.
+
+ponytail: cache lives in a module-level dict, one process lifetime (the MCP
+server). No eviction — fine for the handful of repos one server touches in
+a session; add an LRU cap if that stops being true.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from lore_core import codemap as cm
+
+_cache: dict[str, tuple[str, cm.CodeMap]] = {}
+
+
+def clear_cache() -> None:
+    """Drop all cached maps. Test-only escape hatch."""
+    _cache.clear()
+
+
+def _get_code_map(root: Path) -> cm.CodeMap:
+    """Return a fresh-enough :class:`CodeMap` for *root*, rebuilding on change.
+
+    ``discover()`` alone (no AST parsing) is cheap enough to run on every
+    query just to check the fingerprint; only a mismatch pays for a full
+    :func:`build_code_map`.
+    """
+    root = Path(root).resolve()
+    key = str(root)
+    fingerprint = cm.discover(root).fingerprint
+    cached = _cache.get(key)
+    if cached is not None and cached[0] == fingerprint:
+        return cached[1]
+    code_map = cm.build_code_map(root)
+    _cache[key] = (code_map.fingerprint, code_map)
+    return code_map
+
+
+def _symbol_to_dict(s: cm.Symbol) -> dict[str, Any]:
+    return {
+        "name": s.name,
+        "qualname": s.qualname,
+        "kind": s.kind,
+        "path": s.relpath,
+        "line": s.lineno,
+        "refs": s.refs,
+    }
+
+
+def _dirstat_to_dict(d: cm.DirStat) -> dict[str, Any]:
+    return {
+        "path": d.path,
+        "file_count": d.file_count,
+        "total_bytes": d.total_bytes,
+        "top_extensions": [{"ext": ext, "count": count} for ext, count in d.top_exts],
+    }
+
+
+def query_symbols(root: Path, pattern: str, limit: int = 30) -> dict[str, Any]:
+    """Symbols whose qualname matches *pattern* (regex; falls back to a
+    literal substring search if *pattern* isn't valid regex), ranked by refs,
+    bounded to *limit*.
+    """
+    code_map = _get_code_map(root)
+    try:
+        matcher = re.compile(pattern)
+        matches = [s for s in code_map.symbols if matcher.search(s.qualname)]
+    except re.error:
+        matches = [s for s in code_map.symbols if pattern in s.qualname]
+    return {
+        "mode": "symbols",
+        "pattern": pattern,
+        "symbols": [_symbol_to_dict(s) for s in matches[:limit]],
+        "total_matches": len(matches),
+    }
+
+
+def query_directory(root: Path, directory: str | None, limit: int = 60) -> dict[str, Any]:
+    """Inventory rows for *directory* and its subdirectories.
+
+    ``directory=None`` (or empty) returns the map's top-level bounded
+    inventory (already capped at ``MAX_DIR_ROWS`` by the generator).
+    """
+    code_map = _get_code_map(root)
+    dirs = code_map.inventory.dirs
+    if directory:
+        prefix = directory.rstrip("/")
+        dirs = [d for d in dirs if d.path == prefix or d.path.startswith(prefix + "/")]
+    return {
+        "mode": "directory",
+        "directory": directory,
+        "dirs": [_dirstat_to_dict(d) for d in dirs[:limit]],
+    }
+
+
+def query_top(root: Path, limit: int = 30) -> dict[str, Any]:
+    """The top *limit* symbols, already ranked by refs in the code map."""
+    code_map = _get_code_map(root)
+    return {
+        "mode": "top",
+        "symbols": [_symbol_to_dict(s) for s in code_map.symbols[:limit]],
+        "total_symbols": len(code_map.symbols),
+    }

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -21,6 +21,7 @@ Exposed tools:
                               out to `lore inbox archive`
     lore_repo_docs_list     — list a connected repo's ADRs or PRDs (pull-only)
     lore_repo_docs_fetch    — fetch one ADR or PRD's content (pull-only)
+    lore_codemap            — bounded code-map query (symbols/directory/top-N)
 
 Start:
     lore mcp
@@ -1042,6 +1043,47 @@ def handle_repo_docs_fetch(kind: str, path: str, repo_path: str | None = None) -
     return {"schema": "lore.repo_docs.fetch/1", "kind": kind, **doc}
 
 
+def handle_codemap(
+    mode: str,
+    repo_path: str | None = None,
+    pattern: str | None = None,
+    directory: str | None = None,
+    limit: int = 30,
+) -> dict[str, Any]:
+    """Bounded slice of the connected repo's code map (symbols/directory/top).
+
+    Pull-only, same repo-resolution contract as the repo-docs tools: an
+    explicit `repo_path` wins, otherwise the git repo containing the
+    server's cwd. Cold start (no map cached yet) generates one; the query
+    module caches subsequent calls on the generator's fingerprint.
+    """
+    from lore_core.codemap import query as codemap_query
+
+    if mode not in {"symbols", "directory", "top"}:
+        return _mcp_error(
+            "invalid_mode",
+            f"mode must be one of symbols|directory|top, got {mode!r}",
+        )
+    repo_root = _resolve_repo_root(repo_path)
+    if repo_root is None:
+        return _mcp_error(
+            "repo_not_found",
+            "could not resolve the connected repo",
+            next_="pass `repo_path` explicitly, or run the MCP server from within a git repo",
+        )
+
+    if mode == "symbols":
+        if not pattern:
+            return _mcp_error("pattern_required", "mode=symbols requires a non-empty `pattern`")
+        result = codemap_query.query_symbols(repo_root, pattern, limit=limit)
+    elif mode == "directory":
+        result = codemap_query.query_directory(repo_root, directory, limit=limit)
+    else:
+        result = codemap_query.query_top(repo_root, limit=limit)
+
+    return {"schema": "lore.codemap/1", "repo_root": str(repo_root), **result}
+
+
 # ---------------------------------------------------------------------------
 # MCP server wrapper
 # ---------------------------------------------------------------------------
@@ -1413,6 +1455,55 @@ def _tool_schema() -> list[dict]:
             },
         },
         {
+            "name": "lore_codemap",
+            "description": (
+                "Bounded, cached slice of the connected repo's code map — "
+                "never the whole map. Three modes: `symbols` (qualname "
+                "regex/substring match, ranked by cross-repo references), "
+                "`directory` (inventory rows scoped to a directory prefix, "
+                "or the top-level bounded inventory when `directory` is "
+                "omitted), `top` (the N most-referenced symbols). Use this "
+                "instead of reading CODEMAP.md directly — pull ~30 relevant "
+                "rows instead of a 400-line file. Cached per-repo on the "
+                "generator's fingerprint; a cold repo (no map yet) is "
+                "generated on first call."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "mode": {"type": "string", "enum": ["symbols", "directory", "top"]},
+                    "pattern": {
+                        "type": "string",
+                        "description": (
+                            "Regex/substring to match against symbol "
+                            "qualnames. Required for mode=symbols."
+                        ),
+                    },
+                    "directory": {
+                        "type": "string",
+                        "description": (
+                            "Directory prefix to scope inventory rows to. "
+                            "Only used for mode=directory; omit for the "
+                            "top-level inventory."
+                        ),
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 30,
+                        "description": "Max rows returned.",
+                    },
+                    "repo_path": {
+                        "type": "string",
+                        "description": (
+                            "Override the repo root. Defaults to the git repo "
+                            "containing the server's working directory."
+                        ),
+                    },
+                },
+                "required": ["mode"],
+            },
+        },
+        {
             "name": "lore_repo_docs_fetch",
             "description": (
                 "Fetch one ADR or PRD's full content from a connected repo. "
@@ -1484,6 +1575,8 @@ def _dispatch(tool_name: str, args: dict) -> Any:
             return handle_repo_docs_fetch(**args)
         case "lore_tier_resolve":
             return handle_tier_resolve(**args)
+        case "lore_codemap":
+            return handle_codemap(**args)
         case _:
             return _mcp_error("unknown_tool", f"unknown tool: {tool_name}")
 

--- a/tests/test_codemap_query.py
+++ b/tests/test_codemap_query.py
@@ -1,0 +1,167 @@
+"""Behavioural tests for bounded code-map queries (#167).
+
+``lore_core.codemap.query`` serves symbol-pattern, directory-inventory, and
+top-N slices of the code map from an in-memory cache keyed on the
+generator's fingerprint (git blob SHAs / content hash — see
+``lore_core.codemap.discover``), so repeated queries within one session are
+free until a tracked file changes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from lore_core.codemap import query as q
+
+CORE_PY = """\
+def helper():
+    return 1
+
+
+def widget():
+    helper()
+    helper()
+    return 2
+"""
+
+APP_PY = """\
+from core import helper, widget
+
+
+def run():
+    helper()
+    widget()
+"""
+
+
+def _write(root: Path, relpath: str, content: str) -> None:
+    path = root / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True)
+
+
+def _git_repo(root: Path) -> None:
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@t")
+    _git(root, "config", "user.name", "t")
+
+
+def _commit_all(root: Path) -> None:
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "x")
+
+
+def _fixture_tree(root: Path) -> None:
+    _write(root, "core.py", CORE_PY)
+    _write(root, "app.py", APP_PY)
+
+
+def setup_function() -> None:
+    q.clear_cache()
+
+
+def test_symbols_matches_pattern_bounded(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    _fixture_tree(tmp_path)
+    _commit_all(tmp_path)
+
+    result = q.query_symbols(tmp_path, "helper")
+    assert result["mode"] == "symbols"
+    names = [s["qualname"] for s in result["symbols"]]
+    assert names == ["helper"]
+    assert result["symbols"][0]["refs"] == 3
+
+
+def test_symbols_limit_bounds_result(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    _fixture_tree(tmp_path)
+    _commit_all(tmp_path)
+
+    result = q.query_symbols(tmp_path, ".", limit=2)
+    assert len(result["symbols"]) == 2
+
+
+def test_directory_inventory_scoped_to_prefix(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    _write(tmp_path, "src/a.py", "x = 1\n")
+    _write(tmp_path, "src/sub/b.py", "y = 2\n")
+    _write(tmp_path, "docs/readme.md", "hi\n")
+    _commit_all(tmp_path)
+
+    result = q.query_directory(tmp_path, "src")
+    assert result["mode"] == "directory"
+    paths = {d["path"] for d in result["dirs"]}
+    assert paths == {"src", "src/sub"}
+
+
+def test_directory_inventory_no_prefix_returns_top_level(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    _fixture_tree(tmp_path)
+    _commit_all(tmp_path)
+
+    result = q.query_directory(tmp_path, None)
+    assert result["mode"] == "directory"
+    assert any(d["path"] == "(root)" for d in result["dirs"])
+
+
+def test_top_n_ranked_by_refs(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    _fixture_tree(tmp_path)
+    _commit_all(tmp_path)
+
+    result = q.query_top(tmp_path, limit=1)
+    assert result["mode"] == "top"
+    assert result["symbols"][0]["qualname"] == "helper"
+    assert len(result["symbols"]) == 1
+
+
+def test_cache_hit_avoids_rebuild(tmp_path: Path, monkeypatch) -> None:
+    _git_repo(tmp_path)
+    _fixture_tree(tmp_path)
+    _commit_all(tmp_path)
+
+    calls = []
+    from lore_core import codemap as cm
+
+    real_build = cm.build_code_map
+
+    def counting_build(root):
+        calls.append(root)
+        return real_build(root)
+
+    monkeypatch.setattr(cm, "build_code_map", counting_build)
+
+    q.query_top(tmp_path, limit=5)
+    q.query_top(tmp_path, limit=5)
+    assert len(calls) == 1
+
+
+def test_cache_invalidated_on_change(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    _fixture_tree(tmp_path)
+    _commit_all(tmp_path)
+
+    first = q.query_top(tmp_path, limit=5)
+    _write(tmp_path, "extra.py", "def brandnew():\n    return 1\n")
+    _commit_all(tmp_path)
+    second = q.query_top(tmp_path, limit=5)
+
+    first_names = {s["qualname"] for s in first["symbols"]}
+    second_names = {s["qualname"] for s in second["symbols"]}
+    assert "brandnew" not in first_names
+    assert "brandnew" in second_names
+
+
+def test_cold_start_generates(tmp_path: Path) -> None:
+    """No cache entry yet — first query builds the map from scratch."""
+    _git_repo(tmp_path)
+    _fixture_tree(tmp_path)
+    _commit_all(tmp_path)
+
+    result = q.query_symbols(tmp_path, "widget")
+    assert result["symbols"][0]["qualname"] == "widget"

--- a/tests/test_mcp_codemap.py
+++ b/tests/test_mcp_codemap.py
@@ -1,0 +1,96 @@
+"""MCP tool ``lore_codemap`` — bounded code-map query slices (#167).
+
+Pull-only: mirrors the repo-docs tools' contract (explicit `repo_path`
+wins, otherwise auto-detect the git repo containing the server's cwd).
+Returns bounded slices only, never the full generated map.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from lore_core.codemap import query as codemap_query
+from lore_mcp.server import _dispatch, _tool_schema, handle_codemap
+
+CORE_PY = """\
+def helper():
+    return 1
+
+
+def widget():
+    helper()
+    helper()
+    return 2
+"""
+
+
+def _write(root: Path, relpath: str, content: str) -> None:
+    path = root / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True)
+
+
+def _git_repo(root: Path) -> None:
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@t")
+    _git(root, "config", "user.name", "t")
+    _write(root, "core.py", CORE_PY)
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "x")
+
+
+def setup_function() -> None:
+    codemap_query.clear_cache()
+
+
+def test_tool_schema_includes_lore_codemap() -> None:
+    names = {t["name"] for t in _tool_schema()}
+    assert "lore_codemap" in names
+
+
+def test_symbols_mode(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    result = handle_codemap(mode="symbols", pattern="helper", repo_path=str(tmp_path))
+    assert result["schema"] == "lore.codemap/1"
+    assert result["symbols"][0]["qualname"] == "helper"
+
+
+def test_symbols_mode_requires_pattern(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    result = handle_codemap(mode="symbols", repo_path=str(tmp_path))
+    assert result["error"]["code"] == "pattern_required"
+
+
+def test_directory_mode(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    result = handle_codemap(mode="directory", repo_path=str(tmp_path))
+    assert any(d["path"] == "(root)" for d in result["dirs"])
+
+
+def test_top_mode(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    result = handle_codemap(mode="top", limit=1, repo_path=str(tmp_path))
+    assert result["symbols"][0]["qualname"] == "helper"
+
+
+def test_invalid_mode_error_envelope(tmp_path: Path) -> None:
+    result = handle_codemap(mode="bogus", repo_path=str(tmp_path))
+    assert result["error"]["code"] == "invalid_mode"
+
+
+def test_repo_not_found_when_not_a_git_repo(monkeypatch) -> None:
+    monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
+    result = handle_codemap(mode="top")
+    assert result["error"]["code"] == "repo_not_found"
+    assert "next" in result["error"]
+
+
+def test_dispatch_routes_to_handle_codemap(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    result = _dispatch("lore_codemap", {"mode": "top", "repo_path": str(tmp_path)})
+    assert result["schema"] == "lore.codemap/1"


### PR DESCRIPTION
Closes #167

## Summary
- New `lore_codemap` MCP tool with three query modes: `symbols` (qualname regex/substring match), `directory` (inventory rows scoped to a prefix, or top-level bounded inventory when omitted), `top` (N most-referenced symbols).
- Backed by `lib/lore_core/codemap/query.py` (new file, sibling to the #165 generator — its internals are untouched). Caches the built `CodeMap` in-process keyed on the generator's fingerprint (git blob SHAs / content hash); a cheap `discover()` call detects staleness before paying for a full AST-parse rebuild.
- Registered in `lib/lore_mcp/server.py` following the `lore_repo_docs_list`/`lore_repo_docs_fetch` pull-only pattern: explicit `repo_path` wins, else auto-detect the git repo containing the server's cwd. Cold start (no cache yet) generates on first call.
- Responses are always bounded slices (default `limit=30`), never the full map.

## TDD evidence
Red: `tests/test_codemap_query.py` and `tests/test_mcp_codemap.py` written first against a not-yet-existing `lore_core.codemap.query` module / `handle_codemap` — collection failed with `ModuleNotFoundError` / `ImportError`.

Green after implementing `query.py` and the `server.py` registration:
```
tests/test_codemap_query.py: 8 passed
tests/test_mcp_codemap.py:   8 passed
```

Full suite (mirrors CI):
```
env -u FORCE_COLOR -u COLORTERM -u OPENAI_API_KEY NO_COLOR=1 pytest
2520 passed, 1 warning, 11 subtests passed
```

Touched files (`lib/lore_core/codemap/query.py`, tests) are ruff-clean; my additions to `lib/lore_mcp/server.py` are within the 100-char line limit. Two pre-existing ruff findings remain elsewhere in `server.py` (import order at an unrelated line, blank-line nit) — untouched, out of scope for this PR.

## Test plan
- [x] Symbol pattern mode returns bounded, ranked matches
- [x] Directory mode scopes to a prefix and falls back to top-level inventory
- [x] Top-N mode returns the ranked slice
- [x] Cache hit avoids rebuild (mocked `build_code_map` call count)
- [x] Cache invalidated when tracked files change
- [x] Cold start (no cache) generates the map
- [x] MCP dispatch + tool schema registration
- [x] Error envelopes: invalid mode, missing pattern, repo not found