### PR TITLE
docs: migrate workflow conventions + how-to guides into lore

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,43 @@ pipeline. Ratified decisions live in the connected repo's ADRs/PRDs,
 pulled on demand via MCP — Lore does not extract decisions from
 transcripts.
 
+## Two plugins: `lore` + `lore-workflow`
+
+This repo ships **two marketplace entries**, versioned and installed
+independently:
+
+| Plugin | What it's for | Depends on |
+|---|---|---|
+| **`lore`** | The notes/vault system above: session capture, search, MCP, briefings. | nothing else |
+| **`lore-workflow`** | An opinionated planning chain — epics, PRDs, TDD — that calls `lore`'s deterministic substrate (code map, model tiers). | `lore` |
+
+`lore-workflow` is opt-in: install `lore` alone for the notes pipeline, or
+add `lore-workflow` on top once you also want the planning chain. The
+dependency only runs one way — nothing in `lore` core imports or requires
+`lore-workflow`.
+
+The chain it bundles:
+
+```
+seed-epic → orient → grill-with-docs → to-epic → orchestrate-epic → document-epic
+```
+
+with `implement-issue` as a lighter-weight track for one well-understood
+issue, and `tdd` as the discipline every implementation teammate follows.
+See [`docs/conventions.md`](docs/conventions.md) for the full chain, the
+artifact-home contract (PRD/ADR/`AGENTS.md` placement), and the tier
+vocabulary; [`docs/how-to/`](docs/how-to/) for task recipes
+(run an epic, use the fast path, resume a broken epic, onboard a repo); and
+[`lore-workflow/README.md`](lore-workflow/README.md) for the skill roster.
+
+Install both from this one marketplace:
+
+```text
+/plugin marketplace add buchbend/lore
+/plugin install lore@lore
+/plugin install lore-workflow@lore
+```
+
 ## Canonical shape
 
 ```
@@ -133,7 +170,9 @@ The repo is a self-describing marketplace:
 /plugin install lore@lore
 ```
 
