### PR TITLE
feat(codemap): multi-language symbols via tree-sitter (#166)

### DIFF
--- a/lib/lore_core/codemap/__init__.py
+++ b/lib/lore_core/codemap/__init__.py
@@ -366,6 +366,55 @@ def build_inventory(root: Path, relpaths: list[str]) -> Inventory:
 # ---------------------------------------------------------------------------
 
 
+def _build_language_symbols(root: Path, files: list[str]) -> tuple[list[Symbol], Counter[str]]:
+    """Extract non-Python symbols (#166) via the optional tree-sitter layer.
+
+    A no-op when the ``lore[codemap]`` extra is not installed (import guard
+    lives in :mod:`lore_core.codemap.languages`), so base installs keep
+    working with Python-only symbols. References are counted with a
+    cross-language word-boundary scan over the non-Python sources rather
+    than a per-grammar reference pass \u2014 cheap, deterministic, and good
+    enough to place these symbols into the same ranked table as Python's
+    (ast-based, more precise) reference counts.
+    """
+    from lore_core.codemap import languages
+
+    if not languages.AVAILABLE:
+        return [], Counter()
+
+    lang_sources: dict[str, tuple[str, str]] = {}
+    for rel in files:
+        language = languages.language_for(rel)
+        if language is None:
+            continue
+        try:
+            text_ = (root / rel).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        lang_sources[rel] = (language, text_)
+
+    symbols: list[Symbol] = []
+    file_counts: Counter[str] = Counter()
+    for relpath in sorted(lang_sources):
+        language, source = lang_sources[relpath]
+        found = languages.extract_symbols(relpath, source, language)
+        if found:
+            symbols.extend(found)
+            file_counts[relpath] += len(found)
+
+    if symbols:
+        blob = "\n".join(source for _, source in lang_sources.values())
+        refs: Counter[str] = Counter()
+        for name in {s.name for s in symbols}:
+            refs[name] = len(re.findall(rf"\b{re.escape(name)}\b", blob))
+        symbols = [
+            Symbol(s.name, s.qualname, s.kind, s.relpath, s.lineno, refs=refs[s.name])
+            for s in symbols
+        ]
+
+    return symbols, file_counts
+
+
 def build_code_map(root: Path) -> CodeMap:
     """Discover *root* once, then build the inventory and ranked symbol layers."""
     root = Path(root)
@@ -398,6 +447,10 @@ def build_code_map(root: Path) -> CodeMap:
                 )
             )
             file_counts[relpath] += 1
+
+    lang_symbols, lang_file_counts = _build_language_symbols(root, discovery.files)
+    symbols.extend(lang_symbols)
+    file_counts.update(lang_file_counts)
 
     symbols.sort(key=lambda s: (-s.refs, s.relpath, s.lineno, s.qualname))
     ranked_files = sorted(file_counts.items(), key=lambda kv: (-kv[1], kv[0]))

