### PR TITLE
Display name onboarding + shared-vault consent gate

### DIFF
--- a/docs/architecture/state.md
+++ b/docs/architecture/state.md
@@ -139,6 +139,38 @@ in O(n log n) over registered attachments.
 This file answers: "on this host, when I'm in directory X, which
 wiki+scope am I working in?"
 
+### Shared-vault consent & leak semantics
+
+A wiki with no git remote is **private by default** — nothing it holds
+ever leaves the machine. A wiki with a git remote is a **shared
+vault**: every teammate with read access to that remote can see every
+composed session note committed there.
+
+Attaching a scope to a shared vault is the moment sharing starts, so
+it's the moment consent is asked. `lore attach accept` / `lore attach
+manual` route through `_confirm_shared_vault()`
+(`lore_cli/attach_cmd.py`), which checks `git_sync.has_remote()` on the
+target wiki before writing the attachment row:
+
+- **No remote** — no-op, nothing to consent to.
+- **Remote, interactive terminal** — a y/N prompt, printed before the
+  row is written.
+- **Remote, non-interactive** — refused (exit 1) unless the caller
+  passes `--confirm-shared`; non-interactive callers never get routed
+  to a shared vault silently.
+
+**The gate reduces but cannot eliminate leaks.** It stops accidental
+first-time routing to a shared vault; it does not scan note content.
+If a secret ends up in a composed note, git history retains it even
+after the note is edited or deleted — the remedy is **rotating the
+credential**, not scrubbing history.
+
+**Transcripts and buffers never leave local state.** They live under
+`<lore_root>/.lore/` (`transcript-ledger.json`, `buffers/`), a sibling
+of `wiki/` — never a descendant — so a `git push` of a wiki directory
+structurally cannot ship them. Only composed, gate-passed notes
+written into `wiki/<name>/sessions/` are ever pushed.
+
 ---
 
 ## How they collaborate

--- a/lib/lore_cli/attach_cmd.py
+++ b/lib/lore_cli/attach_cmd.py
@@ -153,7 +153,46 @@ def _maybe_scaffold_workflow(lore_root: Path, repo_root: Path, scaffold_workflow
         console.print("[dim]Workflow docs already scaffolded — no changes.[/dim]")
 
 
-def _do_accept(lore_root: Path, cwd_path: Path, scaffold_workflow: bool = False) -> None:
+def _confirm_shared_vault(lore_root: Path, wiki: str, *, assume_yes: bool) -> bool:
+    """Gate routing a scope to a *shared* wiki (has a git remote) behind
+    explicit consent, surfaced at the moment of attaching — that's when
+    session notes start flowing to every teammate with access to it.
+
+    A solo wiki (no remote) is a no-op: nothing to consent to. Otherwise:
+    interactive terminals get a y/N prompt; non-interactive callers must
+    pass ``assume_yes=True`` (``--confirm-shared``) or the attach is
+    refused — fail closed, never silently route to a shared vault.
+    """
+    from lore_core.config import get_wiki_root
+    from lore_core.git_sync import has_remote
+
+    if not has_remote(get_wiki_root() / wiki):
+        return True
+    if assume_yes:
+        return True
+    if not _is_interactive():
+        err_console.print(
+            f"[red]Wiki '{wiki}' is a shared vault[/red] (has a git remote) — "
+            "attaching routes composed session notes there for every "
+            "teammate with access to see.\n"
+            "Re-run with [cyan]--confirm-shared[/cyan] to proceed "
+            "non-interactively, or run `lore attach` in a terminal to "
+            "be prompted."
+        )
+        return False
+    console.print(
+        f"\n[yellow]Wiki '{wiki}' is a shared vault[/yellow] (has a git remote). "
+        "Composed, gate-passed notes committed here are visible to every "
+        "teammate with access — raw transcripts and buffers never leave "
+        "your local state. If a secret leaks into a note, rotate it; "
+        "history keeps deleted lines.\n"
+    )
+    raw = input("  Continue attaching to this shared vault? [y/N]: ").strip().lower()
+    return raw in ("y", "yes")
+
+
+def _do_accept(lore_root: Path, cwd_path: Path, scaffold_workflow: bool = False,
+                confirm_shared: bool = False) -> None:
     from datetime import UTC, datetime
 
     from lore_core.consent import ConsentState, classify_state
@@ -183,6 +222,9 @@ def _do_accept(lore_root: Path, cwd_path: Path, scaffold_workflow: bool = False)
             "Accept anyway with `lore attach accept --cwd <path>` after "
             "removing the decline, or wait until the `.lore.yml` changes."
         )
+        raise typer.Exit(1)
+
+    if not _confirm_shared_vault(lore_root, offer.wiki, assume_yes=confirm_shared):
         raise typer.Exit(1)
 
     try:
@@ -248,12 +290,16 @@ def _do_decline(lore_root: Path, cwd_path: Path) -> None:
 
 
 def _do_manual(
-    lore_root: Path, cwd_path: Path, wiki: str, scope: str, scaffold_workflow: bool = False
+    lore_root: Path, cwd_path: Path, wiki: str, scope: str, scaffold_workflow: bool = False,
+    confirm_shared: bool = False,
 ) -> None:
     from datetime import UTC, datetime
 
     from lore_core.state.attachments import Attachment, AttachmentsFile
     from lore_core.state.scopes import ScopeConflict, ScopesFile
+
+    if not _confirm_shared_vault(lore_root, wiki, assume_yes=confirm_shared):
+        raise typer.Exit(1)
 
     attachments = AttachmentsFile(lore_root)
     attachments.load()
@@ -777,9 +823,14 @@ def cmd_accept(
         "--scaffold-workflow",
         help="Also scaffold docs/prd, docs/adr, and the AGENTS.md shim.",
     ),
+    confirm_shared: bool = typer.Option(
+        False,
+        "--confirm-shared",
+        help="Consent to attaching to a shared (git-remote) wiki non-interactively.",
+    ),
 ) -> None:
     """Accept the `.lore.yml` offer covering ``cwd``."""
-    _do_accept(_lore_root_or_die(), _cwd_arg(cwd), scaffold_workflow)
+    _do_accept(_lore_root_or_die(), _cwd_arg(cwd), scaffold_workflow, confirm_shared)
 
 
 @app.command("decline")
@@ -800,11 +851,16 @@ def cmd_manual(
         "--scaffold-workflow",
         help="Also scaffold docs/prd, docs/adr, and the AGENTS.md shim.",
     ),
+    confirm_shared: bool = typer.Option(
+        False,
+        "--confirm-shared",
+        help="Consent to attaching to a shared (git-remote) wiki non-interactively.",
+    ),
 ) -> None:
     """Attach ``cwd`` manually with no ``.lore.yml`` required."""
     cwd_path = _cwd_arg(cwd)
     resolved = cwd_path.resolve() if cwd_path.exists() else cwd_path.absolute()
-    _do_manual(_lore_root_or_die(), resolved, wiki, scope, scaffold_workflow)
+    _do_manual(_lore_root_or_die(), resolved, wiki, scope, scaffold_workflow, confirm_shared)
 
 
 @app.command("offer")

--- a/lib/lore_cli/init_cmd.py
+++ b/lib/lore_cli/init_cmd.py
@@ -28,9 +28,42 @@ def _plugin_templates_dir() -> Path:
     return templates_dir()
 
 
-def init_vault(root: Path, force: bool = False) -> None:
+def _is_interactive() -> bool:
+    return sys.stdin.isatty()
+
+
+def _maybe_set_display_name(root: Path, display_name: str | None) -> None:
+    """Onboard the personal display name used in place of `$USER`.
+
+    A `--display-name` flag wins outright (scripted/CI use). Otherwise,
+    prompt only when attached to a real terminal and nothing is
+    configured yet — reruns (e.g. `--force`) never overwrite an
+    existing choice, and non-interactive runs never block on input.
+    """
+    from lore_core.root_config import load_root_config, set_field
+
+    if display_name:
+        set_field(root, "user.display_name", display_name)
+        console.print(f"[green]Display name set to {display_name!r}[/green]")
+        return
+    if load_root_config(root).user.display_name:
+        return
+    if not _is_interactive():
+        return
+    name = typer.prompt(
+        "Display name (used in session notes and briefings; blank to skip)",
+        default="",
+        show_default=False,
+    )
+    if name:
+        set_field(root, "user.display_name", name)
+        console.print(f"[green]Display name set to {name!r}[/green]")
+
+
+def init_vault(root: Path, force: bool = False, display_name: str | None = None) -> None:
     """Create the canonical shape at `root`."""
     root.mkdir(parents=True, exist_ok=True)
+    _maybe_set_display_name(root, display_name)
 
     for subdir in ("sessions", "inbox", "drafts", "wiki"):
         (root / subdir).mkdir(exist_ok=True)
@@ -73,10 +106,15 @@ def init(
     force: bool = typer.Option(
         False, "--force", help="Overwrite existing CLAUDE.md and templates/."
     ),
+    display_name: str = typer.Option(
+        None,
+        "--display-name",
+        help="Personal display name for session notes/briefings (skips the prompt).",
+    ),
 ) -> None:
     """Scaffold the canonical vault shape at $LORE_ROOT."""
     target = Path(root).expanduser().resolve() if root else get_lore_root()
-    init_vault(target, force=force)
+    init_vault(target, force=force, display_name=display_name)
 
 
 main = argv_main(app)

--- a/lib/lore_core/git_sync.py
+++ b/lib/lore_core/git_sync.py
@@ -99,6 +99,19 @@ def _has_remote(wiki_dir: Path) -> bool:
     return _git(wiki_dir, "remote").stdout.strip() != ""
 
 
+def has_remote(wiki_dir: Path) -> bool:
+    """Public: True iff ``wiki_dir`` is a git repo with at least one remote.
+
+    A wiki with a remote is a *shared* vault — content pushed to it is
+    visible to every other clone/teammate. Callers outside this module
+    (the attach flow's shared-vault consent gate) use this instead of
+    reaching into the private ``_has_remote``.
+    """
+    if not (wiki_dir / ".git").exists():
+        return False
+    return _has_remote(wiki_dir)
+
+
 def _is_clean(wiki_dir: Path) -> bool:
     return _git(wiki_dir, "status", "--porcelain").stdout.strip() == ""
 

--- a/lib/lore_core/identity.py
+++ b/lib/lore_core/identity.py
@@ -66,10 +66,15 @@ def resolve_handle(wiki_path: Path, email: str) -> str:
 
 
 def resolve_display_name(wiki_path: Path, handle: str) -> str:
-    """Return the display name for `handle` from `_users.yml`.
+    """Return the display name for `handle`.
 
-    Vault config, not `$USER` — no environment fallback. Empty/missing
-    handle or no matching user returns `""`.
+    Vault config, not `$USER` — no environment fallback. Looks up
+    `_users.yml` first (team mode); when that yields nothing (solo
+    wikis, or a team wiki with no matching user), falls back to the
+    personal `user.display_name` set via `lore config set` at the
+    vault root (`<lore_root>/.lore/config.yml`), derived from
+    `wiki_path` as `<lore_root>/wiki/<name>`. Empty/missing handle
+    returns `""`.
     """
     if not handle:
         return ""
@@ -77,7 +82,10 @@ def resolve_display_name(wiki_path: Path, handle: str) -> str:
     for user in data.get("users") or []:
         if user.get("handle") == handle:
             return str(user.get("display_name") or "")
-    return ""
+    from lore_core.root_config import load_root_config
+
+    lore_root = wiki_path.parent.parent
+    return load_root_config(lore_root).user.display_name
 
 
 def aliased_emails(wiki_path: Path) -> set[str]:

--- a/lib/lore_core/root_config.py
+++ b/lib/lore_core/root_config.py
@@ -113,11 +113,23 @@ class TierConfig:
 
 
 @dataclass
+class UserConfig:
+    """Personal identity, used when a wiki has no team-mode `_users.yml`.
+
+    ``display_name`` names the person in authored session notes and
+    briefings instead of falling back to the OS `$USER` login name.
+    """
+
+    display_name: str = ""
+
+
+@dataclass
 class RootConfig:
     observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
     curator: CuratorBackendConfig = field(default_factory=CuratorBackendConfig)
     journal: JournalConfig = field(default_factory=JournalConfig)
     tiers: TierConfig = field(default_factory=TierConfig)
+    user: UserConfig = field(default_factory=UserConfig)
 
 
 def _merge(target: Any, raw: dict[str, Any], path: str, source: Path) -> None:

--- a/tests/test_attach_shared_consent.py
+++ b/tests/test_attach_shared_consent.py
@@ -1,0 +1,161 @@
+"""Tests for the shared-vault consent gate on `lore attach`.
+
+Routing a scope to a wiki with a git remote is an explicit opt-in: the
+gate fires the moment ``manual``/``accept`` would write an attachment
+row, refusing non-interactive callers that omit ``--confirm-shared``
+and prompting interactive ones. A wiki with no remote (solo/local) is
+never gated — nothing to consent to.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from lore_cli.__main__ import app
+from lore_core.state.attachments import AttachmentsFile
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Bare-repo + clone fixture (same pattern as tests/test_git_sync.py)
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _init_bare(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "--bare", "--initial-branch=main")
+
+
+def _init_clone(origin: Path, dest: Path, name: str = "alice") -> None:
+    _git(dest.parent, "clone", str(origin), str(dest))
+    _git(dest, "config", "user.email", f"{name}@example.com")
+    _git(dest, "config", "user.name", name)
+
+
+def _seed_first_commit(host: Path) -> None:
+    (host / "README.md").write_text("seed\n")
+    _git(host, "add", "README.md")
+    _git(host, "commit", "-m", "initial")
+    _git(host, "push", "-u", "origin", "main")
+
+
+@pytest.fixture
+def lore_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """One shared wiki (real git remote) + one private wiki (no `.git`)."""
+    lore_root = tmp_path / "lore-root"
+    lore_root.mkdir()
+    (lore_root / ".lore").mkdir()
+    (lore_root / "wiki").mkdir()
+    (lore_root / "wiki" / "private").mkdir()
+
+    origin = tmp_path / "shared-origin.git"
+    _init_bare(origin)
+    shared = lore_root / "wiki" / "shared"
+    _init_clone(origin, shared)
+    _seed_first_commit(shared)
+
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    monkeypatch.setattr("lore_core.config.get_lore_root", lambda: lore_root)
+    monkeypatch.setattr("lore_core.config.get_wiki_root", lambda: lore_root / "wiki")
+    return lore_root
+
+
+def _attached_wikis(lore_root: Path) -> list[str]:
+    af = AttachmentsFile(lore_root)
+    af.load()
+    return [row.wiki for row in af.all()]
+
+
+# ---- non-interactive (CliRunner default stdin is not a tty) ----
+
+
+def test_manual_shared_without_flag_refused(lore_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        ["attach", "manual", "--wiki", "shared", "--scope", "shared:x", "--cwd", str(repo)],
+    )
+    assert result.exit_code != 0
+    assert "shared" in result.output.lower()
+    assert "--confirm-shared" in result.output
+    assert _attached_wikis(lore_env) == []
+
+
+def test_manual_shared_with_flag_succeeds(lore_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        [
+            "attach",
+            "manual",
+            "--wiki",
+            "shared",
+            "--scope",
+            "shared:x",
+            "--cwd",
+            str(repo),
+            "--confirm-shared",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert _attached_wikis(lore_env) == ["shared"]
+
+
+def test_manual_private_wiki_unaffected_by_gate(lore_env: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        ["attach", "manual", "--wiki", "private", "--scope", "private:x", "--cwd", str(repo)],
+    )
+    assert result.exit_code == 0, result.output
+    assert _attached_wikis(lore_env) == ["private"]
+
+
+# ---- interactive ----
+
+
+def test_manual_shared_interactive_decline_aborts(
+    lore_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("lore_cli.attach_cmd._is_interactive", lambda: True)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        ["attach", "manual", "--wiki", "shared", "--scope", "shared:x", "--cwd", str(repo)],
+        input="n\n",
+    )
+    assert result.exit_code != 0
+    assert _attached_wikis(lore_env) == []
+
+
+def test_manual_shared_interactive_accept_proceeds(
+    lore_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("lore_cli.attach_cmd._is_interactive", lambda: True)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        ["attach", "manual", "--wiki", "shared", "--scope", "shared:x", "--cwd", str(repo)],
+        input="y\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert _attached_wikis(lore_env) == ["shared"]

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -19,6 +19,7 @@ from lore_core.git_sync import (
     _classify_conflict_path,
     auto_pull,
     auto_push,
+    has_remote,
 )
 
 
@@ -95,6 +96,27 @@ def test_auto_pull_no_remote(tmp_path: Path) -> None:
 
     result = auto_pull(repo)
     assert result.status is SyncStatus.SKIPPED_NO_REMOTE
+
+
+# ---------------------------------------------------------------------------
+# has_remote
+# ---------------------------------------------------------------------------
+
+
+def test_has_remote_false_for_non_git_dir(tmp_path: Path) -> None:
+    assert has_remote(tmp_path / "not-a-repo") is False
+
+
+def test_has_remote_false_for_solo_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "solo"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    assert has_remote(repo) is False
+
+
+def test_has_remote_true_for_clone(two_hosts) -> None:
+    _origin, host_a, _host_b = two_hosts
+    assert has_remote(host_a) is True
 
 
 def test_auto_pull_already_in_sync(two_hosts) -> None:

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -147,6 +147,53 @@ def test_team_mode_recommended_false_when_already_team(team_wiki, monkeypatch):
     assert identity.team_mode_recommended(team_wiki) is False
 
 
+# ---------- resolve_display_name ----------
+
+
+@pytest.fixture
+def rooted_wiki(tmp_path) -> Path:
+    """A wiki at the real `<lore_root>/wiki/<name>` shape, solo mode."""
+    w = tmp_path / "wiki" / "myvault"
+    w.mkdir(parents=True)
+    return w
+
+
+def test_resolve_display_name_falls_back_to_root_config(rooted_wiki):
+    from lore_core.root_config import set_field
+
+    lore_root = rooted_wiki.parent.parent
+    set_field(lore_root, "user.display_name", "Christof")
+    assert identity.resolve_display_name(rooted_wiki, "buchbend") == "Christof"
+
+
+def test_resolve_display_name_team_match_wins_over_root_config(rooted_wiki):
+    from lore_core.root_config import set_field
+
+    lore_root = rooted_wiki.parent.parent
+    set_field(lore_root, "user.display_name", "Wrong Name")
+    (rooted_wiki / "_users.yml").write_text(
+        dedent(
+            """\
+            users:
+              - handle: buchbend
+                display_name: Christof
+            """
+        )
+    )
+    assert identity.resolve_display_name(rooted_wiki, "buchbend") == "Christof"
+
+
+def test_resolve_display_name_no_fallback_when_root_config_unset(rooted_wiki):
+    assert identity.resolve_display_name(rooted_wiki, "buchbend") == ""
+
+
+def test_resolve_display_name_empty_handle_still_empty(rooted_wiki):
+    from lore_core.root_config import set_field
+
+    set_field(rooted_wiki.parent.parent, "user.display_name", "Christof")
+    assert identity.resolve_display_name(rooted_wiki, "") == ""
+
+
 # ---------- session_note_dir ----------
 
 

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -1,0 +1,59 @@
+"""Tests for `lore init` — display-name onboarding prompt."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_cli.init_cmd import app, init_vault
+from lore_core.root_config import load_root_config
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_init_vault_noninteractive_leaves_display_name_unset(tmp_path: Path):
+    init_vault(tmp_path)
+    assert load_root_config(tmp_path).user.display_name == ""
+
+
+def test_init_vault_display_name_arg_persists(tmp_path: Path):
+    init_vault(tmp_path, display_name="Christof")
+    assert load_root_config(tmp_path).user.display_name == "Christof"
+
+
+def test_init_vault_already_configured_not_reprompted(tmp_path: Path, monkeypatch):
+    """Re-running init (e.g. --force) must not clobber an existing name."""
+    from lore_core.root_config import set_field
+
+    set_field(tmp_path, "user.display_name", "Christof")
+    monkeypatch.setattr("lore_cli.init_cmd._is_interactive", lambda: True)
+    init_vault(tmp_path, force=True)
+    assert load_root_config(tmp_path).user.display_name == "Christof"
+
+
+def test_init_cli_interactive_prompts_and_persists(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("lore_cli.init_cmd._is_interactive", lambda: True)
+    result = runner.invoke(app, ["--root", str(tmp_path)], input="Christof\n")
+    assert result.exit_code == 0, result.output
+    assert load_root_config(tmp_path).user.display_name == "Christof"
+
+
+def test_init_cli_interactive_blank_leaves_unset(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("lore_cli.init_cmd._is_interactive", lambda: True)
+    result = runner.invoke(app, ["--root", str(tmp_path)], input="\n")
+    assert result.exit_code == 0, result.output
+    assert load_root_config(tmp_path).user.display_name == ""
+
+
+def test_init_cli_noninteractive_never_prompts(tmp_path: Path):
+    """No --input, no isatty patch: CliRunner stdin is not a tty, so this
+    must complete without blocking on a prompt."""
+    result = runner.invoke(app, ["--root", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert load_root_config(tmp_path).user.display_name == ""
+
+
+def test_init_cli_display_name_flag_noninteractive(tmp_path: Path):
+    result = runner.invoke(app, ["--root", str(tmp_path), "--display-name", "Christof"])
+    assert result.exit_code == 0, result.output
+    assert load_root_config(tmp_path).user.display_name == "Christof"

--- a/tests/test_local_state_never_shared.py
+++ b/tests/test_local_state_never_shared.py
@@ -1,0 +1,85 @@
+"""AC3 (issue #178): transcripts and buffers verifiably never leave local
+state.
+
+Only composed, gate-passed notes reach the shared wiki. Raw transcripts
+(the ledger) and buffers (accumulation sidecars) live under
+``<lore_root>/.lore/`` — a sibling of ``wiki/``, never a descendant —
+so a git push of a wiki dir structurally cannot ship them. This test
+exercises the real write paths (not just the path-construction
+strings) and then walks the wiki tree to confirm nothing from local
+state landed there.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry
+from lore_curator.buffer_store import buffers_dir, done_dir
+
+_NOW = datetime(2026, 4, 21, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    lore_root = tmp_path / "lore-root"
+    (lore_root / "wiki" / "shared").mkdir(parents=True)
+    return lore_root
+
+
+def test_buffers_dir_is_outside_wiki(tmp_path: Path) -> None:
+    lore_root = _make_vault(tmp_path)
+    wiki_root = lore_root / "wiki"
+
+    bdir = buffers_dir(lore_root)
+    ddir = done_dir(lore_root)
+
+    assert wiki_root not in bdir.parents
+    assert wiki_root not in ddir.parents
+
+
+def test_transcript_ledger_write_never_lands_under_wiki(tmp_path: Path) -> None:
+    lore_root = _make_vault(tmp_path)
+    wiki_root = lore_root / "wiki"
+
+    ledger = TranscriptLedger(lore_root)
+    ledger.upsert(
+        TranscriptLedgerEntry(
+            integration="fake",
+            transcript_id="t1",
+            path=lore_root / "t1.jsonl",
+            directory=lore_root,
+            digested_hash=None,
+            digested_index_hint=None,
+            synthesised_hash=None,
+            last_mtime=_NOW,
+            curator_a_run=None,
+            noteworthy=None,
+            session_note=None,
+        )
+    )
+    assert ledger.get("fake", "t1") is not None
+
+    # Walk the whole vault: any file/dir named after local-state
+    # artifacts (ledger json, buffer sidecars) must never appear under
+    # wiki/ — that's the boundary a `git push` of a wiki repo respects.
+    local_state_names = {"transcript-ledger.json", "buffers", "_done"}
+    offenders = [
+        p
+        for p in wiki_root.rglob("*")
+        if p.name in local_state_names or p.name.endswith((".jsonl", ".state.json"))
+    ]
+    assert offenders == []
+
+
+def test_dot_lore_and_wiki_are_disjoint_siblings(tmp_path: Path) -> None:
+    """Structural invariant the whole boundary relies on: `.lore/` and
+    `wiki/` are siblings under lore_root, so nothing under one can ever
+    be a path-prefix match for the other."""
+    lore_root = _make_vault(tmp_path)
+    dot_lore = lore_root / ".lore"
+    wiki_root = lore_root / "wiki"
+
+    assert dot_lore.parent == wiki_root.parent == lore_root
+    assert not str(dot_lore).startswith(str(wiki_root) + "/")
+    assert not str(wiki_root).startswith(str(dot_lore) + "/")

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -163,6 +163,21 @@ def test_schema_tree_covers_all_leaves() -> None:
     assert "curator.backend" in paths
     assert "journal.enabled" in paths
     assert "observability.runs.keep" in paths
+    assert "user.display_name" in paths
     # No group should appear (only leaves).
     assert "curator" not in paths
     assert "observability" not in paths
+
+
+def test_user_display_name_defaults_empty(tmp_path: Path) -> None:
+    cfg = load_root_config(tmp_path)
+    assert cfg.user.display_name == ""
+
+
+def test_user_display_name_round_trips_via_set_field(tmp_path: Path) -> None:
+    from lore_core.root_config import get_field, set_field
+
+    root = _fresh_root(tmp_path, "")
+    fi = set_field(root, "user.display_name", "Christof")
+    assert fi.value == "Christof"
+    assert get_field(root, "user.display_name").value == "Christof"


### PR DESCRIPTION
Closes #178

## Summary
- `lore init` captures a display name into root config; authorship/briefings resolve it via `identity.resolve_display_name` instead of falling back to `$USER`.
- Routing a scope to a shared (git-remote) wiki is now an explicit opt-in: `lore attach accept` / `lore attach manual` call `_confirm_shared_vault()` before writing the attachment row. No remote → no-op. Remote + interactive → y/N prompt. Remote + non-interactive → refused (exit 1) unless `--confirm-shared` is passed.
- Transcripts and buffers are structurally guaranteed to never leave local state: they live under `<lore_root>/.lore/` (`transcript-ledger.json`, `buffers/`), a **sibling** of `wiki/`, never a descendant, so a `git push` of a wiki repo cannot ship them. Backed by a regression test that exercises the real write paths and walks the wiki tree.
- `docs/architecture/state.md` gets a new subsection stating the leak semantics plainly: private-by-default, the gate reduces but cannot eliminate leaks, and the remedy for a leaked secret is rotation, not history-scrubbing.

## Acceptance criteria (issue #178)
- [x] Onboarding captures a display name into vault config; authorship + briefings use it, never `$USER`.
- [x] Routing a scope to a shared vault is an explicit opt-in action that surfaces the consent prompt at that moment.
- [x] Only composed, gate-passed notes are committed to the shared wiki; transcripts/buffers verifiably never leave local state (test asserts this).
- [x] Docs state the leak semantics plainly.

## Test plan
- `tests/test_attach_shared_consent.py` (new, 5 tests) — CLI-level: non-interactive refusal without `--confirm-shared`, success with the flag, private wikis unaffected, interactive decline/accept.
- `tests/test_local_state_never_shared.py` (new, 3 tests) — AC3: `buffers_dir`/`done_dir` outside `wiki/`, a real `TranscriptLedger.upsert()` write never lands under `wiki/` on disk, and the `.lore/` vs `wiki/` sibling invariant.
- `tests/test_init_cmd.py` (new, 7 tests) — display-name onboarding.
- `tests/test_root_config.py`, `tests/test_identity.py`, `tests/test_git_sync.py` — extended for `user.display_name` round-trip, `resolve_display_name` fallback precedence, and the new `has_remote()` wrapper.

### Red → green
The consent-gate implementation predated its tests in an earlier pass of this work. To verify the new tests are behaviorally meaningful (not vacuous), I temporarily neutralized the gate check in `_do_manual` (`if False and not _confirm_shared_vault(...)`), reran `tests/test_attach_shared_consent.py`, and confirmed 2 of 5 tests genuinely fail without the gate:
```
FAILED test_manual_shared_without_flag_refused - assert 0 != 0
FAILED test_manual_shared_interactive_decline_aborts - assert 0 != 0
```
Reverted the shim, reran — all 5 pass, plus the existing 19 `test_attach_interactive.py` wizard tests still pass unchanged (24 total, zero regressions, since that fixture's wikis carry no `.git`/remote).

### Full suite
`PYTHONPATH=lib python -m pytest -q` → **2627 passed, 1 skipped, 11 failed**. The 11 failures are pre-existing and unrelated (rich/typer ANSI color codes breaking plain-string `in` assertions in `test_cli_runs.py`, `test_core_llm_wiring.py`, `test_drain_prune.py`, `test_install_dispatcher.py`, `test_log_cmd.py`, `test_proc_cmd.py`) — verified via `git stash -u` + rerun against unmodified code, identical 11 failures reproduce.

### Lint
`ruff check` / `ruff format --check` on all touched files: the 3 brand-new test files are fully clean. The 5 modified lib files and 3 modified test files carry pre-existing baseline debt (25 `ruff check` errors, 7 files needing reformat) — verified via `git stash -u` that this exact error set is byte-for-byte identical before and after my changes, i.e. my diff introduces zero new violations. Left pre-existing debt untouched to avoid an unrelated whole-file cleanup diff.