-That alone gives you the plugin (hooks, skills, subagents, MCP) — it
+That alone gives you the `lore` plugin (hooks, skills, subagents, MCP); add
+`/plugin install lore-workflow@lore` for the planning-chain skills too — see
+[§ Two plugins](#two-plugins-lore--lore-workflow). Installing `lore` alone
 does not install the `lore` CLI itself. Run
 `pipx install "git+https://github.com/buchbend/lore.git#egg=lore[capture]"`
 separately, or use `lore install --integration claude` once `lore` is on

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,256 @@
+# Conventions
+
+The canonical conventions for the `lore-workflow` planning chain: what the
+chain's steps are, where every artifact it produces lives, and the vocabulary
+it uses. A repo that adopts `lore-workflow` speaks this language — PRDs, ADRs,
+the agent guide, and epics all land in the same places, regardless of which
+repo the chain is run in.
+
+It answers two questions:
+
+1. **What is the workflow chain** — the steps, bundled or not.
+2. **Where does each artifact live.**
+
+For the tier-resolution mechanics (which model a semantic tier maps to on
+which host), see [`docs/model-tiers.md`](model-tiers.md); this page only fixes
+which *stage* runs at which tier.
+
+---
+
+## The workflow chain
+
+A piece of work flows through a fixed chain of skills. Each step hands off to
+the next; the human is the checkpoint between *shaping* and *autonomous
+build*.
+
+```
+seed-epic → orient → grill-with-docs → to-epic → orchestrate-epic → document-epic
+```
+
+| Step | What it does |
+|------|--------------|
+| `seed-epic` | End-of-session capture: distils hard-won context into a GitHub **epic seed** issue a cold session can `orient` on. A discussion seed, not a spec. |
+| `orient` | First step of any work. The session does its own homework with read-only subagents, then reflects its understanding back for confirmation. Explores; does not implement or fix scope. |
+| `grill-with-docs` | A relentless, one-question-at-a-time interview that stress-tests a plan against the project's domain model and documented decisions, sharpening terminology and updating `CONTEXT.md`/ADRs inline. Composes `grilling` + `domain-modeling`. |
+| `to-epic` | The human checkpoint. Turns a shaped plan into an **epic tracker** issue (linking a PRD under `docs/prd/`) plus one sub-issue per feature, emitting the canonical roadmap DAG `orchestrate-epic` consumes. |
+| `orchestrate-epic` | Fully autonomous: fans out one test-first teammate per feature, crosschecks every pull request, integrates onto an `epic/<n>` branch in dependency order, and lands one final pull request to the detected target branch. |
+| `document-epic` | Runs as `orchestrate-epic`'s **final automatic stage** (see below), not a manual step. Updates the Diátaxis docs to match the landed epic. |
+| `tdd` | The red→green→refactor loop every implementation teammate follows. |
+
+`code-review` is a **built-in** Claude Code command, not a bundled skill —
+the workflow uses it but does not ship it.
+
+`implement-issue` is a **track beside this chain, not a step in it** — the
+fast path for one well-understood issue, keeping the same discipline (strict
+TDD, ADR check, Diátaxis docs pass) at single-issue weight.
+
+**Bundled skills:** `ccat-workflow-init`, `seed-epic`, `orient`, `grilling`,
+`domain-modeling`, `grill-with-docs`, `grill-me`, `to-epic`,
+`orchestrate-epic`, `document-epic`, `tdd`, `debug`, `implement-issue` — all
+shipped as `lore-workflow:<name>` skills. `ccat-workflow-init` is a one-time
+onboarding scaffold, not part of the per-epic chain above; see
+[Onboard a repo](how-to/onboard-a-repo.md).
+
+---
+
+## Artifact homes
+
+Every workflow artifact has exactly one canonical home:
+
+| Artifact | Canonical home | Format |
+|----------|----------------|--------|
+| PRD (source of truth) | `docs/prd/NNNN-kebab.md` | MyST Markdown |
+| ADR | `docs/adr/NNNN-kebab.md` | MADR-lite |
+| Epic | GitHub issue (tracker) | issue body, *links* the PRD |
+| Sub-issue | GitHub issue | one per feature |
+| Per-repo agent guide | `AGENTS.md` (repo root) | Markdown, canonical |
+| Agent guide shim | `CLAUDE.md` (repo root) | one-line `@AGENTS.md` import |
+
+`NNNN` is zero-padded (`0001`, `0002`, ...).
+
+**PRD stays in the repo, not the issue body.** `docs/prd/NNNN-kebab.md` is
+MyST Markdown; the GitHub epic **links** the PRD rather than embedding it —
+the issue body carries the roadmap DAG and sub-issue checklist, while the PRD
+carries the durable spec. This keeps the spec versioned and reviewable in
+PRs, rather than frozen in an issue body. `lore workflow create-prd` writes
+the file and wires it into `docs/prd/index.md` idempotently — see
+[`to-epic`](../lore-workflow/skills/to-epic/SKILL.md).
+
+**ADR** lives at `docs/adr/NNNN-kebab.md` in **MADR-lite** form — Context,
+Decision, Consequences / Trade-offs, Alternatives considered, plus a Status
+line.
+
+**Bidirectional cross-references** tie the chain together so any node reaches
+the others:
+
+```
+PRD ↔ epic issue ↔ ADR ↔ sub-issue
+```
+
+The PRD links the epic and any ADR it depends on; the epic links the PRD and
+its sub-issues; an ADR links the PRD/epic it records; each sub-issue links
+back to the epic.
+
+### Per-repo agent guide
+
+Each repo carries one canonical agent guide, **`AGENTS.md`**, at the root —
+project-specific instructions for any coding agent. **`CLAUDE.md` becomes a
+one-line shim** that re-exports it:
+
+```markdown
+@AGENTS.md
+```
+
+This keeps a single source of truth (`AGENTS.md`) while staying compatible
+with Claude Code's `CLAUDE.md` auto-load. `lore attach --scaffold-workflow`
+(and the `ccat-workflow-init` skill, a thin pointer at the same command)
+migrates an existing `CLAUDE.md` into this shape.
+
+### gh-epic-as-tracker
+
+The GitHub epic issue is a coordination surface, not a spec:
+
+- a one-paragraph problem/solution summary, linking the PRD;
+- the roadmap DAG (`# | Feature | Issue | Repo | Type | Blocked by`);
+- a checklist of sub-issues for the parallel-batch plan.
+
+`orchestrate-epic` reads the tracker — specifically the roadmap DAG — to
+decide fan-out order. The detailed spec stays in the linked PRD; the tracker
+stays the coordination surface.
+
+### Reading the tracker with `gh`
+
+Read epic and sub-issue bodies through the JSON API, never the rendered text
+view: `gh issue view <n> --json body -q .body` (same for PR bodies and
+comments). The plain-text view times out on large trackers.
+
+---
+
+## `document-epic`'s auto stage
+
+`document-epic` is **not a manual step**. It runs as `orchestrate-epic`'s
+final automatic subagent stage, **after the epic PR lands**:
+
+1. The epic's feature PRs are integrated and the epic branch lands on the
+   target branch.
+2. `orchestrate-epic` dispatches `document-epic` as its last subagent.
+3. `document-epic` generates the Diátaxis docs for the change, **opens a
+   docs PR**, and **auto-merges it on green CI**.
+4. A human **reviews post-hoc** — the docs land autonomously; review happens
+   without blocking the merge.
+
+This keeps documentation in lock-step with shipped code without adding a
+manual gate to the autonomous loop.
+
+### Diátaxis handoff
+
+`document-epic` produces the Diátaxis four, and only these:
+
+| Quadrant | What | Where |
+|----------|------|-------|
+| Tutorial | learning-oriented walkthrough | `docs/tutorials/` |
+| How-to guide | task-oriented recipe | `docs/how-to/` |
+| Reference | docstrings + code-level reference | code + `docs/` |
+| Explanation | understanding-oriented background | `docs/explanation/` |
+
+**`document-epic` NEVER touches `docs/prd/` or `docs/adr/`.** Those are the
+human-owned record of intent and decisions — `to-epic` and ADR authorship
+write them; `document-epic` only reads them for context.
+
+---
+
+## Model tiers
+
+Every delegation point in the workflow selects a **semantic tier**
+(`frontier` / `strong` / `mid` / `cheap`), never a concrete model name. The
+tiers, the per-host resolution table, the ordinal/collapse rule, the
+fallback behavior, and the cheap-reservation rule all live in
+[`docs/model-tiers.md`](model-tiers.md) and are resolved via
+`lore tier resolve <tier>`. This section fixes *which stage runs at which
+tier* and *how strictly the mapping is enforced* — see also
+[`lore-workflow/TIER-DELEGATION.md`](../lore-workflow/TIER-DELEGATION.md) for
+the shared spawn-resolution boilerplate every skill points back to.
+
+### Stage → tier
+
+| Stage | Tier |
+|-------|------|
+| Orchestration | `frontier` |
+| Grilling / synthesis | `frontier` |
+| Exploration / gathering | `mid` |
+| Implementation — mechanical | `mid` |
+| Implementation — architectural, ambiguous, cross-cutting | `strong` |
+| Crosscheck / review | `strong` |
+
+`cheap` appears in no row: it is reserved explicitly for bulk-mechanical
+sub-tasks and is **no stage's default** (see `docs/model-tiers.md`).
+
+### Enforcement: REQUIRED vs ADVISORY
+
+The mapping is enforced at two strengths:
+
+- **REQUIRED** — every run: the **exploration / gathering** tier (`mid`) and
+  the **crosscheck / review** tier (`strong`); and the rule that **no
+  delegation ever inherits the session model implicitly** — every spawn
+  names a tier *and* resolves it to a concrete model in the spawn call
+  itself (see "Resolution at spawn time" in `docs/model-tiers.md`; tier
+  prose alone resolves nothing). `tests/test_workflow_plugin_structural.py`
+  enforces the no-hardcoded-model-name half of this mechanically.
+- **ADVISORY** — the table is the default for the **implementation-teammate**
+  tiers (mechanical vs. architectural/cross-cutting); a deviation is allowed
+  but recorded in the supervision trail.
+
+For the REQUIRED categories, inadequate output at a tier is retried **once**
+at the next tier up (**T+1**); a second inadequate result is not escalated
+again — it is raised as a blocker instead.
+
+---
+
+## House style for human-facing output
+
+Artifacts written for humans — issue bodies, PR bodies, status comments,
+reports — use plain, direct sentences. Expand abbreviations on first use (the
+Glossary below has the full list). Prefer the standard term over the
+metaphor: write "create branch", not "cut branch"; "merge into the target
+branch", not "land". Every skill that writes a human-facing artifact
+inherits this rule; it is not opt-in per skill.
+
+This does not touch the workflow's own terms of art (`AFK`, `HITL`, and the
+machine-read table columns) — those stay precise and unchanged so tooling
+that checks them keeps working. The rule is about the surrounding prose a
+human reads.
+
+## Glossary
+
+Plain-English definitions of the workflow's terms of art. The terms
+themselves stay — they are precise and machine-checked (the roadmap
+validator reads the literal `AFK`/`HITL` tokens, for example) — these
+definitions just remove the decoding cost for a reader meeting them for the
+first time.
+
+- **tracer bullet** — a thin slice of a feature, built end-to-end, that
+  proves the approach works before the feature is built out further.
+- **vertical slice** — a piece of work that cuts through every layer (data,
+  logic, UI) instead of one layer at a time.
+- **AFK** — "away from keyboard": the feature runs autonomously, no human
+  input needed.
+- **HITL** — "human-in-the-loop": the feature needs a human decision or
+  design review.
+- **crosscheck** — the strong-tier review a delegated reviewer performs on a
+  teammate's PR before merge.
+- **land** — merge a pull request into its target branch.
+- **cut** (a branch) — create a new branch.
+- **fan out** — dispatch multiple teammate agents to work in parallel, one
+  per feature.
+- **green / red** — a test suite that passes / fails; shorthand for the
+  TDD loop.
+- **deploy gate** — a marker a repo declares that requires human
+  confirmation before a merge that would deploy, instead of merging
+  automatically.
+- **supervision trail** — the durable, on-GitHub record of what an
+  autonomous run did: status comments, crosscheck verdicts, tier
+  escalations.
+- **epic seed** — a tracker issue capturing a session's context for a cold
+  session to `orient` on; not yet a formed spec.
+- **cold session** — a fresh session with no memory of prior conversation,
+  starting only from the repo and issue it is pointed at.

