### PR TITLE
feat(lore-workflow): port 13 workflow skills + rewire tier/codemap/script refs

### DIFF
--- a/lore-workflow/.claude-plugin/plugin.json
+++ b/lore-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lore-workflow",
-  "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams. Depends on lore; ships no skills yet.",
+  "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams. Depends on lore.",
   "version": "0.1.0",
   "author": {
     "name": "Christof Buchbender"

--- a/lore-workflow/README.md
+++ b/lore-workflow/README.md
@@ -1,16 +1,33 @@
 # lore-workflow
 
 Companion plugin to [`lore`](../README.md): deterministic epic/PRD/TDD
-workflow skills (orient, grill, to-epic, orchestrate-epic, tdd, debug,
-document-epic, implement-issue, seed-epic, domain-modeling).
-
-Empty for now — skills migrate in from `ccatobs/ccat-agent-workflow` in a
-later slice (see PRD 0003).
+workflow skills, ported from `ccatobs/ccat-agent-workflow` (see PRD 0003).
 
 **Dependency direction: `lore-workflow` depends on `lore`; `lore` never
 depends on `lore-workflow`.** Workflow skills call `lore`'s CLI/MCP surface
-(code map, tier resolver, workflow subcommands); nothing in `lore` core
-imports or requires this plugin. This keeps `lore` installable standalone
-and lets `lore-workflow` stay opt-in.
+(`lore codemap` / `lore_codemap`, `lore tier resolve`, `lore workflow
+validate-roadmap` / `create-prd`, `lore attach --scaffold-workflow`); nothing
+in `lore` core imports or requires this plugin. This keeps `lore` installable
+standalone and lets `lore-workflow` stay opt-in.
 
-Versioned independently from `lore` — see `.claude-plugin/plugin.json`.
+Versioned independently from `lore` — see `.claude-plugin/plugin.json`. Tier
+delegation conventions shared across skills live in
+[TIER-DELEGATION.md](./TIER-DELEGATION.md).
+
+## Bundled skills
+
+| Skill | What it's for |
+|-------|----------------|
+| `ccat-workflow-init` | Onboard a repo — a thin pointer at `lore attach --scaffold-workflow`. |
+| `orient` | First step of a task — homework, then reflect understanding back before planning. |
+| `grilling` | Interview the user relentlessly to stress-test a plan or design. |
+| `grill-me` | Run a `/lore-workflow:grilling` session. |
+| `grill-with-docs` | Run a `/lore-workflow:grilling` session that also drives `domain-modeling`. |
+| `domain-modeling` | Build and sharpen a project's domain model (CONTEXT.md, ADRs). |
+| `to-epic` | Turn a plan/PRD into a PRD file plus an epic tracker issue with a roadmap DAG. |
+| `orchestrate-epic` | Supervise parallel TDD implementation of an epic — plan, dispatch, crosscheck, land. |
+| `implement-issue` | Fast path for one well-understood GitHub issue, outside the epic chain. |
+| `tdd` | Test-driven red-green-refactor loop. |
+| `debug` | Systematic root-cause debugging with a hard circuit breaker. |
+| `document-epic` | After an epic merges, update Diátaxis docs to match the implemented state. |
+| `seed-epic` | End a session by turning follow-up context into an epic-seed tracker issue. |

--- a/lore-workflow/TIER-DELEGATION.md
+++ b/lore-workflow/TIER-DELEGATION.md
@@ -1,0 +1,28 @@
+# Tier delegation
+
+Every subagent spawn in this plugin names a **semantic tier**
+(`frontier` / `strong` / `mid` / `cheap`), never a concrete model. Resolve
+the tier to a concrete model at spawn time:
+
+```
+lore tier resolve <tier>
+lore tier resolve <tier> --host cursor
+```
+
+and pass the *result* as the spawn's model parameter. See
+`docs/model-tiers.md` in the `lore` package for the full table, the
+ordinal/collapse rule, the fallback behavior, and the cheap-tier
+reservation (bulk-mechanical only).
+
+**No-implicit-inherit.** A spawn with no explicit model resolution
+silently inherits the orchestrating session's model — this both violates
+the tier contract and burns frontier-tier tokens on work a cheaper tier
+would do. Every delegation point in this plugin names its tier and
+resolves it explicitly; none relies on inheritance.
+
+**Frontier main-session note.** Some steps (`grilling`, `seed-epic`) run
+**in the main session**, at frontier-tier reasoning, and are never
+delegated to a subagent at all — there is no spawn to resolve. That is a
+different rule from the one above and the two are not interchangeable:
+delegation-point skills resolve a tier for a spawn; main-session skills
+simply state they don't spawn.

--- a/lore-workflow/skills/ccat-workflow-init/SKILL.md
+++ b/lore-workflow/skills/ccat-workflow-init/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: lore-workflow:ccat-workflow-init
+description: Onboard a target repository into the ccat-agent-workflow conventions — migrates CLAUDE.md into AGENTS.md, scaffolds docs/prd/, docs/adr/, the permissions allowlist, and the code-map and spawn-model hooks. Idempotent. Use when setting up a new repo to adopt the CCAT agent workflow.
+argument-hint: [target-repo-path]
+disable-model-invocation: true
+---
+
+# /lore-workflow:ccat-workflow-init
+
+Onboard a target repository into the **ccat-agent-workflow** conventions.
+
+## What it does
+
+1. **Migrate `CLAUDE.md` → `AGENTS.md`**: moves existing agent instructions
+   into `AGENTS.md` (the canonical per-repo guide), then replaces `CLAUDE.md`
+   with a one-line `@AGENTS.md` import shim so Claude Code still auto-loads it.
+
+2. **Create `docs/prd/index.md`** — MyST toctree stub for Product Requirements
+   Documents, if the file does not already exist.
+
+3. **Create `docs/adr/index.md`** — MyST toctree stub for Architecture Decision
+   Records, if the file does not already exist.
+
+4. **Wire `prd/index` and `adr/index` into `docs/index.md`**, creating it with
+   a minimal root toctree if it does not exist (idempotent either way).
+
+5. **Scaffold the autonomy permissions allowlist** — merges the Bash/`gh`
+   rules the autonomous `orchestrate-epic` loop needs into
+   `.claude/settings.json`'s `permissions.allow`, so `git worktree`/`push`/
+   `fetch`/`merge`/`rebase`/`branch`/`checkout` and `gh pr create`/`merge`/
+   `view`/`checks`/`comment`, `gh issue view`/`comment`/`edit`/`close`, and
+   `gh api` never trigger a harness approval prompt mid-run. `.claude/
+   settings.json` (not `settings.local.json`) is used deliberately: this is a
+   repo-wide, checked-in contract, not a per-developer preference. Merging is
+   idempotent — existing keys and existing allow entries (including unrelated,
+   user-added rules) are preserved verbatim; only missing required rules are
+   appended.
+
+6. **Append the `## Epic merge policy` section to `AGENTS.md`** — documents
+   the `epic-merge-policy: confirm` marker: absent (the default), the final
+   epic→target merge is fully autonomous like every other merge in the loop;
+   present, `orchestrate-epic` asks for one human confirmation before that
+   final merge only. Idempotent — if the heading is already present (from a
+   prior run, or because the repo author hand-authored/customized the
+   section, e.g. already opted into `confirm`), the file is left untouched.
+
+7. **Scaffold the code-map `SessionStart` hook** — wires a background hook
+   into `.claude/settings.json` that runs the plugin-bundled code-map generator
+   (`scripts/code_map.py`) at every session start. It keeps the committed
+   `CODEMAP.md` fresh at zero token cost (no model call): silent on the no-op
+   fast path, non-interactive, and concurrency-safe (atomic write). Merging is
+   idempotent — a re-run leaves exactly one wiring entry and preserves any
+   pre-existing hooks, exactly like the permissions allowlist.
+
+8. **Scaffold the spawn-model `PreToolUse` hook** — wires a gate
+   (`scripts/require_spawn_model.py`) into `.claude/settings.json` that blocks
+   any subagent spawn whose call carries no explicit model, feeding the
+   tier-resolution instruction back so the session retries with the model
+   parameter set. This is the mechanical enforcement of the `MODEL-TIERS.md`
+   rule that no delegation ever inherits the session model implicitly —
+   without it the rule is prose only, and exploration subagents silently run
+   on the session's frontier-tier model. Merging is idempotent, same contract
+   as the code-map hook.
+
+All steps are additive and idempotent: re-running never overwrites an existing
+`index.md`, existing ADR/PRD files, an already-correct `AGENTS.md`,
+already-present permission rules, or already-wired hooks.
+
+## Usage
+
+```
+/ccat-agent-workflow:ccat-workflow-init [target-repo-path]
+```
+
+`target-repo-path` defaults to the current working directory.
+
+## Instructions
+
+Run the scaffold script bundled with this plugin:
+
+```bash
+python "${CLAUDE_SKILL_DIR}/../../scripts/ccat_workflow_init.py" $ARGUMENTS
+```
+
+If `$ARGUMENTS` is empty, the script defaults to the current directory.
+
+After the script exits, report:
+- Which files were created (AGENTS.md, CLAUDE.md shim, docs/prd/index.md,
+  docs/adr/index.md, .claude/settings.json).
+- Which files were skipped because they already existed.
+- Whether the Epic merge policy section was newly added to AGENTS.md or was
+  already present.
+- Whether the code-map SessionStart hook was newly wired into
+  .claude/settings.json or was already present.
+- Whether the spawn-model PreToolUse hook was newly wired into
+  .claude/settings.json or was already present.
+- Any warnings if the target directory is not a git repository.

--- a/lore-workflow/skills/ccat-workflow-init/SKILL.md
+++ b/lore-workflow/skills/ccat-workflow-init/SKILL.md
@@ -1,97 +1,57 @@
 ---
 name: lore-workflow:ccat-workflow-init
-description: Onboard a target repository into the ccat-agent-workflow conventions — migrates CLAUDE.md into AGENTS.md, scaffolds docs/prd/, docs/adr/, the permissions allowlist, and the code-map and spawn-model hooks. Idempotent. Use when setting up a new repo to adopt the CCAT agent workflow.
+description: Onboard a target repository into the workflow conventions — docs/prd/, docs/adr/, and the AGENTS.md shim. Idempotent, a thin pointer at `lore attach --scaffold-workflow`. Use when setting up a repo to adopt the workflow skills.
 argument-hint: [target-repo-path]
 disable-model-invocation: true
 ---
 
 # /lore-workflow:ccat-workflow-init
 
-Onboard a target repository into the **ccat-agent-workflow** conventions.
+Onboard a target repository into the workflow conventions this plugin's skills
+assume: `docs/prd/`, `docs/adr/`, and an `AGENTS.md` (with a `CLAUDE.md` shim).
 
-## What it does
+## One onboarding command, not a separate flow
 
-1. **Migrate `CLAUDE.md` → `AGENTS.md`**: moves existing agent instructions
+This used to be a standalone script bundled with the workflow plugin. It no
+longer is — `lore` (the plugin this one depends on) owns repo onboarding, and
+workflow scaffolding is one flag on that single entry point:
+
+```
+lore attach --scaffold-workflow [target-repo-path]
+```
+
+Idempotent, same as before: re-running never overwrites an existing
+`index.md`, existing ADR/PRD files, or an already-correct `AGENTS.md`. See
+`lore attach --help` for the full onboarding flow (wiki attachment, scope,
+consent) that this flag rides alongside.
+
+## What it scaffolds
+
+1. **Migrate `CLAUDE.md` → `AGENTS.md`** — moves existing agent instructions
    into `AGENTS.md` (the canonical per-repo guide), then replaces `CLAUDE.md`
    with a one-line `@AGENTS.md` import shim so Claude Code still auto-loads it.
+2. **`docs/prd/index.md`** — MyST toctree stub for Product Requirements
+   Documents, if it does not already exist.
+3. **`docs/adr/index.md`** — MyST toctree stub for Architecture Decision
+   Records, if it does not already exist.
+4. **Wires both into `docs/index.md`**, creating it with a minimal root
+   toctree if it does not exist.
 
-2. **Create `docs/prd/index.md`** — MyST toctree stub for Product Requirements
-   Documents, if the file does not already exist.
+## What moved elsewhere
 
-3. **Create `docs/adr/index.md`** — MyST toctree stub for Architecture Decision
-   Records, if the file does not already exist.
-
-4. **Wire `prd/index` and `adr/index` into `docs/index.md`**, creating it with
-   a minimal root toctree if it does not exist (idempotent either way).
-
-5. **Scaffold the autonomy permissions allowlist** — merges the Bash/`gh`
-   rules the autonomous `orchestrate-epic` loop needs into
-   `.claude/settings.json`'s `permissions.allow`, so `git worktree`/`push`/
-   `fetch`/`merge`/`rebase`/`branch`/`checkout` and `gh pr create`/`merge`/
-   `view`/`checks`/`comment`, `gh issue view`/`comment`/`edit`/`close`, and
-   `gh api` never trigger a harness approval prompt mid-run. `.claude/
-   settings.json` (not `settings.local.json`) is used deliberately: this is a
-   repo-wide, checked-in contract, not a per-developer preference. Merging is
-   idempotent — existing keys and existing allow entries (including unrelated,
-   user-added rules) are preserved verbatim; only missing required rules are
-   appended.
-
-6. **Append the `## Epic merge policy` section to `AGENTS.md`** — documents
-   the `epic-merge-policy: confirm` marker: absent (the default), the final
-   epic→target merge is fully autonomous like every other merge in the loop;
-   present, `orchestrate-epic` asks for one human confirmation before that
-   final merge only. Idempotent — if the heading is already present (from a
-   prior run, or because the repo author hand-authored/customized the
-   section, e.g. already opted into `confirm`), the file is left untouched.
-
-7. **Scaffold the code-map `SessionStart` hook** — wires a background hook
-   into `.claude/settings.json` that runs the plugin-bundled code-map generator
-   (`scripts/code_map.py`) at every session start. It keeps the committed
-   `CODEMAP.md` fresh at zero token cost (no model call): silent on the no-op
-   fast path, non-interactive, and concurrency-safe (atomic write). Merging is
-   idempotent — a re-run leaves exactly one wiring entry and preserves any
-   pre-existing hooks, exactly like the permissions allowlist.
-
-8. **Scaffold the spawn-model `PreToolUse` hook** — wires a gate
-   (`scripts/require_spawn_model.py`) into `.claude/settings.json` that blocks
-   any subagent spawn whose call carries no explicit model, feeding the
-   tier-resolution instruction back so the session retries with the model
-   parameter set. This is the mechanical enforcement of the `MODEL-TIERS.md`
-   rule that no delegation ever inherits the session model implicitly —
-   without it the rule is prose only, and exploration subagents silently run
-   on the session's frontier-tier model. Merging is idempotent, same contract
-   as the code-map hook.
-
-All steps are additive and idempotent: re-running never overwrites an existing
-`index.md`, existing ADR/PRD files, an already-correct `AGENTS.md`,
-already-present permission rules, or already-wired hooks.
+The permissions allowlist, the code-map `SessionStart` hook, and the
+spawn-model `PreToolUse` hook (the mechanical enforcement of the
+no-implicit-inherit tier rule — see
+[TIER-DELEGATION.md](../../TIER-DELEGATION.md)) are no longer this skill's
+concern: `lore`'s own installer wires them for every attached repo, once, so
+there is nothing workflow-specific left to scaffold here.
 
 ## Usage
 
 ```
-/ccat-agent-workflow:ccat-workflow-init [target-repo-path]
+/lore-workflow:ccat-workflow-init [target-repo-path]
 ```
 
-`target-repo-path` defaults to the current working directory.
-
-## Instructions
-
-Run the scaffold script bundled with this plugin:
-
-```bash
-python "${CLAUDE_SKILL_DIR}/../../scripts/ccat_workflow_init.py" $ARGUMENTS
-```
-
-If `$ARGUMENTS` is empty, the script defaults to the current directory.
-
-After the script exits, report:
-- Which files were created (AGENTS.md, CLAUDE.md shim, docs/prd/index.md,
-  docs/adr/index.md, .claude/settings.json).
-- Which files were skipped because they already existed.
-- Whether the Epic merge policy section was newly added to AGENTS.md or was
-  already present.
-- Whether the code-map SessionStart hook was newly wired into
-  .claude/settings.json or was already present.
-- Whether the spawn-model PreToolUse hook was newly wired into
-  .claude/settings.json or was already present.
-- Any warnings if the target directory is not a git repository.
+Run `lore attach --scaffold-workflow` (targeting `target-repo-path`, or the
+current directory if omitted) and report which files were created versus
+already present, and any warning if the target is not a git repository.

--- a/lore-workflow/skills/debug/SKILL.md
+++ b/lore-workflow/skills/debug/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: lore-workflow:debug
+description: Systematic root-cause debugging with a hard circuit breaker. Use when a bug resists fixing, a test keeps failing, a teammate is stuck after repeated fix attempts, or you catch yourself guessing at fixes instead of finding the cause.
+---
+
+# Debug
+
+The building discipline is `/lore-workflow:tdd`. This is its diagnostic counterpart: a phased
+process for finding the **root cause** of a bug instead of guessing at fixes,
+plus a hard circuit breaker that stops a doomed fix loop before it wastes a
+whole session.
+
+The failure mode this skill exists to prevent: patching the **symptom** you can
+see (the red test, the stack trace, the wrong number) without ever locating the
+**fault** that produced it — so the bug moves, reappears, or splits into two.
+
+## Phased process
+
+Work the phases in order. Do not skip ahead to a fix; a fix you can't explain is
+a guess, and guesses are what the circuit breaker below exists to catch.
+
+### 1. Reproduce
+
+Get a reliable, minimal reproduction first. A bug you cannot trigger on demand,
+you cannot prove you fixed — you can only convince yourself. Shrink it: the
+smallest input, the fewest steps, the tightest test that still shows the fault.
+A minimal reproduction is often already half the diagnosis.
+
+### 2. Observe
+
+Read the actual evidence before theorizing — the real error message, the full
+stack trace, the failing assertion, the logs, the diff since it last worked. Do
+not skim the first line and pattern-match. Separate the **symptom** (what you
+observe) from the candidate **fault** (what is actually wrong); they are rarely
+the same line.
+
+### 3. Hypothesize
+
+Form ONE falsifiable hypothesis about the root cause, and state what must be true
+if it holds. "The timestamp is UTC but compared as local" is a hypothesis you can
+test; "something's wrong with the dates" is not. One hypothesis at a time — a
+scattershot of simultaneous guesses is how the attempt counter below runs out.
+
+### 4. Isolate
+
+Test the hypothesis with the cheapest decisive experiment. Bisect the change
+history, binary-search the input, add one targeted log line or assertion, or
+disable half the pipeline — whatever localizes the fault fastest. Each experiment
+must be able to come back *no*; an experiment that can only confirm your
+hypothesis proves nothing. Narrow until the fault sits on a known line.
+
+### 5. Fix the root cause
+
+Fix the fault the isolation step localized, not the symptom. If a change makes
+the symptom disappear but you cannot say *why* it was failing, you have written a
+patch, not a fix — the bug is still there, now hidden. Prefer the fix that makes
+the whole class of bug impossible over the one that silences this instance.
+
+### 6. Verify
+
+Confirm the symptom is gone against the reproduction from phase 1, then add a
+regression test that fails without the fix (hand this to `/lore-workflow:tdd`). Finally check
+you did not just move the bug: re-run the surrounding suite and reason about what
+else touched the fault.
+
+## Circuit breaker
+
+Count your fix attempts on a single bug. **After 3 failed fix attempts, STOP.**
+Do not attempt a 4th.
+
+Three failures on the same fault is not bad luck — it is evidence that your model
+of the system is wrong. The bug is not where you keep looking, or the design
+makes the correct fix unreachable from where you are standing. A 4th attempt from
+the same mental model is very likely to fail the same way, and each blind retry
+digs the hole deeper.
+
+When the breaker trips, change altitude instead of trying again: **question the
+architecture, not the line.**
+
+- State, in writing, what you *assumed* was true that the three failures
+  contradict. The wrong assumption is the actual bug.
+- Widen the frame: is the fault in a different module, a shared dependency, the
+  data, the environment, or the interface contract rather than the code you keep
+  editing?
+- Ask whether the architecture itself is forcing the bug — a leaky abstraction, a
+  missing seam, two components that should not be coupled. The right fix may be a
+  design change, not a code change.
+- If you are a teammate under a supervisor, this is the point to escalate with
+  what you have ruled out — not to spend the session on a 4th, 5th, 6th attempt.
+
+Resetting the counter is legitimate only when you have genuinely new information
+(a new reproduction, a disproven assumption, a different hypothesis) — not when
+you simply want to keep trying the same thing.

--- a/lore-workflow/skills/document-epic/SKILL.md
+++ b/lore-workflow/skills/document-epic/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: lore-workflow:document-epic
+description: After an epic merges, update a repo's Diátaxis documentation (tutorials, how-to,
+  reference, explanation) to reflect the implemented state, then open a docs PR that
+  auto-merges on green. NEVER touches docs/prd or docs/adr. Use after an epic lands and its
+  user-facing docs need to catch up. Standalone and cross-repo aware.
+---
+
+# Document Epic
+
+You are the **documenter**: a merged epic changed what the software does, and the
+user-facing docs must catch up. You update the **Diátaxis four** to match the implemented
+state, then open a docs PR and let it auto-merge on green — a human reviews post-hoc. You do
+not change behavior; you describe it.
+
+**Input:** a merged epic (issue number or URL), possibly spanning repos.
+**Mode:** autonomous — run the loop without asking. Stop only to report completion or to
+escalate a hard blocker (see Stop conditions).
+
+## Hard rule — never edit the canonical record
+
+**NEVER modify anything under `docs/prd/` or `docs/adr/`.** PRDs and ADRs are the canonical,
+human-owned record of intent and decisions. This skill *reads* them — the PRD for what the
+epic set out to do, ADRs for the "why" an *explanation* doc may cite — but it must never
+write, rename, or delete them. If your edit plan contains a `docs/prd/**` or `docs/adr/**`
+path, that is a bug: drop it. The classification heuristic (below) enforces this by returning
+no quadrant for those paths; trust it and double-check the final diff yourself.
+
+## The Diátaxis four (and what each means here)
+
+Every documentation edit you make belongs to exactly one quadrant
+(https://diataxis.fr/). Classify before you write:
+
+- **tutorial** — learning-oriented. A guided, first-time, start-to-finish walkthrough. New
+  user-facing capability that someone would meet for the first time → extend or add a
+  tutorial step.
+- **how-to** — task-oriented. A recipe to accomplish one specific goal ("how do I export a
+  widget from the terminal"). New CLI command, new task someone performs → a how-to.
+- **reference** — information-oriented, and for us this means **docstrings + the
+  autosummary/toctree wiring that surfaces them — NOT hand-written prose.** A new or changed
+  *public* API → make sure the symbol has a complete docstring (Parameters / Returns /
+  Raises) and is wired into the Sphinx `autosummary`/`toctree` so it appears in the rendered
+  API reference. Do not paraphrase the API in prose; fix the docstring and the wiring.
+- **explanation** — understanding-oriented. Background, trade-offs, the "why". A design
+  choice worth understanding (it may cite an ADR) → an explanation doc.
+
+## Loop
+
+**Map the deltas.** Read the merged epic with `gh ... --json` (see `CONVENTIONS.md`).
+From it gather three sources of truth: the **merged PRD** (intent), the **sub-issue PRs**
+(per-feature acceptance notes that reveal which behaviors are user-facing), and the
+**cumulative epic diff** (every path the epic touched, with its change kind). Build one list
+of changed paths, each tagged with its change kind and — for source files — whether it
+touches the **public API** (a non-underscore symbol exported from the package). This list is
+the input to classification.
+
+**Classify into quadrants.** Run each changed path through the deterministic heuristic in
+`diataxis.py` (bundled next to this skill): `classify(path, public_api=...)` returns the
+quadrant (`tutorial` / `how-to` / `reference` / `explanation`) or `None` for changes that
+warrant no docs edit, and `is_excluded(path)` flags the `docs/prd`/`docs/adr` paths you must
+skip. Use `classify_changeset(changes)` to turn the whole diff into an edit plan in one call;
+its output never assigns a quadrant to an excluded path. Adopt the target repo's actual docs
+layout — the heuristic recognises the canonical directory names plus common synonyms
+(`guide`/`guides` → how-to, `api` → reference, `concepts`/`discussion` → explanation). The
+heuristic decides *which quadrant*; you still write the *content*, judging from the PRD and
+sub-issue notes what each doc should say.
+
+**Write the edits.** For each planned edit, update the doc in its quadrant to match the
+implemented state. For **reference**, edit docstrings on the changed public symbols and the
+autosummary/toctree entries — never substitute prose for a docstring. Keep edits scoped to
+what the epic changed; do not rewrite untouched docs. Re-confirm no `docs/prd`/`docs/adr`
+path is in your diff.
+
+**Open the docs PR.** Branch off the repo's integration branch, commit the doc edits, and
+open a PR that summarizes the documented deltas and links the epic and its sub-issues. **Auto-
+merge it on green CI** — documentation lands without blocking on human review; a human reviews
+post-hoc. Never auto-merge on red.
+
+**Cross-repo.** An epic may span repos. Repeat the loop per affected repo, each against its
+own docs layout and its own integration branch. One docs PR per repo.
+
+## Dry-run
+
+When asked to dry-run (or before writing anything), produce the edit plan only: run the
+changeset through `classify_changeset` and print, per path, the quadrant (or "skip" /
+"excluded: prd/adr"). The fixture under `tests/fixtures/merged-epic/` is a worked example —
+its `changeset.json` carries the expected quadrant for each path.
+
+## Stop conditions (escalate, don't guess)
+
+A change whose user-facing meaning you cannot determine from the PRD + sub-issue notes; an
+ambiguous docs layout with no recognisable quadrant directories; a doc edit that would
+require a behavior change to be correct; CI red on the docs PR that is not a docs problem; or
+anything that would force a `docs/prd`/`docs/adr` edit. Otherwise keep going. Report the edit
+plan (path → quadrant) and the PR on completion.

--- a/lore-workflow/skills/document-epic/SKILL.md
+++ b/lore-workflow/skills/document-epic/SKILL.md
@@ -46,7 +46,8 @@ Every documentation edit you make belongs to exactly one quadrant
 
 ## Loop
 
-**Map the deltas.** Read the merged epic with `gh ... --json` (see `CONVENTIONS.md`).
+**Map the deltas.** Read the merged epic with `gh ... --json` (see the repo's own
+conventions doc, if any).
 From it gather three sources of truth: the **merged PRD** (intent), the **sub-issue PRs**
 (per-feature acceptance notes that reveal which behaviors are user-facing), and the
 **cumulative epic diff** (every path the epic touched, with its change kind). Build one list
@@ -55,7 +56,8 @@ touches the **public API** (a non-underscore symbol exported from the package). 
 the input to classification.
 
 **Classify into quadrants.** Run each changed path through the deterministic heuristic in
-`diataxis.py` (bundled next to this skill): `classify(path, public_api=...)` returns the
+the `lore_workflow.diataxis` module (part of the `lore` package this plugin depends on):
+`classify(path, public_api=...)` returns the
 quadrant (`tutorial` / `how-to` / `reference` / `explanation`) or `None` for changes that
 warrant no docs edit, and `is_excluded(path)` flags the `docs/prd`/`docs/adr` paths you must
 skip. Use `classify_changeset(changes)` to turn the whole diff into an edit plan in one call;

--- a/lore-workflow/skills/domain-modeling/ADR-FORMAT.md
+++ b/lore-workflow/skills/domain-modeling/ADR-FORMAT.md
@@ -66,9 +66,9 @@ step you must always do.** After creating `docs/adr/NNNN-slug.md`, add its
 stem (`NNNN-slug`, no `.md` extension) to the **first `{toctree}` block** in
 `docs/adr/index.md` — the single-brace MyST stub already seeded in the repo.
 Insert the entry on its own line **before the closing `` ``` `` fence** of that
-block, preserving the existing entries. This mirrors the `_wire_toctree_entry()`
-convention in `scripts/ccat_workflow_init.py`; it is idempotent, so skip the
-insert if the stem is already present. Without this wiring Sphinx will not pick
+block, preserving the existing entries. This mirrors the idempotent toctree-wiring
+`lore workflow create-prd` and `lore attach --scaffold-workflow` use elsewhere; skip
+the insert if the stem is already present. Without this wiring Sphinx will not pick
 the ADR up and it will not render.
 
 ## When to offer an ADR

--- a/lore-workflow/skills/domain-modeling/ADR-FORMAT.md
+++ b/lore-workflow/skills/domain-modeling/ADR-FORMAT.md
@@ -1,0 +1,92 @@
+<!--
+Adapted for CCAT: MADR-lite template (Context · Decision · Consequences /
+Trade-offs · Alternatives considered · Status) plus a deterministic toctree-
+wiring step. Deviates from upstream mattpocock/skills, whose ADR-FORMAT.md uses
+a freeform 1-3 sentence template with optional sections and no docs-site wiring.
+The three-criteria "offer ADRs sparingly" gate is kept verbatim from upstream.
+See THIRD-PARTY.md for provenance.
+-->
+
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`,
+`0002-slug.md`, etc. The slug is kebab-case.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+CCAT uses **MADR-lite**: a fixed set of sections so every ADR reads the same way
+and renders predictably in the docs site. Fill them all — terse is fine, but an
+ADR is more than a single paragraph here.
+
+```md
+# NNNN — {Short title of the decision}
+
+- **Status:** {Proposed | Accepted | Deprecated | Superseded by ADR-NNNN}
+- **Date:** {YYYY-MM-DD}
+- **Deciders:** {who}
+- **Relates to:** {links to the PRD / epic / sub-issue this records}
+
+## Context
+
+What forces are in play — the problem, the constraints, the background a future
+reader needs.
+
+## Decision
+
+What we decided, stated plainly.
+
+## Consequences / Trade-offs
+
+What becomes easier and what becomes harder as a result. Call out the costs, not
+just the wins.
+
+## Alternatives considered
+
+The genuine alternatives and why each was rejected. The non-obvious rejections
+are the valuable part — they stop someone re-proposing a settled option later.
+
+## Status
+
+(Also carried in the header line above.) Track the decision's lifecycle:
+`Proposed` → `Accepted`, and later `Deprecated` or `Superseded by ADR-NNNN` when
+revisited.
+```
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing `NNNN` and increment by one. Zero-pad
+to four digits.
+
+## Wire the ADR into the docs site
+
+Writing the ADR body is your job; **wiring it into the toctree is a deterministic
+step you must always do.** After creating `docs/adr/NNNN-slug.md`, add its
+stem (`NNNN-slug`, no `.md` extension) to the **first `{toctree}` block** in
+`docs/adr/index.md` — the single-brace MyST stub already seeded in the repo.
+Insert the entry on its own line **before the closing `` ``` `` fence** of that
+block, preserving the existing entries. This mirrors the `_wire_toctree_entry()`
+convention in `scripts/ccat_workflow_init.py`; it is idempotent, so skip the
+insert if the stem is already present. Without this wiring Sphinx will not pick
+the ADR up and it will not render.
+
+## When to offer an ADR
+
+ADRs are offered **sparingly**. All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/lore-workflow/skills/domain-modeling/CONTEXT-FORMAT.md
+++ b/lore-workflow/skills/domain-modeling/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/lore-workflow/skills/domain-modeling/SKILL.md
+++ b/lore-workflow/skills/domain-modeling/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: lore-workflow:domain-modeling
+description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
+---
+
+# Domain Modeling
+
+Actively build and sharpen the project's domain model as you design. This is the *active* discipline — challenging terms, inventing edge-case scenarios, and writing the glossary and decisions down the moment they crystallise. (Merely *reading* `CONTEXT.md` for vocabulary is not this skill — that's a one-line habit any skill can do. This skill is for when you're changing the model, not just consuming it.)
+
+## File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).

--- a/lore-workflow/skills/grill-me/SKILL.md
+++ b/lore-workflow/skills/grill-me/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: lore-workflow:grill-me
+description: A relentless interview to sharpen a plan or design.
+disable-model-invocation: true
+---
+
+Run a `/lore-workflow:grilling` session.

--- a/lore-workflow/skills/grill-with-docs/SKILL.md
+++ b/lore-workflow/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: lore-workflow:grill-with-docs
+description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
+disable-model-invocation: true
+---
+
+Run a `/lore-workflow:grilling` session, using the `/lore-workflow:domain-modeling` skill.

--- a/lore-workflow/skills/grilling/SKILL.md
+++ b/lore-workflow/skills/grilling/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: lore-workflow:grilling
+description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+---
+
+**Tier note:** this step runs in the main session at frontier-tier — it is not delegated to a
+subagent.
+
+Interview the user relentlessly about every aspect of this plan until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Show the user the questions you have in one list with a short explanation first 1-2 lines max and numbered. Then user can opt to align on the questions by giving their context up-front shortening the grill. Do not take input that is ambigous or confusing at face value but ask back if you need to clarify more or the questions were not understood correctly. 
+
+If opts to grill slow: 
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+Else: if all questions solved to satisfaction, check if /lore-workflow:domain-modeling is needed and if need be align with the user before updating the domain model then if all questions and domain modle updates are satisfactory say so and invoke /lore-workflow:to-epic. 
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/lore-workflow/skills/implement-issue/SKILL.md
+++ b/lore-workflow/skills/implement-issue/SKILL.md
@@ -31,8 +31,8 @@ not here.
 
 ### 1. Read the issue and the code map
 
-Read the GitHub issue the user wrote, then read the repo's **code map**
-([`CODEMAP.md`](../../CODEMAP.md)) to locate the symbols and files the change
+Read the GitHub issue the user wrote, then run `lore codemap` (or the
+`lore_codemap` MCP tool) to locate the symbols and files the change
 touches. That is the whole intake — **no exploration fan-out**. The code map is a
 ranked navigation index built for exactly this: find the symbol, open the cited
 file and line. Spinning up parallel explorer subagents for a single clear issue is
@@ -53,13 +53,13 @@ a quota to fill — when in doubt, prefer to proceed.
 
 Create one branch, `feat/<issue>-slug`, off the **detected target branch** —
 `develop` if that branch exists on the remote, else the repo default (`main`);
-never assume it. Implement the change with [`/lore-workflow:tdd`](../lore-workflow:tdd/SKILL.md): the strict
+never assume it. Implement the change with [`/lore-workflow:tdd`](../tdd/SKILL.md): the strict
 red → green → refactor loop, one behavior at a time, tests before code. Everything
 lands in **one PR** on that branch.
 
 ### 4. ADR gate
 
-Apply `domain-modeling`'s three [ADR](../lore-workflow:domain-modeling/ADR-FORMAT.md) criteria to
+Apply `domain-modeling`'s three [ADR](../domain-modeling/ADR-FORMAT.md) criteria to
 the decision the change embodies:
 
 1. **Hard to reverse** — the cost of changing your mind later is meaningful.
@@ -69,17 +69,18 @@ the decision the change embodies:
 
 If **all three** hold, draft the ADR at `docs/adr/NNNN-kebab.md` in the **same
 PR**. If any one is missing, **skip the ADR silently** — no note, no placeholder.
-(See [`domain-modeling`](../lore-workflow:domain-modeling/SKILL.md).)
+(See [`domain-modeling`](../domain-modeling/SKILL.md).)
 
 ### 5. Docs — Diátaxis pass
 
-Run [`document-epic`](../lore-workflow:document-epic/SKILL.md)'s
-[`diataxis.py`](../lore-workflow:document-epic/diataxis.py) classification over the change's diff:
-`classify_changeset(changes)` maps each changed path to its Diátaxis **quadrant**
-(tutorial / how-to / reference / explanation) or to "skip". Update the touched
-quadrants in the **same PR** — for reference, that means docstrings plus the
-autosummary/toctree wiring, not hand-written prose. `diataxis.py` never assigns a
-quadrant to `docs/prd/` or `docs/adr/`; leave those alone.
+Run [`document-epic`](../document-epic/SKILL.md)'s classification over the
+change's diff using the `lore_workflow.diataxis` module (part of the `lore`
+package this plugin depends on): `classify_changeset(changes)` maps each changed
+path to its Diátaxis **quadrant** (tutorial / how-to / reference / explanation) or
+to "skip". Update the touched quadrants in the **same PR** — for reference, that
+means docstrings plus the autosummary/toctree wiring, not hand-written prose.
+`classify_changeset` never assigns a quadrant to `docs/prd/` or `docs/adr/`;
+leave those alone.
 
 ### 6. Review, open the PR, report
 
@@ -96,5 +97,5 @@ the PR and stops there — it does not self-merge. **Never merge on red.**
 
 This track and the epic chain solve different problems and do not compose: one
 clear issue takes this fast path; a shaped, multi-feature body of work takes the
-chain. See [`CONVENTIONS.md`](../../CONVENTIONS.md) for the canonical chain and the
-artifact homes this skill writes into (`docs/adr/`, the Diátaxis `docs/`).
+chain. See the repo's own conventions doc, if any, for the canonical chain and
+the artifact homes this skill writes into (`docs/adr/`, the Diátaxis `docs/`).

--- a/lore-workflow/skills/implement-issue/SKILL.md
+++ b/lore-workflow/skills/implement-issue/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: lore-workflow:implement-issue
+description: Fast path for one well-understood GitHub issue — read the issue and the code map, clarify only if needed, then TDD it on one branch to one PR with the ADR and docs gates applied. Use when the user points at a single clear issue and wants it implemented directly, not run through the whole epic chain.
+---
+
+# Implement Issue
+
+A fast path for a single, well-understood GitHub issue. It is a **second track
+beside the epic chain, not a new chain phase**: the chain
+(`seed-epic → orient → grill-with-docs → to-epic → orchestrate-epic → document-epic`)
+is the right weight for a shaped body of work, but far too heavy for one small,
+clear change. Bypassing the workflow for that change is the other trap — it drops
+exactly the discipline the workflow exists to keep (test-first development, the
+architectural-decision check, the docs update). This skill keeps that discipline
+at the weight of a single issue.
+
+It **inherits the workflow invariants**: **strict TDD**, **ruff** clean, and
+**never merge on red**. What it deliberately drops for the small track is the
+fan-out and the multi-PR integration — one issue, one branch, one PR — and the
+human stays present, so **merging stays with the user**.
+
+## When to use
+
+Reach for this when the user hands you a single GitHub issue they wrote and the
+change is small and clear enough that spinning up the full epic chain would be
+pure overhead. If the work is really several features, or the shape is still
+unsettled, it belongs on the chain (`orient` → `grill-with-docs` → `to-epic`),
+not here.
+
+## Flow
+
+### 1. Read the issue and the code map
+
+Read the GitHub issue the user wrote, then read the repo's **code map**
+([`CODEMAP.md`](../../CODEMAP.md)) to locate the symbols and files the change
+touches. That is the whole intake — **no exploration fan-out**. The code map is a
+ranked navigation index built for exactly this: find the symbol, open the cited
+file and line. Spinning up parallel explorer subagents for a single clear issue is
+the epic-chain weight this track exists to avoid.
+
+### 2. Clarify only if needed
+
+A gate, not an interview. If the issue's intent or acceptance criteria are
+**ambiguous**, ask the user **at most three targeted questions** and wait for the
+answers. If the issue is already clear, proceed with **no interview at all**.
+
+This is explicitly **not a grilling**. `grilling` stress-tests an unshaped plan
+one relentless question at a time; that is the wrong tool for an issue the user
+has already written down. Three questions is a ceiling for genuine ambiguity, not
+a quota to fill — when in doubt, prefer to proceed.
+
+### 3. Implement with `/lore-workflow:tdd`
+
+Create one branch, `feat/<issue>-slug`, off the **detected target branch** —
+`develop` if that branch exists on the remote, else the repo default (`main`);
+never assume it. Implement the change with [`/lore-workflow:tdd`](../lore-workflow:tdd/SKILL.md): the strict
+red → green → refactor loop, one behavior at a time, tests before code. Everything
+lands in **one PR** on that branch.
+
+### 4. ADR gate
+
+Apply `domain-modeling`'s three [ADR](../lore-workflow:domain-modeling/ADR-FORMAT.md) criteria to
+the decision the change embodies:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful.
+2. **Surprising without context** — a future reader will wonder "why this way?".
+3. **A real trade-off** — there were genuine alternatives and you picked one for
+   specific reasons.
+
+If **all three** hold, draft the ADR at `docs/adr/NNNN-kebab.md` in the **same
+PR**. If any one is missing, **skip the ADR silently** — no note, no placeholder.
+(See [`domain-modeling`](../lore-workflow:domain-modeling/SKILL.md).)
+
+### 5. Docs — Diátaxis pass
+
+Run [`document-epic`](../lore-workflow:document-epic/SKILL.md)'s
+[`diataxis.py`](../lore-workflow:document-epic/diataxis.py) classification over the change's diff:
+`classify_changeset(changes)` maps each changed path to its Diátaxis **quadrant**
+(tutorial / how-to / reference / explanation) or to "skip". Update the touched
+quadrants in the **same PR** — for reference, that means docstrings plus the
+autosummary/toctree wiring, not hand-written prose. `diataxis.py` never assigns a
+quadrant to `docs/prd/` or `docs/adr/`; leave those alone.
+
+### 6. Review, open the PR, report
+
+Run **one review pass** with `code-review` at the **mid tier** by default — this is
+the small track, so the review is lighter than the epic chain's strong-tier
+crosscheck; escalate a genuinely architectural change to a stronger tier by
+judgement. Address the findings, keep the PR green, then open it linking the issue
+it closes and report back.
+
+**Merging stays with the user.** They are present on this track, so the skill opens
+the PR and stops there — it does not self-merge. **Never merge on red.**
+
+## Relationship to the chain
+
+This track and the epic chain solve different problems and do not compose: one
+clear issue takes this fast path; a shaped, multi-feature body of work takes the
+chain. See [`CONVENTIONS.md`](../../CONVENTIONS.md) for the canonical chain and the
+artifact homes this skill writes into (`docs/adr/`, the Diátaxis `docs/`).

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: lore-workflow:orchestrate-epic
+description: Supervise parallel TDD implementation of an epic tracker issue across one or
+  more repos — plans, dispatches teammates, crosschecks every PR, and lands the epic
+  autonomously. Use when the user points at an epic/tracker issue and wants orchestrated,
+  batched, autonomous implementation.
+---
+
+# Orchestrate Epic
+
+You are the **orchestrator**: you plan, dispatch, crosscheck, integrate. Teammate agents
+write the feature code; you do not. Your job is supervision and integration.
+
+**Input:** an epic tracker issue (number or URL), possibly spanning repos.
+**Mode:** fully autonomous — run the whole loop without asking. Stop only to report
+completion or to escalate a hard blocker (see Stop conditions).
+
+## Invariants
+- **Target branch is detected, never assumed.** Resolve the target branch once, at Map
+  time: `develop` if that branch exists on the remote, else the repo default (`main`).
+  Apply this same detection to BOTH the epic-branch cut point (cut `epic/<issue>` from
+  the detected target) AND the final PR target (the Land-stage PR lands on the detected
+  target). The workflow never creates `develop` — standing one up is a deploy-pipeline
+  decision outside this workflow's scope, and the epic branch already provides
+  integration buffering.
+- Integration target is an **epic branch** `epic/<issue>`, cut from the detected target
+  branch (`develop` if present, else `main`). Feature PRs target the epic branch; the
+  epic branch lands on the detected target branch via one final PR.
+- **Merges are pre-authorized.** Feature→epic merges and the epic→target merge are
+  pre-authorized by this skill — the orchestrator merges on a passing crosscheck and must
+  never ask the user to confirm either kind of merge. The only exception is the
+  deploy-gate marker below, which can require one human confirmation before the final
+  epic→target merge specifically.
+- **Deploy-gate marker.** A repo whose target-branch merge triggers a deployment may
+  declare, in its `AGENTS.md`, a `## Epic merge policy` section containing the line
+  `epic-merge-policy: confirm`. Marker present → the final epic→target merge (only that
+  merge; feature→epic merges stay pre-authorized regardless) requires one human
+  confirmation before merging — the deploy gate. Marker absent (the default) → fully
+  autonomous, merge without asking. Read this marker at Map time alongside target-branch
+  detection; never guess deploy semantics.
+- One feature = one teammate = one worktree = one branch `feat/<sub-issue>-slug` = one PR.
+- **Compact mode narrows fan-out only.** A small epic (see Effort bands in Map) may run
+  with one teammate implementing every feature of the band sequentially in one worktree —
+  but one branch `feat/<sub-issue>-slug` and one PR per feature is unchanged, strict TDD
+  stays strict, and every PR is still crosschecked before merge (see Dispatch).
+- Strict TDD (red→green→refactor) per feature. No green PR without tests mapping to its
+  acceptance criteria.
+- Never merge on red CI.
+
+## Loop
+
+**Map.** Read the epic with `gh ... --json` (see `CONVENTIONS.md`). Extract roadmap
+items, per-feature acceptance criteria, dependency edges, target repo(s). If the epic was
+produced by `/lore-workflow:to-epic`, its **Roadmap** table is the canonical DAG (Feature | Issue | Repo |
+Type | Blocked by); read acceptance criteria from each linked sub-issue, and treat
+HITL-flagged features as escalation points, not auto-implemented.
+
+**Resume.** This is the resume entry point — reached first, before the Roadmap-validator
+gate, before cutting the epic branch, before creating a fresh status comment. Three steps:
+1. **Find the status comment** — list comments on the epic issue (`gh api
+   repos/<owner>/<repo>/issues/<issue>/comments`) for one carrying this skill's per-feature
+   state table from a prior run.
+2. **Reconcile** merged/queued/blocked against the epic branch's actual state: a feature
+   already merged into `epic/<issue>` is done — skip it, never redispatch it; a feature still
+   queued or blocked is redispatched from where it left off. The epic branch itself, if it
+   already exists, is reused, never re-cut, so a resumed run never collides with half-merged
+   state.
+3. **Continue editing the same comment** — resume by editing that same existing comment in
+   place (`gh api ... -X PATCH`) for every further update; a resumed run never opens a second
+   one.
+
+No prior status comment found → this is a fresh run; proceed to the Roadmap-validator gate
+and create the status comment as described below.
+
+**Roadmap-validator gate.** Before dispatching any teammate, validate that roadmap table
+with the deterministic, dependency-free `roadmap_validator.py` shipped beside the `to-epic`
+skill — required columns, fully-qualified `owner/repo#n` refs, blocked-by edges that resolve
+to rows, an acyclic DAG. **Refuse to start on a malformed or cyclic roadmap:** report the
+validator's problems and stop rather than dispatch teammates against a table it rejects.
+
+**Effort bands.** Once the roadmap validates, classify the epic into an effort band from
+that same table — feature count, the `Repo` column, and `Blocked by` edge count — decided
+once, at Map time, before any dispatch. This skill runs two bands:
+- **compact** — the lowest band this skill handles: the roadmap has ≤ 2 features, one
+  repo, every row's `Type` is AFK, no HITL flags. Runs the compact dispatch path (see
+  Dispatch).
+- **standard** — everything else: the full batched Loop described here, concurrency cap N.
+
+Work smaller than compact — a single well-understood issue, no roadmap DAG worth cutting —
+does not enter this skill; that is the fast path (`implement-issue`, a separate skill), not
+a further-compacted band. Record the chosen band on the status comment alongside the
+per-feature state.
+
+Build the feature
+DAG; split into dependency-ordered batches (features in a batch are independent). Detect
+the target branch (`develop` if it exists on the remote, else `main`) and cut and push
+`epic/<issue>` from the up-to-date detected target. **The supervision trail is durable, not
+a temp file:** create one status comment on the epic issue (feature × repo × state:
+queued/running/PR/crosscheck/merged/blocked) via `gh issue comment <issue> --body ...`, then
+edit that same comment in place — `gh api repos/<owner>/<repo>/issues/comments/<id> -X PATCH
+-f body=...` — never opening a new one. Edit points are deliberately few, not one per
+intermediate transition: at batch start, on each merge, on each blocker, and at epic
+completion. Record tier decisions and deviations there as they happen.
+
+**Context pack (built once at Map time, reused by every teammate).** Assemble one
+short context pack now, so codebase discovery happens once for the whole epic
+instead of once per teammate. Source it from the deterministic code map (`CODEMAP.md`,
+refreshed deterministically by `scripts/code_map.py`): rank that map's symbols
+against this epic's shared touchpoints and pull only the top **token-budgeted
+excerpts (~1k tokens)** — never paste the whole map, which would swamp every
+brief. Shape the pack as Anthropic's four-part subagent brief checklist — their
+documented fix for subagents duplicating each other's searches — so every
+teammate reads the same framing:
+- **Objective** — the epic's shared goal and how each feature slices through it.
+- **Expected output format** — one branch `feat/<n>-slug` and one PR per feature,
+  strict TDD with red→green evidence.
+- **Tool/source guidance** — the ranked code-map excerpts (files, key symbols,
+  conventions), the `CODEMAP.md` index to widen from, and where the domain
+  language lives (CONTEXT.md / glossary, `docs/adr`).
+- **Task boundaries** — the scope fence and the shared-file touchpoints to stay
+  clear of.
+Paste this same pack, unchanged, into every teammate brief below.
+
+**Dispatch.** For each feature in the current batch, create a worktree off `epic/<issue>`
+and spawn a background teammate pinned to it (concurrency cap N, default 4). **Choose each
+teammate's model tier from the feature's assessed complexity** — a cheaper/faster tier for
+mechanical or well-scoped features, the strongest tier for architectural, ambiguous, or
+cross-cutting ones — and pass the chosen tier's resolved model in the spawn call
+(`MODEL-TIERS.md`, "Resolution at spawn time"). Fill the teammate brief below per feature.
+
+_Liveness._ Liveness is event-driven, not polled: the harness's completion notification
+— fired when a background teammate finishes or sends a message — is the primary signal,
+and is acted on as it arrives rather than on a cycle. The one defined fallback: a teammate
+that has produced neither a message nor a completion notification for ~30 minutes is
+treated as silent. A silent or dead teammate is respawned once, into the same worktree
+with the same brief. A second death on the same feature is not respawned again — mark
+the feature blocked and escalate.
+
+_Compact mode._ When Map selected the compact band, skip the per-feature fan-out above:
+create one worktree off `epic/<issue>` and spawn one teammate pinned to it, briefed to
+implement every feature of the band sequentially — still one branch `feat/<n>-slug` and
+one PR per feature, still strict TDD per feature, and each PR is still crosschecked before
+merge exactly as in Crosscheck below (the concurrency cap does not apply — there is only
+one teammate). Optionally batch the review: one reviewer subagent, still spawned explicitly
+at the strong-tier, reviews every PR of the band in a single strong-tier pass — checking
+cross-PR consistency too — instead of one reviewer spawn per PR.
+
+**Crosscheck (delegated).** When a teammate reports its PR, you do **not** read the diff.
+Delegating the read is what keeps the orchestrator's context free for supervision as the epic
+grows. Spawn one reviewer subagent per PR at the **strong-tier** — set the spawn's model
+parameter to the strong-tier resolution (`MODEL-TIERS.md`, "Resolution at spawn time");
+no delegation ever inherits the session model implicitly. The reviewer reads the
+diff and the linked sub-issue, runs the checks below, and returns a structured verdict. The
+orchestrator reads no diffs; it consumes only the verdict.
+
+_Reviewer contract_ — the reviewer verifies, on the PR it is handed:
+- **CI green** — the PR's required checks pass.
+- **tests map to acceptance criteria** — every acceptance criterion of the sub-issue has a
+  test that exercises it.
+- **red→green evidence present** — the report or commit history shows a failing test before
+  the fix.
+- **scope respected** — only the files this feature needs are touched; nothing outside scope.
+- **ruff clean** — `ruff check` and `ruff format --check` both pass.
+
+_Structured verdict_ — the reviewer returns exactly this, and the same text is the PR comment
+body (machine-skimmable, one check per line):
+```
+PR #<n>
+reviewer tier: strong
+verdict: PASS | FAIL
+- CI green: pass | fail — <note>
+- tests map to acceptance criteria: pass | fail — <note>
+- red→green evidence present: pass | fail — <note>
+- scope respected: pass | fail — <note>
+- ruff clean: pass | fail — <note>
+fixes (only on FAIL): 1. <precise fix>  2. <precise fix>  …
+```
+Post the verdict as a comment on the reviewed PR with `gh pr comment <n> --body …`; the verdict
+text is the comment body, so each supervision decision lives on the PR, not only in the
+orchestrator's context. On **PASS**, advance the PR to Merge. On **FAIL**, `SendMessage` the
+same teammate the numbered fix list from the verdict and re-review once it reports back —
+**max 2 fix rounds**, each driven by the next verdict. When a teammate is **stuck** — a fix
+round that fails to move the verdict — send it the `/lore-workflow:debug` skill's method rather than a
+vaguer "try again": reproduce, isolate the root cause, and heed its circuit breaker (after 3
+failed fix attempts, stop and question the architecture instead of throwing a 4th blind fix at
+the same fault). Still FAIL after the second round → mark the feature blocked and escalate.
+
+_Tier rules for this step._ The reviewer spawn carries the strong-tier's resolved model in
+its spawn call and never inherits the orchestrator's session model; the
+implementation-teammate tier the Dispatch step
+assigns is advisory — a deviation is allowed but recorded in the supervision trail. For the
+full tier contract — ordinal/collapse, fallback, and one-step escalation — comply with
+`MODEL-TIERS.md` and `CONVENTIONS.md` ("Model tiers"); record any tier escalation in the
+supervision trail.
+
+**Merge.** Merge crosscheck-passed PRs into `epic/<issue>` in dependency order; rebase later
+siblings on the updated epic branch and re-run their CI. If that rebase conflicts, it goes
+back to that feature's teammate — respawned with the same brief plus the conflict context if
+it has already exited — since the orchestrator never resolves merge conflicts by hand;
+escalate only if the teammate fails to resolve it. Cross-repo: merge a producer's feature and
+capture its commit SHA before dispatching the consumer feature that pins it (e.g. a consumer
+repo pins the producer library by commit SHA). **As each feature merges, close the loop on
+GitHub:** tick its roadmap checkbox in the epic issue's task list (`- [ ]` → `- [x]`), close
+its sub-issue (`gh issue close <n> --comment "Merged via PR #<pr>"`), and edit the status
+comment to mark it merged and record the teammate's tier decision and any deviation from the
+Dispatch-assigned tier.
+
+_Post-merge invariants._ After every merge into `epic/<issue>`, verify CI is green
+on the epic branch before dispatching anything that depends on it. Where the repo
+carries migrations, also verify a single migration head (e.g. `alembic heads`) —
+squash-merges can silently drop a re-pointed revision from a parallel feature
+branch, forking the migration DAG. An invariant that fails blocks the batch: fix
+forward or escalate before advancing.
+
+**Advance.** When a batch is fully merged, dispatch the next batch. Repeat to roadmap end.
+
+**Land.** With all features merged and epic-branch CI green, open one PR
+`epic/<issue> → <detected target>` summarizing the delivered roadmap and linking every
+sub-issue.
+
+**Whole-epic review (delegated).** Before merging that PR, spawn one whole-epic
+reviewer subagent, explicitly at the strong-tier, over the cumulative epic diff
+(`<detected target>...epic/<issue>`). This is not a per-feature re-review — per-PR
+crosscheck already covers each feature in isolation. Scope it explicitly to
+cross-feature consistency: inconsistent naming, duplicated helpers, and conflicting
+edits to shared files — the class of problem that only shows up once every feature's
+diff lands together, which per-PR crosscheck structurally cannot see. Reuse the
+Crosscheck reviewer contract and structured-verdict shape (see above), substituting
+this cross-feature checklist for the per-feature one. Post the verdict as a comment
+on the epic PR with `gh pr comment <n> --body …`. Its verdict gates this PR exactly
+like a crosscheck: on **PASS**, proceed to merge; on **FAIL**, route the numbered fix
+list to the teammate(s) owning the affected files and re-review once — **max 2 fix
+rounds**, same as Crosscheck — still FAIL after the second round marks the epic
+blocked and escalates rather than merging.
+
+This epic→target merge follows the merge pre-authorization and deploy-gate policy in the
+Invariants above — comply with it, and if that repo's deploy-gate marker gates this merge,
+record the human confirmation in the supervision trail. Merge it. Mark the epic issue done
+with the merge SHA.
+
+**Cleanup.** Once the epic lands, delete every merged feature branch, local and
+remote (`git branch -d feat/<n>-<slug>`, `git push origin --delete
+feat/<n>-<slug>`), and remove its worktree (`git worktree remove`). Leave nothing
+behind but the epic branch's own history.
+
+**Document.** After the epic PR merges, invoke `document-epic` as the final automatic
+stage: it reads the merged epic, classifies each changed path into the Diátaxis four,
+writes or updates the relevant docs, opens a docs PR, and auto-merges it on green CI.
+A human reviews post-hoc and may revert if needed. Never auto-merge on red.
+
+**Land checklist.** Before reporting completion, emit and satisfy this checklist — every item
+verified true, not merely intended:
+- [ ] every roadmap checkbox ticked in the epic issue's task list
+- [ ] every sub-issue closed
+- [ ] the epic PR merged, with its merge SHA recorded on the epic issue
+- [ ] the status comment finalized to the end state (no stale queued/running rows)
+- [ ] every merged feature's branch and worktree gone, local and remote
+- [ ] the docs PR opened, and merged once its CI is green
+
+Report.
+
+## Teammate brief (fill, pass to each agent)
+
+> Implement **<feature title>** (sub-issue #<n>) in repo <repo>.
+> Worktree <path>, branch `feat/<n>-<slug>` off `epic/<issue>`; PR targets `epic/<issue>`.
+> Acceptance criteria: <criteria>.
+> Context pack (shared, built once at Map time — the same text for every teammate):
+> the objective, expected output format, tool/source guidance, and task boundaries,
+> carrying the ranked ~1k-token code-map excerpts from `CODEMAP.md` (never the whole
+> map). Read it before exploring — the repo discovery is already done; widen from
+> these excerpts only as needed.
+> Method: strict TDD via the `/lore-workflow:tdd` skill — failing test first, make it pass, refactor;
+> include the failing-test output in the PR body. Before pushing, run ruff (check +
+> format) and the full suite; both clean.
+> Skip-excuses to catch yourself making — keep the discipline even when you think
+> "this is just a mechanical change" (trivial edits are exactly where a typo ships),
+> "I'll add tests after" (after-the-fact tests ratify the code you wrote, not the behavior
+> you meant; the failing test comes first), or "the skill is overkill here" (the red→green
+> loop is the floor, not ceremony reserved for hard problems). When stuck, use the `/lore-workflow:debug`
+> skill's circuit breaker instead of a 4th blind fix.
+> Scope fence: change only what this feature needs; no edits to shared files outside scope.
+> Sibling-write hazard: parallel teammates in separate worktrees under one session
+> can share an isolation pointer, so in-place editor writes (edit/write tools) from
+> one teammate can clobber another's. Workaround: apply file changes via shell
+> (heredoc or scripted edits) with absolute paths instead of in-place editor tools.
+> Deliver: push, open the PR linking #<n>, report the PR number, red→green evidence, and a
+> one-paragraph summary of changes and any decisions you made.
+
+## Stop conditions (escalate, pause that branch only)
+A feature flagged HITL (needs a human decision or design review); teammate fails crosscheck
+after 2 fix rounds; ambiguous spec needing a scientific/architectural call; unresolvable merge
+conflict; or CI-infra failure. Otherwise keep going. Emit the status table on every escalation and at completion.

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -49,7 +49,7 @@ completion or to escalate a hard blocker (see Stop conditions).
 
 ## Loop
 
-**Map.** Read the epic with `gh ... --json` (see `CONVENTIONS.md`). Extract roadmap
+**Map.** Read the epic with `gh ... --json` (see the repo's own conventions doc, if any). Extract roadmap
 items, per-feature acceptance criteria, dependency edges, target repo(s). If the epic was
 produced by `/lore-workflow:to-epic`, its **Roadmap** table is the canonical DAG (Feature | Issue | Repo |
 Type | Blocked by); read acceptance criteria from each linked sub-issue, and treat
@@ -73,8 +73,8 @@ No prior status comment found → this is a fresh run; proceed to the Roadmap-va
 and create the status comment as described below.
 
 **Roadmap-validator gate.** Before dispatching any teammate, validate that roadmap table
-with the deterministic, dependency-free `roadmap_validator.py` shipped beside the `to-epic`
-skill — required columns, fully-qualified `owner/repo#n` refs, blocked-by edges that resolve
+with the deterministic, dependency-free `lore workflow validate-roadmap` — required columns,
+fully-qualified `owner/repo#n` refs, blocked-by edges that resolve
 to rows, an acyclic DAG. **Refuse to start on a malformed or cyclic roadmap:** report the
 validator's problems and stop rather than dispatch teammates against a table it rejects.
 
@@ -104,8 +104,8 @@ completion. Record tier decisions and deviations there as they happen.
 
 **Context pack (built once at Map time, reused by every teammate).** Assemble one
 short context pack now, so codebase discovery happens once for the whole epic
-instead of once per teammate. Source it from the deterministic code map (`CODEMAP.md`,
-refreshed deterministically by `scripts/code_map.py`): rank that map's symbols
+instead of once per teammate. Source it from `lore codemap` (or the `lore_codemap`
+MCP tool for bounded, queryable slices): rank the map's symbols
 against this epic's shared touchpoints and pull only the top **token-budgeted
 excerpts (~1k tokens)** — never paste the whole map, which would swamp every
 brief. Shape the pack as Anthropic's four-part subagent brief checklist — their
@@ -115,7 +115,7 @@ teammate reads the same framing:
 - **Expected output format** — one branch `feat/<n>-slug` and one PR per feature,
   strict TDD with red→green evidence.
 - **Tool/source guidance** — the ranked code-map excerpts (files, key symbols,
-  conventions), the `CODEMAP.md` index to widen from, and where the domain
+  conventions), `lore codemap` / `lore_codemap` to widen from, and where the domain
   language lives (CONTEXT.md / glossary, `docs/adr`).
 - **Task boundaries** — the scope fence and the shared-file touchpoints to stay
   clear of.
@@ -125,8 +125,8 @@ Paste this same pack, unchanged, into every teammate brief below.
 and spawn a background teammate pinned to it (concurrency cap N, default 4). **Choose each
 teammate's model tier from the feature's assessed complexity** — a cheaper/faster tier for
 mechanical or well-scoped features, the strongest tier for architectural, ambiguous, or
-cross-cutting ones — and pass the chosen tier's resolved model in the spawn call
-(`MODEL-TIERS.md`, "Resolution at spawn time"). Fill the teammate brief below per feature.
+cross-cutting ones — and pass the chosen tier's resolved model (`lore tier resolve <tier>`,
+see [TIER-DELEGATION.md](../../TIER-DELEGATION.md)) in the spawn call. Fill the teammate brief below per feature.
 
 _Liveness._ Liveness is event-driven, not polled: the harness's completion notification
 — fired when a background teammate finishes or sends a message — is the primary signal,
@@ -148,7 +148,8 @@ cross-PR consistency too — instead of one reviewer spawn per PR.
 **Crosscheck (delegated).** When a teammate reports its PR, you do **not** read the diff.
 Delegating the read is what keeps the orchestrator's context free for supervision as the epic
 grows. Spawn one reviewer subagent per PR at the **strong-tier** — set the spawn's model
-parameter to the strong-tier resolution (`MODEL-TIERS.md`, "Resolution at spawn time");
+parameter to `lore tier resolve strong` (see
+[TIER-DELEGATION.md](../../TIER-DELEGATION.md));
 no delegation ever inherits the session model implicitly. The reviewer reads the
 diff and the linked sub-issue, runs the checks below, and returns a structured verdict. The
 orchestrator reads no diffs; it consumes only the verdict.
@@ -189,9 +190,9 @@ _Tier rules for this step._ The reviewer spawn carries the strong-tier's resolve
 its spawn call and never inherits the orchestrator's session model; the
 implementation-teammate tier the Dispatch step
 assigns is advisory — a deviation is allowed but recorded in the supervision trail. For the
-full tier contract — ordinal/collapse, fallback, and one-step escalation — comply with
-`MODEL-TIERS.md` and `CONVENTIONS.md` ("Model tiers"); record any tier escalation in the
-supervision trail.
+full tier contract — ordinal/collapse, fallback, and one-step escalation — see
+[TIER-DELEGATION.md](../../TIER-DELEGATION.md) and `docs/model-tiers.md`; record any tier
+escalation in the supervision trail.
 
 **Merge.** Merge crosscheck-passed PRs into `epic/<issue>` in dependency order; rebase later
 siblings on the updated epic branch and re-run their CI. If that rebase conflicts, it goes
@@ -266,7 +267,7 @@ Report.
 > Acceptance criteria: <criteria>.
 > Context pack (shared, built once at Map time — the same text for every teammate):
 > the objective, expected output format, tool/source guidance, and task boundaries,
-> carrying the ranked ~1k-token code-map excerpts from `CODEMAP.md` (never the whole
+> carrying the ranked ~1k-token code-map excerpts from `lore codemap` (never the whole
 > map). Read it before exploring — the repo discovery is already done; widen from
 > these excerpts only as needed.
 > Method: strict TDD via the `/lore-workflow:tdd` skill — failing test first, make it pass, refactor;

--- a/lore-workflow/skills/orient/SKILL.md
+++ b/lore-workflow/skills/orient/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: lore-workflow:orient
+description: The first step of a piece of work — the session does its own homework, then
+  reflects its understanding back for confirmation before any planning or grilling. Use at
+  the start of a task, when the user says "orient", "get oriented", "what's your
+  understanding", or wants the session to reflect back before planning.
+---
+
+# Orient
+
+You are orienting: before any planning or grilling, do your own homework on what the user
+asked, then reflect your understanding back for confirmation. You explore and restate; you do
+not implement, and you do not fix scope unilaterally.
+
+**Mode:** conversation only — nothing is persisted. The reflected understanding lives in the
+chat and becomes the input to the next step.
+
+## Process
+
+### 1. Capture intent
+Take the user's stated goal as the seed, verbatim. Don't expand it or jump to solutions yet.
+If they pass an issue reference (e.g. an epic seed from `/lore-workflow:seed-epic`), fetch and read it
+(`gh ... --json`) and treat its Intent + Findings as the seed.
+
+### 2. Explore in parallel (subagents)
+Fan out read-only `Explore` subagents concurrently — one per facet, in a single message — and
+keep only their findings here (drop the file dumps). This fan-out runs at **mid-tier
+(REQUIRED)**: resolve the tier to a concrete model via the harness table in
+[MODEL-TIERS.md](../../MODEL-TIERS.md) ("Resolution at spawn time") and set each spawn's
+model parameter to that resolution. Tier prose inside the subagent prompt resolves
+nothing — a spawn with no explicit model implicitly inherits the session model, which both
+violates the tier contract and burns frontier-model tokens on gathering work.
+Default facets:
+- **Code map** — where this touches the codebase: key modules, interfaces, current behavior,
+  relevant tests.
+- **Docs & decisions** — CONTEXT.md / glossary, `docs/adr`, relevant guides; what is already
+  decided or constrained.
+- **Prior art** — related issues/PRs and similar existing features.
+- **Cross-repo / external** — only when the intent plausibly spans repos or downstream consumers.
+
+Scale the fan-out to the ask: a small change may need a single Explore pass; a broad feature
+warrants all facets.
+
+### 3. Reflect back
+Present a tight brief in the conversation:
+- **What I understand you want** — restated in the project's domain language.
+- **Relevant landscape** — the code + docs/ADR constraints and prior art that bear on it.
+- **What we're actually deciding** — the crux, and the real choices ahead.
+- **Open questions & assumptions** — the unknowns, and the assumptions you're running on.
+- **Tentative scope** — in / out, marked provisional.
+
+### 4. Loop
+Ask whether this matches. If the user corrects or adds input, re-orient with a *targeted*
+re-explore — only the facets that moved, not a full re-run. Repeat until they confirm.
+
+### 5. Handoff
+On confirmation, carry the shared understanding into the grilling step — default
+`/lore-workflow:grill-with-docs` (it aligns terminology against CONTEXT.md/ADRs, which the downstream
+`/lore-workflow:to-epic` slices depend on). Use `/lore-workflow:grill-me` instead when there is no domain model to align
+against.
+
+Chain: `/lore-workflow:orient` → `/lore-workflow:grill-with-docs` → `/lore-workflow:to-epic` → `/lore-workflow:orchestrate-epic`.

--- a/lore-workflow/skills/orient/SKILL.md
+++ b/lore-workflow/skills/orient/SKILL.md
@@ -25,14 +25,13 @@ If they pass an issue reference (e.g. an epic seed from `/lore-workflow:seed-epi
 ### 2. Explore in parallel (subagents)
 Fan out read-only `Explore` subagents concurrently — one per facet, in a single message — and
 keep only their findings here (drop the file dumps). This fan-out runs at **mid-tier
-(REQUIRED)**: resolve the tier to a concrete model via the harness table in
-[MODEL-TIERS.md](../../MODEL-TIERS.md) ("Resolution at spawn time") and set each spawn's
-model parameter to that resolution. Tier prose inside the subagent prompt resolves
-nothing — a spawn with no explicit model implicitly inherits the session model, which both
-violates the tier contract and burns frontier-model tokens on gathering work.
+(REQUIRED)**: resolve the tier to a concrete model with `lore tier resolve mid` and set each
+spawn's model parameter to that resolution — see
+[TIER-DELEGATION.md](../../TIER-DELEGATION.md) for the no-implicit-inherit rule this enforces.
 Default facets:
 - **Code map** — where this touches the codebase: key modules, interfaces, current behavior,
-  relevant tests.
+  relevant tests. Start from `lore codemap` (or the `lore_codemap` MCP tool) for a ranked,
+  deterministic index instead of a blind directory walk.
 - **Docs & decisions** — CONTEXT.md / glossary, `docs/adr`, relevant guides; what is already
   decided or constrained.
 - **Prior art** — related issues/PRs and similar existing features.

--- a/lore-workflow/skills/seed-epic/SKILL.md
+++ b/lore-workflow/skills/seed-epic/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: lore-workflow:seed-epic
+description: At the end of a long session — often after /lore-workflow:orchestrate-epic surfaced follow-up
+  work — capture this session's context into an epic seed, a GitHub tracker issue a fresh
+  session can pick up cold and run /lore-workflow:orient on. Use when follow-up issues surfaced, the
+  session is too long to continue cleanly, and you want to hand the discussion to a new
+  session.
+---
+
+# Seed Epic
+
+Capture this session's context into an **epic seed** — a tracker issue a fresh session can
+orient on cold. The seed is a **discussion seed, not a spec**: it carries the intent and the
+expensive-to-rebuild context, then the new session forms the epic via
+`/lore-workflow:orient → /lore-workflow:grill-with-docs → /lore-workflow:to-epic → /lore-workflow:orchestrate-epic`. Do NOT pre-slice or pre-decide
+scope — that is orient/grill/lore-workflow:to-epic's job.
+
+**Tier note:** this step runs in the main session at frontier-tier — it is not delegated to a
+subagent.
+
+**When:** end of a session (typically after `/lore-workflow:orchestrate-epic`) where follow-up work surfaced,
+the context is rich, but the session is too long to continue cleanly.
+
+**Quality bar:** a cold session must be able to orient from the seed issue alone (plus the
+repo). Capture what would otherwise have to be rediscovered.
+
+## Process
+
+### 1. Harvest
+Gather the follow-up work that surfaced this session: new problems, deferred ideas, loose ends,
+gotchas hit during implementation. Synthesize from context — don't interview.
+
+### 2. Group
+Cluster the threads into coherent seeds (one future epic each); unrelated threads → separate
+seeds. Trivially small, well-understood follow-ups don't need the chain — note them for direct
+filing instead. Confirm the grouping with the user before publishing.
+
+### 3. Write the seed(s)
+Draft each body with the template below. Lead with intent; make the **findings** section rich —
+that is the handover value. Pointers are starting points, not gospel (they may go stale).
+
+### 4. Publish
+Create each seed as a GitHub issue (`gh`), labeled `epic-seed` (create the label if missing).
+Link the originating epic and merged PRs. Do not modify the finished epic.
+
+Finish by printing each seed reference and the command for the fresh session:
+`/lore-workflow:orient <owner/repo#seed>`.
+
+## Seed template
+
+<seed-template>
+## Intent
+What we want to do next, as the seed for discussion — in domain language. Not a solution.
+
+## Origin
+Where this came from: the finished epic (`owner/repo#n`), merged PRs/commits, and why it
+surfaced. Enough provenance for a cold session.
+
+## Findings from this session
+The hard-won context a fresh session would otherwise rediscover: constraints, decisions already
+made, dead ends, gotchas, what turned out true or false. This is the point of the seed.
+
+## Open questions
+What `/lore-workflow:orient` and the grilling should dig into before forming the epic.
+
+## Pointers (starting points, may be stale)
+Relevant modules/files, docs/ADR/CONTEXT, related issues, repos likely involved.
+
+## Out of scope / deferred
+What this seed deliberately excludes.
+
+## Next step
+A fresh session starts here: `/lore-workflow:orient owner/repo#<this-seed>`.
+</seed-template>

--- a/lore-workflow/skills/tdd/SKILL.md
+++ b/lore-workflow/skills/tdd/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: lore-workflow:tdd
+description: Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **weak, implementation-coupled tests**:
+
+- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
+- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
+- You commit to test structure before understanding the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Skip-excuses
+
+Under time pressure the discipline gets dropped with a stock rationalization. Name it as you hear yourself think it — that is the tell that you are about to cut the corner, not a reason to:
+
+- **"This is just a mechanical change."** The changes that look too trivial to test are exactly where an unguarded typo ships — a flipped comparison, an off-by-one, a wrong constant. Mechanical is cheap to test; test it.
+- **"I'll add tests after."** Tests written after the code test the code you wrote, not the behavior you meant; they ratify bugs instead of catching them, and "after" rarely comes. The failing test comes first — that is the whole method.
+- **"The skill is overkill here."** The red→green loop is the floor, not a ceremony reserved for hard problems. If the change is small the loop is small; it is never so small that skipping it is faster than the bug it prevents.
+
+## Workflow
+
+### 1. Planning
+
+When exploring the codebase, use the project's domain glossary so that test names and interface vocabulary match the project's language, and respect ADRs in the area you're touching.
+
+Before writing any code, resolve these gates. How you resolve them is **mode-conditional**:
+
+- **Interactive** (a user is present to respond): ask, and wait for an answer, at each gate below.
+- **Autonomous** (e.g. a teammate implementing a sub-issue with no user available to ask): decide each gate from the sub-issue's acceptance criteria and the codebase's existing conventions, then record the decisions in the PR body under a "Planning decisions" heading so a reviewer can see what was chosen and why.
+
+Gates:
+
+- [ ] What interface changes are needed
+- [ ] Which behaviors to test (prioritize)
+- [ ] Identify opportunities for deep modules (small interface, deep implementation)
+- [ ] Design interfaces for testability
+- [ ] List the behaviors to test (not implementation steps)
+- [ ] Plan is approved — interactive: by the user; autonomous: self-certified against the acceptance criteria, recorded in the PR body
+
+Interactive prompt: "What should the public interface look like? Which behaviors are most important to test?"
+
+**You can't test everything.** In interactive mode, confirm with the user exactly which behaviors matter most. In autonomous mode, prioritize the critical paths and complex logic implied by the acceptance criteria, not every possible edge case — and record that prioritization alongside the other planning decisions.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for refactor candidates:
+
+- [ ] Extract duplication
+- [ ] Deepen modules (move complexity behind simple interfaces)
+- [ ] Apply SOLID principles where natural
+- [ ] Consider what new code reveals about existing code
+- [ ] Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```

--- a/lore-workflow/skills/to-epic/SKILL.md
+++ b/lore-workflow/skills/to-epic/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: lore-workflow:to-epic
+description: Turn the current conversation or a plan/PRD into a PRD file under docs/prd/ plus
+  an epic tracker issue with one sub-issue per feature, structured so /lore-workflow:orchestrate-epic can
+  implement it autonomously. Use when the user wants an epic/tracker issue, or to turn a
+  plan/PRD into an orchestratable epic.
+---
+
+# To Epic
+
+Produce two coupled artifacts that `/lore-workflow:orchestrate-epic` consumes:
+
+1. **The PRD as a file** at `docs/prd/NNNN-kebab.md` (MyST Markdown) — the **source of
+   truth**, versioned in the repo, reviewable in PRs, and rendered in the docs site. It is
+   auto-wired into `docs/prd/index.md`'s toctree.
+2. **The epic tracker issue** — a GitHub issue that **links** the PRD (it does **not embed**
+   it), and carries the **roadmap table** (the canonical dependency DAG) plus one sub-issue
+   per feature (one feature = one teammate = one branch = one PR).
+
+This skill is the human checkpoint — `/lore-workflow:orchestrate-epic` runs hands-off afterward, so get the
+breakdown right here.
+
+Tracker: the project's GitHub issues, via `gh` (use `--json` for reads — see `CONVENTIONS.md`).
+This set is self-contained: it defines its own epic/sub-issue conventions below and
+does not rely on an external label vocabulary.
+
+The PRD-in-docs / gh-epic-as-tracker model is documented in `CONVENTIONS.md`; this skill
+implements it. The deterministic file mechanics — create the PRD at `docs/prd/NNNN-kebab.md`
+with front-matter that links the epic and lists the involved repos, and wire it idempotently
+into `docs/prd/index.md`'s toctree — live in the `prd_docs.py` helper beside this file so they
+are reproducible and tested. Use `prd_docs.create_prd(repo_root, slug=..., title=...,
+epic_url=..., repos=[...])`; it returns the PRD path and wires the toctree.
+
+## Process
+
+### 1. Gather context
+Work from the conversation. If the user passes a plan, PRD, or issue reference — including
+an epic-seed issue produced by `/lore-workflow:seed-epic` (labeled `epic-seed`) — fetch and read it
+(`gh ... --json`; see `CONVENTIONS.md`).
+
+### 2. Explore the repo(s)
+Understand the current state. Identify **every target repo** — an epic may be cross-repo.
+Use each project's domain language — its CONTEXT.md / glossary if present — and respect its
+ADRs (`docs/adr`).
+
+### 3. Synthesize the PRD
+Condense a PRD — do NOT interview, synthesize what you already know: Problem, Solution,
+Implementation decisions, Testing decisions, Out of scope. Prefer deep modules testable in
+isolation. This PRD is the **source of truth** and becomes the **file** at
+`docs/prd/NNNN-kebab.md`, **not** the epic body. The epic body links it and carries only the
+one-paragraph summary + roadmap (see Publish).
+
+### 4. Draft the roadmap (vertical slices)
+Break the work into **tracer-bullet** features — each a thin slice cutting end-to-end through
+all layers, sized as one teammate / one branch / one PR. Prefer many thin slices over few
+thick ones. For each feature capture: title, target repo, type (AFK / HITL — prefer AFK),
+blocked-by, and acceptance criteria as checkboxes. HITL slices need a human decision or
+design review; `/lore-workflow:orchestrate-epic` escalates rather than auto-implements them, so resolve
+what you can into AFK during planning.
+
+### 5. Quiz the user (the checkpoint)
+Present the breakdown as a numbered list (Title · Repo · Type · Blocked by · criteria) **and
+the parallel batches it implies** (topological grouping of the DAG). Ask: right granularity?
+dependencies correct? repos correct? AFK/HITL correct? merge or split any slice? Iterate to
+approval — `/lore-workflow:orchestrate-epic` will not ask again.
+
+### 6. Publish
+Order matters so every cross-reference resolves:
+
+1. **Write the PRD file.** Call `prd_docs.create_prd(...)` to write
+   `docs/prd/NNNN-kebab.md` and wire it into `docs/prd/index.md`'s toctree. Front-matter
+   carries `epic:` (filled with the epic URL once it exists — step 4 closes this loop) and
+   `repos:` (every involved repo). Fill the PRD body sections with the synthesized PRD. Commit
+   it to the repo on the branch the docs PR will carry.
+2. **Create sub-issues** in dependency order so refs resolve, each in its target repo using the
+   sub-issue template (optionally labeled `epic:<n>` for grouping). Each sub-issue **links back
+   to the epic**.
+3. **Create the epic tracker issue**, labeled `epic` (create the label if missing). The body
+   **links the PRD file** and carries a one-paragraph summary + the roadmap table + a task list
+   of the sub-issues — **no PRD content is duplicated in the epic body** (link only).
+4. **Close the cross-reference loop.** Set the PRD front-matter `epic:` to the epic issue URL,
+   and (if an ADR records this decision) cross-link PRD ↔ ADR. The result is **bidirectional
+   cross-references** PRD ↔ epic ↔ ADR ↔ sub-issue: a PRD links its epic (and ADR); the epic
+   links the PRD and its sub-issues; each sub-issue links back to the epic.
+5. **Close the consumed seed.** If this epic was formed from an epic-seed issue (labeled
+   `epic-seed`, produced by `/lore-workflow:seed-epic`), close that seed issue with a comment linking the
+   newly formed epic (`gh issue close <seed> --comment "Formed into epic <owner/repo#epic>"`).
+   Skip this step when the epic was not formed from a seed.
+
+**Gate publishing on the roadmap validator.** The roadmap table is the dependency DAG
+`/lore-workflow:orchestrate-epic` consumes, so it must be well-formed before the epic goes live. Run the
+deterministic, dependency-free `roadmap_validator.py` (stdlib only, beside this file) on the
+composed epic body — e.g. `gh issue view <epic> --json body -q .body | python "$SKILL_DIR/roadmap_validator.py" -`, or point it at the drafted body file. It checks
+the required columns (`# | Feature | Issue | Repo | Type | Blocked by`), fully-qualified
+`owner/repo#n` Issue refs, blocked-by edges that resolve to rows in the table, and an acyclic
+dependency DAG. **Publish only a roadmap it accepts:** a table it rejects is malformed and
+would break the orchestrator, so fix the columns, refs, or edges it reports and re-run until
+it passes.
+
+Use fully-qualified refs (`owner/repo#n`) for every cross-repo link. Do not modify unrelated
+parent issues.
+
+Finish by printing the PRD file path, the epic reference, and the exact next command:
+`/lore-workflow:orchestrate-epic <owner/repo#n>`.
+
+## PRD file template
+
+The PRD is the **source of truth**, written to `docs/prd/NNNN-kebab.md` by `prd_docs.create_prd`
+(front-matter + skeleton) and filled with the synthesized PRD. Front-matter links the epic and
+lists involved repos; the body carries the full spec that the epic body only links to.
+
+<prd-file-template>
+---
+title: <Title>
+status: draft
+epic: https://github.com/owner/repo/issues/<epic>
+repos:
+  - owner/repo
+  - owner/repo-b
+---
+
+# PRD NNNN: <Title>
+
+> Source of truth for this epic. Tracker: [epic issue](https://github.com/owner/repo/issues/<epic>).
+> The epic links here; this file is not embedded in the issue body.
+
+## Problem
+The problem, from the user's perspective.
+
+## Solution
+The solution, from the user's perspective.
+
+## Implementation decisions
+Modules to build/modify and their interfaces, schema/API contracts, architectural decisions.
+No file paths or code snippets (exception: a decision-encoding snippet from a prototype —
+state machine, schema, type shape — trimmed to the decision-rich parts).
+
+## Testing decisions
+What makes a good test here (external behavior, not implementation detail), which modules are
+tested, and prior art in the codebase.
+
+## Out of scope
+What this epic deliberately does not cover.
+</prd-file-template>
+
+## Epic body template
+
+The epic is a **tracker, not a spec**: it **links** the PRD (no PRD content duplicated here)
+and carries the roadmap DAG. The **roadmap table stays in the epic body** — it is what
+`/lore-workflow:orchestrate-epic` reads.
+
+<epic-body-template>
+## Summary
+One paragraph: problem → solution. Full spec lives in the PRD.
+
+**PRD:** [`docs/prd/NNNN-kebab.md`](../blob/<branch>/docs/prd/NNNN-kebab.md) — the source of truth.
+
+## Roadmap
+Canonical DAG for `/lore-workflow:orchestrate-epic` — one row per feature/sub-issue. Type is AFK (runs
+autonomously, no human input) or HITL (human-in-the-loop: needs a human decision); the table
+below keeps the literal token, which is what the roadmap validator and `/lore-workflow:orchestrate-epic` read.
+
+| # | Feature | Issue | Repo | Type | Blocked by |
+|---|---------|-------|------|------|------------|
+| 1 | <slice title> | owner/repo#12 | repo-a | AFK | — |
+| 2 | <slice title> | owner/repo#13 | repo-a | AFK | #12 |
+| 3 | <slice title> | owner/other#7 | repo-b | HITL | #12 |
+
+- [ ] owner/repo#12 — Feature 1
+- [ ] owner/repo#13 — Feature 2
+- [ ] owner/other#7 — Feature 3
+</epic-body-template>
+
+## Sub-issue template
+
+<sub-issue-template>
+## Epic
+owner/repo#<epic>
+
+## Repo
+The repo this slice is implemented in.
+
+## What to build
+End-to-end behavior of this vertical slice — not layer-by-layer implementation. No file paths
+or code snippets (same prototype exception as above).
+
+## Acceptance criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Blocked by
+owner/repo#<n>, or "None — can start immediately".
+
+## Type
+AFK (runs autonomously, no human input) or HITL (human-in-the-loop: needs a human decision).
+
+## Pointers (starting points, may be stale)
+Non-authoritative starting points so a teammate reuses the discovery already done
+during shaping instead of re-exploring the repo from scratch. Everything here may
+have gone stale since the epic was formed — verify before trusting, and widen from
+here rather than treat it as the whole picture. The PRD stays path-free; these
+pointers live only in this disposable sub-issue (closed on merge), where staleness
+is a non-issue.
+- **Dev notes** — modules/files to start from and interfaces to build against.
+- **Architecture excerpts** — the conventions and shared touchpoints this slice sits within.
+- **Test criteria** — tests that are prior art for what a good test looks like here.
+</sub-issue-template>

--- a/lore-workflow/skills/to-epic/SKILL.md
+++ b/lore-workflow/skills/to-epic/SKILL.md
@@ -20,23 +20,30 @@ Produce two coupled artifacts that `/lore-workflow:orchestrate-epic` consumes:
 This skill is the human checkpoint — `/lore-workflow:orchestrate-epic` runs hands-off afterward, so get the
 breakdown right here.
 
-Tracker: the project's GitHub issues, via `gh` (use `--json` for reads — see `CONVENTIONS.md`).
-This set is self-contained: it defines its own epic/sub-issue conventions below and
-does not rely on an external label vocabulary.
+Tracker: the project's GitHub issues, via `gh` (use `--json` for reads — see the repo's own
+conventions doc, if any). This set is self-contained: it defines its own epic/sub-issue
+conventions below and does not rely on an external label vocabulary.
 
-The PRD-in-docs / gh-epic-as-tracker model is documented in `CONVENTIONS.md`; this skill
-implements it. The deterministic file mechanics — create the PRD at `docs/prd/NNNN-kebab.md`
-with front-matter that links the epic and lists the involved repos, and wire it idempotently
-into `docs/prd/index.md`'s toctree — live in the `prd_docs.py` helper beside this file so they
-are reproducible and tested. Use `prd_docs.create_prd(repo_root, slug=..., title=...,
-epic_url=..., repos=[...])`; it returns the PRD path and wires the toctree.
+The PRD-in-docs / gh-epic-as-tracker model is implemented by this skill. The deterministic
+file mechanics — create the PRD at `docs/prd/NNNN-kebab.md` with front-matter that links the
+epic and lists the involved repos, and wire it idempotently into `docs/prd/index.md`'s toctree
+— live in `lore`'s `lore workflow create-prd` subcommand, so they are reproducible and tested
+independently of this skill:
+
+```
+lore workflow create-prd --slug <kebab> --title "<Title>" --epic-url <url> \
+    --repo owner/repo [--repo owner/repo-b ...] [--target <repo-root>]
+```
+
+It prints the PRD path and wires the toctree; there is no Python helper bundled with this
+skill any more.
 
 ## Process
 
 ### 1. Gather context
 Work from the conversation. If the user passes a plan, PRD, or issue reference — including
 an epic-seed issue produced by `/lore-workflow:seed-epic` (labeled `epic-seed`) — fetch and read it
-(`gh ... --json`; see `CONVENTIONS.md`).
+(`gh ... --json`; see the repo's own conventions doc, if any).
 
 ### 2. Explore the repo(s)
 Understand the current state. Identify **every target repo** — an epic may be cross-repo.
@@ -67,7 +74,7 @@ approval — `/lore-workflow:orchestrate-epic` will not ask again.
 ### 6. Publish
 Order matters so every cross-reference resolves:
 
-1. **Write the PRD file.** Call `prd_docs.create_prd(...)` to write
+1. **Write the PRD file.** Call `lore workflow create-prd` (see above) to write
    `docs/prd/NNNN-kebab.md` and wire it into `docs/prd/index.md`'s toctree. Front-matter
    carries `epic:` (filled with the epic URL once it exists — step 4 closes this loop) and
    `repos:` (every involved repo). Fill the PRD body sections with the synthesized PRD. Commit
@@ -89,8 +96,9 @@ Order matters so every cross-reference resolves:
 
 **Gate publishing on the roadmap validator.** The roadmap table is the dependency DAG
 `/lore-workflow:orchestrate-epic` consumes, so it must be well-formed before the epic goes live. Run the
-deterministic, dependency-free `roadmap_validator.py` (stdlib only, beside this file) on the
-composed epic body — e.g. `gh issue view <epic> --json body -q .body | python "$SKILL_DIR/roadmap_validator.py" -`, or point it at the drafted body file. It checks
+deterministic, dependency-free `lore workflow validate-roadmap` on the composed epic body —
+e.g. `gh issue view <epic> --json body -q .body | lore workflow validate-roadmap -`, or point
+it at the drafted body file (`lore workflow validate-roadmap <path>`). It checks
 the required columns (`# | Feature | Issue | Repo | Type | Blocked by`), fully-qualified
 `owner/repo#n` Issue refs, blocked-by edges that resolve to rows in the table, and an acyclic
 dependency DAG. **Publish only a roadmap it accepts:** a table it rejects is malformed and
@@ -105,8 +113,9 @@ Finish by printing the PRD file path, the epic reference, and the exact next com
 
 ## PRD file template
 
-The PRD is the **source of truth**, written to `docs/prd/NNNN-kebab.md` by `prd_docs.create_prd`
-(front-matter + skeleton) and filled with the synthesized PRD. Front-matter links the epic and
+The PRD is the **source of truth**, written to `docs/prd/NNNN-kebab.md` by
+`lore workflow create-prd` (front-matter + skeleton) and filled with the synthesized PRD.
+Front-matter links the epic and
 lists involved repos; the body carries the full spec that the epic body only links to.
 
 <prd-file-template>

--- a/tests/test_workflow_plugin_structural.py
+++ b/tests/test_workflow_plugin_structural.py
@@ -1,0 +1,296 @@
+"""Structural gates for the `lore-workflow` plugin (PRD 0003 / epic #161).
+
+Ported from `ccat-agent-workflow`'s `tests/validate.py`, scoped to
+`lore-workflow/` instead of a whole-repo layout, and updated for this repo's
+rewires: skills delegate tiers via `lore tier resolve` (not a bundled
+MODEL-TIERS.md), and the shared boilerplate that used to repeat across five
+skills now lives in one `TIER-DELEGATION.md`.
+
+Each check appends to a shared failure list rather than asserting inline, so
+a single test run reports every problem at once — mirroring the source
+validator's design.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_ROOT = REPO_ROOT / "lore-workflow"
+PLUGIN_MANIFEST = PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
+SKILLS_ROOT = PLUGIN_ROOT / "skills"
+SKILLS_GLOB = "skills/*/SKILL.md"
+TIER_DELEGATION_DOC = PLUGIN_ROOT / "TIER-DELEGATION.md"
+MODEL_TIERS_DOC = REPO_ROOT / "docs" / "model-tiers.md"
+
+REQUIRED_PLUGIN_FIELDS = ("name", "version", "description", "author")
+REQUIRED_SKILL_FRONTMATTER = ("name", "description")
+KEBAB_CASE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# Every ported skill must carry the plugin's slash-command prefix.
+EXPECTED_SKILL_NAMES = {
+    "ccat-workflow-init",
+    "debug",
+    "document-epic",
+    "domain-modeling",
+    "grilling",
+    "grill-me",
+    "grill-with-docs",
+    "implement-issue",
+    "orchestrate-epic",
+    "orient",
+    "seed-epic",
+    "tdd",
+    "to-epic",
+}
+
+GRILLING_SKILL_FILES = {
+    "grilling": ("SKILL.md",),
+    "grill-me": ("SKILL.md",),
+    "grill-with-docs": ("SKILL.md",),
+    "domain-modeling": ("SKILL.md", "CONTEXT-FORMAT.md", "ADR-FORMAT.md"),
+}
+
+DOCUMENT_EPIC_SKILL = SKILLS_ROOT / "document-epic" / "SKILL.md"
+
+# No skill under lore-workflow may name a concrete model — tiers are resolved
+# via `lore tier resolve`, never hardcoded.
+BANNED_MODEL_NAME_SUBSTRINGS = (
+    "opus",
+    "sonnet",
+    "haiku",
+    "fable",
+    "mythos",
+    "claude-",
+    "gpt-",
+    "gemini",
+)
+
+SEMANTIC_TIERS = ("frontier", "strong", "mid", "cheap")
+
+# Scripts that used to ship beside a skill; superseded by `lore` CLI/MCP
+# surface. A reference to any of these under skills/ is stale.
+BANNED_SCRIPT_REFERENCES = (
+    "roadmap_validator.py",
+    "prd_docs.py",
+    "diataxis.py",
+    "code_map.py",
+    "ccat_workflow_init.py",
+)
+
+SKILL_LINE_BUDGET = 150
+SKILL_LINE_BUDGET_WAIVERS: dict[str, int] = {
+    "orchestrate-epic": 300,
+    "to-epic": 220,
+}
+
+_MARKDOWN_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+_TIER_REF_HYPHEN = re.compile(r"\b([a-z]+)-tier(?![a-z])")
+_TIER_REF_ASSIGN = re.compile(r"\btier:\s*`?([a-z]+)`?")
+
+
+def _parse_frontmatter(text: str) -> dict[str, str] | None:
+    if not text.startswith("---"):
+        return None
+    match = re.match(r"^---\s*\n(.*?)\n---\s*(\n|$)", text, re.DOTALL)
+    if not match:
+        return None
+    data: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        line = line.rstrip()
+        if not line or line.lstrip().startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        data[key.strip()] = value.strip().strip("'\"")
+    return data
+
+
+def _skill_files() -> list[Path]:
+    return sorted(PLUGIN_ROOT.glob(SKILLS_GLOB))
+
+
+def _skill_dirs() -> list[Path]:
+    return sorted(p for p in SKILLS_ROOT.iterdir() if p.is_dir())
+
+
+def _all_skill_files() -> list[Path]:
+    return sorted(p for p in SKILLS_ROOT.rglob("*") if p.is_file())
+
+
+def test_plugin_manifest_required_fields() -> None:
+    manifest = json.loads(PLUGIN_MANIFEST.read_text())
+    missing = [f for f in REQUIRED_PLUGIN_FIELDS if not manifest.get(f)]
+    assert not missing, f"plugin.json missing required field(s): {missing}"
+    assert KEBAB_CASE.match(manifest["name"]), (
+        f"plugin.json name not kebab-case: {manifest['name']}"
+    )
+
+
+def test_every_expected_skill_ships() -> None:
+    present = {p.parent.name for p in _skill_files()}
+    assert present == EXPECTED_SKILL_NAMES, (
+        f"skill set mismatch — missing: {EXPECTED_SKILL_NAMES - present}, "
+        f"unexpected: {present - EXPECTED_SKILL_NAMES}"
+    )
+
+
+@pytest.mark.parametrize("skill_path", _skill_files(), ids=lambda p: p.parent.name)
+def test_skill_frontmatter_valid(skill_path: Path) -> None:
+    frontmatter = _parse_frontmatter(skill_path.read_text(encoding="utf-8"))
+    assert frontmatter is not None, f"{skill_path}: missing or unparseable YAML frontmatter"
+    for field in REQUIRED_SKILL_FRONTMATTER:
+        assert frontmatter.get(field), f"{skill_path}: frontmatter missing '{field}'"
+
+
+@pytest.mark.parametrize("skill_path", _skill_files(), ids=lambda p: p.parent.name)
+def test_skill_name_carries_plugin_prefix(skill_path: Path) -> None:
+    frontmatter = _parse_frontmatter(skill_path.read_text(encoding="utf-8"))
+    name = frontmatter["name"] if frontmatter else ""
+    assert name == f"lore-workflow:{skill_path.parent.name}", (
+        f"{skill_path}: name '{name}' must be 'lore-workflow:{skill_path.parent.name}'"
+    )
+
+
+def test_no_legacy_skill_install_path() -> None:
+    offenders = []
+    for path in _all_skill_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if ".claude/skills" in text:
+            offenders.append(path.relative_to(REPO_ROOT))
+    assert not offenders, f"references to legacy ~/.claude/skills path: {offenders}"
+
+
+def test_skill_relative_references_resolve() -> None:
+    failures = []
+    for path in sorted(SKILLS_ROOT.rglob("*.md")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        in_fence = False
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            for target in _MARKDOWN_LINK.findall(line):
+                target = target.strip()
+                if not target or target.startswith(("http://", "https://", "mailto:", "#")):
+                    continue
+                if "<" in target or ">" in target:
+                    continue
+                target_path = target.split("#", 1)[0].strip()
+                if not target_path:
+                    continue
+                resolved = (path.parent / target_path).resolve()
+                if not resolved.exists():
+                    failures.append(
+                        f"{path.relative_to(REPO_ROOT)}:{lineno}: '{target}' -> {resolved}"
+                    )
+    assert not failures, "broken relative references:\n  " + "\n  ".join(failures)
+
+
+def test_document_epic_skill_contract() -> None:
+    text = DOCUMENT_EPIC_SKILL.read_text().lower()
+    for quadrant in ("tutorial", "how-to", "reference", "explanation"):
+        assert quadrant in text, f"document-epic must mention Diátaxis quadrant '{quadrant}'"
+    for protected in ("docs/prd", "docs/adr"):
+        assert protected in text, f"document-epic must state the never-edit rule for '{protected}'"
+    assert "docstring" in text, "document-epic reference handling must mention docstrings"
+    assert "autosummary" in text or "toctree" in text, (
+        "document-epic reference handling must mention autosummary/toctree wiring"
+    )
+
+
+def test_grilling_subsystem_cohesion() -> None:
+    for skill, files in GRILLING_SKILL_FILES.items():
+        for filename in files:
+            path = SKILLS_ROOT / skill / filename
+            assert path.exists(), f"missing required file: {path.relative_to(REPO_ROOT)}"
+    gwd_text = (SKILLS_ROOT / "grill-with-docs" / "SKILL.md").read_text()
+    for referenced in ("grilling", "domain-modeling"):
+        assert referenced in gwd_text, f"grill-with-docs must reference '{referenced}'"
+    grill_me_text = (SKILLS_ROOT / "grill-me" / "SKILL.md").read_text()
+    assert "grilling" in grill_me_text, "grill-me must reference 'grilling'"
+
+
+def test_no_hardcoded_model_names() -> None:
+    failures = []
+    for path in _all_skill_files():
+        lowered = path.read_text(encoding="utf-8", errors="replace").lower()
+        for banned in BANNED_MODEL_NAME_SUBSTRINGS:
+            if banned in lowered:
+                failures.append(f"{path.relative_to(REPO_ROOT)}: hardcoded model name '{banned}'")
+    assert not failures, (
+        "skills must name a semantic tier (see TIER-DELEGATION.md / docs/model-tiers.md), "
+        "not a concrete model:\n  " + "\n  ".join(failures)
+    )
+
+
+def test_no_stale_script_references() -> None:
+    failures = []
+    for path in _all_skill_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for banned in BANNED_SCRIPT_REFERENCES:
+            if banned in text:
+                failures.append(f"{path.relative_to(REPO_ROOT)}: stale reference to '{banned}'")
+    assert not failures, (
+        "skills must call the lore CLI/MCP surface, not a skill-local script:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_skill_tiers_are_defined() -> None:
+    failures = []
+    for path in _all_skill_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        referenced = set(_TIER_REF_HYPHEN.findall(text)) | set(_TIER_REF_ASSIGN.findall(text))
+        for tier in sorted(referenced - set(SEMANTIC_TIERS)):
+            failures.append(f"{path.relative_to(REPO_ROOT)}: undefined tier '{tier}'")
+    assert not failures, (
+        f"tiers referenced under skills/ must be one of {SEMANTIC_TIERS}:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_tier_delegation_doc_states_the_rules() -> None:
+    assert TIER_DELEGATION_DOC.exists(), "missing lore-workflow/TIER-DELEGATION.md"
+    text = TIER_DELEGATION_DOC.read_text().lower()
+    assert "lore tier resolve" in text
+    assert "implicit" in text and "inherit" in text, (
+        "TIER-DELEGATION.md must state the no-implicit-inherit rule"
+    )
+    for tier in SEMANTIC_TIERS:
+        assert tier in text, f"TIER-DELEGATION.md must name tier '{tier}'"
+
+
+def test_model_tiers_doc_covers_ordinal_fallback_cheap_rules() -> None:
+    """The shared lore-level tier doc (docs/model-tiers.md) is what
+    TIER-DELEGATION.md points readers at for the full contract; assert it
+    still states the rules the source repo's MODEL-TIERS.md carried."""
+    text = MODEL_TIERS_DOC.read_text().lower()
+    assert "ordinal" in text and "collapse" in text
+    assert "fallback" in text
+    assert "bulk-mechanical" in text or "bulk mechanical" in text
+
+
+def test_readme_skill_table_matches_shipped_skills() -> None:
+    readme = (PLUGIN_ROOT / "README.md").read_text(encoding="utf-8")
+    row = re.compile(r"^\|\s*`([a-z0-9]+(?:-[a-z0-9]+)*)`\s*\|", re.M)
+    documented = set(row.findall(readme))
+    actual = {p.name for p in _skill_dirs()}
+    assert documented == actual, (
+        f"README skill table out of sync — missing: {actual - documented}, "
+        f"extra: {documented - actual}"
+    )
+
+
+@pytest.mark.parametrize("skill_dir", _skill_dirs(), ids=lambda p: p.name)
+def test_skill_line_budget(skill_dir: Path) -> None:
+    cap = SKILL_LINE_BUDGET_WAIVERS.get(skill_dir.name, SKILL_LINE_BUDGET)
+    n_lines = len((skill_dir / "SKILL.md").read_text(encoding="utf-8").splitlines())
+    assert n_lines <= cap, (
+        f"{skill_dir.name}/SKILL.md: {n_lines} lines exceeds its {cap}-line budget"
+    )


### PR DESCRIPTION
Closes #172

## What
Ports 13 workflow skills from `ccatobs/ccat-agent-workflow` into the
`lore-workflow` plugin (skeleton from #164), verbatim except for the five
required rewires:

1. **Tier prose → resolver.** Every skill that names a model tier now says
   `lore tier resolve <tier>` and points at `docs/model-tiers.md` (#168) —
   no skill names a concrete model.
2. **CODEMAP → generator/MCP.** `implement-issue` and `orient` now cite
   `lore codemap` (#165) / the `lore_codemap` MCP tool (#167) instead of a
   committed `CODEMAP.md` or skill-local `code_map.py`.
3. **Scripts → `lore workflow` subcommands.** `to-epic` calls
   `lore workflow create-prd` / `lore workflow validate-roadmap` (#169)
   instead of bundling `prd_docs.py` / `roadmap_validator.py`;
   `document-epic` calls the `lore_workflow.diataxis` module instead of a
   bundled `diataxis.py`. The three now-superseded scripts were deleted.
4. **Tier boilerplate deduped** into one shared `lore-workflow/TIER-DELEGATION.md`
   that every delegation-point skill links to, instead of repeating the
   same paragraph five times.
5. **`ccat-workflow-init` reshaped**, not ported verbatim: it's now a thin
   pointer at `lore attach --scaffold-workflow` (#171/#206) — no standalone
   workflow-init entry point.

`orchestrate-epic` (293 lines) and `to-epic` (216 lines) keep their
line-budget waivers (300 / 220).

## Structural checks (ported from `tests/validate.py` + `test_tier_delegation.py`)
New `tests/test_workflow_plugin_structural.py`, 51 deterministic pytest
cases, no LLM involved:
- plugin manifest required fields; every expected skill ships with valid
  frontmatter carrying the `lore-workflow:` name prefix
- no legacy `.claude/skills` install-path references
- every relative markdown reference resolves on disk
- document-epic contract + grilling-subsystem cohesion hold
- no hardcoded model-name substrings anywhere under `lore-workflow/skills/`
- no stale references to the five superseded scripts
- only the four defined semantic tiers (`frontier`/`strong`/`mid`/`cheap`)
  appear anywhere
- `TIER-DELEGATION.md` and `docs/model-tiers.md` state the no-implicit-inherit
  and frontier-main-session rules
- README skill table matches shipped skills
- per-skill line budgets (with the two waivers)

### Red → green
Verified the new tests are load-bearing, not tautological, by breaking an
invariant and confirming failure before restoring:
```
mv lore-workflow/skills/orient lore-workflow/skills/orient.bak
pytest tests/test_workflow_plugin_structural.py -q
# 3 failed, 48 passed — test_every_expected_skill_ships,
# test_skill_name_carries_plugin_prefix[orient.bak],
# test_readme_skill_table_matches_shipped_skills
mv lore-workflow/skills/orient.bak lore-workflow/skills/orient
pytest tests/test_workflow_plugin_structural.py -q
# 51 passed
```

### Full suite (mirrors CI)
```
env -u FORCE_COLOR -u COLORTERM -u OPENAI_API_KEY NO_COLOR=1 python -m pytest -q
# 2614 passed, 1 warning, 11 subtests passed
```
`ruff check .` / `ruff format --check .` clean on every file authored or
touched (the one new test file; the ~791 pre-existing repo-wide ruff
findings are untouched files, out of scope per #172's fence).

## Scope
Touched only `lore-workflow/skills/**`, `lore-workflow/TIER-DELEGATION.md`,
`lore-workflow/README.md`, `lore-workflow/.claude-plugin/plugin.json`, and
`tests/test_workflow_plugin_structural.py`. No changes to `lib/`,
`attach_cmd.py`, codemap, the `lore` plugin manifest, or any version file.