### PR TITLE
feat: lore_context_pack MCP tool — deterministic linkage join

### DIFF
--- a/lib/lore_core/context_pack.py
+++ b/lib/lore_core/context_pack.py
@@ -1,0 +1,147 @@
+"""Deterministic context pack — the join `lore_context_pack` exposes.
+
+Bounded pointer pack: session notes, ADR/PRD entries, and epic state
+for a given cwd/branch/issue, joined purely on linkage keys (repo,
+scope, issue/epic numbers) drawn from session-note frontmatter and
+`repo_docs` — never an LLM call, never an FTS ranking dressed up as a
+join (PRD 0004). Cold start (no git repo, no vault, no attached scope)
+degrades to a well-formed empty pack, never an error envelope: this is
+a planning front door and must always return something usable. Bodies
+are pulled selectively afterward via `lore_read` / `lore_repo_docs_fetch`
+— never eagerly inlined here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from lore_core.config import get_wiki_root
+from lore_core.gh import gh_issue_view
+from lore_core.git import git_repo_root
+from lore_core.linkage import Linkage, classify_refs, extract_linkage
+from lore_core.repo_docs import list_docs
+from lore_core.resume import _iter_session_notes, _list_wikis
+from lore_core.schema import parse_frontmatter
+from lore_core.scope_resolver import resolve_scope
+
+MAX_SESSIONS = 10
+# ponytail: scan window before the top-MAX_SESSIONS cut. A note past this
+# age has no realistic shot at surviving the sort. Widen if a use case
+# needs older joins.
+SCAN_DAYS = 90
+
+
+def _repo_root(cwd: Path, repo_path: str | None) -> Path | None:
+    """Resolve the connected repo's root. Explicit `repo_path` wins (test seam)."""
+    if repo_path:
+        p = Path(repo_path).expanduser().resolve()
+        return p if p.is_dir() else None
+    return git_repo_root(cwd)
+
+
+def _focus_issues(
+    linkage: Linkage, branch: str | None, issue: int | None
+) -> tuple[set[int], set[int]]:
+    """Return (all focus numbers, epics-only) — epics drive the gh epic-state lookup."""
+    issues = set(linkage.issues)
+    epics = set(linkage.epics)
+    if branch and branch != linkage.branch:
+        i, _p, e = classify_refs(branch)
+        issues |= i
+        epics |= e
+    if issue is not None:
+        issues.add(issue)
+    return issues | epics, epics
+
+
+def _session_matches(fm: dict[str, Any], *, repo: str, scope: str, focus: set[int]) -> bool:
+    linkage = fm.get("linkage") or {}
+    if repo and linkage.get("repo") == repo:
+        return True
+    if scope and str(fm.get("scope") or "") == scope:
+        return True
+    refs = set(linkage.get("issues") or []) | set(linkage.get("epics") or [])
+    return bool(focus) and bool(refs & focus)
+
+
+def _matching_sessions(
+    wiki_root: Path, *, repo: str, scope: str, focus: set[int]
+) -> list[dict[str, Any]]:
+    if not wiki_root.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for wiki_path in _list_wikis(wiki_root):
+        for d, md in _iter_session_notes(wiki_path, SCAN_DAYS):
+            fm = parse_frontmatter(md.read_text(errors="replace"))
+            if not _session_matches(fm, repo=repo, scope=scope, focus=focus):
+                continue
+            out.append(
+                {
+                    "wiki": wiki_path.name,
+                    "path": str(md.relative_to(wiki_path)),
+                    "date": d.isoformat(),
+                    "description": fm.get("description"),
+                }
+            )
+    out.sort(key=lambda s: s["date"], reverse=True)
+    return out[:MAX_SESSIONS]
+
+
+def _matching_docs(repo_root: Path | None, kind: str, focus: set[int]) -> list[dict[str, Any]]:
+    if repo_root is None:
+        return []
+    entries = list_docs(repo_root, kind)
+    if not focus:
+        return entries
+    out = []
+    for entry in entries:
+        text = (repo_root / entry["path"]).read_text(errors="replace")
+        i, _p, e = classify_refs(text)
+        if (i | e) & focus:
+            out.append(entry)
+    return out
+
+
+def _epic_state(repo: str, epics: set[int]) -> list[dict[str, Any]]:
+    if not repo:
+        return []
+    out = []
+    for num in sorted(epics):
+        info = gh_issue_view(repo, num)
+        if info is not None:
+            out.append(info)
+    return out
+
+
+def gather(
+    *,
+    cwd: Path | str | None = None,
+    branch: str | None = None,
+    issue: int | None = None,
+    repo_path: str | None = None,
+) -> dict[str, Any]:
+    """Join session-note linkage + repo_docs into a bounded pointer pack."""
+    cwd_path = Path(cwd).expanduser().resolve() if cwd else Path.cwd()
+    linkage = extract_linkage(cwd=cwd_path)
+    repo_root = _repo_root(cwd_path, repo_path)
+    focus, epics = _focus_issues(linkage, branch, issue)
+
+    scope_obj = resolve_scope(cwd_path)
+    scope = scope_obj.scope if scope_obj else ""
+    wiki = scope_obj.wiki if scope_obj else ""
+
+    sessions = _matching_sessions(get_wiki_root(), repo=linkage.repo, scope=scope, focus=focus)
+
+    return {
+        "schema": "lore.context_pack/1",
+        "repo": linkage.repo,
+        "branch": branch or linkage.branch,
+        "scope": scope,
+        "wiki": wiki,
+        "focus_issues": sorted(focus),
+        "sessions": sessions,
+        "adr": _matching_docs(repo_root, "adr", focus),
+        "prd": _matching_docs(repo_root, "prd", focus),
+        "epic_state": _epic_state(linkage.repo, epics),
+    }