--- a/docs/explanation/why-prd-in-repo.md
+++ b/docs/explanation/why-prd-in-repo.md
@@ -1,0 +1,52 @@
+# Why the PRD lives in the repo
+
+The **product requirements document** (PRD) is the source of truth for what
+an epic sets out to do, and it lives in the repo at `docs/prd/NNNN-kebab.md`
+as Markdown — *not* embedded in a GitHub issue. The GitHub epic issue is a
+**tracker** that links the PRD. This page explains why the spec lives in the
+repo and the issue stays a coordination surface.
+
+## The problem it solves
+
+A specification frozen in a GitHub issue body is hard to live with. It is
+not versioned alongside the code it describes, so the two drift apart with
+no diff to show it. It is not reviewable in a pull request, so a change to
+the spec gets no review.
+
+Putting the PRD in the repo fixes both at once:
+
+- **It is versioned with the code.** The spec and the implementation move
+  through the same history; a change to intent is a commit, visible in
+  `git log`.
+- **It is reviewable.** A PRD change arrives as a pull request diff and gets
+  the same review as any other change.
+
+## The tracker-versus-spec split
+
+The division of labour is deliberate:
+
+- The **PRD** (in the repo) carries the durable spec — the problem, the
+  solution, the requirements.
+- The **epic issue** (on GitHub) carries the coordination surface — a
+  one-paragraph summary and a link to the PRD, the roadmap dependency table,
+  and the sub-issue checklist. `orchestrate-epic` reads this tracker to
+  decide fan-out order; it does not need the full spec to schedule the
+  work.
+
+This keeps each artifact doing the one thing it is good at: GitHub is good
+at tracking state across issues and pull requests; a versioned repo file is
+good at holding a reviewable specification.
+
+## Why `document-epic` never touches it
+
+The PRD and the ADRs (`docs/adr/`) are the **human-owned record of intent
+and decisions**. The autonomous `document-epic` stage writes only the
+Diátaxis docs that *describe the shipped result*; it reads the PRD and ADRs
+for context but is forbidden from writing, renaming, or deleting them.
+Keeping the source of truth out of the autonomous writer's reach is what
+lets the docs be generated autonomously without ever putting the spec at
+risk.
+
+See [`docs/conventions.md`](../conventions.md) ("Artifact homes") for the
+canonical home of every artifact and the cross-reference contract that ties
+the PRD, epic, ADR, and sub-issues together.

