### PR TITLE
feat(#176): compose hardening — verbatim quote skeleton

### DIFF
--- a/lib/lore_core/git.py
+++ b/lib/lore_core/git.py
@@ -107,6 +107,24 @@ def canonical_repo_name(remote_url: str) -> str | None:
     return "/".join(parts[-2:])
 
 
+def current_branch(cwd: Path | str | None = None) -> str:
+    """Resolve the current branch name for `cwd`. Empty string on any failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
 def current_repo(cwd: Path | str | None = None) -> str | None:
     """Resolve the current repo as `org/name`. Returns None if not in a repo."""
     root = git_repo_root(cwd)

--- a/lib/lore_core/identity.py
+++ b/lib/lore_core/identity.py
@@ -65,6 +65,21 @@ def resolve_handle(wiki_path: Path, email: str) -> str:
     return email.split("@", 1)[0] if "@" in email else email
 
 
+def resolve_display_name(wiki_path: Path, handle: str) -> str:
+    """Return the display name for `handle` from `_users.yml`.
+
+    Vault config, not `$USER` — no environment fallback. Empty/missing
+    handle or no matching user returns `""`.
+    """
+    if not handle:
+        return ""
+    data = _load_users_yml(wiki_path)
+    for user in data.get("users") or []:
+        if user.get("handle") == handle:
+            return str(user.get("display_name") or "")
+    return ""
+
+
 def aliased_emails(wiki_path: Path) -> set[str]:
     """Union of every email in `_users.yml` aliases."""
     data = _load_users_yml(wiki_path)

--- a/lib/lore_core/linkage.py
+++ b/lib/lore_core/linkage.py
@@ -1,0 +1,100 @@
+"""Deterministic linkage extraction — zero-LLM, zero-network cross-note refs.
+
+Every session note gets a schema-versioned `linkage` snapshot: repo,
+branch, and issue/PR/epic numbers found in the branch name and commit
+text, plus the author's display name. Missing signals degrade to
+absent/empty fields — this module never guesses.
+
+Repo and branch come from `lore_core.git` (already-resolved git state).
+Commit subject/body text is supplied by the caller (resolved via
+`lore_curator.session_activity.collect_commits_by_sha`, a curator-layer
+concern) so this module stays in the core layer with no upward import.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from lore_core.git import current_branch, current_repo
+from lore_core.identity import resolve_display_name
+
+__all__ = ["Linkage", "extract_linkage"]
+
+SCHEMA_VERSION = 1
+
+# Epic refs: "epic #162", "epic/162", "Epic 162".
+_EPIC_RE = re.compile(r"\bepic[\s/#]*(\d+)\b", re.IGNORECASE)
+# PR refs: "PR #200", "pr 200", or a GitHub PR URL's /pull/200.
+_PR_RE = re.compile(r"\bpr[\s#]*(\d+)\b|/pull/(\d+)", re.IGNORECASE)
+# Bare issue refs: "#175". Catch-all, so it runs last and excludes
+# numbers already classified as epic or PR.
+_ISSUE_HASH_RE = re.compile(r"#(\d+)\b")
+# Feature-branch convention: "feat/175-...", "fix/42", "chore/9-cleanup".
+_BRANCH_ISSUE_RE = re.compile(
+    r"^(?:feat|fix|chore|feature|bug|bugfix)/(\d+)(?:[-/]|$)", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class Linkage:
+    """Cross-note linkage frontmatter, schema-versioned for round-trip."""
+
+    schema_version: int = SCHEMA_VERSION
+    repo: str = ""
+    branch: str = ""
+    issues: list[int] = field(default_factory=list)
+    prs: list[int] = field(default_factory=list)
+    epics: list[int] = field(default_factory=list)
+    author: str = ""
+
+
+def _classify_refs(text: str) -> tuple[set[int], set[int], set[int]]:
+    """Return (issues, prs, epics) found in `text`, mutually exclusive."""
+    epics = {int(m) for m in _EPIC_RE.findall(text)}
+    prs = {int(a or b) for a, b in _PR_RE.findall(text)} - epics
+    issues = {int(m) for m in _ISSUE_HASH_RE.findall(text)} - epics - prs
+    return issues, prs, epics
+
+
+def extract_linkage(
+    *,
+    cwd: Path | str | None = None,
+    commit_texts: list[str] | None = None,
+    wiki_root: Path | None = None,
+    handle: str = "",
+) -> Linkage:
+    """Derive linkage from git state, branch name, and commit text.
+
+    `commit_texts` is one string per commit (subject + body); the caller
+    resolves it (e.g. via `collect_commits_by_sha`) since fetching commit
+    text is a curator-layer concern, not this module's.
+    """
+    branch = current_branch(cwd) or ""
+    repo = current_repo(cwd) or ""
+
+    issues: set[int] = set()
+    prs: set[int] = set()
+    epics: set[int] = set()
+    for text in (branch, *(commit_texts or [])):
+        i, p, e = _classify_refs(text)
+        issues |= i
+        prs |= p
+        epics |= e
+    m = _BRANCH_ISSUE_RE.match(branch)
+    if m:
+        issues.add(int(m.group(1)))
+    issues -= prs | epics
+    prs -= epics
+
+    author = resolve_display_name(wiki_root, handle) if wiki_root and handle else ""
+
+    return Linkage(
+        repo=repo,
+        branch=branch,
+        issues=sorted(issues),
+        prs=sorted(prs),
+        epics=sorted(epics),
+        author=author,
+    )

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -32,6 +32,7 @@ from typing import Any
 import yaml
 
 from lore_core.io import atomic_write_text
+from lore_core.linkage import Linkage
 from lore_core.schema import parse_frontmatter, strip_frontmatter
 
 __all__ = [
@@ -42,6 +43,7 @@ __all__ = [
     "TopicBlock",
     "Chapter",
     "SessionFacts",
+    "Linkage",
     "NoteView",
     "create_note",
     "append_chapter",
@@ -224,6 +226,20 @@ def _apply_facts(fm: dict[str, Any], facts: SessionFacts | None) -> None:
         fm["duration_seconds"] = int(facts.duration_seconds)
 
 
+def _apply_linkage(fm: dict[str, Any], linkage: Linkage | None) -> None:
+    if linkage is None:
+        return
+    fm["linkage"] = {
+        "schema_version": linkage.schema_version,
+        "repo": linkage.repo,
+        "branch": linkage.branch,
+        "issues": list(linkage.issues),
+        "prs": list(linkage.prs),
+        "epics": list(linkage.epics),
+        "author": linkage.author,
+    }
+
+
 def _today() -> str:
     return date.today().isoformat()
 
@@ -267,6 +283,7 @@ def create_note(
     handle: str | None = None,
     created: str | None = None,
     facts: SessionFacts | None = None,
+    linkage: Linkage | None = None,
     extra_frontmatter: dict[str, Any] | None = None,
     wiki_root: Path | None = None,
 ) -> None:
@@ -290,6 +307,7 @@ def create_note(
     if handle:
         fm["user"] = handle
     _apply_facts(fm, facts)
+    _apply_linkage(fm, linkage)
     if extra_frontmatter:
         for k, v in extra_frontmatter.items():
             fm.setdefault(k, v)
@@ -306,6 +324,7 @@ def append_chapter(
     slice_from_turn: int,
     slice_to_turn: int,
     facts: SessionFacts | None = None,
+    linkage: Linkage | None = None,
     wiki_root: Path | None = None,
 ) -> int:
     """Append a chapter of topic blocks; record its slice turn range.
@@ -331,6 +350,7 @@ def append_chapter(
     )
     fm["chapters"] = chapters
     _apply_facts(fm, facts)
+    _apply_linkage(fm, linkage)
     fm["last_reviewed"] = _today()
 
     _write(path, fm, new_body, wiki_root=wiki_root)
@@ -345,6 +365,7 @@ def append_marker_chapter(
     slice_from_turn: int,
     slice_to_turn: int,
     facts: SessionFacts | None = None,
+    linkage: Linkage | None = None,
     wiki_root: Path | None = None,
 ) -> int:
     """Append a deterministic marker chapter (failed or withheld).
@@ -374,6 +395,7 @@ def append_marker_chapter(
     )
     fm["chapters"] = chapters
     _apply_facts(fm, facts)
+    _apply_linkage(fm, linkage)
     fm["last_reviewed"] = _today()
 
     _write(path, fm, new_body, wiki_root=wiki_root)
@@ -384,6 +406,7 @@ def close_note(
     path: Path,
     *,
     facts: SessionFacts | None = None,
+    linkage: Linkage | None = None,
     wiki_root: Path | None = None,
 ) -> None:
     """Finalize the note: mark it closed and immutable.
@@ -396,6 +419,7 @@ def close_note(
 
     fm["note_status"] = _CLOSED
     _apply_facts(fm, facts)
+    _apply_linkage(fm, linkage)
     fm["last_reviewed"] = _today()
     _write(path, fm, body, wiki_root=wiki_root)
 

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -90,7 +90,10 @@ class TopicBlock:
     ``lead`` is a bold one-sentence self-sufficient statement (no
     pronouns reaching into the body). ``body`` is short prose.
     ``anchor_turn`` is the transcript turn where the topic starts,
-    rendered as a single ``@N`` anchor at the block's end.
+    rendered as a single ``@N`` anchor at the block's end. ``quote``,
+    when set, is a verbatim excerpt from that anchor turn — code-
+    attached from the transcript, never model-authored (see
+    ``compose_chapter``'s ``turns_by_index``).
 
     A continuation block (``continued=True``) resumes or corrects an
     earlier topic; it renders a ``Continued: <continued_topic>`` lead
@@ -102,6 +105,7 @@ class TopicBlock:
     anchor_turn: int = 0
     continued: bool = False
     continued_topic: str = ""
+    quote: str = ""
 
 
 @dataclass
@@ -148,6 +152,9 @@ def _render_block(block: TopicBlock) -> str:
     body = (block.body or "").strip()
     if body:
         parts.append(body)
+    quote = (block.quote or "").strip()
+    if quote:
+        parts.append(f'> "{quote}"')
     if block.anchor_turn:
         parts.append(f"@{int(block.anchor_turn)}")
     return "\n\n".join(parts)

--- a/lib/lore_curator/chapter_compose.py
+++ b/lib/lore_curator/chapter_compose.py
@@ -63,6 +63,7 @@ __all__ = [
 
 CHAPTER_MAX_ATTEMPTS = 2
 CHAPTER_MAX_OUTPUT_TOKENS = 4000
+_QUOTE_MAX_CHARS = 240
 
 # Sentinel anchor for a block whose model output carried no usable turn
 # index. It can never satisfy the in-slice lint (turn indices are >= 0),
@@ -173,6 +174,26 @@ def chapter_same_anchor_lint(chapter: Chapter) -> int | None:
     return None
 
 
+def _attach_quotes(chapter: Chapter, turns_by_index: dict[int, str] | None) -> None:
+    """Fill each block's verbatim quote from its anchor turn's text.
+
+    Called after anchor lint passes, so every ``anchor_turn`` is a valid
+    key into ``turns_by_index`` — and before the chapter is rendered, so
+    the same single gate scan covers the quote too. Deterministic given
+    the same (chapter, turns_by_index); truncated to a fixed length so
+    one long paste can't dominate the note.
+    """
+    if not turns_by_index:
+        return
+    for block in chapter.blocks:
+        text = (turns_by_index.get(block.anchor_turn) or "").strip()
+        if not text:
+            continue
+        if len(text) > _QUOTE_MAX_CHARS:
+            text = text[:_QUOTE_MAX_CHARS].rstrip() + "…"
+        block.quote = text
+
+
 # ---------------------------------------------------------------------------
 # Compose loop
 # ---------------------------------------------------------------------------
@@ -190,8 +211,14 @@ def compose_chapter(
     logger: RunLogger | None = None,
     transcript_id: str = "",
     max_output_tokens: int = CHAPTER_MAX_OUTPUT_TOKENS,
+    turns_by_index: dict[int, str] | None = None,
 ) -> ComposeResult:
     """Compose one chapter in a single LLM call, with a bounded retry.
+
+    ``turns_by_index`` maps turn index to raw transcript text; when given,
+    each block's verbatim ``quote`` is code-attached from its anchor
+    turn after the anchor lint passes, before the chapter is rendered
+    for the gate. The model never writes this text.
 
     Attempt 1 composes; a deterministic anchor lint and the injected
     gate then judge the result. An anchor-lint miss or a gate withhold
@@ -269,6 +296,7 @@ def compose_chapter(
                 )
             continue
 
+        _attach_quotes(chapter, turns_by_index)
         chapter_text = render_chapter_body(chapter)
         verdict = gate.evaluate(chapter_text)
         if verdict.passed:

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -432,6 +432,7 @@ def flush_chapter(
             gate=gate,
             logger=logger,
             transcript_id=sidecar.transcript_id,
+            turns_by_index={t.index: t.text for t in unflushed},
         )
     else:
         # No readable turns / no client: bound the span to the buffer's

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -69,7 +69,11 @@ from lore_curator.buffer_store import (
 )
 from lore_curator.chapter_compose import ComposeStatus, Gate, compose_chapter
 from lore_curator.session_filer import _slug
-from lore_curator.session_note import ensure_note_from_sidecar, facts_from_replay
+from lore_curator.session_note import (
+    ensure_note_from_sidecar,
+    facts_from_replay,
+    linkage_from_replay,
+)
 from lore_curator.stub_note import _lead_for_rename, _resolve_renamed_path
 
 if TYPE_CHECKING:
@@ -514,6 +518,7 @@ def _apply_outcome(
 ) -> FlushOutcome:
     sidecar = buffer.read_sidecar() or Sidecar(transcript_id=buffer.stem)
     facts = facts_from_replay(rb)
+    linkage = linkage_from_replay(rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=sidecar.handle)
     out = FlushOutcome(
         buffer_stem=buffer.stem,
         state_before=state_before,
@@ -540,6 +545,7 @@ def _apply_outcome(
             slice_from_turn=slice_from,
             slice_to_turn=slice_to,
             facts=facts,
+            linkage=linkage,
             wiki_root=wiki_root,
         )
         if out.chapter_n == 1:
@@ -603,6 +609,7 @@ def _apply_outcome(
                 slice_from_turn=slice_from,
                 slice_to_turn=slice_to,
                 facts=facts,
+                linkage=linkage,
                 wiki_root=wiki_root,
             )
             out.status = "failed"
@@ -614,6 +621,7 @@ def _apply_outcome(
                 slice_from_turn=slice_from,
                 slice_to_turn=slice_to,
                 facts=facts,
+                linkage=linkage,
                 wiki_root=wiki_root,
             )
             _reset_buffer_fresh(buffer)
@@ -646,7 +654,7 @@ def _apply_outcome(
 
     if close:
         if not out.discarded and not nd.is_closed(note_path):
-            nd.close_note(note_path, facts=facts, wiki_root=wiki_root)
+            nd.close_note(note_path, facts=facts, linkage=linkage, wiki_root=wiki_root)
         buffer.transition("closed")
         out.closed = True
     return out
@@ -725,13 +733,21 @@ def _finish_no_new_turns(
         skipped_reason="" if close else "no-new-turns",
     )
     with buffer.with_lock():
+        sc = buffer.read_sidecar()
         if close:
             if not nd.is_closed(note_path):
-                nd.close_note(note_path, facts=facts_from_replay(rb), wiki_root=wiki_root)
+                linkage = linkage_from_replay(
+                    rb,
+                    cwd=sc.cwd if sc else "",
+                    wiki_root=wiki_root,
+                    handle=sc.handle if sc else "",
+                )
+                nd.close_note(
+                    note_path, facts=facts_from_replay(rb), linkage=linkage, wiki_root=wiki_root
+                )
             buffer.transition("closed")
             out.closed = True
         else:
-            sc = buffer.read_sidecar()
             if sc is not None and sc.flush_requested is not None:
                 buffer.patch(flush_requested=None)
     if close:

--- a/lib/lore_curator/session_activity.py
+++ b/lib/lore_curator/session_activity.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from lore_core.gh import gh_issues
-from lore_core.git import current_repo
+from lore_core.git import current_branch, current_repo
 from lore_core.types import Turn
 
 if TYPE_CHECKING:
@@ -122,7 +122,7 @@ def collect_commits_by_sha(
     if log.returncode != 0:
         return []
 
-    branch = _current_branch(repo_root, timeout_seconds)
+    branch = current_branch(repo_root)
     repo_name = current_repo(repo_root) or ""
 
     # Map full-SHA → CommitRef so we can return in the order the caller asked.
@@ -160,20 +160,6 @@ def collect_commits_by_sha(
                 out.append(ref)
                 break
     return out
-
-
-def _current_branch(repo_root: Path, timeout_seconds: float) -> str:
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True, text=True,
-            timeout=timeout_seconds, check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if result.returncode != 0:
-        return ""
-    return result.stdout.strip()
 
 
 def render_commits_section(commits: list[CommitRef]) -> list[str]:

--- a/lib/lore_curator/session_note.py
+++ b/lib/lore_curator/session_note.py
@@ -20,11 +20,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lore_core import note_document as nd
+from lore_core.linkage import Linkage, extract_linkage
 from lore_core.note_document import SessionFacts
 from lore_core.types import Scope, TranscriptHandle
 
 from lore_curator.buffer_append import AppendOutcome
 from lore_curator.buffer_store import Buffer, ReplayedBuffer, Sidecar
+from lore_curator.session_activity import collect_commits_by_sha
 from lore_curator.stub_note import (
     _derive_slug,
     _placeholder_title,
@@ -40,6 +42,7 @@ __all__ = [
     "ensure_note",
     "ensure_note_from_sidecar",
     "facts_from_replay",
+    "linkage_from_replay",
 ]
 
 
@@ -65,6 +68,31 @@ def facts_from_replay(rb: ReplayedBuffer, *, duration_seconds: int = 0) -> Sessi
         files_read=list(rb.files_read),
         projects=list(rb.projects),
         duration_seconds=duration_seconds,
+    )
+
+
+def linkage_from_replay(
+    rb: ReplayedBuffer,
+    *,
+    cwd: str,
+    wiki_root: Path,
+    handle: str,
+) -> Linkage:
+    """Build the deterministic linkage snapshot from a replayed buffer.
+
+    Resolves commit subject/body text via ``collect_commits_by_sha`` (this
+    module's own curator layer), then hands off to
+    ``lore_core.linkage.extract_linkage`` for repo/branch/ref classification —
+    keeping that module free of any curator-layer import.
+    """
+    repo_root = Path(cwd) if cwd else None
+    commits = collect_commits_by_sha(repo_root, list(rb.commit_shas))
+    commit_texts = [f"{c.subject}\n{c.body}".strip() for c in commits]
+    return extract_linkage(
+        cwd=cwd or None,
+        commit_texts=commit_texts,
+        wiki_root=wiki_root,
+        handle=handle,
     )
 
 
@@ -119,6 +147,9 @@ def ensure_note(
         handle=handle_label or None,
         created=work_time.date().isoformat(),
         facts=facts_from_replay(rb),
+        linkage=linkage_from_replay(
+            rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=handle_label
+        ),
         extra_frontmatter={
             "transcript_id": sidecar.transcript_id or transcript.id,
             "integration": integration or transcript.integration,
@@ -202,6 +233,9 @@ def ensure_note_from_sidecar(
         handle=sidecar.handle or None,
         created=work_time.date().isoformat(),
         facts=facts_from_replay(rb),
+        linkage=linkage_from_replay(
+            rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=sidecar.handle
+        ),
         extra_frontmatter={
             "transcript_id": sidecar.transcript_id,
             "integration": sidecar.integration,

--- a/tests/test_chapter_compose.py
+++ b/tests/test_chapter_compose.py
@@ -397,6 +397,90 @@ def test_persistent_same_anchor_still_publishes():
 
 
 # ---------------------------------------------------------------------------
+# Verbatim quote skeleton — code-attached, never model-authored
+# ---------------------------------------------------------------------------
+
+
+def test_turns_by_index_fills_verbatim_quote_from_anchor_turn():
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@2] hi\n[assistant@4] yo",
+        slice_from_turn=2,
+        slice_to_turn=4,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+        turns_by_index={2: "hi", 4: "yo"},
+    )
+    assert result.status is ComposeStatus.COMPOSED
+    quotes = {b.anchor_turn: b.quote for b in result.chapter.blocks}
+    assert quotes == {2: "hi", 4: "yo"}
+
+
+def test_missing_turns_by_index_leaves_quote_empty():
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@2] hi\n[assistant@4] yo",
+        slice_from_turn=2,
+        slice_to_turn=4,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+    )
+    assert result.status is ComposeStatus.COMPOSED
+    assert all(b.quote == "" for b in result.chapter.blocks)
+
+
+def test_long_quote_is_truncated_deterministically():
+    long_text = "x" * 500
+    msgs = _RecordingMessages([_valid_payload()])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@2] hi\n[assistant@4] yo",
+        slice_from_turn=2,
+        slice_to_turn=4,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+        turns_by_index={2: long_text, 4: "yo"},
+    )
+    block = next(b for b in result.chapter.blocks if b.anchor_turn == 2)
+    assert block.quote.endswith("…")
+    assert len(block.quote) <= 241
+
+
+def test_gate_sees_the_verbatim_quote_text():
+    # The quote is attached before the single gate scan — a token that
+    # appears only in the quoted turn (never in lead/body) must still
+    # reach the gate, proving the quote slot cannot bypass it.
+    class _TokenGate:
+        def evaluate(self, chapter_text: str) -> GateResult:
+            if "PLANTED_TOKEN" in chapter_text:
+                return GateResult.withheld("secret", "token present")
+            return GateResult.ok()
+
+    msgs = _RecordingMessages([_valid_payload(), _valid_payload()])
+    client = _FakeClient(msgs)
+
+    result = compose_chapter(
+        slice_text="[user@2] hi\n[assistant@4] yo",
+        slice_from_turn=2,
+        slice_to_turn=4,
+        note_so_far="note",
+        llm_client=client,
+        model="m",
+        gate=_TokenGate(),
+        turns_by_index={2: "contains PLANTED_TOKEN here", 4: "yo"},
+    )
+    assert result.status is ComposeStatus.WITHHELD
+
+
+# ---------------------------------------------------------------------------
 # Gate seam — withhold drives the retry with feedback; two withholds defer
 # ---------------------------------------------------------------------------
 

--- a/tests/test_chapter_flush.py
+++ b/tests/test_chapter_flush.py
@@ -169,6 +169,30 @@ def test_inplace_flush_composes_one_call_and_appends_chapter(tmp_path):
     assert buf.read_sidecar().state == "accumulating"
 
 
+def test_inplace_flush_writes_verbatim_quote_at_anchor_turn(tmp_path):
+    # End-to-end wiring proof: the flush passes each unflushed turn's raw
+    # text through to compose_chapter, which attaches it as the block's
+    # quote — landing in the note body verbatim, code-attached.
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    all_turns = _turns(0, 4)
+    buf = _append(lore_root, all_turns)
+    client = _Client([_chapter_payload("Traced the flush race", "prose.", 2)])
+
+    outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+        auto_commit=False,
+    )
+    assert outcome.status == "composed"
+    view = nd.read_note(outcome.note_path)
+    assert '"line 2"' in view.body
+
+
 def test_note_so_far_carries_prior_chapter_into_next_compose(tmp_path):
     lore_root = _lore_root(tmp_path)
     wiki_root = lore_root / "wiki" / "private"

--- a/tests/test_linkage.py
+++ b/tests/test_linkage.py
@@ -1,0 +1,121 @@
+"""Tests for lore_core.linkage — deterministic cross-note ref extraction.
+
+Zero-LLM, zero-network: repo/branch come from git state already resolved
+by lore_core.git; issue/PR/epic refs come from regex classification of
+the branch name plus commit subject/body text handed in by the caller.
+Missing signals degrade to absent fields, never guesses.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import yaml
+from lore_core.linkage import Linkage, extract_linkage
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(repo_root: Path, *, branch: str = "main", remote_url: str | None = None) -> None:
+    repo_root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", branch], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo_root, check=True)
+    if remote_url:
+        subprocess.run(["git", "remote", "add", "origin", remote_url], cwd=repo_root, check=True)
+    (repo_root / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "-A"], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init", "--no-verify"], cwd=repo_root, check=True)
+
+
+# ---------------------------------------------------------------------------
+# repo / branch resolution
+# ---------------------------------------------------------------------------
+
+
+def test_extract_linkage_resolves_repo_and_branch(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="feat/175-linkage-frontmatter",
+               remote_url="git@github.com:buchbend/lore.git")
+    linkage = extract_linkage(cwd=repo)
+    assert linkage.repo == "buchbend/lore"
+    assert linkage.branch == "feat/175-linkage-frontmatter"
+
+
+def test_extract_linkage_outside_repo_degrades_to_empty(tmp_path):
+    linkage = extract_linkage(cwd=tmp_path)
+    assert linkage == Linkage()
+
+
+# ---------------------------------------------------------------------------
+# issue / PR / epic classification
+# ---------------------------------------------------------------------------
+
+
+def test_extract_linkage_issue_number_from_feature_branch(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="feat/175-linkage-frontmatter")
+    linkage = extract_linkage(cwd=repo)
+    assert linkage.issues == [175]
+
+
+def test_extract_linkage_epic_number_from_branch(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="epic/162")
+    linkage = extract_linkage(cwd=repo)
+    assert linkage.epics == [162]
+
+
+def test_extract_linkage_classifies_commit_text_mutually_exclusive(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="main")
+    linkage = extract_linkage(
+        cwd=repo,
+        commit_texts=["Closes #175, part of epic #162, see PR #200"],
+    )
+    assert linkage.issues == [175]
+    assert linkage.prs == [200]
+    assert linkage.epics == [162]
+
+
+def test_extract_linkage_dedupes_across_branch_and_commits(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="feat/175-linkage-frontmatter")
+    linkage = extract_linkage(cwd=repo, commit_texts=["Closes #175"])
+    assert linkage.issues == [175]
+
+
+# ---------------------------------------------------------------------------
+# author (vault config, never $USER)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_linkage_author_from_users_yml(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wiki_root = tmp_path / "wiki"
+    wiki_root.mkdir()
+    (wiki_root / "_users.yml").write_text(yaml.safe_dump({
+        "users": [{"handle": "alice", "display_name": "Alice A."}],
+    }))
+    linkage = extract_linkage(cwd=repo, wiki_root=wiki_root, handle="alice")
+    assert linkage.author == "Alice A."
+
+
+def test_extract_linkage_no_handle_or_wiki_root_gives_empty_author(tmp_path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    linkage = extract_linkage(cwd=repo)
+    assert linkage.author == ""
+
+
+# ---------------------------------------------------------------------------
+# schema version
+# ---------------------------------------------------------------------------
+
+
+def test_linkage_default_schema_version_is_1():
+    assert Linkage().schema_version == 1

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -235,6 +235,25 @@ def test_continuation_block_renders_continued_lead(tmp_path):
     assert "The cap-trip now flushes in place." in body
 
 
+def test_block_quote_renders_between_body_and_anchor(tmp_path):
+    path = _create(tmp_path)
+    chapter = nd.Chapter(
+        blocks=[
+            _block(
+                lead="Found the root cause.",
+                body="The cache never invalidated.",
+                anchor=12,
+                quote="the cache never gets cleared on deploy",
+            ),
+        ]
+    )
+    nd.append_chapter(path, chapter, slice_from_turn=1, slice_to_turn=40)
+    body = strip_frontmatter(path.read_text())
+    assert '"the cache never gets cleared on deploy"' in body
+    assert body.index("The cache never invalidated.") < body.index("the cache never gets cleared")
+    assert body.index("the cache never gets cleared") < body.index("@12")
+
+
 def test_append_updates_session_facts(tmp_path):
     path = _create(tmp_path, facts=nd.SessionFacts(commits=["aaa0001 first"]))
     nd.append_chapter(

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -103,6 +103,54 @@ def test_create_includes_handle_when_team_mode(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# linkage frontmatter (schema-versioned, round-trips)
+# ---------------------------------------------------------------------------
+
+
+def test_create_writes_linkage_block(tmp_path):
+    path = _create(tmp_path, linkage=nd.Linkage(
+        repo="buchbend/lore", branch="feat/175-linkage-frontmatter",
+        issues=[175], epics=[162], author="Christof Buchbender",
+    ))
+    fm = parse_frontmatter(path.read_text())
+    assert fm["linkage"] == {
+        "schema_version": 1,
+        "repo": "buchbend/lore",
+        "branch": "feat/175-linkage-frontmatter",
+        "issues": [175],
+        "prs": [],
+        "epics": [162],
+        "author": "Christof Buchbender",
+    }
+
+
+def test_create_without_linkage_omits_block(tmp_path):
+    path = _create(tmp_path)
+    fm = parse_frontmatter(path.read_text())
+    assert "linkage" not in fm
+
+
+def test_append_chapter_updates_linkage(tmp_path):
+    path = _create(tmp_path, linkage=nd.Linkage(branch="main"))
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[_block()]),
+        slice_from_turn=1,
+        slice_to_turn=10,
+        linkage=nd.Linkage(branch="main", issues=[175]),
+    )
+    fm = parse_frontmatter(path.read_text())
+    assert fm["linkage"]["issues"] == [175]
+
+
+def test_close_note_can_record_final_linkage(tmp_path):
+    path = _create(tmp_path)
+    nd.close_note(path, linkage=nd.Linkage(repo="buchbend/lore", branch="main"))
+    fm = parse_frontmatter(path.read_text())
+    assert fm["linkage"]["repo"] == "buchbend/lore"
+
+
+# ---------------------------------------------------------------------------
 # append chapter
 # ---------------------------------------------------------------------------
 

--- a/tests/test_session_note.py
+++ b/tests/test_session_note.py
@@ -104,6 +104,30 @@ def test_first_heartbeat_creates_note_document_note(tmp_path):
     assert view.frontmatter["scope"] == "proj:x"
 
 
+def test_first_heartbeat_records_linkage_frontmatter(tmp_path):
+    (tmp_path / ".lore" / "buffers").mkdir(parents=True)
+    wiki_root = tmp_path / "wiki" / "private"
+    result = ensure_note(
+        outcome=_append(tmp_path),
+        scope=_scope(),
+        transcript=_handle(tmp_path),
+        wiki_root=wiki_root,
+        work_time=_NOW,
+        handle_label="",
+        integration="claude-code",
+    )
+    view = nd.read_note(result.path)
+    assert view.frontmatter["linkage"] == {
+        "schema_version": 1,
+        "repo": "",
+        "branch": "",
+        "issues": [],
+        "prs": [],
+        "epics": [],
+        "author": "",
+    }
+
+
 def test_stub_path_is_stamped_and_reused(tmp_path):
     (tmp_path / ".lore" / "buffers").mkdir(parents=True)
     wiki_root = tmp_path / "wiki" / "private"


### PR DESCRIPTION
## Summary

Hardens compose structurally rather than with a bigger model. Each topic block can now carry a `quote` — a verbatim excerpt from the transcript turn at its `anchor_turn` — attached by code, never authored by the LLM.

- `TopicBlock` gains a `quote: str = ""` field, rendered between the body paragraph and the `@anchor_turn` line.
- `compose_chapter(...)` accepts `turns_by_index: dict[int, str] | None`. New helper `_attach_quotes` fills each block's quote from its anchor turn's raw text, truncated deterministically to 240 chars (+ `…`).
- `_attach_quotes` runs **after** both anchor lints pass (so every `anchor_turn` is a valid, in-slice key) and **immediately before** the existing single `render_chapter_body` / `gate.evaluate` call — so the same gate scan automatically covers quote text, with no new call site and no restructuring of the retry/withhold/failed state machine.
- `chapter_flush.py`'s `flush_chapter` passes `turns_by_index={t.index: t.text for t in unflushed}` into the existing `compose_chapter(...)` call — the only change needed there.

### AC mapping (issue #176)

- **Byte-stable skeleton** — `_attach_quotes` is a pure function of `(chapter, turns_by_index)`; same inputs, same quote text every time.
- **LLM confined to narrative slots** — quotes come from `turns_by_index` (raw transcript text), never from the model's lead/body output.
- **Gate tests unchanged and extended** — no new gate call site; `test_gate_sees_the_verbatim_quote_text` proves a token that exists *only* in `turns_by_index` (never in the LLM-authored text) still triggers a withhold, so the existing single gate scan really does cover quote content.
- **Skeleton present even when the model call fails** — needed no new code. Marker chapters (`_render_marker_chapter`) carry no `Chapter` object, so `_attach_quotes` never runs on that path; this AC is already covered by the pre-existing `test_give_up_at_double_cap_writes_marker_and_fresh_buffer` and `test_session_end_failure_writes_marker_and_closes`.

Note: an earlier draft of this feature also planned to render `SessionFacts`/`Linkage` as a body-level "skeleton" subsection in chapters. That was dropped — it would have duplicated data already in frontmatter, which an existing test (`test_create_records_session_facts_in_frontmatter_only`) and repo convention both rule out. Body narrates; frontmatter is the source of facts.

## Test plan

- [x] `pytest tests/test_note_document.py -q` — 24 passed (23 pre-existing + 1 new: quote renders between body and anchor)
- [x] `pytest tests/test_chapter_compose.py -q` — 40 passed (36 pre-existing + 4 new: fill from anchor turn, missing turns_by_index leaves quote empty, deterministic truncation, gate sees quote text)
- [x] `pytest tests/test_chapter_flush.py -q` — 18 passed (17 pre-existing + 1 new: end-to-end flush → compose → persisted note body carries the verbatim quote)
- [x] `ruff check` on all six touched files — clean
- [x] Full suite: 2600 passed, 13 pre-existing failures unrelated to this change (CLI output tests asserting on plain text but hitting ANSI color codes from rich/typer in this shell — confirmed to fail identically with these changes stashed out, i.e. pre-existing on `feat/175-linkage-frontmatter` tip)

Red→green: each of the 4 new `test_chapter_compose.py` tests and the new `test_note_document.py`/`test_chapter_flush.py` tests failed first with `TypeError: unexpected keyword argument` / assertion failures against the not-yet-added `quote` field and `turns_by_index` param, then passed once the corresponding implementation landed.