### PR TITLE
fix(#179): collision-free multi-author note sync

### DIFF
--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -24,6 +24,7 @@ seams here.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
@@ -251,14 +252,27 @@ def _today() -> str:
     return date.today().isoformat()
 
 
-def _write(path: Path, fm: dict[str, Any], body: str, *, wiki_root: Path | None) -> None:
+def _write(
+    path: Path, fm: dict[str, Any], body: str, *, wiki_root: Path | None, exclusive: bool = False
+) -> None:
     dumped = yaml.safe_dump(fm, sort_keys=False, allow_unicode=True).strip()
     text = f"---\n{dumped}\n---\n\n{body.rstrip()}\n"
     if wiki_root is not None:
         from lore_core.wikilinks import sanitize_for_write
 
         text = sanitize_for_write(text, wiki_root)
-    atomic_write_text(path, text)
+    if not exclusive:
+        atomic_write_text(path, text)
+        return
+    # Exclusive create: refuse to clobber a file a concurrent writer just
+    # claimed. Raises FileExistsError instead of silently overwriting —
+    # callers creating a brand-new note (never an update) retry elsewhere.
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    try:
+        os.write(fd, text.encode("utf-8"))
+    finally:
+        os.close(fd)
 
 
 def _load(path: Path) -> tuple[dict[str, Any], str]:
@@ -293,12 +307,18 @@ def create_note(
     linkage: Linkage | None = None,
     extra_frontmatter: dict[str, Any] | None = None,
     wiki_root: Path | None = None,
+    exclusive: bool = False,
 ) -> None:
     """Create the session note: disclaimer + machine-first frontmatter.
 
     The note starts ``open`` (append-only). Session facts, when supplied,
     are recorded in frontmatter. The body carries the fixed disclaimer
     and no chapters yet.
+
+    ``exclusive=True`` refuses to overwrite an existing file at ``path``,
+    raising ``FileExistsError`` instead — for callers where two
+    authors/sessions might race on the same first-write path (default
+    ``False`` preserves plain overwrite for known-fresh paths).
     """
     created = created or _today()
     fm: dict[str, Any] = {
@@ -321,7 +341,7 @@ def create_note(
     fm["chapters"] = []
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    _write(path, fm, DISCLAIMER, wiki_root=wiki_root)
+    _write(path, fm, DISCLAIMER, wiki_root=wiki_root, exclusive=exclusive)
 
 
 def append_chapter(

--- a/lib/lore_curator/session_note.py
+++ b/lib/lore_curator/session_note.py
@@ -28,9 +28,9 @@ from lore_curator.buffer_append import AppendOutcome
 from lore_curator.buffer_store import Buffer, ReplayedBuffer, Sidecar
 from lore_curator.session_activity import collect_commits_by_sha
 from lore_curator.stub_note import (
+    _claim_first_write_slot,
     _derive_slug,
     _placeholder_title,
-    _resolve_first_write_path,
 )
 
 if TYPE_CHECKING:
@@ -133,29 +133,34 @@ def ensure_note(
         scope=scope,
         work_time=work_time,
     )
-    path = _resolve_first_write_path(
+
+    def _write(candidate: Path) -> None:
+        nd.create_note(
+            candidate,
+            title=_placeholder_title(scope, work_time),
+            description="Lab-notebook session note.",
+            scope=scope.scope,
+            handle=handle_label or None,
+            created=work_time.date().isoformat(),
+            facts=facts_from_replay(rb),
+            linkage=linkage_from_replay(
+                rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=handle_label
+            ),
+            extra_frontmatter={
+                "transcript_id": sidecar.transcript_id or transcript.id,
+                "integration": integration or transcript.integration,
+                "buffer_stem": buffer.stem,
+            },
+            wiki_root=wiki_root,
+            exclusive=True,
+        )
+
+    path = _claim_first_write_slot(
         wiki_root=wiki_root,
         handle_label=handle_label,
         work_time=work_time,
         slug=slug,
-    )
-    nd.create_note(
-        path,
-        title=_placeholder_title(scope, work_time),
-        description="Lab-notebook session note.",
-        scope=scope.scope,
-        handle=handle_label or None,
-        created=work_time.date().isoformat(),
-        facts=facts_from_replay(rb),
-        linkage=linkage_from_replay(
-            rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=handle_label
-        ),
-        extra_frontmatter={
-            "transcript_id": sidecar.transcript_id or transcript.id,
-            "integration": integration or transcript.integration,
-            "buffer_stem": buffer.stem,
-        },
-        wiki_root=wiki_root,
+        write_fn=_write,
     )
     with buffer.with_lock():
         buffer.patch(stub_path=str(path))
@@ -219,29 +224,34 @@ def ensure_note_from_sidecar(
         scope=scope,
         work_time=work_time,
     )
-    path = _resolve_first_write_path(
+
+    def _write(candidate: Path) -> None:
+        nd.create_note(
+            candidate,
+            title=_placeholder_title(scope, work_time),
+            description="Lab-notebook session note.",
+            scope=sidecar.scope,
+            handle=sidecar.handle or None,
+            created=work_time.date().isoformat(),
+            facts=facts_from_replay(rb),
+            linkage=linkage_from_replay(
+                rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=sidecar.handle
+            ),
+            extra_frontmatter={
+                "transcript_id": sidecar.transcript_id,
+                "integration": sidecar.integration,
+                "buffer_stem": buffer.stem,
+            },
+            wiki_root=wiki_root,
+            exclusive=True,
+        )
+
+    path = _claim_first_write_slot(
         wiki_root=wiki_root,
         handle_label=sidecar.handle,
         work_time=work_time,
         slug=slug,
-    )
-    nd.create_note(
-        path,
-        title=_placeholder_title(scope, work_time),
-        description="Lab-notebook session note.",
-        scope=sidecar.scope,
-        handle=sidecar.handle or None,
-        created=work_time.date().isoformat(),
-        facts=facts_from_replay(rb),
-        linkage=linkage_from_replay(
-            rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=sidecar.handle
-        ),
-        extra_frontmatter={
-            "transcript_id": sidecar.transcript_id,
-            "integration": sidecar.integration,
-            "buffer_stem": buffer.stem,
-        },
-        wiki_root=wiki_root,
+        write_fn=_write,
     )
     buffer.patch(stub_path=str(path))
     if logger is not None:

--- a/lib/lore_curator/stub_note.py
+++ b/lib/lore_curator/stub_note.py
@@ -29,9 +29,12 @@ Frontmatter contract for a stub:
 The deterministic-final note left behind on Phase 2 LLM failure is
 exactly the same shape minus ``state: stub``.
 """
+
 from __future__ import annotations
 
+import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -82,9 +85,7 @@ _TRANSCRIPTS_CAP = 20
 #   - `<short_hash>` <subject> (<repo>/<branch>)?
 # We pull the subject so the slug derivation can use it without
 # re-running the git collectors.
-_COMMIT_BULLET_RE = re.compile(
-    r"^\s*-\s+`[0-9a-f]+`\s+(?P<subject>.+?)(?:\s+\([^)]+\))?\s*$"
-)
+_COMMIT_BULLET_RE = re.compile(r"^\s*-\s+`[0-9a-f]+`\s+(?P<subject>.+?)(?:\s+\([^)]+\))?\s*$")
 
 
 def _commit_subject_from_bullet(bullet: str) -> str:
@@ -159,7 +160,7 @@ def _resolve_renamed_path(note_path: Path, slug: str) -> Path:
     """Return the rename target for ``note_path`` once ``slug`` is known.
 
     Preserves the ``<DD>-<HHMM>-`` prefix and probes the same directory for
-    a free filename exactly like :func:`_resolve_first_write_path`'s
+    a free filename exactly like :func:`_claim_first_write_slot`'s
     same-minute collision handling (numeric ``-2``, ``-3`` ... suffix) —
     two notes composed in the same minute must never collide. Returns
     ``note_path`` unchanged when its stem isn't the canonical
@@ -223,10 +224,7 @@ def _parse_iso_z(timestamp: str) -> datetime | None:
 def _stub_duration_seconds(sidecar: Sidecar) -> int:
     """Seconds between buffer creation and the most recent heartbeat."""
     start = _parse_iso_z(sidecar.created_at)
-    end = (
-        _parse_iso_z(sidecar.last_heartbeat)
-        or _parse_iso_z(sidecar.last_appended_at)
-    )
+    end = _parse_iso_z(sidecar.last_heartbeat) or _parse_iso_z(sidecar.last_appended_at)
     if start is None or end is None:
         return 0
     return max(0, int((end - start).total_seconds()))
@@ -246,9 +244,7 @@ def _render_stub_summary_block(rb: ReplayedBuffer, sidecar: Sidecar) -> str:
 
     turn_count = rb.turn_count or sidecar.counters.turn_count
     duration = _format_duration(_stub_duration_seconds(sidecar))
-    parts: list[str] = [
-        f"{_pluralize(turn_count, 'turn', 'turns')} over {duration}"
-    ]
+    parts: list[str] = [f"{_pluralize(turn_count, 'turn', 'turns')} over {duration}"]
 
     commits = len(rb.activity_commits)
     if commits:
@@ -315,16 +311,18 @@ def _render_body(
     activity_issues_opened: list[str],
     activity_issues_closed: list[str],
 ) -> str:
-    return render_body_sections(BodySections(
-        title=title_placeholder,
-        summary=summary,
-        adr_candidates=[],
-        worked_on=[],
-        loose_ends=[],
-        commits=activity_commits,
-        issues_opened=activity_issues_opened,
-        issues_closed=activity_issues_closed,
-    ))
+    return render_body_sections(
+        BodySections(
+            title=title_placeholder,
+            summary=summary,
+            adr_candidates=[],
+            worked_on=[],
+            loose_ends=[],
+            commits=activity_commits,
+            issues_opened=activity_issues_opened,
+            issues_closed=activity_issues_closed,
+        )
+    )
 
 
 def _render_markdown(fm: dict[str, Any], body: str, *, wiki_root: Path) -> str:
@@ -422,24 +420,68 @@ def _build_first_write_frontmatter(
     return fm
 
 
-def _resolve_first_write_path(
+def _claim_first_write_slot(
     *,
     wiki_root: Path,
     handle_label: str,
     work_time: datetime,
     slug: str,
+    write_fn: Callable[[Path], None],
 ) -> Path:
+    """Atomically claim a first-write filename slot and call `write_fn(path)`.
+
+    Two authors/sessions racing on the same slug in the same minute must
+    not clobber each other. A separate "resolve path" then "write" step
+    is a TOCTOU race: both can observe the candidate as free before
+    either writes. `write_fn` MUST create the file exclusively (e.g. via
+    `os.O_CREAT | os.O_EXCL`) and raise `FileExistsError` if the path is
+    already taken — the loser of the race then retries the next numbered
+    candidate here, so no writer ever silently overwrites another's note.
+    """
     sessions_base = session_note_dir(wiki_root, handle_label)
     month_dir = sessions_base / str(work_time.year) / f"{work_time.month:02d}"
     month_dir.mkdir(parents=True, exist_ok=True)
     day_prefix = f"{work_time.day:02d}"
     time_prefix = work_time.strftime("%H%M")
-    candidate = month_dir / f"{day_prefix}-{time_prefix}-{slug}.md"
     counter = 1
-    while candidate.exists():
-        counter += 1
-        candidate = month_dir / f"{day_prefix}-{time_prefix}-{slug}-{counter}.md"
-    return candidate
+    candidate = month_dir / f"{day_prefix}-{time_prefix}-{slug}.md"
+    while True:
+        try:
+            write_fn(candidate)
+        except FileExistsError:
+            counter += 1
+            candidate = month_dir / f"{day_prefix}-{time_prefix}-{slug}-{counter}.md"
+            continue
+        return candidate
+
+
+def _claim_first_write_path(
+    *,
+    wiki_root: Path,
+    handle_label: str,
+    work_time: datetime,
+    slug: str,
+    text: str,
+) -> Path:
+    """Atomically claim a first-write path and write `text` to it."""
+    if not text.endswith("\n"):
+        text += "\n"
+    content = text.encode("utf-8")
+
+    def _write(path: Path) -> None:
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        try:
+            os.write(fd, content)
+        finally:
+            os.close(fd)
+
+    return _claim_first_write_slot(
+        wiki_root=wiki_root,
+        handle_label=handle_label,
+        work_time=work_time,
+        slug=slug,
+        write_fn=_write,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -510,12 +552,6 @@ def write_or_update(
             scope=scope,
             work_time=work_time,
         )
-        path = _resolve_first_write_path(
-            wiki_root=wiki_root,
-            handle_label=handle_label,
-            work_time=work_time,
-            slug=slug,
-        )
         body = _render_body(
             title_placeholder=title_placeholder,
             summary=_render_stub_summary_block(rb, sidecar),
@@ -541,7 +577,13 @@ def write_or_update(
             description=_render_stub_description(rb, sidecar),
         )
         text = _render_markdown(fm, body, wiki_root=wiki_root)
-        atomic_write_text(path, text)
+        path = _claim_first_write_path(
+            wiki_root=wiki_root,
+            handle_label=handle_label,
+            work_time=work_time,
+            slug=slug,
+            text=text,
+        )
 
         with buffer.with_lock():
             buffer.patch(stub_path=str(path))
@@ -651,12 +693,14 @@ def write_or_update(
     src = fm.get("source_transcripts") or []
     if not isinstance(src, list):
         src = []
-    src.append({
-        "integration": integration,
-        "id": transcript_id,
-        "from_hash": chunk_from_hash,
-        "to_hash": chunk_to_hash,
-    })
+    src.append(
+        {
+            "integration": integration,
+            "id": transcript_id,
+            "from_hash": chunk_from_hash,
+            "to_hash": chunk_to_hash,
+        }
+    )
     fm["source_transcripts"] = src
 
     existing_uuids = fm.get("transcripts") or []
@@ -691,17 +735,19 @@ def write_or_update(
         body_worked_on = existing_body.worked_on
         body_loose_ends = existing_body.loose_ends
         body_discussion = existing_body.discussion
-    body = render_body_sections(BodySections(
-        title=body_title,
-        summary=body_summary,
-        adr_candidates=body_decisions,
-        worked_on=body_worked_on,
-        loose_ends=body_loose_ends,
-        commits=rb.activity_commits,
-        issues_opened=rb.activity_issues_opened,
-        issues_closed=rb.activity_issues_closed,
-        discussion=body_discussion,
-    ))
+    body = render_body_sections(
+        BodySections(
+            title=body_title,
+            summary=body_summary,
+            adr_candidates=body_decisions,
+            worked_on=body_worked_on,
+            loose_ends=body_loose_ends,
+            commits=rb.activity_commits,
+            issues_opened=rb.activity_issues_opened,
+            issues_closed=rb.activity_issues_closed,
+            discussion=body_discussion,
+        )
+    )
     new_text = _render_markdown(fm, body, wiki_root=wiki_root)
     atomic_write_text(path, new_text)
 

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -12,7 +12,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from lore_core.git_sync import (
     ConflictKind,
     SyncStatus,
@@ -20,7 +19,6 @@ from lore_core.git_sync import (
     auto_pull,
     auto_push,
 )
-
 
 # ---------------------------------------------------------------------------
 # Bare-repo + two-clone fixture
@@ -133,6 +131,23 @@ def test_auto_pull_skipped_when_diverged(two_hosts) -> None:
     assert result.status is SyncStatus.SKIPPED_DIVERGED
 
 
+def test_auto_pull_unreachable_remote_recovers_on_next_sync(two_hosts) -> None:
+    _, host_a, host_b = two_hosts
+    _commit_file(host_a, "concepts/foo.md", "---\ntype: concept\n---\n# foo\n", "add foo")
+    _git(host_a, "push")
+
+    # Remote goes unreachable (e.g. offline host, VPN down).
+    _git(host_b, "remote", "set-url", "origin", str(host_b.parent / "nowhere.git"))
+    result = auto_pull(host_b)
+    assert result.status is SyncStatus.SKIPPED_UNREACHABLE
+
+    # Remote comes back — next sync recovers without any human input.
+    _git(host_b, "remote", "set-url", "origin", str(two_hosts[0]))
+    result2 = auto_pull(host_b)
+    assert result2.status is SyncStatus.OK
+    assert (host_b / "concepts" / "foo.md").exists()
+
+
 # ---------------------------------------------------------------------------
 # auto_push (clean paths)
 # ---------------------------------------------------------------------------
@@ -153,6 +168,32 @@ def test_auto_push_pushes_local_commit(two_hosts) -> None:
     assert result.pushed_commits == 1
 
     # Host B can pull it.
+    pull_b = auto_pull(host_b)
+    assert pull_b.status is SyncStatus.OK
+    assert (host_b / "concepts" / "foo.md").exists()
+
+
+def test_auto_push_unreachable_remote_queues_locally_and_recovers_on_next_sync(
+    two_hosts,
+) -> None:
+    origin, host_a, host_b = two_hosts
+    _commit_file(host_a, "concepts/foo.md", "---\ntype: concept\n---\n# foo\n", "add foo")
+
+    # Remote goes unreachable (e.g. offline host, VPN down).
+    _git(host_a, "remote", "set-url", "origin", str(host_a.parent / "nowhere.git"))
+    result = auto_push(host_a)
+    assert result.status is SyncStatus.SKIPPED_UNREACHABLE
+
+    # Nothing was lost — the commit is still queued locally.
+    log = _git(host_a, "log", "--oneline", "-1").stdout
+    assert "add foo" in log
+
+    # Remote comes back — next sync recovers without any human input.
+    _git(host_a, "remote", "set-url", "origin", str(origin))
+    result2 = auto_push(host_a)
+    assert result2.status is SyncStatus.OK
+    assert result2.pushed_commits == 1
+
     pull_b = auto_pull(host_b)
     assert pull_b.status is SyncStatus.OK
     assert (host_b / "concepts" / "foo.md").exists()
@@ -210,9 +251,7 @@ def test_auto_push_resolves_surface_conflict_via_llm(two_hosts) -> None:
         "host_b adds foo",
     )
 
-    merged_body = (
-        "---\ntype: concept\n---\n# foo\n\nFact A. Fact B.\n"
-    )
+    merged_body = "---\ntype: concept\n---\n# foo\n\nFact A. Fact B.\n"
     result = auto_push(
         host_b,
         llm_client=StubLlm(merged_body),

--- a/tests/test_multi_author_sync.py
+++ b/tests/test_multi_author_sync.py
@@ -1,0 +1,145 @@
+"""Integration: two authors' first heartbeats racing across two clones of
+one wiki repo (issue #179, AC3).
+
+Composes already-tested primitives — ``ensure_note``'s collision-free path
+claim (AC1) and ``auto_push``'s fetch/merge/retry (AC2) — through the real
+flush-time wiring (``maybe_auto_commit``) rather than adding new machinery.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from lore_core.session_writer import FiledNote
+from lore_core.types import Scope, TranscriptHandle, Turn
+from lore_core.wiki_config import WikiConfig
+from lore_curator._auto_commit import maybe_auto_commit
+from lore_curator.buffer_append import append_chunk
+from lore_curator.session_note import ensure_note
+
+_NOW = datetime(2026, 5, 1, 9, 30, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _patch_collectors(monkeypatch):
+    monkeypatch.setattr("lore_curator.session_activity.collect_commits_by_sha", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_issues_in_window", lambda *a, **k: ([], [])
+    )
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_projects_for_session", lambda **k: []
+    )
+    monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
+    monkeypatch.setattr("lore_core.git.current_repo", lambda cwd: "")
+
+
+class _RecordingLogger:
+    """Fake ``RunLogger`` — the only channel a conflict/failure would reach
+    the user through, since ``maybe_auto_commit`` never raises."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def emit(self, record_type: str, **fields) -> None:
+        self.events.append((record_type, fields))
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True)
+
+
+def _init_bare(path: Path) -> None:
+    path.mkdir(parents=True)
+    _git(path, "init", "--bare", "--initial-branch=main")
+
+
+def _init_clone(origin: Path, dest: Path, name: str) -> None:
+    _git(dest.parent, "clone", str(origin), str(dest))
+    _git(dest, "config", "user.email", f"{name}@example.com")
+    _git(dest, "config", "user.name", name)
+
+
+def _turns(n: int = 3) -> list[Turn]:
+    return [
+        Turn(index=i, timestamp=None, role="user" if i % 2 == 0 else "assistant", text=f"t{i}")
+        for i in range(n)
+    ]
+
+
+def _write_note(host: Path, lore_root: Path, *, handle: str, tid: str, scope_label: str) -> Path:
+    """One author's first heartbeat: compose + file a session note."""
+    (lore_root / ".lore" / "buffers").mkdir(parents=True)
+    outcome = append_chunk(
+        lore_root=lore_root,
+        chunk_turns=_turns(),
+        local_date="2026-05-01",
+        transcript_id=tid,
+        integration="claude-code",
+        wiki="private",
+        scope=scope_label,
+        cwd=lore_root,
+        wiki_root=host,
+        cfg=WikiConfig(),
+    )
+    scope = Scope(
+        wiki="private", scope=scope_label, backend="none", claude_md_path=Path("/nonexistent")
+    )
+    transcript = TranscriptHandle(
+        integration="claude-code", id=tid, path=lore_root / "t.jsonl", cwd=lore_root, mtime=_NOW
+    )
+    result = ensure_note(
+        outcome=outcome,
+        scope=scope,
+        transcript=transcript,
+        wiki_root=host,
+        work_time=_NOW,
+        handle_label=handle,
+        integration="claude-code",
+    )
+    assert result is not None
+    return result.path
+
+
+def test_two_writers_interleaved_flushes_no_lost_notes_no_surfaced_conflicts(
+    tmp_path: Path,
+) -> None:
+    origin = tmp_path / "origin.git"
+    host_a = tmp_path / "host_a"
+    host_b = tmp_path / "host_b"
+    _init_bare(origin)
+    _init_clone(origin, host_a, "alice")
+    (host_a / ".lore-wiki.yml").write_text("git:\n  auto_commit: true\n  auto_push: true\n")
+    _git(host_a, "add", ".lore-wiki.yml")
+    _git(host_a, "commit", "-m", "configure auto sync")
+    _git(host_a, "push", "-u", "origin", "main")
+    _init_clone(origin, host_b, "bob")
+
+    # Two authors' first heartbeats — different scopes, so their
+    # deterministically-derived slugs differ, matching the "pre-pull
+    # eliminates" same-slug collision the sync layer documents as rare.
+    alice_path = _write_note(
+        host_a, tmp_path / "lore_a", handle="alice", tid="alice-1", scope_label="proj:x"
+    )
+    bob_path = _write_note(
+        host_b, tmp_path / "lore_b", handle="bob", tid="bob-1", scope_label="proj:y"
+    )
+
+    log_a, log_b = _RecordingLogger(), _RecordingLogger()
+    maybe_auto_commit(host_a, FiledNote(path=alice_path, wikilink="[[a]]", was_merge=False), log_a)
+    # Bob's push races against alice's already-pushed commit — forces the
+    # fetch/merge/retry path (AC2) with a real note file (not a synthetic
+    # fixture), interleaved with alice's flush (AC3).
+    maybe_auto_commit(host_b, FiledNote(path=bob_path, wikilink="[[b]]", was_merge=False), log_b)
+
+    assert [e for e in log_a.events if e[0] == "warning"] == []
+    assert [e for e in log_b.events if e[0] == "warning"] == []
+
+    # Both notes converge on both hosts — nothing lost, nothing clobbered.
+    _git(host_a, "pull")
+    assert alice_path.exists()
+    assert (host_a / bob_path.relative_to(host_b)).exists()
+    assert (host_b / alice_path.relative_to(host_a)).exists()
+    assert bob_path.exists()

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -102,16 +102,41 @@ def test_create_includes_handle_when_team_mode(tmp_path):
     assert fm["user"] == "alice"
 
 
+def test_create_exclusive_refuses_to_clobber_existing_note(tmp_path):
+    """exclusive=True must refuse an existing path instead of overwriting it.
+
+    Two authors/sessions racing on the same first-write path (same slug,
+    same minute) must not have one silently clobber the other's note.
+    """
+    path = _note_path(tmp_path)
+    _create(tmp_path, path=path, title="alice's note")
+    with pytest.raises(FileExistsError):
+        _create(tmp_path, path=path, title="bob's note", exclusive=True)
+    # alice's note survives untouched.
+    assert "alice's note" in path.read_text()
+
+
+def test_create_exclusive_succeeds_for_a_free_path(tmp_path):
+    path = _create(tmp_path, title="alice's note", exclusive=True)
+    assert "alice's note" in path.read_text()
+
+
 # ---------------------------------------------------------------------------
 # linkage frontmatter (schema-versioned, round-trips)
 # ---------------------------------------------------------------------------
 
 
 def test_create_writes_linkage_block(tmp_path):
-    path = _create(tmp_path, linkage=nd.Linkage(
-        repo="buchbend/lore", branch="feat/175-linkage-frontmatter",
-        issues=[175], epics=[162], author="Christof Buchbender",
-    ))
+    path = _create(
+        tmp_path,
+        linkage=nd.Linkage(
+            repo="buchbend/lore",
+            branch="feat/175-linkage-frontmatter",
+            issues=[175],
+            epics=[162],
+            author="Christof Buchbender",
+        ),
+    )
     fm = parse_frontmatter(path.read_text())
     assert fm["linkage"] == {
         "schema_version": 1,

--- a/tests/test_session_note.py
+++ b/tests/test_session_note.py
@@ -158,6 +158,42 @@ def test_stub_path_is_stamped_and_reused(tmp_path):
     assert len(notes) == 1
 
 
+def test_two_authors_same_minute_same_slug_both_get_notes(tmp_path, monkeypatch):
+    """Two authors' first heartbeats racing on an identical slug in the
+    same minute must not have the second clobber the first's note.
+
+    Neither is in team mode (no _users.yml), so both land in the same
+    flat sessions/ dir — the collision scenario AC1 guards against.
+    """
+    (tmp_path / ".lore" / "buffers").mkdir(parents=True)
+    wiki_root = tmp_path / "wiki" / "private"
+    monkeypatch.setattr("lore_curator.session_note._derive_slug", lambda **kw: "fixed-a-bug")
+
+    alice = ensure_note(
+        outcome=_append(tmp_path, tid="alice-session"),
+        scope=_scope(),
+        transcript=_handle(tmp_path),
+        wiki_root=wiki_root,
+        work_time=_NOW,
+        handle_label="alice",
+        integration="claude-code",
+    )
+    bob = ensure_note(
+        outcome=_append(tmp_path, tid="bob-session"),
+        scope=_scope(),
+        transcript=_handle(tmp_path),
+        wiki_root=wiki_root,
+        work_time=_NOW,
+        handle_label="bob",
+        integration="claude-code",
+    )
+    assert alice.path != bob.path
+    assert alice.path.exists()
+    assert bob.path.exists()
+    assert nd.read_note(alice.path).frontmatter["user"] == "alice"
+    assert nd.read_note(bob.path).frontmatter["user"] == "bob"
+
+
 def test_noop_heartbeat_returns_none(tmp_path):
     (tmp_path / ".lore" / "buffers").mkdir(parents=True)
     wiki_root = tmp_path / "wiki" / "private"

--- a/tests/test_stub_note.py
+++ b/tests/test_stub_note.py
@@ -1,8 +1,11 @@
 """Tests for lore_curator.stub_note — live deterministic stub."""
+
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from pathlib import Path
+from threading import Barrier
 
 import pytest
 
@@ -15,6 +18,8 @@ from lore_curator.buffer_append import append_chunk
 from lore_curator.stub_note import (
     STUB_DESCRIPTION_PLACEHOLDER,
     STUB_SUMMARY_PLACEHOLDER,
+    _claim_first_write_path,
+    _claim_first_write_slot,
     _lead_for_rename,
     _resolve_renamed_path,
     write_or_update,
@@ -83,10 +88,16 @@ def patch_collectors(monkeypatch):
     )
 
 
-def _do_append(lore_root: Path, transcript_id: str = "abc", *,
-               turns=None, files_touched=None, files_read=None,
-               monkeypatch=None,
-               local_date: str = "2026-05-01") -> tuple:
+def _do_append(
+    lore_root: Path,
+    transcript_id: str = "abc",
+    *,
+    turns=None,
+    files_touched=None,
+    files_read=None,
+    monkeypatch=None,
+    local_date: str = "2026-05-01",
+) -> tuple:
     """Run one heartbeat; return (outcome, chunk_from_hash, chunk_to_hash).
 
     ``files_touched`` drives both the legacy-union mock and the new
@@ -130,7 +141,9 @@ def _do_append(lore_root: Path, transcript_id: str = "abc", *,
 
 
 def test_first_heartbeat_creates_stub_at_canonical_path(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     work_time = datetime(2026, 5, 1, 14, 32, tzinfo=UTC)
     outcome, fh, th = _do_append(
@@ -173,7 +186,9 @@ def test_first_heartbeat_creates_stub_at_canonical_path(
 
 
 def test_slug_falls_back_to_files_touched_basename(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     outcome, fh, th = _do_append(
         lore_root,
@@ -195,7 +210,9 @@ def test_slug_falls_back_to_files_touched_basename(
 
 
 def test_slug_falls_back_to_session_scope_hhmm(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     """No commits, no files_touched -> slug uses scope+HHMM fallback."""
     outcome, fh, th = _do_append(
@@ -219,7 +236,9 @@ def test_slug_falls_back_to_session_scope_hhmm(
 
 
 def test_subsequent_heartbeat_rewrites_in_place_with_same_path(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     work_time = datetime(2026, 5, 1, 14, 32, tzinfo=UTC)
     o1, fh1, th1 = _do_append(
@@ -228,11 +247,15 @@ def test_subsequent_heartbeat_rewrites_in_place_with_same_path(
         monkeypatch=monkeypatch,
     )
     r1 = write_or_update(
-        outcome=o1, scope=_make_scope(), transcript=_make_handle(),
+        outcome=o1,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh1, chunk_to_hash=th1,
+        chunk_from_hash=fh1,
+        chunk_to_hash=th1,
     )
 
     # Second heartbeat with new files.
@@ -246,16 +269,27 @@ def test_subsequent_heartbeat_rewrites_in_place_with_same_path(
     )
     turns_b = [Turn(index=2, timestamp=None, role="user", text="more")]
     outcome2 = append_chunk(
-        lore_root=lore_root, chunk_turns=turns_b, local_date="2026-05-01",
-        transcript_id="abc", integration="claude-code", wiki="private", scope="proj:feature",
-        cwd=lore_root, wiki_root=lore_root / "wiki" / "private", cfg=WikiConfig(),
+        lore_root=lore_root,
+        chunk_turns=turns_b,
+        local_date="2026-05-01",
+        transcript_id="abc",
+        integration="claude-code",
+        wiki="private",
+        scope="proj:feature",
+        cwd=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        cfg=WikiConfig(),
     )
     r2 = write_or_update(
-        outcome=outcome2, scope=_make_scope(), transcript=_make_handle(),
+        outcome=outcome2,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=turns_b[0].content_hash(), chunk_to_hash=turns_b[-1].content_hash(),
+        chunk_from_hash=turns_b[0].content_hash(),
+        chunk_to_hash=turns_b[-1].content_hash(),
     )
 
     assert r2.path == r1.path
@@ -273,7 +307,9 @@ def test_subsequent_heartbeat_rewrites_in_place_with_same_path(
 
 
 def test_unchanged_accumulators_skip_disk_rewrite(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     work_time = datetime(2026, 5, 1, 14, 32, tzinfo=UTC)
     o1, fh1, th1 = _do_append(
@@ -282,11 +318,15 @@ def test_unchanged_accumulators_skip_disk_rewrite(
         monkeypatch=monkeypatch,
     )
     r1 = write_or_update(
-        outcome=o1, scope=_make_scope(), transcript=_make_handle(),
+        outcome=o1,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh1, chunk_to_hash=th1,
+        chunk_from_hash=fh1,
+        chunk_to_hash=th1,
     )
     mtime_before = r1.path.stat().st_mtime_ns
 
@@ -299,18 +339,24 @@ def test_unchanged_accumulators_skip_disk_rewrite(
     )
     assert o2.accumulators_unchanged is True
     r2 = write_or_update(
-        outcome=o2, scope=_make_scope(), transcript=_make_handle(),
+        outcome=o2,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh2, chunk_to_hash=th2,
+        chunk_from_hash=fh2,
+        chunk_to_hash=th2,
     )
     assert r2.skipped is True
     assert r2.path.stat().st_mtime_ns == mtime_before
 
 
 def test_slug_never_changes_across_heartbeats(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     work_time = datetime(2026, 5, 1, 14, 32, tzinfo=UTC)
     o1, fh1, th1 = _do_append(
@@ -319,11 +365,15 @@ def test_slug_never_changes_across_heartbeats(
         monkeypatch=monkeypatch,
     )
     r1 = write_or_update(
-        outcome=o1, scope=_make_scope(), transcript=_make_handle(),
+        outcome=o1,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh1, chunk_to_hash=th1,
+        chunk_from_hash=fh1,
+        chunk_to_hash=th1,
     )
     original_slug = r1.path.stem
     # New chunk introduces a different filename — should NOT change the slug.
@@ -337,22 +387,35 @@ def test_slug_never_changes_across_heartbeats(
     )
     turns_b = [Turn(index=2, timestamp=None, role="user", text="payments work")]
     outcome2 = append_chunk(
-        lore_root=lore_root, chunk_turns=turns_b, local_date="2026-05-01",
-        transcript_id="abc", integration="claude-code", wiki="private", scope="proj:feature",
-        cwd=lore_root, wiki_root=lore_root / "wiki" / "private", cfg=WikiConfig(),
+        lore_root=lore_root,
+        chunk_turns=turns_b,
+        local_date="2026-05-01",
+        transcript_id="abc",
+        integration="claude-code",
+        wiki="private",
+        scope="proj:feature",
+        cwd=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        cfg=WikiConfig(),
     )
     r2 = write_or_update(
-        outcome=outcome2, scope=_make_scope(), transcript=_make_handle(),
+        outcome=outcome2,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=turns_b[0].content_hash(), chunk_to_hash=turns_b[-1].content_hash(),
+        chunk_from_hash=turns_b[0].content_hash(),
+        chunk_to_hash=turns_b[-1].content_hash(),
     )
     assert r2.path.stem == original_slug
 
 
 def test_stub_path_recorded_in_sidecar_on_first_write(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     work_time = datetime(2026, 5, 1, 14, 32, tzinfo=UTC)
     outcome, fh, th = _do_append(
@@ -361,11 +424,15 @@ def test_stub_path_recorded_in_sidecar_on_first_write(
         monkeypatch=monkeypatch,
     )
     result = write_or_update(
-        outcome=outcome, scope=_make_scope(), transcript=_make_handle(),
+        outcome=outcome,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh, chunk_to_hash=th,
+        chunk_from_hash=fh,
+        chunk_to_hash=th,
     )
     sidecar = outcome.buffer.read_sidecar()
     assert sidecar.stub_path == str(result.path)
@@ -374,12 +441,21 @@ def test_stub_path_recorded_in_sidecar_on_first_write(
 def test_skipped_no_op_returns_none(lore_root, patch_collectors):
     """An empty-chunk AppendOutcome must short-circuit stub writing."""
     outcome = append_chunk(
-        lore_root=lore_root, chunk_turns=[], local_date="2026-05-01",
-        transcript_id="abc", integration="claude-code", wiki="private", scope="proj:x",
-        cwd=lore_root, wiki_root=lore_root / "wiki" / "private", cfg=WikiConfig(),
+        lore_root=lore_root,
+        chunk_turns=[],
+        local_date="2026-05-01",
+        transcript_id="abc",
+        integration="claude-code",
+        wiki="private",
+        scope="proj:x",
+        cwd=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        cfg=WikiConfig(),
     )
     result = write_or_update(
-        outcome=outcome, scope=_make_scope(), transcript=_make_handle(),
+        outcome=outcome,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
         work_time=datetime(2026, 5, 1, 14, 32, tzinfo=UTC),
         now=datetime(2026, 5, 1, 14, 32, tzinfo=UTC),
@@ -394,7 +470,9 @@ def test_skipped_no_op_returns_none(lore_root, patch_collectors):
 
 
 def test_first_write_renders_live_stub_preview(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     """First-write surfaces the C-phrased framing + a stats line keyed
     on the deterministic accumulators."""
@@ -405,11 +483,15 @@ def test_first_write_renders_live_stub_preview(
         monkeypatch=monkeypatch,
     )
     result = write_or_update(
-        outcome=outcome, scope=_make_scope(), transcript=_make_handle(),
+        outcome=outcome,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh, chunk_to_hash=th,
+        chunk_from_hash=fh,
+        chunk_to_hash=th,
     )
     text = result.path.read_text()
     fm = parse_frontmatter(text)
@@ -429,7 +511,9 @@ def test_first_write_renders_live_stub_preview(
 
 
 def test_first_write_preview_includes_project_wikilinks(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     """A buffer that observed projects surfaces them as wikilinks in the
     body stats line + the description prefix."""
@@ -445,11 +529,15 @@ def test_first_write_preview_includes_project_wikilinks(
         monkeypatch=monkeypatch,
     )
     result = write_or_update(
-        outcome=outcome, scope=_make_scope(), transcript=_make_handle(),
+        outcome=outcome,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh, chunk_to_hash=th,
+        chunk_from_hash=fh,
+        chunk_to_hash=th,
     )
     text = result.path.read_text()
     fm = parse_frontmatter(text)
@@ -458,7 +546,9 @@ def test_first_write_preview_includes_project_wikilinks(
 
 
 def test_heartbeat_refreshes_preview_while_sentinel_set(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     """A second heartbeat with new accumulators rewrites the preview."""
     work_time = datetime(2026, 5, 1, 14, 32, tzinfo=UTC)
@@ -468,11 +558,15 @@ def test_heartbeat_refreshes_preview_while_sentinel_set(
         monkeypatch=monkeypatch,
     )
     r1 = write_or_update(
-        outcome=o1, scope=_make_scope(), transcript=_make_handle(),
+        outcome=o1,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh1, chunk_to_hash=th1,
+        chunk_from_hash=fh1,
+        chunk_to_hash=th1,
     )
     fm1 = parse_frontmatter(r1.path.read_text())
     assert "1 file modified" in fm1["description"]
@@ -488,15 +582,24 @@ def test_heartbeat_refreshes_preview_while_sentinel_set(
     )
     turns_b = [Turn(index=2, timestamp=None, role="user", text="more")]
     o2 = append_chunk(
-        lore_root=lore_root, chunk_turns=turns_b, local_date="2026-05-01",
-        transcript_id="abc", integration="claude-code", wiki="private",
-        scope="proj:feature", cwd=lore_root,
-        wiki_root=lore_root / "wiki" / "private", cfg=WikiConfig(),
+        lore_root=lore_root,
+        chunk_turns=turns_b,
+        local_date="2026-05-01",
+        transcript_id="abc",
+        integration="claude-code",
+        wiki="private",
+        scope="proj:feature",
+        cwd=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        cfg=WikiConfig(),
     )
     r2 = write_or_update(
-        outcome=o2, scope=_make_scope(), transcript=_make_handle(),
+        outcome=o2,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
         chunk_from_hash=turns_b[0].content_hash(),
         chunk_to_hash=turns_b[-1].content_hash(),
@@ -510,7 +613,9 @@ def test_heartbeat_refreshes_preview_while_sentinel_set(
 
 
 def test_heartbeat_preserves_phase2_summary_when_sentinel_absent(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     """Once Phase 2 has popped the sentinel and written an LLM summary,
     a subsequent heartbeat must NOT clobber the narrative or re-add
@@ -522,17 +627,22 @@ def test_heartbeat_preserves_phase2_summary_when_sentinel_absent(
         monkeypatch=monkeypatch,
     )
     r1 = write_or_update(
-        outcome=o1, scope=_make_scope(), transcript=_make_handle(),
+        outcome=o1,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh1, chunk_to_hash=th1,
+        chunk_from_hash=fh1,
+        chunk_to_hash=th1,
     )
     # Simulate a Phase-2 in-place rewrite: pop the sentinel, drop a
     # composed narrative + description on disk.
     text = r1.path.read_text()
     import yaml
     from lore_core.schema import parse_frontmatter, strip_frontmatter
+
     fm = parse_frontmatter(text)
     body = strip_frontmatter(text)
     fm.pop("narrative", None)
@@ -546,8 +656,7 @@ def test_heartbeat_preserves_phase2_summary_when_sentinel_absent(
         "## Activity\n\n### Commits\n\n- `abc1234` fix: stuff\n"
     )
     new_text = (
-        f"---\n{yaml.safe_dump(fm, sort_keys=False, allow_unicode=True).strip()}\n"
-        f"---\n\n{body}\n"
+        f"---\n{yaml.safe_dump(fm, sort_keys=False, allow_unicode=True).strip()}\n---\n\n{body}\n"
     )
     r1.path.write_text(new_text)
 
@@ -562,15 +671,24 @@ def test_heartbeat_preserves_phase2_summary_when_sentinel_absent(
     )
     turns_b = [Turn(index=2, timestamp=None, role="user", text="more")]
     o2 = append_chunk(
-        lore_root=lore_root, chunk_turns=turns_b, local_date="2026-05-01",
-        transcript_id="abc", integration="claude-code", wiki="private",
-        scope="proj:feature", cwd=lore_root,
-        wiki_root=lore_root / "wiki" / "private", cfg=WikiConfig(),
+        lore_root=lore_root,
+        chunk_turns=turns_b,
+        local_date="2026-05-01",
+        transcript_id="abc",
+        integration="claude-code",
+        wiki="private",
+        scope="proj:feature",
+        cwd=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        cfg=WikiConfig(),
     )
     r2 = write_or_update(
-        outcome=o2, scope=_make_scope(), transcript=_make_handle(),
+        outcome=o2,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
         chunk_from_hash=turns_b[0].content_hash(),
         chunk_to_hash=turns_b[-1].content_hash(),
@@ -590,7 +708,9 @@ def test_heartbeat_preserves_phase2_summary_when_sentinel_absent(
 
 
 def test_preview_singular_plural_and_no_extras(
-    lore_root, patch_collectors, monkeypatch,
+    lore_root,
+    patch_collectors,
+    monkeypatch,
 ):
     """Counts at 1 use the singular form; zero-valued segments are
     omitted from the stats line."""
@@ -601,11 +721,15 @@ def test_preview_singular_plural_and_no_extras(
         monkeypatch=monkeypatch,
     )
     result = write_or_update(
-        outcome=outcome, scope=_make_scope(), transcript=_make_handle(),
+        outcome=outcome,
+        scope=_make_scope(),
+        transcript=_make_handle(),
         wiki_root=lore_root / "wiki" / "private",
-        work_time=work_time, now=work_time,
+        work_time=work_time,
+        now=work_time,
         integration="claude-code",
-        chunk_from_hash=fh, chunk_to_hash=th,
+        chunk_from_hash=fh,
+        chunk_to_hash=th,
     )
     text = result.path.read_text()
     assert "1 file modified" in text
@@ -620,18 +744,26 @@ def test_preview_singular_plural_and_no_extras(
 
 
 def test_lead_for_rename_picks_first_block_lead():
-    chapter = Chapter(blocks=[
-        TopicBlock(lead="Traced the flush race", body="prose", anchor_turn=2),
-    ])
+    chapter = Chapter(
+        blocks=[
+            TopicBlock(lead="Traced the flush race", body="prose", anchor_turn=2),
+        ]
+    )
     assert _lead_for_rename(chapter) == "Traced the flush race"
 
 
 def test_lead_for_rename_uses_continued_topic_for_continuation_block():
-    chapter = Chapter(blocks=[
-        TopicBlock(
-            lead="", body="prose", anchor_turn=2, continued=True, continued_topic="Flush race",
-        ),
-    ])
+    chapter = Chapter(
+        blocks=[
+            TopicBlock(
+                lead="",
+                body="prose",
+                anchor_turn=2,
+                continued=True,
+                continued_topic="Flush race",
+            ),
+        ]
+    )
     assert _lead_for_rename(chapter) == "Flush race"
 
 
@@ -672,3 +804,90 @@ def test_resolve_renamed_path_leaves_malformed_stem_untouched(tmp_path: Path):
     old.write_text("stub")
     new = _resolve_renamed_path(old, "traced-the-flush-race")
     assert new == old
+
+
+def test_claim_first_write_path_two_authors_same_minute_same_slug_dont_clobber(
+    tmp_path: Path,
+):
+    """Two authors' first-write claims for the same slug in the same minute
+    must land on distinct files with both contents intact.
+
+    Neither author is in team mode (no _users.yml), so both land in the
+    same flat sessions/ dir — the exact scenario where a check-then-act
+    resolver (Path.exists() then a separate write) lets two concurrent
+    writers both see "free" and one clobber the other via os.replace.
+    """
+    wiki_root = tmp_path / "wiki"
+    work_time = datetime(2026, 7, 9, 14, 5, tzinfo=UTC)
+
+    path_a = _claim_first_write_path(
+        wiki_root=wiki_root,
+        handle_label="alice",
+        work_time=work_time,
+        slug="fixed-a-bug",
+        text="alice's note",
+    )
+    path_b = _claim_first_write_path(
+        wiki_root=wiki_root,
+        handle_label="bob",
+        work_time=work_time,
+        slug="fixed-a-bug",
+        text="bob's note",
+    )
+    assert path_a != path_b
+    assert path_a.read_text() == "alice's note\n"
+    assert path_b.read_text() == "bob's note\n"
+
+
+def test_claim_first_write_slot_under_real_thread_contention(tmp_path: Path):
+    """Force genuine concurrent writers (not just back-to-back calls) onto
+    the identical slot and prove none is lost.
+
+    A Barrier holds every thread until all N have resolved the same
+    candidate path, then releases them together so their O_CREAT|O_EXCL
+    attempts race for real at the OS level — the scenario a check-then-act
+    resolver cannot survive.
+    """
+    wiki_root = tmp_path / "wiki"
+    work_time = datetime(2026, 7, 9, 14, 5, tzinfo=UTC)
+    n = 8
+    barrier = Barrier(n)
+
+    def _claim(i: int) -> Path:
+        def _write(path: Path) -> None:
+            fd = stub_note.os.open(
+                str(path), stub_note.os.O_WRONLY | stub_note.os.O_CREAT | stub_note.os.O_EXCL, 0o644
+            )
+            try:
+                stub_note.os.write(fd, f"writer-{i}\n".encode())
+            finally:
+                stub_note.os.close(fd)
+
+        barrier.wait()  # release all N threads together, so their first os.open races for real
+        return _claim_first_write_slot(
+            wiki_root=wiki_root,
+            handle_label="alice",
+            work_time=work_time,
+            slug="race",
+            write_fn=_write,
+        )
+
+    with ThreadPoolExecutor(max_workers=n) as pool:
+        paths = list(pool.map(_claim, range(n)))
+
+    assert len(set(paths)) == n  # every writer got its own file
+    contents = {p.read_text() for p in paths}
+    assert len(contents) == n  # no writer's content got clobbered
+
+
+def test_claim_first_write_path_no_collision_uses_bare_slug(tmp_path: Path):
+    wiki_root = tmp_path / "wiki"
+    work_time = datetime(2026, 7, 9, 14, 5, tzinfo=UTC)
+    path = _claim_first_write_path(
+        wiki_root=wiki_root,
+        handle_label="alice",
+        work_time=work_time,
+        slug="fixed-a-bug",
+        text="alice's note",
+    )
+    assert path.name == "09-1405-fixed-a-bug.md"


### PR DESCRIPTION
Closes #179

## Summary

- **AC1** — note paths are collision-free by construction across authors and sessions. The old check-then-act path resolver had a TOCTOU race: two writers could both observe a candidate filename as free before either wrote it. Replaced with an atomic `O_CREAT|O_EXCL` claim (retry-on-`EEXIST`) in `_claim_first_write_slot`/`_claim_first_write_path` (`lib/lore_curator/stub_note.py`), plumbed through `note_document.create_note(..., exclusive=True)` and both `session_note.ensure_note`/`ensure_note_from_sidecar` call sites.
- **AC2** (concurrent push races) and **AC4** (unreachable remote queues locally, recovers on next sync) — investigated `lib/lore_core/git_sync.py` and found the existing `auto_push`/`auto_pull` fetch/merge/classify/retry design and `SyncStatus.SKIPPED_UNREACHABLE` handling already satisfy both. No new implementation code; added tests confirming the behavior (`tests/test_git_sync.py`).
- **AC3** — new `tests/test_multi_author_sync.py` drives two authors' first heartbeats (`ensure_note`) across two clones of one wiki repo through the real flush-time commit/push wiring (`maybe_auto_commit`), interleaved so the second push races a non-fast-forward. Asserts no `warning` event reaches the (fake) `RunLogger` and both notes converge on both hosts after a final pull.

## Red → green evidence

**AC1** — a sequential-call test passes even against the pre-fix resolver (calls never actually race), so it's not proof by itself. Added `test_claim_first_write_slot_under_real_thread_contention` (`tests/test_stub_note.py`) using a `threading.Barrier` to force 8 threads to race a real `os.open(O_CREAT|O_EXCL)` on the identical slot:
- Against the pre-fix (check-then-act) resolver: `ImportError: cannot import name '_claim_first_write_path'` when the implementation files are stashed back — and manually reverting to the check-then-act logic reproduces lost writers (fewer than 8 distinct files).
- Against the fix: 8/8 distinct files, no content clobbered, verified across 5 consecutive runs (not flaky).

**AC2 / AC4** — `test_auto_pull_unreachable_remote_recovers_on_next_sync` and `test_auto_push_unreachable_remote_queues_locally_and_recovers_on_next_sync` (`tests/test_git_sync.py`): remote pointed at a nonexistent path → `SyncStatus.SKIPPED_UNREACHABLE`, local commit intact; remote restored → next `auto_pull`/`auto_push` call recovers with `SyncStatus.OK` and no human input. Full `test_git_sync.py`: 33 passed.

**AC3** — `test_two_writers_interleaved_flushes_no_lost_notes_no_surfaced_conflicts`: verified via direct instrumentation that bob's push genuinely takes the non-fast-forward fetch/merge/retry path (not a trivial no-op) before landing on `SyncStatus.OK`. Test passes; both `alice`'s and `bob`'s note files exist, uncorrupted, on both hosts.

**Full suite**: `pytest -q` → 2612 passed, 1 skipped, 11 failed — the same 11 failures present on baseline (confirmed via `git stash` isolation), all pre-existing rich-ANSI-color-vs-plain-string assertion mismatches in `test_cli_runs.py` / `test_core_llm_wiring.py` / `test_drain_prune.py` / `test_install_dispatcher.py` / `test_log_cmd.py` / `test_proc_cmd.py`, unrelated to this branch.

`ruff check` / `ruff format --check`: clean on all touched files (new file 100% clean; modified files zero new violations vs. baseline, with some pre-existing baseline format debt cleaned up as a zero-risk side effect).

## Test plan

- [x] `pytest tests/test_stub_note.py tests/test_note_document.py tests/test_session_note.py tests/test_git_sync.py tests/test_multi_author_sync.py -q` — 88 passed
- [x] `pytest -q` (full suite) — 2612 passed / 11 pre-existing unrelated failures / 1 skipped
- [x] `ruff check` / `ruff format --check` on all touched files