--- a/lib/lore_core/gh.py
+++ b/lib/lore_core/gh.py
@@ -58,6 +58,23 @@ def gh_prs(repo: str, filter_str: str) -> list[dict]:
     return run_gh("pr", repo, split_filter(filter_str))
 
 
+def gh_issue_view(repo: str, number: int) -> dict | None:
+    """Fetch one issue/epic's number, title, state. None on any failure."""
+    cmd = ["gh", "issue", "view", str(number), "--repo", repo, "--json", "number,title,state"]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
 def format_issue_line(issue: dict) -> str:
     number = issue.get("number")
     title = issue.get("title") or ""

--- a/lib/lore_core/linkage.py
+++ b/lib/lore_core/linkage.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from lore_core.git import current_branch, current_repo
 from lore_core.identity import resolve_display_name
 
-__all__ = ["Linkage", "extract_linkage"]
+__all__ = ["Linkage", "classify_refs", "extract_linkage"]
 
 SCHEMA_VERSION = 1
 
@@ -50,7 +50,7 @@ class Linkage:
     author: str = ""
 
 
-def _classify_refs(text: str) -> tuple[set[int], set[int], set[int]]:
+def classify_refs(text: str) -> tuple[set[int], set[int], set[int]]:
     """Return (issues, prs, epics) found in `text`, mutually exclusive."""
     epics = {int(m) for m in _EPIC_RE.findall(text)}
     prs = {int(a or b) for a, b in _PR_RE.findall(text)} - epics
