### PR TITLE
feat: fold workflow scaffolding into lore attach (#171)

### DIFF
--- a/lib/lore_cli/attach_cmd.py
+++ b/lib/lore_cli/attach_cmd.py
@@ -683,9 +683,9 @@ def _config_wizard(
     # Step D.5: Offer workflow scaffolding (docs/prd, docs/adr, AGENTS.md
     # shim) — same onboarding command, one extra opt-in step, never a
     # separate entry point.
-    raw = input(
-        "\n  Scaffold workflow docs (docs/prd, docs/adr, AGENTS.md)? [y/N]: "
-    ).strip().lower()
+    raw = (
+        input("\n  Scaffold workflow docs (docs/prd, docs/adr, AGENTS.md)? [y/N]: ").strip().lower()
+    )
     scaffold_workflow = raw in ("y", "yes")
 
     # Step E: Summary + confirm
@@ -773,7 +773,8 @@ def attach_interactive(
 def cmd_accept(
     cwd: str = typer.Option(None, "--cwd", help="Directory containing `.lore.yml` (default: current dir)."),
     scaffold_workflow: bool = typer.Option(
-        False, "--scaffold-workflow",
+        False,
+        "--scaffold-workflow",
         help="Also scaffold docs/prd, docs/adr, and the AGENTS.md shim.",
     ),
 ) -> None:
@@ -795,7 +796,8 @@ def cmd_manual(
     scope: str = typer.Option(..., "--scope", help="Scope ID (colon-separated)."),
     cwd: str = typer.Option(None, "--cwd", help="Directory to attach (default: current dir)."),
     scaffold_workflow: bool = typer.Option(
-        False, "--scaffold-workflow",
+        False,
+        "--scaffold-workflow",
         help="Also scaffold docs/prd, docs/adr, and the AGENTS.md shim.",
     ),
 ) -> None:

--- a/lib/lore_cli/attach_cmd.py
+++ b/lib/lore_cli/attach_cmd.py
@@ -128,7 +128,32 @@ def _no_applicable_offer_message(cwd_path: Path) -> None:
     )
 
 
-def _do_accept(lore_root: Path, cwd_path: Path) -> None:
+def _maybe_scaffold_workflow(lore_root: Path, repo_root: Path, scaffold_workflow: bool) -> None:
+    """Run the workflow scaffold (docs/prd, docs/adr, AGENTS.md shim) and
+    record it, if the caller opted in. One onboarding command per repo: this
+    is a step of `lore attach`, never a separate entry point.
+    """
+    if not scaffold_workflow:
+        return
+    from lore_core.state.workflow_scaffold import WorkflowScaffoldFile
+    from lore_workflow.scaffold import scaffold
+
+    changed = scaffold(repo_root)
+    record = WorkflowScaffoldFile(lore_root)
+    record.load()
+    record.record(repo_root)
+    record.save()
+
+    if changed:
+        console.print(
+            "[green]Scaffolded workflow docs[/green] "
+            "(docs/prd, docs/adr, AGENTS.md) at " + str(repo_root)
+        )
+    else:
+        console.print("[dim]Workflow docs already scaffolded — no changes.[/dim]")
+
+
+def _do_accept(lore_root: Path, cwd_path: Path, scaffold_workflow: bool = False) -> None:
     from datetime import UTC, datetime
 
     from lore_core.consent import ConsentState, classify_state
@@ -189,6 +214,7 @@ def _do_accept(lore_root: Path, cwd_path: Path) -> None:
         f"[green]Attached[/green] {repo_root} → wiki [cyan]{offer.wiki}[/cyan], "
         f"scope [magenta]{offer.scope}[/magenta]"
     )
+    _maybe_scaffold_workflow(lore_root, repo_root, scaffold_workflow)
     stub = _maybe_stub_project_note(
         lore_root=lore_root,
         wiki=offer.wiki,
@@ -221,7 +247,9 @@ def _do_decline(lore_root: Path, cwd_path: Path) -> None:
     )
 
 
-def _do_manual(lore_root: Path, cwd_path: Path, wiki: str, scope: str) -> None:
+def _do_manual(
+    lore_root: Path, cwd_path: Path, wiki: str, scope: str, scaffold_workflow: bool = False
+) -> None:
     from datetime import UTC, datetime
 
     from lore_core.state.attachments import Attachment, AttachmentsFile
@@ -254,6 +282,7 @@ def _do_manual(lore_root: Path, cwd_path: Path, wiki: str, scope: str) -> None:
         f"[green]Attached[/green] {cwd_path} → wiki [cyan]{wiki}[/cyan], "
         f"scope [magenta]{scope}[/magenta] (manual)"
     )
