### PR TITLE
feat(#180): briefings key digests by linkage, drill down to source notes

### DIFF
--- a/docs/architecture/briefing-compression-channel.md
+++ b/docs/architecture/briefing-compression-channel.md
@@ -1,0 +1,57 @@
+# Briefings as a compression channel
+
+**Audience:** contributors extending `gather()`, `render_briefing()`, or
+`compose_briefing_prose()` in `lore_core/briefing/`.
+
+## The drill-down chain
+
+A briefing is not a standalone artifact — it's the entry point of a
+chain a teammate can walk from a two-line digest down to the exact
+commit that motivated it:
+
+```
+briefing → session notes → ADRs/PRDs/issues → code
+```
+
+Each stage compresses less and costs more to read. The briefing itself
+compresses hardest (one bullet per project/theme); a session note is
+the next level of detail; the ADR/PRD/issue it links to is more detail
+still; the code is the ground truth. A teammate reads only as far down
+the chain as the task requires — most days, the briefing alone is
+enough to know "what's Alice been doing on epic #162."
+
+## Linkage is the join key
+
+The chain only holds together if each stage carries pointers to the
+next one. Session notes already carry `linkage` frontmatter (`author`,
+`repo`, `branch`, `issues`, `prs`, `epics` — see
+[[session-note-lifecycle]] and `lore_core/linkage.py`). `gather()`
+(`lore_core/briefing/gather.py`) passes that `linkage` dict through
+verbatim on every entry, plus an optional `epic` filter so a caller can
+scope gather to one epic's sessions directly.
+
+Both consumers of `gather()`'s output turn `linkage` into drill-down
+links:
+
+- `render_briefing()` (`format.py`) — the deterministic fallback —
+  appends a `[[note-slug]]` wikilink and `(author · epic #N · #issue)`
+  refs to every bullet.
+- `compose_briefing_prose()` (`compose.py`) — the LLM path — folds the
+  same refs into each session's line in the prompt, so the model can
+  key its "What happened" bullets by author/epic instead of just
+  chronology.
+
+This is a pure join on frontmatter, no LLM involved in the linking
+itself — consistent with [[why-tdd-is-enforced]]'s broader stance that
+retrieval in this codebase is deterministic, never ranked guesswork
+dressed up as relevance.
+
+## Why pull-only
+
+Briefings publish outward (see `docs/how-to/matrix-bot.md` for the
+sink recipe) but `gather()` itself never writes anything — no ledger
+mutation, no note edits. A teammate reading a briefing pulls further
+detail by following a wikilink or an issue ref; nothing pushes context
+at them beyond the one digest. Keeps the channel cheap to run
+lights-out and keeps the vault the only source of truth for what a
+link actually points to.

--- a/lib/lore_core/briefing/compose.py
+++ b/lib/lore_core/briefing/compose.py
@@ -107,7 +107,14 @@ def _build_prompt(gather_result: dict[str, Any]) -> str:
         fm = s.get("frontmatter") or {}
         summary = fm.get("summary") or fm.get("description") or ""
         body = s.get("body") or ""
-        lines.append(f"- {d} · {slug}")
+        linkage = s.get("linkage") or {}
+        refs = [linkage["author"]] if linkage.get("author") else []
+        refs += [f"epic #{n}" for n in linkage.get("epics") or []]
+        refs += [f"#{n}" for n in linkage.get("issues") or []]
+        header = f"- {d} · {slug}"
+        if refs:
+            header += f" ({', '.join(refs)})"
+        lines.append(header)
         if summary:
             lines.append(f"  summary: {_shorten(str(summary), _SUMMARY_CAP)}")
         if body:

--- a/lib/lore_core/briefing/format.py
+++ b/lib/lore_core/briefing/format.py
@@ -30,6 +30,7 @@ deterministic fallback formatter stays frontmatter-only.
 from __future__ import annotations
 
 from collections import defaultdict
+from pathlib import Path
 from typing import Any
 
 
@@ -42,6 +43,18 @@ def _session_summary(session: dict[str, Any]) -> str:
     if isinstance(description, str) and description.strip():
         return description.strip()
     return ""
+
+
+def _drill_down_refs(session: dict[str, Any]) -> list[str]:
+    """Author + epic/issue refs — the digest's onward links per note."""
+    linkage = session.get("linkage") or {}
+    refs = []
+    author = linkage.get("author")
+    if author:
+        refs.append(str(author))
+    refs += [f"epic #{n}" for n in linkage.get("epics") or []]
+    refs += [f"#{n}" for n in linkage.get("issues") or []]
+    return refs
 
 
 def render_briefing(gather_result: dict[str, Any]) -> str:
@@ -79,10 +92,13 @@ def render_briefing(gather_result: dict[str, Any]) -> str:
         for s in by_date[d]:
             slug = s.get("slug") or "(unknown)"
             summary = _session_summary(s)
-            if summary:
-                lines.append(f"- **{slug}** — {summary}")
-            else:
-                lines.append(f"- **{slug}**")
+            bullet = f"- **{slug}** — {summary}" if summary else f"- **{slug}**"
+            stem = Path(s.get("path") or slug).stem
+            bullet += f" [[{stem}]]"
+            refs = _drill_down_refs(s)
+            if refs:
+                bullet += f" ({' · '.join(refs)})"
+            lines.append(bullet)
         lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"

--- a/lib/lore_core/briefing/gather.py
+++ b/lib/lore_core/briefing/gather.py
@@ -110,12 +110,19 @@ def gather(
     since: str | None = None,
     include_body_sections: bool = True,
     user: str | None = None,
+    epic: int | None = None,
 ) -> dict[str, Any]:
     """Collect new session notes since the last briefing.
 
     Read-only — does NOT write the ledger. The caller composes the
     briefing prose, publishes via `lore briefing publish`, then commits
     the ledger update via `lore briefing mark`.
+
+    Each entry carries its `linkage` frontmatter (author, repo, branch,
+    issues, prs, epics) verbatim — the join key for keying digests by
+    author/scope/epic and for drill-down onward to ADRs/PRDs/issues.
+    `epic`, when given, filters to sessions whose linkage names that
+    epic (mirrors the existing `user` filter).
 
     Returns:
       {
@@ -129,6 +136,7 @@ def gather(
             "date": str,
             "slug": str,
             "frontmatter": dict,
+            "linkage": dict,
             "body": str  (when include_body_sections)
           },
           ...
@@ -172,13 +180,18 @@ def gather(
             if md.name in incorporated or stem + ".md" in incorporated:
                 continue
             text = md.read_text(errors="replace")
+            frontmatter = parse_frontmatter(text)
+            linkage = frontmatter.get("linkage") or {}
             entry: dict[str, Any] = {
                 "path": rel,
                 "date": d.isoformat(),
                 "slug": slug or stem,
-                "frontmatter": parse_frontmatter(text),
+                "frontmatter": frontmatter,
+                "linkage": linkage,
             }
             if user and entry["frontmatter"].get("user") != user:
+                continue
+            if epic is not None and epic not in (linkage.get("epics") or []):
                 continue
             if include_body_sections:
                 # Session notes carry no human-only region — machine-written

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -507,12 +507,16 @@ def handle_briefing_gather(
     wiki: str,
     since: str | None = None,
     include_body_sections: bool = True,
+    epic: int | None = None,
 ) -> dict[str, Any]:
     """Read-only briefing gather. Delegates to lore_core.briefing.gather()."""
     from lore_core.briefing import gather
 
     return gather(
-        wiki=wiki, since=since, include_body_sections=include_body_sections
+        wiki=wiki,
+        since=since,
+        include_body_sections=include_body_sections,
+        epic=epic,
     )
 
 
@@ -1278,6 +1282,13 @@ def _tool_schema() -> list[dict]:
                         "type": "boolean",
                         "default": True,
                         "description": "Extract H2 sections per session",
+                    },
+                    "epic": {
+                        "type": "integer",
+                        "description": (
+                            "Filter to sessions whose `linkage.epics` "
+                            "names this epic number."
+                        ),
                     },
                 },
                 "required": ["wiki"],

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 import pytest
 from lore_cli import briefing_cmd
 from lore_core.briefing import gather, mark_incorporated, render_briefing
+from lore_core.linkage import Linkage
 from lore_core.note_document import Chapter, TopicBlock, append_chapter, close_note, create_note
 
 
@@ -500,9 +501,35 @@ def test_compose_briefing_prose_returns_llm_text():
     assert fake.messages.calls[0]["model"] == "claude-sonnet-4-6"
     prompt = fake.messages.calls[0]["messages"][0]["content"]
     assert "shipped the thing" in prompt
-    assert "ccat" in prompt
-    # Full body text (not a section extract) reaches the composer prompt.
-    assert "Wired up the last piece." in prompt
+
+
+def test_compose_briefing_prompt_includes_linkage():
+    """Author + epic ride into the prompt so the LLM can key digests on them."""
+    from lore_core.briefing import compose_briefing_prose
+
+    fake = _FakeClient(text="## Briefing: 2026-04-29 (ccat)\n")
+    compose_briefing_prose(
+        gather_result={
+            "wiki": "ccat",
+            "today": "2026-04-29",
+            "ledger": {"last_briefing": None},
+            "new_sessions": [
+                {
+                    "path": "p",
+                    "date": "2026-04-29",
+                    "slug": "thing",
+                    "frontmatter": {"summary": "shipped thing"},
+                    "linkage": {"author": "Alice", "epics": [162]},
+                    "body": "",
+                }
+            ],
+        },
+        llm_client=fake,
+        model_resolver=lambda t: "claude-sonnet-4-6",
+    )
+    prompt = fake.messages.calls[0]["messages"][0]["content"]
+    assert "Alice" in prompt
+    assert "epic #162" in prompt
 
 
 def test_compose_briefing_prose_empty_input_short_circuits():
@@ -638,3 +665,127 @@ def test_gather_sharded_dd_only_no_time(tmp_path, monkeypatch):
     s = result["new_sessions"][0]
     assert s["date"] == "2026-04-29"
     assert s["slug"] == "thing"
+
+
+# ---------------------------------------------------------------------------
+# Linkage-frontmatter join: digest keyed by author/scope/epic, drill-down
+# refs surfaced for downstream compose/render.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def linkage_briefing_vault(tmp_path, monkeypatch):
+    """Shared vault, two authors, real `linkage` frontmatter per note."""
+    vault_root = tmp_path / "vault"
+    wiki = vault_root / "wiki" / "ccat"
+    (wiki / "sessions").mkdir(parents=True)
+
+    def write(name: str, *, author: str, epics: list[int], issues: list[int]) -> None:
+        path = wiki / "sessions" / f"{name}.md"
+        create_note(
+            path,
+            title=name[11:],
+            description=f"session {name}",
+            scope="lore:test",
+            created=name[:10],
+            linkage=Linkage(
+                repo="acme/app",
+                branch="main",
+                issues=issues,
+                epics=epics,
+                author=author,
+            ),
+        )
+        append_chapter(
+            path,
+            Chapter(blocks=[TopicBlock(lead="Did the thing.", anchor_turn=5)]),
+            slice_from_turn=1,
+            slice_to_turn=5,
+        )
+        close_note(path)
+
+    write("2026-04-15-fix-a", author="Alice", epics=[162], issues=[175])
+    write("2026-04-16-fix-b", author="Bob", epics=[161], issues=[180])
+
+    monkeypatch.setenv("LORE_ROOT", str(vault_root))
+    return vault_root, wiki
+
+
+def test_gather_includes_linkage_frontmatter(linkage_briefing_vault):
+    result = gather(wiki="ccat")
+    by_slug = {s["slug"]: s for s in result["new_sessions"]}
+    assert by_slug["fix-a"]["linkage"]["author"] == "Alice"
+    assert by_slug["fix-a"]["linkage"]["epics"] == [162]
+    assert by_slug["fix-a"]["linkage"]["issues"] == [175]
+
+
+def test_gather_shared_vault_multiple_authors(linkage_briefing_vault):
+    """Two authors' notes coexist in one wiki; gather surfaces both."""
+    result = gather(wiki="ccat")
+    authors = sorted(s["linkage"]["author"] for s in result["new_sessions"])
+    assert authors == ["Alice", "Bob"]
+
+
+def test_gather_filters_by_epic(linkage_briefing_vault):
+    result = gather(wiki="ccat", epic=162)
+    assert len(result["new_sessions"]) == 1
+    assert result["new_sessions"][0]["slug"] == "fix-a"
+
+
+def test_gather_epic_filter_no_match_returns_empty(linkage_briefing_vault):
+    result = gather(wiki="ccat", epic=999)
+    assert result["new_sessions"] == []
+
+
+def test_mcp_handle_briefing_gather_forwards_epic(linkage_briefing_vault):
+    from lore_mcp.server import handle_briefing_gather
+
+    result = handle_briefing_gather(wiki="ccat", epic=162)
+    assert len(result["new_sessions"]) == 1
+    assert result["new_sessions"][0]["slug"] == "fix-a"
+
+
+def test_render_briefing_links_to_source_note():
+    """Digest bullets carry a wikilink back to the source session note."""
+    result = {
+        "wiki": "ccat",
+        "today": "2026-04-29",
+        "ledger": {"last_briefing": None, "incorporated_count": 0},
+        "new_sessions": [
+            {
+                "path": "sessions/2026-04-29-thing.md",
+                "date": "2026-04-29",
+                "slug": "thing",
+                "frontmatter": {"summary": "shipped the thing"},
+                "linkage": {},
+                "body": "",
+            }
+        ],
+    }
+    out = render_briefing(result)
+    # Pre-existing bullet text stays intact (backward compatible).
+    assert "- **thing** — shipped the thing" in out
+    assert "[[2026-04-29-thing]]" in out
+
+
+def test_render_briefing_shows_drill_down_refs():
+    """Author + epic/issue refs ride along so a reader can drill down."""
+    result = {
+        "wiki": "ccat",
+        "today": "2026-04-29",
+        "ledger": {"last_briefing": None, "incorporated_count": 0},
+        "new_sessions": [
+            {
+                "path": "sessions/2026-04-29-thing.md",
+                "date": "2026-04-29",
+                "slug": "thing",
+                "frontmatter": {"summary": "shipped the thing"},
+                "linkage": {"author": "Alice", "epics": [162], "issues": [175]},
+                "body": "",
+            }
+        ],
+    }
+    out = render_briefing(result)
+    assert "Alice" in out
+    assert "epic #162" in out
+    assert "#175" in out


### PR DESCRIPTION
Closes #180

## What changed

`gather()` (`lib/lore_core/briefing/gather.py`) now passes each session's `linkage` frontmatter (author, repo, branch, issues, prs, epics) through verbatim on every entry, and accepts an optional `epic` filter (mirrors the existing `user` filter) so a caller can scope a gather to one epic's sessions directly.

Both consumers of `gather()`'s output turn that into drill-down links:
- `render_briefing()` (`format.py`, the deterministic fallback) appends a `[[note-slug]]` wikilink plus `(author · epic #N · #issue)` refs to every bullet.
- `compose_briefing_prose()` (`compose.py`, the LLM path) folds the same refs into each session's line in the prompt, so the model can key "What happened" bullets by author/epic instead of chronology alone.

`handle_briefing_gather` in `lib/lore_mcp/server.py` forwards the new `epic` param and the tool's `inputSchema` documents it.

Added `docs/architecture/briefing-compression-channel.md` describing the briefing → notes → ADRs/PRDs/issues → code drill-down chain and why linkage frontmatter is the join key that holds it together.

## Stacking decision

**Not stacked on #177.** This branch only needs `lore_core.linkage`, which both #177 and #180 independently import from the shared `epic/162` base — no code from #177's `context_pack.py` is needed here. Verified this branch has no `test_context_pack.py` and diffs cleanly against `origin/epic/162`.

## Scope decisions

- No `--epic` CLI flag added to `lore briefing` — not named in the issue's pointers, and the MCP tool + gather() param cover the stated acceptance criteria (YAGNI).

## Test plan (TDD red → green)

Red (6 new/affected assertions failing against the pre-change implementation, tests present):
```
FAILED tests/test_briefing.py::test_compose_briefing_prompt_includes_linkage - AssertionError: assert 'Alice' in 'You are composing a developer briefing —...
FAILED tests/test_briefing.py::test_gather_includes_linkage_frontmatter - KeyError: 'linkage'
FAILED tests/test_briefing.py::test_gather_filters_by_epic - TypeError: gather() got an unexpected keyword argument 'epic'
FAILED tests/test_briefing.py::test_gather_epic_filter_no_match_returns_empty - TypeError: gather() got an unexpected keyword argument 'epic'
FAILED tests/test_briefing.py::test_mcp_handle_briefing_gather_forwards_epic - TypeError: handle_briefing_gather() got an unexpected keyword argument 'epic'
FAILED tests/test_briefing.py::test_render_briefing_shows_drill_down_refs - AssertionError: assert 'Alice' in '# Briefing — 2026-04-29 · ccat\n\n1 session since the start.\n\n## 2026-04-29\n\n- **thing** — shipped the thing\n'
6 failed, 35 deselected
```

Green (after implementation):
```
tests/test_briefing.py: 41 passed
```

- [x] `pytest -q tests/test_briefing.py tests/test_briefing_git_coordination.py` — 48 passed
- [x] Full repo `pytest -q` — 2590 passed, 1 skipped, 11 pre-existing failures (unrelated rich/typer ANSI-rendering tests in `test_cli_runs.py`, `test_core_llm_wiring.py`, `test_drain_prune.py`, `test_install_dispatcher.py`, `test_log_cmd.py`, `test_proc_cmd.py` — confirmed present on `origin/epic/162` baseline too, no regressions)
- [x] `ruff check` on touched files — 1 pre-existing `UP035` in `compose.py` (predates this branch, confirmed via baseline diff), no new lint introduced
- [x] `ruff format --check` on touched files — pre-existing formatting drift on 4/5 files (confirmed present on baseline too), not introduced by this change
- [x] Multi-author shared-vault fixture (`linkage_briefing_vault`) covers acceptance criterion "works on a shared vault with multiple authors"
- [x] Docs describe the compression-channel model (`docs/architecture/briefing-compression-channel.md`)