@@ -78,7 +78,7 @@ def extract_linkage(
     prs: set[int] = set()
     epics: set[int] = set()
     for text in (branch, *(commit_texts or [])):
-        i, p, e = _classify_refs(text)
+        i, p, e = classify_refs(text)
         issues |= i
         prs |= p
         epics |= e

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -22,6 +22,8 @@ Exposed tools:
     lore_repo_docs_list     — list a connected repo's ADRs or PRDs (pull-only)
     lore_repo_docs_fetch    — fetch one ADR or PRD's content (pull-only)
     lore_codemap            — bounded code-map query (symbols/directory/top-N)
+    lore_context_pack       — bounded pointer pack (sessions/ADR/PRD/epic state)
+                              joined from linkage frontmatter, given cwd/branch/issue
 
 Start:
     lore mcp
@@ -1043,6 +1045,23 @@ def handle_repo_docs_fetch(kind: str, path: str, repo_path: str | None = None) -
     return {"schema": "lore.repo_docs.fetch/1", "kind": kind, **doc}
 
 
+def handle_context_pack(
+    cwd: str | None = None,
+    branch: str | None = None,
+    issue: int | None = None,
+    repo_path: str | None = None,
+) -> dict[str, Any]:
+    """Bounded pointer pack for cwd/branch/issue, joined on linkage frontmatter.
+
+    Cold start (no git repo, no vault, no attached scope) degrades to a
+    well-formed empty pack rather than an error — this is a planning
+    front door and must always return something usable.
+    """
+    from lore_core.context_pack import gather
+
+    return gather(cwd=cwd, branch=branch, issue=issue, repo_path=repo_path)
+
+
 def handle_codemap(
     mode: str,
     repo_path: str | None = None,
@@ -1526,6 +1545,45 @@ def _tool_schema() -> list[dict]:
                 "required": ["kind", "path"],
             },
         },
+        {
+            "name": "lore_context_pack",
+            "description": (
+                "Bounded pointer pack (recent session notes, ADR/PRD entries, "
+                "epic state) for a cwd/branch/issue, joined purely on linkage "
+                "frontmatter — never an LLM call, never FTS ranking dressed up "
+                "as a join. Cold start (no repo, no vault, no attached scope) "
+                "returns a well-formed empty pack, never an error. Bodies are "
+                "pulled selectively afterward via `lore_read`/`lore_repo_docs_fetch`."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "cwd": {
+                        "type": "string",
+                        "description": (
+                            "Working directory to resolve repo/scope from. "
+                            "Defaults to the server's cwd."
+                        ),
+                    },
+                    "branch": {
+                        "type": "string",
+                        "description": "Override branch (defaults to the repo's current branch).",
+                    },
+                    "issue": {
+                        "type": "integer",
+                        "description": "Explicit issue/epic number to widen the focus set.",
+                    },
+                    "repo_path": {
+                        "type": "string",
+                        "description": (
+                            "Override the repo root. Defaults to the git repo "
+                            "containing the server's working directory."
+                        ),
+                    },
+                },
+                "required": [],
+            },
+        },
     ]
 
 
@@ -1577,6 +1635,8 @@ def _dispatch(tool_name: str, args: dict) -> Any:
             return handle_tier_resolve(**args)
         case "lore_codemap":
             return handle_codemap(**args)