--- a/docs/explanation/why-tdd-is-enforced.md
+++ b/docs/explanation/why-tdd-is-enforced.md
@@ -1,0 +1,54 @@
+# Why test-first development is enforced
+
+`lore-workflow` makes **test-driven development** (TDD) a hard rule, not a
+suggestion: every implementation teammate writes a failing test first, makes
+it pass, then refactors — the red → green → refactor loop (`lore-workflow:tdd`)
+— and no pull request merges on red. This page explains why the discipline
+is mandatory rather than left to judgement.
+
+## The problem it solves
+
+Most of the code in this workflow is written by autonomous teammate agents
+you are not watching. That changes the economics of a dropped test. When a
+human writes code and skips the test, the human still has the mental model
+of what the code should do and can catch a regression by eye. An agent that
+skips the test leaves **no such safety net** — the next agent to touch the
+file has only the code, and the code cannot tell you whether it does what
+was *meant*, only what it *does*.
+
+Tests written **first** pin the intended behaviour before the implementation
+exists to bias them. Tests written after the fact ratify whatever the code
+already does — including its bugs. That difference is the whole point: the
+failing test is a specification the code must satisfy, and it is only a
+specification if it comes first.
+
+## Why it is enforced, not encouraged
+
+The moments where a teammate is most tempted to skip the test are exactly
+the moments where skipping costs the most:
+
+- *"This is just a mechanical change."* Trivial edits are where a typo ships
+  unnoticed, because nobody looks hard at a one-liner.
+- *"I'll add tests after."* After-the-fact tests ratify the code you wrote,
+  not the behaviour you meant.
+- *"The skill is overkill here."* The red → green loop is the floor, not
+  ceremony reserved for hard problems.
+
+Because these excuses are predictable, the workflow names them explicitly in
+the teammate brief and closes the door on them, rather than trusting each
+agent to resist them in the moment. A green pull request with no test
+mapping to its acceptance criteria is not accepted.
+
+## How it shows up in the chain
+
+- On the [epic chain](../how-to/run-an-epic.md), every fan-out teammate
+  follows `lore-workflow:tdd`, and each feature's crosscheck verifies the
+  tests map to the acceptance criteria before the pull request merges.
+- On the [fast path](../how-to/use-the-fast-path.md), the same strict loop
+  is one of the invariants the single-issue track keeps even though it drops
+  the fan-out and multi-PR integration.
+
+Enforcing the loop everywhere is what lets the autonomous build be trusted
+at all: the tests are the standing evidence that the shipped behaviour is
+the intended behaviour, produced by the same process no matter who — or
+which agent — wrote the code.

