### PR TITLE
feat: spawn-model PreToolUse gate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -80,6 +80,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "lore hook spawn-model-gate"
+          }
+        ]
+      }
     ]
   },
   "mcpServers": {

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -994,6 +994,7 @@ from lore_adapters import get_adapter  # noqa: E402
 from lore_core.hook_log import HookEventLogger  # noqa: E402
 from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry  # noqa: E402
 from lore_core.scope_resolver import resolve_scope  # noqa: E402
+from lore_core.spawn_gate import check_spawn  # noqa: E402
 from lore_cli._argv_compat import argv_main  # noqa: E402
 
 # Re-export the spawn machinery so hooks-internal heartbeat code and any
@@ -1440,6 +1441,26 @@ def cmd_stop(
         return
     out = _stop()
     _emit("Stop", out, plain=plain)
+
+
+@hook_app.command("spawn-model-gate")
+@_shield_hook("PreToolUse")
+def cmd_spawn_model_gate() -> None:
+    """PreToolUse gate: deny Task/Agent spawns that omit an explicit model.
+
+    Reads the PreToolUse payload from stdin. Denial protocol (Claude
+    Code): exit code 2 blocks the tool call and routes stderr back to
+    the model as feedback; exit 0 allows it. See
+    :mod:`lore_core.spawn_gate` for the deny/allow rule itself — this
+    command is just the stdin/stdout/exit-code plumbing, matching the
+    other `lore hook ...` entry points.
+    """
+    payload = _read_hook_payload()
+    deny_message = check_spawn(payload)
+    if deny_message is None:
+        return
+    sys.stderr.write(deny_message)
+    raise typer.Exit(code=2)
 
 
 @hook_app.command("context-log")

--- a/lib/lore_core/spawn_gate.py
+++ b/lib/lore_core/spawn_gate.py
@@ -1,0 +1,54 @@
+"""PreToolUse gate: block subagent spawns that omit an explicit model.
+
+The tier contract (docs/model-tiers.md) says no delegation ever inherits
+the session model implicitly — every spawn carries its semantic tier's
+resolved model in the spawn call itself. Skills state that rule in
+prose; prose can be ignored. This gate is the mechanical backstop:
+wired as a PreToolUse hook on the spawn tools (Task/Agent), it denies
+any spawn whose input has no explicit model and points the caller at
+``lore tier resolve <tier>`` to pick one and retry.
+
+Ported from ccat-agent-workflow's ``scripts/require_spawn_model.py``.
+Host wiring differs (Claude Code only, for now — see
+``lore_cli.hooks``); the deny/allow logic is host-agnostic and lives
+here so other hosts can reuse it later.
+"""
+
+from __future__ import annotations
+
+# Tool names under which Claude Code exposes the subagent spawn.
+SPAWN_TOOL_NAMES = frozenset({"Task", "Agent"})
+
+_DENY_MESSAGE = (
+    "Spawn blocked: this subagent call carries no explicit model, so it "
+    "would implicitly inherit the session model — the tier contract "
+    "forbids that (docs/model-tiers.md). Resolve the step's semantic tier "
+    "with `lore tier resolve <frontier|strong|mid|cheap>` and retry the "
+    "spawn with the model parameter set to that command's output. For a "
+    "deliberate frontier-tier delegation, pass the session's own model "
+    "explicitly.\n"
+)
+
+
+def check_spawn(payload: dict) -> str | None:
+    """Return a deny message if `payload` is a model-less subagent spawn, else None.
+
+    Fail-open by construction: any shape that isn't recognizably a
+    Task/Agent spawn (wrong tool, missing/malformed tool_input) returns
+    None rather than guessing. Forks always inherit the parent model by
+    design — the model parameter is documented as ignored for them, so
+    requiring it would be noise.
+    """
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("tool_name") not in SPAWN_TOOL_NAMES:
+        return None
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    if tool_input.get("subagent_type") == "fork":
+        return None
+    model = tool_input.get("model")
+    if isinstance(model, str) and model.strip():
+        return None
+    return _DENY_MESSAGE

--- a/tests/test_hooks_spawn_model_gate.py
+++ b/tests/test_hooks_spawn_model_gate.py
@@ -1,0 +1,47 @@
+"""`lore hook spawn-model-gate` — PreToolUse CLI wiring for the spawn gate.
+
+Covers the stdin/exit-code/stderr plumbing around
+lore_core.spawn_gate.check_spawn(): denial protocol is exit 2 + stderr
+message, allow is exit 0 + silent, and malformed stdin fails open.
+"""
+
+from __future__ import annotations
+
+import json
+
+from lore_cli.hooks import hook_app
+from typer.testing import CliRunner
+
+
+def _invoke(payload) -> object:
+    runner = CliRunner()
+    stdin = payload if isinstance(payload, str) else json.dumps(payload)
+    return runner.invoke(hook_app, ["spawn-model-gate"], input=stdin)
+
+
+def test_denies_model_less_spawn() -> None:
+    result = _invoke({"tool_name": "Task", "tool_input": {"prompt": "explore"}})
+    assert result.exit_code == 2
+    assert "lore tier resolve" in result.stderr
+
+
+def test_allows_spawn_with_explicit_model() -> None:
+    result = _invoke({"tool_name": "Task", "tool_input": {"model": "sonnet"}})
+    assert result.exit_code == 0
+    assert result.stderr == ""
+
+
+def test_allows_fork_without_model() -> None:
+    result = _invoke({"tool_name": "Task", "tool_input": {"subagent_type": "fork"}})
+    assert result.exit_code == 0
+
+
+def test_ignores_unrelated_tools() -> None:
+    result = _invoke({"tool_name": "Bash", "tool_input": {"command": "ls"}})
+    assert result.exit_code == 0
+
+
+def test_fails_open_on_malformed_stdin() -> None:
+    for garbage in ("", "not json", "[]"):
+        result = _invoke(garbage)
+        assert result.exit_code == 0, f"must fail open on {garbage!r}"

--- a/tests/test_install_claude.py
+++ b/tests/test_install_claude.py
@@ -209,9 +209,11 @@ def test_install_wires_spawn_model_gate():
         "PreToolUse must call `lore hook spawn-model-gate`"
     )
 
-    matchers = [grp["matcher"] for grp in pretooluse if "lore hook spawn-model-gate" in [
-        h["command"] for h in grp["hooks"]
-    ]]
+    matchers = [
+        grp["matcher"]
+        for grp in pretooluse
+        if "lore hook spawn-model-gate" in [h["command"] for h in grp["hooks"]]
+    ]
     assert matchers, "spawn-model-gate hook must declare a matcher"
     matcher = matchers[0]
     assert re.fullmatch(matcher, "Task"), f"matcher {matcher!r} must match Task"

--- a/tests/test_install_claude.py
+++ b/tests/test_install_claude.py
@@ -5,6 +5,7 @@ not-on-PATH self-install case."""
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from pathlib import Path
 
@@ -188,3 +189,31 @@ def test_install_writes_capture_hooks():
     assert "lore hook capture --event session-start" in all_commands("SessionStart"), (
         "SessionStart must call `lore hook capture --event session-start`"
     )
+
+
+def test_install_wires_spawn_model_gate():
+    """plugin.json must wire a PreToolUse hook on Task/Agent spawns to
+    `lore hook spawn-model-gate` (issue #170): the same
+    `claude plugin install lore@lore` / `claude plugin uninstall lore@lore`
+    pair used for every other hook installs and removes this one too,
+    so no separate install/uninstall action is needed — only the
+    manifest wiring is asserted here.
+    """
+    path = _plugin_json_path()
+    data = json.loads(path.read_text())
+    hooks = data["hooks"]
+
+    pretooluse = hooks.get("PreToolUse", [])
+    commands = [h["command"] for grp in pretooluse for h in grp["hooks"]]
+    assert "lore hook spawn-model-gate" in commands, (
+        "PreToolUse must call `lore hook spawn-model-gate`"
+    )
+
+    matchers = [grp["matcher"] for grp in pretooluse if "lore hook spawn-model-gate" in [
+        h["command"] for h in grp["hooks"]
+    ]]
+    assert matchers, "spawn-model-gate hook must declare a matcher"
+    matcher = matchers[0]
+    assert re.fullmatch(matcher, "Task"), f"matcher {matcher!r} must match Task"
+    assert re.fullmatch(matcher, "Agent"), f"matcher {matcher!r} must match Agent"
+    assert not re.fullmatch(matcher, "Bash"), f"matcher {matcher!r} must not match Bash"

--- a/tests/test_spawn_gate.py
+++ b/tests/test_spawn_gate.py
@@ -1,0 +1,59 @@
+"""Pure deny/allow logic for the spawn-model gate (lore_core.spawn_gate).
+
+Ported from ccat-agent-workflow's test_spawn_model_hook.py. The CLI/stdin
+plumbing (exit codes, stderr) is covered separately in
+test_hooks_spawn_model_gate.py; this file only exercises check_spawn().
+"""
+
+from __future__ import annotations
+
+from lore_core.spawn_gate import check_spawn
+
+
+def test_blocks_task_spawn_without_model() -> None:
+    msg = check_spawn({"tool_name": "Task", "tool_input": {"prompt": "explore"}})
+    assert msg is not None
+
+
+def test_blocks_agent_spawn_without_model() -> None:
+    msg = check_spawn({"tool_name": "Agent", "tool_input": {"prompt": "explore"}})
+    assert msg is not None
+
+
+def test_blocks_blank_model() -> None:
+    msg = check_spawn({"tool_name": "Task", "tool_input": {"model": "  "}})
+    assert msg is not None
+
+
+def test_deny_message_points_at_tier_resolver() -> None:
+    msg = check_spawn({"tool_name": "Task", "tool_input": {"prompt": "explore"}})
+    assert msg is not None
+    assert "lore tier resolve" in msg
+    assert "model" in msg.lower()
+
+
+def test_allows_spawn_with_explicit_model() -> None:
+    assert check_spawn({"tool_name": "Task", "tool_input": {"model": "sonnet"}}) is None
+
+
+def test_allows_fork_without_model() -> None:
+    """Forks always inherit the parent model by design; the gate exempts them."""
+    assert (
+        check_spawn({"tool_name": "Task", "tool_input": {"subagent_type": "fork"}}) is None
+    )
+
+
+def test_ignores_unrelated_tools() -> None:
+    assert check_spawn({"tool_name": "Bash", "tool_input": {"command": "ls"}}) is None
+
+
+def test_ignores_near_miss_tool_names() -> None:
+    """Task-management tools (TaskCreate, TaskStop, ...) are not spawns."""
+    for name in ("TaskCreate", "TaskStop", "TaskOutput", "AgentOutput"):
+        assert check_spawn({"tool_name": name, "tool_input": {}}) is None
+
+
+def test_fails_open_on_malformed_payload() -> None:
+    """A broken/unexpected payload shape must never brick delegation."""
+    for garbage in (None, [], 42, "not a dict", {"tool_name": 42}):
+        assert check_spawn(garbage) is None

--- a/tests/test_spawn_gate.py
+++ b/tests/test_spawn_gate.py
@@ -38,9 +38,7 @@ def test_allows_spawn_with_explicit_model() -> None:
 
 def test_allows_fork_without_model() -> None:
     """Forks always inherit the parent model by design; the gate exempts them."""
-    assert (
-        check_spawn({"tool_name": "Task", "tool_input": {"subagent_type": "fork"}}) is None
-    )
+    assert check_spawn({"tool_name": "Task", "tool_input": {"subagent_type": "fork"}}) is None
 
 
 def test_ignores_unrelated_tools() -> None:


### PR DESCRIPTION
Closes #170

## Summary
- `lib/lore_core/spawn_gate.py`: pure `check_spawn(payload)` deny/allow logic, ported from ccat-agent-workflow's `scripts/require_spawn_model.py`. Denies Task/Agent spawns lacking an explicit `model`; `subagent_type: "fork"` is exempt; any unrecognized payload shape fails open (returns `None`).
- `lib/lore_cli/hooks.py`: new `lore hook spawn-model-gate` command reusing the existing `_read_hook_payload()` stdin plumbing and `_shield_hook` crash-safety wrapper; exits 2 + stderr on deny (Claude Code's PreToolUse block protocol), 0 otherwise — including on unexpected exceptions (shield forces exit 0, matching fail-open).
- `.claude-plugin/plugin.json`: wires a `PreToolUse` hook with matcher `Task|Agent` to `lore hook spawn-model-gate`. No separate install/uninstall action needed — the existing `claude plugin install/uninstall lore@lore` steps already apply/remove the whole manifest.
- Retry guidance now says `lore tier resolve <tier>` instead of a hardcoded tier→model table, so it can't drift from the #168 tier resolver.

## Test plan (red → green)
- `tests/test_spawn_gate.py` — pure logic: deny model-less/blank-model spawns, allow explicit-model/fork spawns, ignore non-spawn tools and near-miss names (`TaskCreate`, etc.), fail open on malformed payloads.
- `tests/test_hooks_spawn_model_gate.py` — CLI wiring via `CliRunner`: exit 2 + stderr on deny, exit 0 + silent on allow, fail-open on malformed stdin.
- `tests/test_install_claude.py::test_install_wires_spawn_model_gate` — asserts `plugin.json`'s `PreToolUse` hook calls `lore hook spawn-model-gate` with a matcher that matches `Task`/`Agent` but not `Bash`.

Full suite: `2519 passed, 1 warning, 11 subtests passed` (CI env vars). `ruff check` clean on all touched/new files (pre-existing lint debt in `lib/lore_cli/hooks.py` — 59 unrelated errors, confirmed identical before/after this change — is out of scope per the task fence).