+        case "lore_context_pack":
+            return handle_context_pack(**args)
         case _:
             return _mcp_error("unknown_tool", f"unknown tool: {tool_name}")
 

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -1,0 +1,330 @@
+"""Tests for `lore_core.context_pack` — the deterministic `lore_context_pack`
+join (PRD 0004).
+
+Relevance is a join on linkage keys (repo, scope, issue/epic) between
+session-note frontmatter and a connected repo's ADR/PRD homes — never an
+LLM call, never an FTS ranking dressed up as a join. Cold-start (no repo,
+no vault, no scope) degrades to a well-formed empty pack, never an error.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+from lore_core.context_pack import gather
+from lore_core.state.attachments import Attachment, AttachmentsFile
+
+_TODAY = date.today().isoformat()
+
+
+def _init_repo(repo_root: Path, *, branch: str = "main", remote_url: str | None = None) -> None:
+    repo_root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", branch], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo_root, check=True)
+    if remote_url:
+        subprocess.run(["git", "remote", "add", "origin", remote_url], cwd=repo_root, check=True)
+    (repo_root / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "-A"], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init", "--no-verify"], cwd=repo_root, check=True)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _session_note(
+    *,
+    repo: str = "",
+    epics: list[int] | None = None,
+    issues: list[int] | None = None,
+    scope: str = "w:s",
+    description: str = "a session",
+) -> str:
+    fm = {
+        "schema_version": 2,
+        "type": "session",
+        "created": _TODAY,
+        "last_reviewed": _TODAY,
+        "description": description,
+        "scope": scope,
+        "linkage": {
+            "schema_version": 1,
+            "repo": repo,
+            "branch": "main",
+            "issues": issues or [],
+            "prs": [],
+            "epics": epics or [],
+            "author": "",
+        },
+    }
+    return f"---\n{yaml.safe_dump(fm, sort_keys=False)}---\n\n# s\n"
+
+
+def _no_vault(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path / "no-such-vault"))
+
+
+# ---------------------------------------------------------------------------
+# repo-linkage join
+# ---------------------------------------------------------------------------
+
+
+def test_gather_joins_session_notes_by_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, remote_url="git@github.com:acme/widget.git")
+
+    vault = tmp_path / "vault"
+    wiki = vault / "wiki" / "w"
+    _write(wiki / "sessions" / f"{_TODAY}-matching.md", _session_note(repo="acme/widget"))
+    _write(wiki / "sessions" / f"{_TODAY}-unrelated.md", _session_note(repo="acme/other"))
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+
+    result = gather(cwd=repo, repo_path=str(repo))
+    assert "error" not in result
+    assert result["repo"] == "acme/widget"
+    paths = {s["path"] for s in result["sessions"]}
+    assert any("matching" in p for p in paths)
+    assert not any("unrelated" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# epic / issue join
+# ---------------------------------------------------------------------------
+
+
+def test_gather_joins_by_epic_from_branch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="epic/162")
+
+    vault = tmp_path / "vault"
+    wiki = vault / "wiki" / "w"
+    _write(
+        wiki / "sessions" / f"{_TODAY}-on-epic.md",
+        _session_note(repo="other/repo", epics=[162]),
+    )
+    _write(
+        wiki / "sessions" / f"{_TODAY}-off-epic.md",
+        _session_note(repo="other/repo", epics=[99]),
+    )
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+
+    result = gather(cwd=repo, repo_path=str(repo))
+    assert result["focus_issues"] == [162]
+    paths = {s["path"] for s in result["sessions"]}
+    assert any("on-epic" in p for p in paths)
+    assert not any("off-epic" in p for p in paths)
+
+
+def test_gather_issue_param_widens_focus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    vault = tmp_path / "vault"
+    wiki = vault / "wiki" / "w"
+    _write(
+        wiki / "sessions" / f"{_TODAY}-issue-180.md",
+        _session_note(repo="other/repo", issues=[180]),
+    )
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+
+    result = gather(cwd=repo, repo_path=str(repo), issue=180)
+    assert 180 in result["focus_issues"]
+    paths = {s["path"] for s in result["sessions"]}
+    assert any("issue-180" in p for p in paths)
+
+
+def test_gather_epic_state_calls_gh_issue_view(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="epic/162", remote_url="git@github.com:acme/widget.git")
+    _no_vault(monkeypatch, tmp_path)
+
+    calls = []
+
+    def fake_gh_issue_view(repo_slug: str, number: int):
+        calls.append((repo_slug, number))
+        return {"number": number, "title": "Epic 162", "state": "OPEN"}
+
+    monkeypatch.setattr("lore_core.context_pack.gh_issue_view", fake_gh_issue_view)
+
+    result = gather(cwd=repo, repo_path=str(repo))
+    assert calls == [("acme/widget", 162)]
+    assert result["epic_state"] == [{"number": 162, "title": "Epic 162", "state": "OPEN"}]
+
+
+def test_gather_epic_state_silent_when_gh_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="epic/162", remote_url="git@github.com:acme/widget.git")
+    _no_vault(monkeypatch, tmp_path)
+
+    monkeypatch.setattr("lore_core.context_pack.gh_issue_view", lambda *a: None)
+
+    result = gather(cwd=repo, repo_path=str(repo))
+    assert "error" not in result
+    assert result["epic_state"] == []
+
+
+# ---------------------------------------------------------------------------
+# ADR/PRD join (repo_docs pull + linkage classification of doc content)
+# ---------------------------------------------------------------------------
+
+
+def test_gather_filters_adr_prd_by_epic_reference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="epic/162")
+    _write(repo / "docs/adr/0001-x.md", "# ADR\n\nContext: epic #162.\n")
+    _write(repo / "docs/adr/0002-y.md", "# ADR unrelated\n\nNo epic ref here.\n")
+    _write(repo / "docs/prd/0001-p.md", "---\ntitle: P\n---\nepic #162 tracked here.\n")
+    _no_vault(monkeypatch, tmp_path)
+
+    result = gather(cwd=repo, repo_path=str(repo))
+    adr_paths = {e["path"] for e in result["adr"]}
+    assert "docs/adr/0001-x.md" in adr_paths
+    assert "docs/adr/0002-y.md" not in adr_paths
+    assert {e["path"] for e in result["prd"]} == {"docs/prd/0001-p.md"}
+
+
+def test_gather_returns_all_adr_prd_when_no_focus(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)  # branch "main" — no epic/issue signal
+    _write(repo / "docs/adr/0001-x.md", "# ADR X\n")
+    _write(repo / "docs/adr/0002-y.md", "# ADR Y\n")
+    _no_vault(monkeypatch, tmp_path)
+
+    result = gather(cwd=repo, repo_path=str(repo))
+    assert result["focus_issues"] == []
+    assert {e["path"] for e in result["adr"]} == {"docs/adr/0001-x.md", "docs/adr/0002-y.md"}
+
+
+# ---------------------------------------------------------------------------
+# scope join (via attachments-backed scope_resolver)
+# ---------------------------------------------------------------------------
+
+
+def test_gather_joins_by_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)  # no remote — repo string is empty
+
+    vault = tmp_path / "vault"
+    (vault / ".lore").mkdir(parents=True)
+    af = AttachmentsFile(vault)
+    af.load()
+    af.add(
+        Attachment(path=repo, wiki="w", scope="w:s", attached_at=datetime(2026, 1, 1, tzinfo=UTC))
+    )
+    af.save()
+
+    wiki = vault / "wiki" / "w"
+    _write(
+        wiki / "sessions" / f"{_TODAY}-scoped.md", _session_note(repo="unrelated/repo", scope="w:s")
+    )
+    _write(
+        wiki / "sessions" / f"{_TODAY}-other-scope.md",
+        _session_note(repo="unrelated/repo", scope="w:other"),
+    )
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+
+    result = gather(cwd=repo, repo_path=str(repo))
+    assert result["scope"] == "w:s"
+    assert result["wiki"] == "w"
+    paths = {s["path"] for s in result["sessions"]}
+    assert any("scoped.md" in p and "other-scope" not in p for p in paths)
+    assert not any("other-scope" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# cold start — well-formed empty packs, never errors
+# ---------------------------------------------------------------------------
+
+
+def test_gather_cold_start_no_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo, remote_url="git@github.com:acme/widget.git")
+    _no_vault(monkeypatch, tmp_path)
+
+    result = gather(cwd=repo, repo_path=str(repo))
+    assert "error" not in result
+    assert result["sessions"] == []
+    assert result["repo"] == "acme/widget"
+
+
+def test_gather_cold_start_outside_git_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stranger = tmp_path / "stranger"
+    stranger.mkdir()
+    _no_vault(monkeypatch, tmp_path)
+
+    result = gather(cwd=stranger)
+    assert "error" not in result
+    assert result["repo"] == ""
+    assert result["sessions"] == []
+    assert result["adr"] == []
+    assert result["prd"] == []
+    assert result["epic_state"] == []
+
+
+# ---------------------------------------------------------------------------
+# bounded pack
+# ---------------------------------------------------------------------------
+
+
+def test_gather_bounds_session_count(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from lore_core.context_pack import MAX_SESSIONS
+
+    repo = tmp_path / "repo"
+    _init_repo(repo, remote_url="git@github.com:acme/widget.git")
+
+    vault = tmp_path / "vault"
+    wiki = vault / "wiki" / "w"
+    for i in range(MAX_SESSIONS + 5):
+        d = date.today().isoformat()
+        _write(wiki / "sessions" / f"{d}-note-{i:02d}.md", _session_note(repo="acme/widget"))
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+
+    result = gather(cwd=repo, repo_path=str(repo))
+    assert len(result["sessions"]) == MAX_SESSIONS
+
+
+# ---------------------------------------------------------------------------
+# MCP registration
+# ---------------------------------------------------------------------------
+
+
+def test_context_pack_tool_registered_in_schema() -> None:
+    from lore_mcp.server import _tool_schema
+
+    names = {t["name"] for t in _tool_schema()}
+    assert "lore_context_pack" in names
+
+
+def test_context_pack_dispatch_routes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from lore_mcp.server import _dispatch
+
+    repo = tmp_path / "repo"
+    _init_repo(repo, remote_url="git@github.com:acme/widget.git")
+    _no_vault(monkeypatch, tmp_path)
+
+    result = _dispatch("lore_context_pack", {"cwd": str(repo), "repo_path": str(repo)})
+    assert result["schema"] == "lore.context_pack/1"
+    assert result["repo"] == "acme/widget"


### PR DESCRIPTION
Closes #177

## Summary

`lore_context_pack.gather()` returns a bounded pointer pack — recent
session notes, ADR/PRD entries, and epic state — for a given
cwd/branch/issue. Relevance is computed purely by joining linkage keys
(repo, scope, issue/epic numbers) drawn from session-note frontmatter
(#175) and repo_docs content, never by an LLM call and never by an FTS
ranking dressed up as a join. Cold start (no git repo, no vault, no
attached scope) degrades to a well-formed empty pack rather than an
error envelope — this is meant to be a safe planning front door.

Bodies are never eagerly inlined; pointers only, drilled down
afterward via `lore_read` / `lore_repo_docs_fetch`.

## Decisions

- `classify_refs` (was `_classify_refs`) is exported from
  `lore_core.linkage` so the join can classify epic/issue/PR refs
  found inside ADR/PRD body text, not just branch names — reused
  rather than re-implemented.
- `gh_issue_view()` added to `lore_core.gh` alongside the existing
  `gh_issues`/`gh_prs` list helpers; same fail-silent contract (`None`
  on any failure, never raises).
- The join unions `issues | epics` on both the session-note side and
  the ADR/PRD side rather than requiring an epic-only match — this
  generalizes to real-world ADR prose (`epic [#151](url)`) beyond the
  stricter branch-name convention, without extra code.
- Cold-start paths return well-formed empty results (`sessions: []`,
  `adr: []`, etc.) rather than reusing `resume.gather()`'s
  `mcp_error` envelope — `lore_context_pack` must always return
  something usable per the acceptance criteria.

## Red → green

Red (before `lore_core.context_pack` existed):
```
ImportError while importing test module '.../tests/test_context_pack.py'.
tests/test_context_pack.py:19: in <module>
    from lore_core.context_pack import gather
E   ModuleNotFoundError: No module named 'lore_core.context_pack'
1 error in 0.40s
```

Green:
```
13 passed in 0.64s
```

## Test plan

- [x] `tests/test_context_pack.py` — 13 tests: repo join, epic/issue
      join (branch + explicit param), gh epic-state lookup (success +
      silent failure), ADR/PRD filtering by epic reference, scope
      join, cold-start (no vault / outside git repo), session-count
      bound, MCP schema registration + dispatch routing.
- [x] Full `pytest -q`: 2595 passed, 11 failed (pre-existing, verified
      identical via `git stash` baseline — all rich/typer ANSI-color
      assertion failures unrelated to this change), 1 skipped.
- [x] `ruff check` / `ruff format --check` clean on touched files.