--- a/lib/lore_core/codemap/languages.py
+++ b/lib/lore_core/codemap/languages.py
@@ -1,0 +1,179 @@
+"""Multi-language symbol extraction via tree-sitter tag queries (#166).
+
+Optional layer: only active when the ``lore[codemap]`` extra
+(``tree-sitter`` + ``tree-sitter-language-pack``) is installed. The import is
+guarded so a base install never touches tree-sitter and the base generator's
+Python-only symbol layer keeps working unchanged (see ``codemap/__init__.py``,
+which imports this module lazily and checks :data:`AVAILABLE` first).
+
+Each supported grammar gets one small tag query (aider's repo-map tag-query
+approach is the conceptual prior art; no code copied) that captures a
+definition's name node as ``@name`` alongside one "kind" capture
+(``@function``, ``@class``, ...) on the enclosing definition node. A query
+match with no kind capture, or no name capture, is skipped.
+
+Vue is a special case: the ``vue`` grammar itself treats ``<script>`` content
+as opaque ``raw_text`` (it does not parse the script body), so Vue files are
+handled by re-running the TypeScript query over the extracted script text,
+with line numbers offset by the script block's position in the file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_core.codemap import Symbol
+
+try:
+    from tree_sitter import Query, QueryCursor
+    from tree_sitter_language_pack import get_language, get_parser
+
+    AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised via degradation test
+    AVAILABLE = False
+
+# File extension -> tree-sitter-language-pack grammar name.
+EXTENSION_LANGUAGES = {
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".vue": "vue",
+    ".rs": "rust",
+    ".jl": "julia",
+    ".html": "html",
+    ".htm": "html",
+}
+
+_JS_QUERY = """
+(function_declaration name: (identifier) @name) @function
+(method_definition name: (property_identifier) @name) @method
+(class_declaration name: (identifier) @name) @class
+"""
+
+# TypeScript's class_declaration name is a type_identifier (JS uses a plain
+# identifier), so this can't just extend _JS_QUERY with an extra pattern.
+_TS_QUERY = """
+(function_declaration name: (identifier) @name) @function
+(method_definition name: (property_identifier) @name) @method
+(class_declaration name: (type_identifier) @name) @class
+(interface_declaration name: (type_identifier) @name) @interface
+"""
+
+_RUST_QUERY = """
+(function_item name: (identifier) @name) @function
+(struct_item name: (type_identifier) @name) @struct
+(trait_item name: (type_identifier) @name) @trait
+"""
+
+_JULIA_QUERY = """
+(function_definition (signature (call_expression (identifier) @name))) @function
+(struct_definition (type_head (identifier) @name)) @struct
+(module_definition (identifier) @name) @module
+"""
+
+# HTML has no function/class definitions; the closest analogue is an element
+# carrying an ``id`` (a named, referenceable anchor/component root).
+_HTML_QUERY = """
+(element
+  (start_tag
+    (tag_name) @tag
+    (attribute
+      (attribute_name) @attr_name
+      (quoted_attribute_value (attribute_value) @name)))
+  (#eq? @attr_name "id")) @element
+"""
+
+_QUERIES = {
+    "javascript": _JS_QUERY,
+    "typescript": _TS_QUERY,
+    "tsx": _TS_QUERY,
+    "rust": _RUST_QUERY,
+    "julia": _JULIA_QUERY,
+    "html": _HTML_QUERY,
+}
+
+# Captures that are metadata, not a kind label, when found alongside @name.
+_NON_KIND_CAPTURES = {"name", "tag", "attr_name"}
+
+
+def language_for(relpath: str) -> str | None:
+    """Return the tree-sitter grammar name for *relpath*, or None if unsupported."""
+    return EXTENSION_LANGUAGES.get(Path(relpath).suffix.lower())
+
+
+def extract_symbols(relpath: str, source: str, language: str) -> list[Symbol]:
+    """Extract tag-query symbols from one *language* source file.
+
+    Mirrors the base Python ``extract_symbols``: any failure (missing
+    grammar, parse error, malformed query match) yields an empty list rather
+    than raising, so one unsupported or broken file never breaks the map.
+    """
+    if not AVAILABLE:
+        return []
+    if language == "vue":
+        return _extract_vue(relpath, source)
+    query_src = _QUERIES.get(language)
+    if query_src is None:
+        return []
+    try:
+        return _run_query(relpath, source.encode("utf-8"), language, query_src, line_offset=0)
+    except Exception:
+        return []
+
+
+def _extract_vue(relpath: str, source: str) -> list[Symbol]:
+    """Delegate each ``<script>`` block's raw text to the TypeScript query."""
+    try:
+        tree = get_parser("vue").parse(source.encode("utf-8"))
+    except Exception:
+        return []
+    symbols: list[Symbol] = []
+    for node in _walk(tree.root_node):
+        if node.type != "script_element":
+            continue
+        raw = next((c for c in node.children if c.type == "raw_text"), None)
+        if raw is None:
+            continue
+        try:
+            symbols.extend(
+                _run_query(
+                    relpath,
+                    raw.text,
+                    "typescript",
+                    _TS_QUERY,
+                    line_offset=raw.start_point[0],
+                )
+            )
+        except Exception:
+            continue
+    return symbols
+
+
+def _walk(node):
+    yield node
+    for child in node.children:
+        yield from _walk(child)
+
+
+def _run_query(
+    relpath: str, source_bytes: bytes, language: str, query_src: str, *, line_offset: int
+) -> list[Symbol]:
+    tree = get_parser(language).parse(source_bytes)
+    query = Query(get_language(language), query_src)
+    cursor = QueryCursor(query)
+    symbols: list[Symbol] = []
+    for _pattern_idx, match in cursor.matches(tree.root_node):
+        name_nodes = match.get("name")
+        if not name_nodes:
+            continue
+        kind = next((k for k in match if k not in _NON_KIND_CAPTURES), None)
+        if kind is None:
+            continue
+        def_node = match[kind][0]
+        name = name_nodes[0].text.decode("utf-8", errors="replace")
+        lineno = def_node.start_point[0] + 1 + line_offset
+        symbols.append(Symbol(name, name, kind, relpath, lineno))
+    return symbols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ capture = [
     "anthropic>=0.40",
     "openai>=1.40",
 ]
+codemap = [
+    "tree-sitter>=0.23",
+    "tree-sitter-language-pack>=0.13",
+]
 
 [project.scripts]
 lore = "lore_cli.__main__:main"

--- a/tests/fixtures/codemap_languages/sample.html
+++ b/tests/fixtures/codemap_languages/sample.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="app">
+      <span class="label">hi</span>
+    </div>
+    <footer id="footer"></footer>
+  </body>
+</html>

--- a/tests/fixtures/codemap_languages/sample.jl
+++ b/tests/fixtures/codemap_languages/sample.jl
@@ -1,0 +1,11 @@
+function double(x)
+    return x * 2
+end
+
+struct Pair
+    a::Int
+    b::Int
+end
+
+module Helpers
+end

--- a/tests/fixtures/codemap_languages/sample.js
+++ b/tests/fixtures/codemap_languages/sample.js
@@ -1,0 +1,13 @@
+function greet() {
+  return helper();
+}
+
+function helper() {
+  return 1;
+}
+
+class Widget {
+  render() {
+    return greet();
+  }
+}

--- a/tests/fixtures/codemap_languages/sample.rs
+++ b/tests/fixtures/codemap_languages/sample.rs
@@ -1,0 +1,12 @@
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+trait Shape {
+    fn area(&self) -> i32;
+}
+
+fn make_point() -> Point {
+    Point { x: 0, y: 0 }
+}

--- a/tests/fixtures/codemap_languages/sample.ts
+++ b/tests/fixtures/codemap_languages/sample.ts
@@ -1,0 +1,13 @@
+interface Shape {
+  area(): number;
+}
+
+function makeShape(): Shape {
+  return new Circle();
+}
+
+class Circle implements Shape {
+  area() {
+    return 1;
+  }
+}

--- a/tests/fixtures/codemap_languages/sample.vue
+++ b/tests/fixtures/codemap_languages/sample.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>{{ label() }}</div>
+</template>
+
+<script setup>
+function label() {
+  return helper();
+}
+
+function helper() {
+  return "hi";
+}
+</script>

--- a/tests/test_codemap_languages.py
+++ b/tests/test_codemap_languages.py
@@ -1,0 +1,152 @@
+"""Multi-language code-map symbols via tree-sitter tag queries (#166).
+
+``lore_core.codemap.languages`` is optional: it activates only when the
+``lore[codemap]`` extra (tree-sitter + tree-sitter-language-pack) is
+installed. These tests cover both paths:
+
+1. WITH the extra: per-language golden fixtures (JS, TS, Vue, Rust, Julia,
+   HTML) extract the expected symbols, and ``build_code_map`` folds them
+   into the same ranked table as Python symbols.
+2. WITHOUT the extra (simulated via monkeypatch): the base generator still
+   produces inventory + Python symbols, with no crash or import error.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from lore_core import codemap as cm
+from lore_core.codemap import languages
+
+FIXTURES = Path(__file__).parent / "fixtures" / "codemap_languages"
+
+needs_tree_sitter = pytest.mark.skipif(
+    not languages.AVAILABLE, reason="lore[codemap] extra (tree-sitter) not installed"
+)
+
+
+def _names(symbols: list[cm.Symbol]) -> set[tuple[str, str]]:
+    return {(s.name, s.kind) for s in symbols}
+
+
+@needs_tree_sitter
+def test_javascript_fixture_extracts_functions_and_class():
+    source = (FIXTURES / "sample.js").read_text(encoding="utf-8")
+    symbols = languages.extract_symbols("sample.js", source, "javascript")
+    assert _names(symbols) == {
+        ("greet", "function"),
+        ("helper", "function"),
+        ("Widget", "class"),
+        ("render", "method"),
+    }
+
+
+@needs_tree_sitter
+def test_typescript_fixture_extracts_interface_function_class():
+    source = (FIXTURES / "sample.ts").read_text(encoding="utf-8")
+    symbols = languages.extract_symbols("sample.ts", source, "typescript")
+    assert _names(symbols) == {
+        ("Shape", "interface"),
+        ("makeShape", "function"),
+        ("Circle", "class"),
+        ("area", "method"),
+    }
+
+
+@needs_tree_sitter
+def test_vue_fixture_delegates_script_block_to_typescript_query():
+    source = (FIXTURES / "sample.vue").read_text(encoding="utf-8")
+    symbols = languages.extract_symbols("sample.vue", source, "vue")
+    assert _names(symbols) == {
+        ("label", "function"),
+        ("helper", "function"),
+    }
+    # Line numbers are offset past the <template> block, into <script setup>.
+    lines = {s.name: s.lineno for s in symbols}
+    assert source.splitlines()[lines["label"] - 1].strip().startswith("function label")
+    assert source.splitlines()[lines["helper"] - 1].strip().startswith("function helper")
+
+
+@needs_tree_sitter
+def test_rust_fixture_extracts_struct_trait_function():
+    source = (FIXTURES / "sample.rs").read_text(encoding="utf-8")
+    symbols = languages.extract_symbols("sample.rs", source, "rust")
+    assert _names(symbols) == {
+        ("Point", "struct"),
+        ("Shape", "trait"),
+        ("make_point", "function"),
+    }
+
+
+@needs_tree_sitter
+def test_julia_fixture_extracts_function_struct_module():
+    source = (FIXTURES / "sample.jl").read_text(encoding="utf-8")
+    symbols = languages.extract_symbols("sample.jl", source, "julia")
+    assert _names(symbols) == {
+        ("double", "function"),
+        ("Pair", "struct"),
+        ("Helpers", "module"),
+    }
+
+
+@needs_tree_sitter
+def test_html_fixture_extracts_elements_with_id():
+    source = (FIXTURES / "sample.html").read_text(encoding="utf-8")
+    symbols = languages.extract_symbols("sample.html", source, "html")
+    assert _names(symbols) == {
+        ("app", "element"),
+        ("footer", "element"),
+    }
+
+
+@needs_tree_sitter
+def test_unsupported_language_returns_empty():
+    assert languages.extract_symbols("x.foo", "whatever", "made-up-language") == []
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True)
+
+
+@needs_tree_sitter
+def test_build_code_map_joins_multilang_symbols_into_one_ranked_table(tmp_path):
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+
+    (tmp_path / "core.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "sample.rs").write_text(
+        (FIXTURES / "sample.rs").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "x")
+
+    code_map = cm.build_code_map(tmp_path)
+    qualnames = {s.qualname for s in code_map.symbols}
+    # Python and Rust symbols land in the SAME list, ranked together.
+    assert "helper" in qualnames
+    assert "make_point" in qualnames
+    assert "Point" in qualnames
+
+
+def test_degradation_without_tree_sitter_extra(monkeypatch, tmp_path):
+    """Simulate the extra not being installed: base path must not crash."""
+    monkeypatch.setattr(languages, "AVAILABLE", False)
+
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "core.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "sample.rs").write_text(
+        (FIXTURES / "sample.rs").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "x")
+
+    code_map = cm.build_code_map(tmp_path)
+    qualnames = {s.qualname for s in code_map.symbols}
+    assert "helper" in qualnames
+    assert "make_point" not in qualnames
+    assert code_map.inventory.total_files == 2


### PR DESCRIPTION
Closes #166

## Summary
Adds an optional `lore[codemap]` extra (`tree-sitter` + `tree-sitter-language-pack`) that extends the deterministic code map (#165) with JS/TS, Vue, Rust, Julia, and HTML symbol extraction via per-grammar tag queries (aider's repo-map tag-query approach is conceptual prior art; no code copied). Symbols land in the same ranked table as Python's ast-based symbols — `build_code_map` gains one small localized hook (`_build_language_symbols`) that lazily imports the new `lore_core/codemap/languages.py` submodule, so the change stays minimal in `codemap/__init__.py` for clean rebasing against the sibling #167 PR.

Base install stays untouched: `languages.py` guards the tree-sitter import with `try/except ImportError`, and without the extra, `build_code_map` silently skips the language layer (inventory + Python symbols only, no crash).

Vue is a special case — the `vue` grammar leaves `<script>` content as opaque `raw_text`, so Vue files re-run the TypeScript tag query over the extracted script text with line numbers offset to match the source file.

## TDD evidence
Red: initial TS/Vue queries failed (`tree_sitter.QueryError: Impossible pattern`) because TypeScript's `class_declaration` name field is `type_identifier`, not `identifier` as in JS — fixed by giving TypeScript its own full query instead of extending the JS one.

Green — full suite:
```
2513 passed, 1 warning, 11 subtests passed in 168.20s
```

New tests (`tests/test_codemap_languages.py`, 12 tests):
- Per-language golden fixtures under `tests/fixtures/codemap_languages/`: JS, TS, Vue, Rust, Julia, HTML — each asserts the exact `(name, kind)` set extracted.
- `test_build_code_map_joins_multilang_symbols_into_one_ranked_table` — Python + Rust symbols in one `CodeMap.symbols` list.
- `test_degradation_without_tree_sitter_extra` — `languages.AVAILABLE` monkeypatched to `False`; `build_code_map` still returns inventory + Python symbols, no crash.

`ruff check` / `ruff format --check` clean on all touched files.

## Scope
`lib/lore_core/codemap/languages.py` (new), `lib/lore_core/codemap/__init__.py` (minimal guarded hook only), `pyproject.toml` (`[codemap]` extra only), `tests/test_codemap_languages.py` + fixtures.