--- a/docs/how-to/onboard-a-repo.md
+++ b/docs/how-to/onboard-a-repo.md
@@ -1,0 +1,56 @@
+# Onboard a repo
+
+**Goal:** prepare a repository to adopt `lore-workflow`, once, before you run
+any of the chain in it.
+
+Onboarding is `lore attach --scaffold-workflow` — the `ccat-workflow-init`
+skill (`lore-workflow:ccat-workflow-init`) is a thin pointer at the same
+command, for when you'd rather trigger it from a skill invocation than a
+shell. It is idempotent — safe to re-run — and additive: it never overwrites
+an existing file.
+
+## Before you start
+
+- The target repo checked out locally, ideally a git repository.
+- `lore` installed and the repo already `lore attach`ed (a plain `lore
+  attach` without the flag also works — the workflow scaffold layers on top).
+
+## Steps
+
+1. **Run the scaffold in the repo.**
+
+   ```
+   lore attach --scaffold-workflow
+   ```
+
+   Or, from a Claude Code session in the repo:
+
+   ```
+   /lore-workflow:ccat-workflow-init
+   ```
+
+2. **Read what it reports.** It tells you which files it created and which
+   it skipped because they already existed.
+
+## What it sets up
+
+- **`AGENTS.md` as the canonical per-repo agent guide**, migrated from any
+  existing `CLAUDE.md`; `CLAUDE.md` becomes a one-line `@AGENTS.md` import
+  shim so Claude Code still auto-loads it.
+- **`docs/prd/index.md` and `docs/adr/index.md`** — stubs for the PRD and
+  ADR homes — and a root **`docs/index.md`** that wires them in.
+
+The code-map (`CODEMAP.md`, refreshed via `lore`'s own `SessionStart` hook)
+and the `lore tier resolve` / spawn-model gate come from `lore` itself —
+nothing workflow-specific to wire up for either. The autonomy-permissions
+allowlist and the `## Epic merge policy` section in `AGENTS.md` (the
+`epic-merge-policy: confirm` marker `orchestrate-epic` reads before its
+final merge — see [Conventions](../conventions.md)) are not yet part of the
+automated scaffold; add the marker to `AGENTS.md` by hand if your repo's
+target-branch merge triggers a deployment.
+
+## Done when
+
+The scaffold reports the agent guide and the docs stubs present (created or
+already there). The repo is ready for the
+[epic chain](run-an-epic.md) and the [fast path](use-the-fast-path.md).

--- a/docs/how-to/resume-a-broken-epic.md
+++ b/docs/how-to/resume-a-broken-epic.md
@@ -1,0 +1,49 @@
+# Resume a broken epic
+
+**Goal:** pick up an `orchestrate-epic` run that was interrupted — a crash, a
+closed laptop, a killed session — without redoing merged work or colliding
+with half-merged state.
+
+You do not need a special command. **Resume is the front door:** re-running
+`/lore-workflow:orchestrate-epic` on the same epic issue *is* the resume
+path. The skill reaches the resume step first — before it validates the
+roadmap, before it creates the epic branch, before it opens a status
+comment — precisely so a second run heals rather than duplicates.
+
+## Before you start
+
+- The epic issue number or URL from the interrupted run.
+- `gh auth status` green (the resume logic reads the epic's comments and
+  branch state through the GitHub API).
+
+## Steps
+
+1. **Re-run `/lore-workflow:orchestrate-epic` on the same epic issue.** Point
+   a fresh session at the epic and run it exactly as you did the first time.
+2. **It finds the prior run's supervision trail.** It lists the epic issue's
+   comments and looks for the status comment carrying its per-feature state
+   table from the earlier run.
+3. **It reconciles against reality.** It compares that table's
+   merged / queued / blocked rows against the epic branch's actual state:
+   - a feature already merged into `epic/<issue>` is **done** — it is
+     skipped, never redispatched;
+   - a feature still queued or blocked is **redispatched** from where it
+     left off;
+   - the `epic/<issue>` branch, if it already exists, is **reused, never
+     re-cut**, so the resumed run never collides with half-merged state.
+4. **It continues in the same status comment.** It edits that one existing
+   comment in place for every further update; a resumed run never opens a
+   second status comment.
+
+## If no prior run is found
+
+If there is no earlier status comment on the epic, the skill treats this as
+a **fresh run**: it proceeds to the roadmap-validator gate and creates the
+status comment as normal. So running it on an epic that never started is
+safe — it just starts.
+
+## Done when
+
+The run reaches the same completion state a first-pass run would: the epic
+pull request merged, every sub-issue closed, the status comment finalized
+with no stale queued or running rows.

--- a/docs/how-to/run-an-epic.md
+++ b/docs/how-to/run-an-epic.md
@@ -1,0 +1,57 @@
+# Run an epic
+
+**Goal:** take a shaped, multi-feature body of work through the epic chain to
+a merged epic and its documentation.
+
+Reach for this when the work is really several features, or when its shape
+is still unsettled and needs shaping before any code is written. For one
+small, clear change, use the [fast path](use-the-fast-path.md) instead.
+
+## Before you start
+
+- The repo is onboarded into the conventions
+  ([Onboard a repo](onboard-a-repo.md)).
+- `gh auth status` is green.
+- You have a rough idea or an epic seed to start from (see the
+  [Glossary](../conventions.md#glossary) in Conventions).
+
+## Steps
+
+1. **Shape it.** In a session pointed at the idea (or the seed issue), run
+   `/lore-workflow:orient` to reflect the work back and confirm it, then
+   `/lore-workflow:grill-with-docs` to stress-test the plan and record
+   decisions inline. Do not skip this: an epic built on an unshaped plan
+   wastes the autonomous build.
+2. **Cross the checkpoint.** Run `/lore-workflow:to-epic`. It writes the PRD
+   to `docs/prd/` via `lore workflow create-prd`, opens the epic tracker
+   issue and one sub-issue per feature, and emits the roadmap dependency
+   table. Review the PRD and the roadmap before continuing — this is the
+   last human gate before the build.
+3. **Build it.** Point a session at the epic issue and run
+   `/lore-workflow:orchestrate-epic`. It validates the roadmap
+   (`lore workflow validate-roadmap`), creates the `epic/<issue>` integration
+   branch from the detected target branch (`develop` if present, else
+   `main`), fans out one test-first teammate per feature, crosschecks every
+   pull request, integrates the features in dependency order, and opens the
+   final pull request to the target branch.
+4. **Let the docs catch up.** After the epic merges, `orchestrate-epic`
+   automatically runs `/lore-workflow:document-epic`, which opens a docs PR
+   and auto-merges it on green. You review post-hoc.
+
+## Notes
+
+- **You do not babysit step 3.** The features are flagged **AFK** (they run
+  autonomously). The orchestrator stops only to report completion or to
+  escalate a genuine blocker — a feature that needs a human decision
+  (**HITL**), a crosscheck that keeps failing, or an unresolvable conflict.
+- **Read the run in the supervision trail.** The orchestrator keeps a single
+  status comment on the epic issue, updated in place, recording each
+  feature's state and every tier or escalation decision.
+- **If the run breaks off, resume — do not restart.** See
+  [Resume a broken epic](resume-a-broken-epic.md).
+
+## Done when
+
+- The final epic pull request is merged to the target branch.
+- Every sub-issue is closed and every roadmap checkbox is ticked.
+- The docs PR has merged on green.

--- a/docs/how-to/use-the-fast-path.md
+++ b/docs/how-to/use-the-fast-path.md
@@ -1,0 +1,61 @@
+# Use the fast path
+
+**Goal:** implement one well-understood GitHub issue directly, keeping the
+workflow's discipline without the weight of the full epic chain.
+
+The fast path is `/lore-workflow:implement-issue` — a **second track beside
+the epic chain, not a step in it**. It exists to avoid two traps: running
+the whole shaping-to-build chain for a change that does not need it, and
+bypassing the workflow entirely and dropping the discipline the workflow
+exists to keep.
+
+## When this is the right track
+
+Reach for the fast path when the user hands you a **single** GitHub issue
+they wrote, and the change is small and clear enough that the epic chain
+would be pure overhead. If the work is really several features, or the shape
+is still unsettled, it belongs on the [epic chain](run-an-epic.md), not
+here.
+
+## Before you start
+
+- A single, clear GitHub issue. A good one makes this track fly — see
+  [Write a good fast-path issue](write-a-fast-path-issue.md).
+- The repo onboarded, so `CODEMAP.md` is present (`lore codemap` / the
+  `SessionStart` hook keeps it fresh — see [Onboard a repo](onboard-a-repo.md)).
+
+## Steps
+
+1. **Point the skill at the issue.** Run `/lore-workflow:implement-issue`
+   with the issue.
+2. **It reads the issue and the code map.** That is the whole intake — no
+   exploration fan-out. `CODEMAP.md` (or the `lore_codemap` MCP tool for a
+   bounded query) is a ranked navigation index built for exactly this: find
+   the symbol, open the cited file and line.
+3. **It clarifies only if needed.** If the issue is ambiguous, it asks you
+   **at most three** targeted questions and waits. If the issue is already
+   clear, it proceeds with no interview.
+4. **It implements with strict test-first development.** One branch,
+   `feat/<issue>-slug`, off the detected target branch; a failing test
+   first, then the code that passes it; everything in one pull request.
+5. **It applies the same gates the epic chain applies.** The
+   architecture-decision-record check (an ADR is drafted only if the
+   decision is hard to reverse, surprising, and a real trade-off), and the
+   Diátaxis docs pass over the change's diff. It never edits `docs/prd/` or
+   `docs/adr/` beyond a warranted ADR.
+6. **It reviews once and opens the pull request.** One review pass at the
+   mid tier by default (lighter than the epic chain's strong-tier
+   crosscheck), then it opens the pull request linking the issue.
+
+## What is different from the epic chain
+
+- **One issue, one branch, one pull request.** No fan-out, no multi-PR
+  integration, no epic branch.
+- **Merging stays with you.** You are present on this track, so the skill
+  opens the pull request and stops. It never self-merges. It never merges on
+  red.
+
+## Done when
+
+The pull request is open, green, and linked to the issue it closes — ready
+for you to merge.

--- a/docs/how-to/write-a-fast-path-issue.md
+++ b/docs/how-to/write-a-fast-path-issue.md
@@ -1,0 +1,50 @@
+# Write a good fast-path issue
+
+**Goal:** write a GitHub issue that the [fast path](use-the-fast-path.md)
+(`/lore-workflow:implement-issue`) can pick up and implement directly, with
+no back-and-forth.
+
+The fast path reads the issue and the code map, then — only if the issue is
+ambiguous — asks **at most three** clarifying questions before it starts. A
+well-written issue spends none of that budget: the skill reads it, locates
+the symbols in `CODEMAP.md`, and goes straight to test-first implementation.
+A vague one either burns the three questions or, worse, ships the wrong
+thing.
+
+## What a good fast-path issue contains
+
+- **One change, clearly scoped.** The fast path is one issue, one branch,
+  one pull request. If the issue describes several features, it belongs on
+  the [epic chain](run-an-epic.md), not here. Split it.
+- **Unambiguous intent.** State what should change and why in plain
+  sentences. The reader should not have to guess the goal.
+- **Concrete acceptance criteria.** List what "done" means as checkable
+  statements — the behaviour a test could assert. These become the
+  test-first targets; without them the skill has to invent them.
+- **Pointers into the code.** Name the command, module, or symbol the
+  change touches. You do not need file-and-line precision — the code map
+  resolves symbols — but naming the entry point removes a whole class of
+  ambiguity.
+- **Out-of-scope notes where they help.** If there is an obvious adjacent
+  change you do *not* want, say so. It keeps the single pull request tight.
+
+## What to leave out
+
+- **A design interview.** The fast path is not a `grilling` session; do not
+  write the issue as an open design question. If the shape is still
+  unsettled, shape it on the chain first.
+- **Multi-repo or multi-feature scope.** That is epic-shaped work.
+
+## Checklist
+
+- [ ] One change, small and clear.
+- [ ] Intent stated plainly.
+- [ ] Acceptance criteria a test could check.
+- [ ] The touched command / module / symbol named.
+- [ ] Anything deliberately out of scope called out.
+
+## Done when
+
+Someone who has never seen the change could read the issue and know exactly
+what to build and how to tell it works — which is precisely what the fast
+path needs.

--- a/docs/model-tiers.md
+++ b/docs/model-tiers.md
@@ -7,9 +7,10 @@ currently running. That indirection is what lets a plugin move from
 Claude Code to another host without editing every prompt — only the
 table in `lib/lore_core/tiers/table.py` changes.
 
-Ported from `ccat-agent-workflow`'s `MODEL-TIERS.md`; see that repo for
-the CI/enforcement side (no skill may name a concrete model — not yet
-ported here, tracked separately).
+The no-hardcoded-model-name contract is enforced in this repo by
+`tests/test_workflow_plugin_structural.py`. For which workflow *stage*
+runs at which tier, and how strictly that mapping is enforced, see
+["Model tiers"](conventions.md#model-tiers) in `docs/conventions.md`.
 
 ## Tiers
 

--- a/tests/test_workflow_docs_drift.py
+++ b/tests/test_workflow_docs_drift.py
@@ -1,0 +1,72 @@
+"""Workflow docs ↔ skill surface honesty (sub-issue #173).
+
+The migrated conventions/how-to docs under ``docs/`` cite
+``lore-workflow:<skill>`` skill names and reference the
+``seed-epic → orient → ... → document-epic`` chain by name. Nothing catches
+it if a skill is renamed or removed and the docs are not updated to match —
+this test does.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = REPO_ROOT / "lore-workflow" / "skills"
+DOCS_FILES = sorted((REPO_ROOT / "docs").rglob("*.md")) + [REPO_ROOT / "README.md"]
+
+SKILL_REF_RE = re.compile(r"lore-workflow:([a-z][a-z-]*)")
+CHAIN_RE = re.compile(
+    r"seed-epic\s*→\s*orient\s*→\s*grill-with-docs\s*→\s*to-epic\s*→\s*orchestrate-epic\s*→\s*document-epic"
+)
+
+
+def _shipped_skill_names() -> set[str]:
+    return {p.name for p in SKILLS_ROOT.iterdir() if p.is_dir()}
+
+
+def test_lore_workflow_skill_references_resolve_to_shipped_skills() -> None:
+    """Every ``lore-workflow:<name>`` cited in a doc must be a real skill dir."""
+    shipped = _shipped_skill_names()
+    failures: list[str] = []
+    for path in DOCS_FILES:
+        text = path.read_text(encoding="utf-8")
+        for name in SKILL_REF_RE.findall(text):
+            if name not in shipped:
+                failures.append(
+                    f"{path.relative_to(REPO_ROOT)}: cites lore-workflow:{name}, no such skill"
+                )
+    assert not failures, "Doc/skill drift:\n  " + "\n  ".join(failures)
+
+
+def test_docs_conventions_chain_matches_readme_chain() -> None:
+    """The chain diagram in docs/conventions.md and README.md must match,
+    verbatim, so the two don't quietly drift apart.
+    """
+    conventions = (REPO_ROOT / "docs" / "conventions.md").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert CHAIN_RE.search(conventions), (
+        "docs/conventions.md is missing the canonical chain diagram"
+    )
+    assert CHAIN_RE.search(readme), "README.md is missing the canonical chain diagram"
+
+
+def test_no_doc_cites_old_repo_as_authoritative() -> None:
+    """Migrated docs must not point at ccatobs/ccat-agent-workflow as the
+    source of truth for conventions or tier semantics — that repo is frozen
+    and superseded by this migration (PRD 0003).
+    """
+    migrated = [
+        REPO_ROOT / "docs" / "conventions.md",
+        REPO_ROOT / "docs" / "model-tiers.md",
+        REPO_ROOT / "docs" / "explanation" / "why-tdd-is-enforced.md",
+        REPO_ROOT / "docs" / "explanation" / "why-prd-in-repo.md",
+        *sorted((REPO_ROOT / "docs" / "how-to").glob("*.md")),
+    ]
+    failures = [
+        str(path.relative_to(REPO_ROOT))
+        for path in migrated
+        if "ccat-agent-workflow" in path.read_text(encoding="utf-8")
+    ]
+    assert not failures, "Old-repo reference in migrated docs:\n  " + "\n  ".join(failures)


### PR DESCRIPTION
Closes #173

## Summary
- `docs/conventions.md` — ported `CONVENTIONS.md` from ccat-agent-workflow: the workflow chain, artifact-home contract (PRD/ADR/AGENTS.md), stage→tier table + REQUIRED/ADVISORY enforcement, house style, glossary. Rewired to `lore-workflow:<skill>` names and `lore workflow` CLI verbs.
- `docs/model-tiers.md` — removed the stale "see that repo for CI enforcement" pointer (now enforced in-repo by `tests/test_workflow_plugin_structural.py`); links to `docs/conventions.md`'s stage-mapping section.
- `docs/explanation/why-tdd-is-enforced.md`, `docs/explanation/why-prd-in-repo.md` — ported explanation pages. (Skipped a separate `why-model-tiers.md` per the epic's guidance — `docs/model-tiers.md` + `docs/conventions.md` already cover that ground; a third page would just restate it.)
- `docs/how-to/{onboard-a-repo,run-an-epic,resume-a-broken-epic,use-the-fast-path,write-a-fast-path-issue}.md` — ported and rewired for `/lore-workflow:*` skill names and the actual shipped CLI (`lore attach --scaffold-workflow`, `lore workflow create-prd`/`validate-roadmap`, `lore codemap`). `onboard-a-repo.md` is honest about what the scaffold does today vs. what's still tracked separately (permissions allowlist, epic-merge-policy section aren't auto-scaffolded yet).
- `README.md` — new "Two plugins: `lore` + `lore-workflow`" section presenting both marketplace entries, the dependency direction, the chain diagram, and doc pointers; install section updated to mention `lore-workflow@lore`.
- `tests/test_workflow_docs_drift.py` — new drift guard: every `lore-workflow:<name>` cited in docs resolves to a real skill dir, the chain diagram in README and conventions.md match verbatim, and none of the migrated docs cite `ccat-agent-workflow` as authoritative.

Not touched (out of scope for #173, no code/skill changes): `lib/`, `lore-workflow/skills/**`, plugin manifests. No version bump.

## Evidence
```
$ ruff check tests/test_workflow_docs_drift.py && ruff format --check tests/test_workflow_docs_drift.py
Ruff: No issues found
1 file already formatted

$ env -u FORCE_COLOR -u COLORTERM -u OPENAI_API_KEY NO_COLOR=1 python -m pytest -q
2617 passed, 1 warning, 11 subtests passed in 68.54s
```

## Test plan
- [x] New drift test passes (`tests/test_workflow_docs_drift.py`)
- [x] Existing `tests/test_workflow_plugin_structural.py` still passes (54/54 with the new file)
- [x] Full suite green (2617 passed)