+    _maybe_scaffold_workflow(lore_root, cwd_path, scaffold_workflow)
     stub = _maybe_stub_project_note(
         lore_root=lore_root,
         wiki=wiki,
@@ -515,13 +544,14 @@ def _execute_attach(
     scope: str,
     backend: str,
     write_offer: bool,
+    scaffold_workflow: bool = False,
 ) -> None:
     """Shared executor: register the attachment, optionally write a
     ``.lore.yml`` and stamp its fingerprint onto the row so the very
     next session doesn't see it as DRIFT."""
     from lore_core.offer import FILENAME
 
-    _do_manual(lore_root, resolved, wiki, scope)
+    _do_manual(lore_root, resolved, wiki, scope, scaffold_workflow)
 
     if write_offer:
         import yaml
@@ -572,6 +602,8 @@ def _config_wizard(
         console.print()
         choice = input("  [A]ccept   [s]tep through   [c]ancel: ").strip().lower()
         if choice in ("", "a", "y", "yes", "accept"):
+            # One-click accept keeps the fast path fast: no scaffold prompt.
+            # `lore attach manual --scaffold-workflow` covers it explicitly.
             _execute_attach(
                 lore_root, resolved,
                 wiki=proposed_wiki, scope=proposed_scope,
@@ -648,6 +680,14 @@ def _config_wizard(
         raw = input("\n  Write .lore.yml so other contributors get this config? [y/N]: ").strip().lower()
         write_offer = raw in ("y", "yes")
 
+    # Step D.5: Offer workflow scaffolding (docs/prd, docs/adr, AGENTS.md
+    # shim) — same onboarding command, one extra opt-in step, never a
+    # separate entry point.
+    raw = input(
+        "\n  Scaffold workflow docs (docs/prd, docs/adr, AGENTS.md)? [y/N]: "
+    ).strip().lower()
+    scaffold_workflow = raw in ("y", "yes")
+
     # Step E: Summary + confirm
     console.print("\n[bold]─── Attach summary ───[/bold]")
     console.print(f"  Directory:  {resolved}")
@@ -656,6 +696,8 @@ def _config_wizard(
     console.print(f"  Backend:    {backend}")
     if write_offer:
         console.print(f"  .lore.yml:  will be written")
+    if scaffold_workflow:
+        console.print("  Workflow:   docs/prd, docs/adr, AGENTS.md will be scaffolded")
     console.print()
 
     raw = input("  Proceed? [Y/n]: ").strip().lower()
@@ -666,6 +708,7 @@ def _config_wizard(
     _execute_attach(
         lore_root, resolved,
         wiki=wiki, scope=scope, backend=backend, write_offer=write_offer,
+        scaffold_workflow=scaffold_workflow,
     )
 
 
@@ -729,9 +772,13 @@ def attach_interactive(
 @app.command("accept")
 def cmd_accept(
     cwd: str = typer.Option(None, "--cwd", help="Directory containing `.lore.yml` (default: current dir)."),
+    scaffold_workflow: bool = typer.Option(
+        False, "--scaffold-workflow",
+        help="Also scaffold docs/prd, docs/adr, and the AGENTS.md shim.",
+    ),
 ) -> None:
     """Accept the `.lore.yml` offer covering ``cwd``."""
-    _do_accept(_lore_root_or_die(), _cwd_arg(cwd))
+    _do_accept(_lore_root_or_die(), _cwd_arg(cwd), scaffold_workflow)
 
 
 @app.command("decline")
@@ -747,11 +794,15 @@ def cmd_manual(
     wiki: str = typer.Option(..., "--wiki", help="Wiki name."),
     scope: str = typer.Option(..., "--scope", help="Scope ID (colon-separated)."),
     cwd: str = typer.Option(None, "--cwd", help="Directory to attach (default: current dir)."),
+    scaffold_workflow: bool = typer.Option(
+        False, "--scaffold-workflow",
+        help="Also scaffold docs/prd, docs/adr, and the AGENTS.md shim.",
+    ),
 ) -> None:
     """Attach ``cwd`` manually with no ``.lore.yml`` required."""
     cwd_path = _cwd_arg(cwd)
     resolved = cwd_path.resolve() if cwd_path.exists() else cwd_path.absolute()
-    _do_manual(_lore_root_or_die(), resolved, wiki, scope)
+    _do_manual(_lore_root_or_die(), resolved, wiki, scope, scaffold_workflow)
 
 
 @app.command("offer")

--- a/lib/lore_core/state/workflow_scaffold.py
+++ b/lib/lore_core/state/workflow_scaffold.py
@@ -1,0 +1,75 @@
+"""Workflow-scaffold record: which repos have had `lore attach`'s scaffold
+step run against them.
+
+Sidecar JSON at ``$LORE_ROOT/.lore/workflow_scaffold.json``, keyed by
+resolved repo path. Purely an observability record — the scaffold's own
+idempotency comes from filesystem checks (`lore_workflow.scaffold`: file
+existence, the CLAUDE.md shim sentinel), never from this file. Deleting it
+loses no correctness, only the "when did we last scaffold this repo" answer.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lore_core.io import atomic_write_text
+
+
+@dataclass
+class ScaffoldRecord:
+    path: Path
+    scaffolded_at: datetime
+
+
+class WorkflowScaffoldFile:
+    """Sidecar at ``<lore_root>/.lore/workflow_scaffold.json``."""
+
+    def __init__(self, lore_root: Path) -> None:
+        self._path = lore_root / ".lore" / "workflow_scaffold.json"
+        self._records: dict[Path, ScaffoldRecord] = {}
+        self._loaded = False
+
+    def load(self) -> None:
+        self._records = {}
+        self._loaded = True
+        if not self._path.exists():
+            return
+        try:
+            raw = json.loads(self._path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return
+        for entry in raw.get("scaffolded", []):
+            path = Path(entry["path"])
+            self._records[path] = ScaffoldRecord(
+                path=path,
+                scaffolded_at=datetime.fromisoformat(entry["scaffolded_at"]),
+            )
+
+    def save(self) -> None:
+        raw = {
+            "scaffolded": [
+                {"path": str(r.path), "scaffolded_at": r.scaffolded_at.isoformat()}
+                for r in self._records.values()
+            ]
+        }
+        atomic_write_text(self._path, json.dumps(raw, indent=2))
+
+    def record(self, path: Path) -> None:
+        """Record *path* as scaffolded now. Re-recording overwrites the timestamp."""
+        resolved = path.resolve()
+        self._records[resolved] = ScaffoldRecord(path=resolved, scaffolded_at=datetime.now(UTC))
+
+    def was_scaffolded(self, path: Path) -> bool:
+        self._ensure_loaded()
+        return path.resolve() in self._records
+
+    def all_paths(self) -> list[Path]:
+        self._ensure_loaded()
+        return list(self._records.keys())
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self.load()

--- a/lib/lore_workflow/prd_docs.py
+++ b/lib/lore_workflow/prd_docs.py
@@ -113,17 +113,19 @@ def _body(seq: int, title: str, epic_url: str) -> str:
     )
 
 
-def wire_toctree(index_path: Path, entry: str) -> None:
+def wire_toctree(index_path: Path, entry: str, stub: str = _PRD_INDEX_STUB) -> None:
     """Add *entry* into *index_path*'s first toctree block, idempotently.
 
-    Creates the index from the stub when absent, then inserts the entry before
-    the closing fence of the first `{toctree}` block. Does nothing if the entry
-    is already present anywhere in the file. Mirrors the wiring contract in
-    scripts/ccat_workflow_init.py (single-brace MyST directive).
+    Creates the index from *stub* when absent (default: the PRD index stub),
+    then inserts the entry before the closing fence of the first `{toctree}`
+    block. Does nothing if the entry is already present anywhere in the file.
+    Mirrors the wiring contract in scripts/ccat_workflow_init.py (single-brace
+    MyST directive). Generic over *stub* so other scaffolded index files
+    (docs/adr/index.md, docs/index.md) reuse the same wiring logic.
     """
     if not index_path.exists():
         index_path.parent.mkdir(parents=True, exist_ok=True)
-        index_path.write_text(_PRD_INDEX_STUB, encoding="utf-8")
+        index_path.write_text(stub, encoding="utf-8")
 
     text = index_path.read_text(encoding="utf-8")
     if entry in text:

--- a/lib/lore_workflow/scaffold.py
+++ b/lib/lore_workflow/scaffold.py
@@ -1,0 +1,135 @@
+"""Repo workflow-onboarding scaffold (PRD 0003 / sub-issue #171).
+
+Ported from ccat-agent-workflow's `scripts/ccat_workflow_init.py`, which used
+to be a separate `ccat-workflow-init` onboarding entry point. Lore has exactly
+one onboarding command per repo (`lore attach`); this module supplies the
+step that command calls, it is never a subcommand of its own.
+
+Idempotent: safe to re-run. Creates only what is missing; never overwrites
+existing files. Stdlib-only, no GitHub I/O.
+
+What it does:
+1. Migrate CLAUDE.md -> AGENTS.md (if CLAUDE.md exists and isn't already the
+   shim), then replace CLAUDE.md with a one-line `@AGENTS.md` import shim.
+2. Create docs/prd/index.md and docs/adr/index.md (toctree stubs) if absent.
+3. Ensure docs/index.md exists and wires both prd/index and adr/index into
+   its first toctree block, idempotently.
+
+Deliberately out of scope (per PRD 0003, a sibling slice, #170): the
+.claude/settings.json permissions allowlist and hook wiring. This module
+never touches settings.json.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_workflow.prd_docs import wire_toctree
+
+# The one-line shim that CLAUDE.md becomes after migration.
+CLAUDE_MD_SHIM = "@AGENTS.md\n"
+SHIM_SENTINEL = "@AGENTS.md"
+
+_ADR_INDEX_STUB = """\
+# Architecture Decision Records
+
+Decision records in MADR-lite form
+(Context · Decision · Consequences / Trade-offs · Alternatives considered).
+
+```{toctree}
+:maxdepth: 1
+
+```
+"""
+
+_PRD_INDEX_STUB = """\
+# Product Requirements Documents
+
+PRDs are the source of truth for decisions. Each PRD lives at
+`docs/prd/NNNN-kebab.md` (MyST Markdown) and is linked from its GitHub epic.
+
+```{toctree}
+:maxdepth: 1
+
+```
+"""
+
+_DOCS_INDEX_STUB = """\
+# Documentation
+
+```{toctree}
+:maxdepth: 2
+
+adr/index
+prd/index
+```
+"""
+
+
+def _migrate_claude_md(target: Path) -> bool:
+    """Move CLAUDE.md content into AGENTS.md; replace CLAUDE.md with the shim.
+
+    Idempotency: if CLAUDE.md is already the shim, do nothing. If AGENTS.md
+    already exists, never overwrite it (migration already happened, or the
+    user authored it). Returns whether anything changed.
+    """
+    claude_md = target / "CLAUDE.md"
+    agents_md = target / "AGENTS.md"
+
+    if claude_md.exists():
+        current = claude_md.read_text(encoding="utf-8")
+        already_shim = current.strip() == SHIM_SENTINEL
+    else:
+        current = ""
+        already_shim = False
+
+    if already_shim:
+        if not agents_md.exists():
+            agents_md.write_text("", encoding="utf-8")
+            return True
+        return False
+
+    changed = False
+    if not agents_md.exists():
+        agents_md.write_text(current, encoding="utf-8")
+        changed = True
+    if not claude_md.exists() or claude_md.read_text(encoding="utf-8") != CLAUDE_MD_SHIM:
+        claude_md.write_text(CLAUDE_MD_SHIM, encoding="utf-8")
+        changed = True
+    return changed
+
+
+def _create_index_stub(index_path: Path, stub: str) -> bool:
+    if index_path.exists():
+        return False
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(stub, encoding="utf-8")
+    return True
+
+
+def _wire_docs_index(target: Path) -> bool:
+    """Ensure docs/index.md exists and references both prd/index and adr/index."""
+    docs_index = target / "docs" / "index.md"
+    changed = _create_index_stub(docs_index, _DOCS_INDEX_STUB)
+    if changed:
+        return True  # Stub already carries both entries.
+
+    before = docs_index.read_text(encoding="utf-8")
+    wire_toctree(docs_index, "adr/index", stub=_DOCS_INDEX_STUB)
+    wire_toctree(docs_index, "prd/index", stub=_DOCS_INDEX_STUB)
+    return docs_index.read_text(encoding="utf-8") != before
+
+
+def scaffold(target: Path) -> bool:
+    """Onboard the repo at *target* into the workflow conventions.
+
+    Returns whether anything was written (for state recording / caller
+    messaging) — a second call on an unchanged repo returns False.
+    """
+    target = Path(target).resolve()
+
+    changed = _migrate_claude_md(target)
+    changed |= _create_index_stub(target / "docs" / "adr" / "index.md", _ADR_INDEX_STUB)
+    changed |= _create_index_stub(target / "docs" / "prd" / "index.md", _PRD_INDEX_STUB)
+    changed |= _wire_docs_index(target)
+    return changed

--- a/tests/test_attach_interactive.py
+++ b/tests/test_attach_interactive.py
@@ -96,7 +96,7 @@ def test_manual_pick_existing(lore_env: Path, tmp_path: Path) -> None:
     # wikis sorted: ccat=1, private=2, science=3
     # 1=ccat wiki, "ccat:newscope"=scope (bare input, no scopes in registry),
     # Enter=default backend, n=no .lore.yml, y=proceed
-    input_lines = "1\nccat:newscope\n\nn\ny\n"
+    input_lines = "1\nccat:newscope\n\nn\nn\ny\n"
     result = runner.invoke(app, ["attach", "--cwd", str(repo)], input=input_lines)
     assert result.exit_code == 0, result.output
     assert "Attached" in result.output
@@ -115,7 +115,7 @@ def test_manual_custom_wiki(lore_env: Path, tmp_path: Path) -> None:
 
     # c=custom wiki, "newwiki"=name, "newwiki:sub"=scope (bare input),
     # Enter=default backend, n=no .lore.yml, y=proceed
-    input_lines = "c\nnewwiki\nnewwiki:sub\n\nn\ny\n"
+    input_lines = "c\nnewwiki\nnewwiki:sub\n\nn\nn\ny\n"
     result = runner.invoke(app, ["attach", "--cwd", str(repo)], input=input_lines)
     assert result.exit_code == 0, result.output
     assert "Attached" in result.output
@@ -135,7 +135,7 @@ def test_manual_write_lore_yml(lore_env: Path, tmp_path: Path) -> None:
     # wikis sorted: ccat=1, private=2, science=3
     # 2=private wiki, "lore:test"=scope (bare input), Enter=default backend,
     # y=write .lore.yml, y=proceed
-    input_lines = "2\nlore:test\n\ny\ny\n"
+    input_lines = "2\nlore:test\n\ny\nn\ny\n"
     result = runner.invoke(app, ["attach", "--cwd", str(repo)], input=input_lines)
     assert result.exit_code == 0, result.output
     assert (repo / FILENAME).exists()
@@ -146,7 +146,7 @@ def test_abort(lore_env: Path, tmp_path: Path) -> None:
     repo.mkdir()
 
     # 2=private wiki, "test"=scope (bare input), Enter=backend, n=no yml, n=abort
-    input_lines = "2\ntest\n\nn\nn\n"
+    input_lines = "2\ntest\n\nn\nn\nn\n"
     result = runner.invoke(app, ["attach", "--cwd", str(repo)], input=input_lines)
     assert result.exit_code == 0
     assert "Aborted" in result.output
@@ -249,7 +249,7 @@ def test_step_through_overrides_suggestion(
     # s = step through, then: Enter (wiki=ccat default), c=custom scope,
     # "ccat:custom"=custom value, Enter (backend=github default),
     # n (no .lore.yml), y (proceed).
-    input_lines = "s\n\nc\nccat:custom\n\nn\ny\n"
+    input_lines = "s\n\nc\nccat:custom\n\nn\nn\ny\n"
     result = runner.invoke(app, ["attach", "--cwd", str(repo)], input=input_lines)
     assert result.exit_code == 0, result.output
     assert "Proposed config" in result.output
@@ -290,7 +290,7 @@ def test_no_suggestion_when_no_ancestor_attached(
     repo = tmp_path / "lonely"
     repo.mkdir()
     # 1=ccat wiki, custom scope, default backend (now github), no .lore.yml, proceed
-    input_lines = "1\nccat:lonely\n\nn\ny\n"
+    input_lines = "1\nccat:lonely\n\nn\nn\ny\n"
     result = runner.invoke(app, ["attach", "--cwd", str(repo)], input=input_lines)
     assert result.exit_code == 0, result.output
     assert "Suggested from parent attachment" not in result.output

--- a/tests/test_attach_workflow_scaffold.py
+++ b/tests/test_attach_workflow_scaffold.py
@@ -36,9 +36,15 @@ def test_manual_scaffold_flag_creates_docs(lore_env: Path, tmp_path: Path) -> No
     result = runner.invoke(
         app,
         [
-            "attach", "manual",
-            "--wiki", "ccat", "--scope", "ccat:backend",
-            "--cwd", str(repo), "--scaffold-workflow",
+            "attach",
+            "manual",
+            "--wiki",
+            "ccat",
+            "--scope",
+            "ccat:backend",
+            "--cwd",
+            str(repo),
+            "--scaffold-workflow",
         ],
     )
     assert result.exit_code == 0, result.output
@@ -65,9 +71,15 @@ def test_manual_scaffold_flag_records_state(lore_env: Path, tmp_path: Path) -> N
     runner.invoke(
         app,
         [
-            "attach", "manual",
-            "--wiki", "ccat", "--scope", "ccat:backend",
-            "--cwd", str(repo), "--scaffold-workflow",
+            "attach",
+            "manual",
+            "--wiki",
+            "ccat",
+            "--scope",
+            "ccat:backend",
+            "--cwd",
+            str(repo),
+            "--scaffold-workflow",
         ],
     )
     record = WorkflowScaffoldFile(lore_env)
@@ -79,9 +91,15 @@ def test_manual_scaffold_flag_idempotent_on_rerun(lore_env: Path, tmp_path: Path
     repo = tmp_path / "repo"
     repo.mkdir()
     args = [
-        "attach", "manual",
-        "--wiki", "ccat", "--scope", "ccat:backend",
-        "--cwd", str(repo), "--scaffold-workflow",
+        "attach",
+        "manual",
+        "--wiki",
+        "ccat",
+        "--scope",
+        "ccat:backend",
+        "--cwd",
+        str(repo),
+        "--scaffold-workflow",
     ]
     first = runner.invoke(app, args)
     assert first.exit_code == 0, first.output

--- a/tests/test_attach_workflow_scaffold.py
+++ b/tests/test_attach_workflow_scaffold.py
@@ -1,0 +1,92 @@
+"""`lore attach ... --scaffold-workflow` — the workflow-scaffold onboarding
+step folded into the single `lore attach` entry point (sub-issue #171).
+
+No separate `ccat-workflow-init`-style entry point: the scaffold only runs
+as an opt-in step of attach.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lore_cli.__main__ import app
+from lore_core.state.workflow_scaffold import WorkflowScaffoldFile
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def lore_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    lore_root = tmp_path / "lore-root"
+    lore_root.mkdir()
+    (lore_root / ".lore").mkdir()
+    (lore_root / "wiki").mkdir()
+    (lore_root / "wiki" / "ccat").mkdir()
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    monkeypatch.setattr("lore_core.config.get_lore_root", lambda: lore_root)
+    monkeypatch.setattr("lore_core.config.get_wiki_root", lambda: lore_root / "wiki")
+    return lore_root
+
+
+def test_manual_scaffold_flag_creates_docs(lore_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        [
+            "attach", "manual",
+            "--wiki", "ccat", "--scope", "ccat:backend",
+            "--cwd", str(repo), "--scaffold-workflow",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (repo / "docs" / "prd" / "index.md").exists()
+    assert (repo / "docs" / "adr" / "index.md").exists()
+    assert (repo / "AGENTS.md").exists()
+    assert (repo / "CLAUDE.md").read_text().strip() == "@AGENTS.md"
+
+
+def test_manual_without_flag_does_not_scaffold(lore_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        ["attach", "manual", "--wiki", "ccat", "--scope", "ccat:backend", "--cwd", str(repo)],
+    )
+    assert result.exit_code == 0, result.output
+    assert not (repo / "docs" / "prd").exists()
+
+
+def test_manual_scaffold_flag_records_state(lore_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runner.invoke(
+        app,
+        [
+            "attach", "manual",
+            "--wiki", "ccat", "--scope", "ccat:backend",
+            "--cwd", str(repo), "--scaffold-workflow",
+        ],
+    )
+    record = WorkflowScaffoldFile(lore_env)
+    record.load()
+    assert record.was_scaffolded(repo)
+
+
+def test_manual_scaffold_flag_idempotent_on_rerun(lore_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    args = [
+        "attach", "manual",
+        "--wiki", "ccat", "--scope", "ccat:backend",
+        "--cwd", str(repo), "--scaffold-workflow",
+    ]
+    first = runner.invoke(app, args)
+    assert first.exit_code == 0, first.output
+    before = (repo / "docs" / "prd" / "index.md").read_text()
+    second = runner.invoke(app, args)
+    assert second.exit_code == 0, second.output
+    after = (repo / "docs" / "prd" / "index.md").read_text()
+    assert before == after

--- a/tests/test_state_workflow_scaffold.py
+++ b/tests/test_state_workflow_scaffold.py
@@ -1,0 +1,50 @@
+"""Tests for `lore_core.state.workflow_scaffold` — scaffold-run record.
+
+Records only that a repo was scaffolded and when; the scaffold's own
+idempotency comes from the filesystem checks in `lore_workflow.scaffold`
+(file existence / shim sentinel), not from this record — this is an
+observability record, not the source of truth.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_core.state.workflow_scaffold import WorkflowScaffoldFile
+
+
+def test_record_then_reload_roundtrips(tmp_path: Path) -> None:
+    lore_root = tmp_path / "vault"
+    repo = tmp_path / "repo"
+
+    scaffolded = WorkflowScaffoldFile(lore_root)
+    scaffolded.load()
+    scaffolded.record(repo)
+    scaffolded.save()
+
+    reloaded = WorkflowScaffoldFile(lore_root)
+    reloaded.load()
+    assert reloaded.was_scaffolded(repo)
+
+
+def test_unrecorded_repo_returns_false(tmp_path: Path) -> None:
+    lore_root = tmp_path / "vault"
+    scaffolded = WorkflowScaffoldFile(lore_root)
+    scaffolded.load()
+    assert scaffolded.was_scaffolded(tmp_path / "never-scaffolded") is False
+
+
+def test_record_is_idempotent(tmp_path: Path) -> None:
+    """Recording the same repo twice keeps a single entry (last write wins)."""
+    lore_root = tmp_path / "vault"
+    repo = tmp_path / "repo"
+
+    scaffolded = WorkflowScaffoldFile(lore_root)
+    scaffolded.load()
+    scaffolded.record(repo)
+    scaffolded.record(repo)
+    scaffolded.save()
+
+    reloaded = WorkflowScaffoldFile(lore_root)
+    reloaded.load()
+    assert reloaded.all_paths() == [repo.resolve()]

--- a/tests/test_workflow_scaffold.py
+++ b/tests/test_workflow_scaffold.py
@@ -91,11 +91,7 @@ def test_coexistence_agents_md_not_duplicated_when_shim_present(tmp_path: Path) 
 def test_idempotent_full_rerun_is_noop(tmp_path: Path) -> None:
     """Running scaffold twice on a fresh repo must not change any output byte."""
     mod.scaffold(tmp_path)
-    snapshot = {
-        p: p.read_text(encoding="utf-8")
-        for p in tmp_path.rglob("*")
-        if p.is_file()
-    }
+    snapshot = {p: p.read_text(encoding="utf-8") for p in tmp_path.rglob("*") if p.is_file()}
     mod.scaffold(tmp_path)
     for p, before in snapshot.items():
         assert p.read_text(encoding="utf-8") == before, f"{p} changed on re-run"

--- a/tests/test_workflow_scaffold.py
+++ b/tests/test_workflow_scaffold.py
@@ -1,0 +1,106 @@
+"""Tests for `lore_workflow.scaffold` — repo workflow scaffolding.
+
+Ported from ccat-agent-workflow's `tests/test_workflow_init.py`. Only the
+docs/prd, docs/adr, and AGENTS.md/CLAUDE.md shim mechanics are ported; the
+settings.json permissions/hooks scaffolding is a sibling slice (#170) and is
+out of scope here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_workflow import scaffold as mod
+
+
+def test_empty_repo_creates_agents_md(tmp_path: Path) -> None:
+    mod.scaffold(tmp_path)
+    assert (tmp_path / "AGENTS.md").exists()
+
+
+def test_empty_repo_creates_claude_md_shim(tmp_path: Path) -> None:
+    mod.scaffold(tmp_path)
+    claude_md = tmp_path / "CLAUDE.md"
+    assert claude_md.exists()
+    assert claude_md.read_text(encoding="utf-8").strip() == "@AGENTS.md"
+
+
+def test_existing_claude_md_migrated_to_agents_md(tmp_path: Path) -> None:
+    original = "# My Guide\n\nSome content.\n"
+    (tmp_path / "CLAUDE.md").write_text(original, encoding="utf-8")
+    mod.scaffold(tmp_path)
+    agents = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert original.strip() == agents.strip()
+    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8").strip() == "@AGENTS.md"
+
+
+def test_empty_repo_creates_docs_prd_index(tmp_path: Path) -> None:
+    mod.scaffold(tmp_path)
+    assert (tmp_path / "docs" / "prd" / "index.md").exists()
+
+
+def test_empty_repo_creates_docs_adr_index(tmp_path: Path) -> None:
+    mod.scaffold(tmp_path)
+    assert (tmp_path / "docs" / "adr" / "index.md").exists()
+
+
+def test_docs_adr_index_has_toctree(tmp_path: Path) -> None:
+    mod.scaffold(tmp_path)
+    text = (tmp_path / "docs" / "adr" / "index.md").read_text(encoding="utf-8")
+    assert "```{toctree}" in text
+    assert "{{" not in text
+
+
+def test_fresh_repo_creates_docs_index_wired(tmp_path: Path) -> None:
+    mod.scaffold(tmp_path)
+    text = (tmp_path / "docs" / "index.md").read_text(encoding="utf-8")
+    assert "prd/index" in text
+    assert "adr/index" in text
+
+
+def test_docs_index_gains_missing_entry_when_present(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    docs_index = docs_dir / "index.md"
+    docs_index.write_text("# Docs\n\n```{toctree}\nadr/index\n```\n", encoding="utf-8")
+    mod.scaffold(tmp_path)
+    text = docs_index.read_text(encoding="utf-8")
+    assert "prd/index" in text
+    assert text.count("adr/index") == 1
+
+
+def test_existing_adr_index_not_overwritten(tmp_path: Path) -> None:
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    existing = "# ADR Index\n\n```{toctree}\n0001-existing\n```\n"
+    (adr_dir / "index.md").write_text(existing, encoding="utf-8")
+    mod.scaffold(tmp_path)
+    assert (adr_dir / "index.md").read_text(encoding="utf-8") == existing
+
+
+def test_coexistence_agents_md_not_duplicated_when_shim_present(tmp_path: Path) -> None:
+    """If CLAUDE.md is already the shim, re-running must not re-append AGENTS.md."""
+    (tmp_path / "CLAUDE.md").write_text("@AGENTS.md\n", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Guide\n", encoding="utf-8")
+    mod.scaffold(tmp_path)
+    mod.scaffold(tmp_path)
+    agents = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert agents.count("# Guide") == 1
+
+
+def test_idempotent_full_rerun_is_noop(tmp_path: Path) -> None:
+    """Running scaffold twice on a fresh repo must not change any output byte."""
+    mod.scaffold(tmp_path)
+    snapshot = {
+        p: p.read_text(encoding="utf-8")
+        for p in tmp_path.rglob("*")
+        if p.is_file()
+    }
+    mod.scaffold(tmp_path)
+    for p, before in snapshot.items():
+        assert p.read_text(encoding="utf-8") == before, f"{p} changed on re-run"
+
+
+def test_scaffold_returns_whether_anything_changed(tmp_path: Path) -> None:
+    assert mod.scaffold(tmp_path) is True
+    assert mod.scaffold(tmp_path) is False


### PR DESCRIPTION
Closes #171

## Summary
Merges ccat-agent-workflow's repo-onboarding scaffold into lore's existing
`lore attach` command as an opt-in `--scaffold-workflow` step. No separate
`ccat-workflow-init` entry point survives — one onboarding command per repo.

- `lore_workflow.scaffold.scaffold()`: idempotently migrates `CLAUDE.md` ->
  `AGENTS.md` (+ one-line `@AGENTS.md` shim), creates `docs/prd/index.md` and
  `docs/adr/index.md` toctree stubs, and wires both into `docs/index.md`.
  Ported from `ccat-agent-workflow/scripts/ccat_workflow_init.py`.
  `.claude/settings.json` (permissions allowlist, code-map/spawn-model hooks)
  is deliberately untouched — that's #170, a sibling slice.
- `lore_workflow.prd_docs.wire_toctree()` gained an optional `stub` param so
  the ADR/root-index scaffolding reuses the same toctree-wiring logic as the
  existing PRD wiring, instead of a second implementation.
- `lore_core.state.workflow_scaffold.WorkflowScaffoldFile`: sidecar recording
  which repos were scaffolded and when — an observability record only; the
  scaffold's own idempotency stays filesystem-derived (file existence, shim
  sentinel), never state-file-derived.
- `attach_cmd`: `--scaffold-workflow` flag on `attach accept` / `attach
  manual`, plus a step-through wizard prompt. The one-click "accept parent
  defaults" fast path stays flag-only (no extra prompt) to keep it fast.

## Test plan
Red -> green, ported from `ccat-agent-workflow/tests/test_workflow_init.py`
(scaffold behavior only; the settings.json/skill-file assertions are out of
scope here).

- `tests/test_workflow_scaffold.py` — scaffold() idempotency: fresh-repo
  creation, CLAUDE.md migration + shim, adr/prd/docs index wiring,
  full re-run is a byte-for-byte no-op.
- `tests/test_state_workflow_scaffold.py` — WorkflowScaffoldFile roundtrip.
- `tests/test_attach_workflow_scaffold.py` — `lore attach manual
  --scaffold-workflow` end to end via CliRunner: creates docs, records
  state, idempotent on re-run; omitting the flag scaffolds nothing.
- `tests/test_attach_interactive.py` — existing wizard tests updated for the
  new scaffold prompt's extra input line.

Evidence: before `lore_workflow/scaffold.py` existed, `test_workflow_scaffold.py`
failed collection (`ModuleNotFoundError: No module named 'lore_workflow.scaffold'`,
red). After implementing, `pytest tests/test_workflow_scaffold.py -q` → 12 passed
(green). Same red/green cycle for `test_state_workflow_scaffold.py` (3 tests) and
the attach_cmd wiring (4 tests). Full suite: `pytest -q` → 2523 passed, 0 failed.
`ruff check` on touched files: clean (pre-existing baseline violations in
`attach_cmd.py`, untouched by these diffs, left as-is).