### PR TITLE
fix: SessionStart banner reads version from source manifest

### DIFF
--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -30,6 +30,30 @@ from lore_core.config import get_lore_root, get_wiki_root
 
 
 def _lore_version() -> str:
+    """Version for the SessionStart banner.
+
+    Prefer the on-disk source manifest (``.claude-plugin/plugin.json``) so an
+    editable install's banner tracks the checked-out code straight after a
+    ``git pull`` — no reinstall needed. ``resolve_lore_source_root`` walks up
+    from the installed package, so it only resolves for editable (or
+    marketplace-cache) installs; a plain PyPI install returns ``None`` and we
+    fall back to the installed package metadata, which is the only source
+    there.
+    """
+    from lore_core.install._helpers import (
+        read_claude_manifest,
+        resolve_lore_source_root,
+    )
+
+    root = resolve_lore_source_root()
+    if root is not None:
+        try:
+            manifest_version = str(read_claude_manifest(root).get("version") or "")
+        except (OSError, ValueError):
+            manifest_version = ""
+        if manifest_version:
+            return manifest_version
+
     from importlib.metadata import PackageNotFoundError, version
 
     try:

--- a/tests/test_install_version_drift.py
+++ b/tests/test_install_version_drift.py
@@ -113,3 +113,63 @@ def test_doctor_check_finds_repo_via_walk_up() -> None:
     # drift message; the test just pins the shape, not the value.
     assert isinstance(ok, bool)
     assert "lore CLI version" in msg or "drift" in msg
+
+
+# ---------------------------------------------------------------------------
+# SessionStart banner version — `_lore_version` prefers the on-disk source
+# manifest so the status line tracks a `git pull` without a reinstall. The
+# drift check above *warns* about staleness; this is what the banner shows.
+# ---------------------------------------------------------------------------
+
+
+def test_banner_version_prefers_source_manifest(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With a resolvable source tree the banner reads plugin.json, not the
+    (possibly stale) installed package metadata."""
+    from lore_cli import hooks
+    from lore_core.install import _helpers
+
+    monkeypatch.setattr(
+        _helpers, "resolve_lore_source_root", lambda lore_repo=None: tmp_path
+    )
+    monkeypatch.setattr(
+        _helpers, "read_claude_manifest", lambda root: {"version": "1.2.3"}
+    )
+    # Installed metadata deliberately differs — source must win.
+    monkeypatch.setattr("importlib.metadata.version", lambda name: "0.0.1")
+    assert hooks._lore_version() == "1.2.3"
+
+
+def test_banner_version_falls_back_to_metadata_without_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain PyPI install (no resolvable source tree) reports the installed
+    package version."""
+    from lore_cli import hooks
+    from lore_core.install import _helpers
+
+    monkeypatch.setattr(
+        _helpers, "resolve_lore_source_root", lambda lore_repo=None: None
+    )
+    monkeypatch.setattr("importlib.metadata.version", lambda name: "0.9.9")
+    assert hooks._lore_version() == "0.9.9"
+
+
+def test_banner_version_falls_back_when_manifest_unreadable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A resolvable source root with a corrupt plugin.json degrades to the
+    installed metadata rather than crashing the SessionStart hook."""
+    from lore_cli import hooks
+    from lore_core.install import _helpers
+
+    def _boom(root: Path) -> dict:
+        raise ValueError("bad json")
+
+    monkeypatch.setattr(
+        _helpers, "resolve_lore_source_root", lambda lore_repo=None: tmp_path
+    )
+    monkeypatch.setattr(_helpers, "read_claude_manifest", _boom)
+    monkeypatch.setattr("importlib.metadata.version", lambda name: "0.9.9")
+    assert hooks._lore_version() == "0.9.9"


### PR DESCRIPTION
## Problem

`_lore_version()` (the SessionStart banner status line) read the version from `importlib.metadata.version("lore")` — the *installed* package. On an editable install, that lags the checked-out code after a `git pull` until a reinstall, so the banner silently shows a stale version.

## Fix

Prefer the on-disk source manifest (`.claude-plugin/plugin.json`) before falling back to package metadata, reusing helpers already in `_helpers.py`:

- `resolve_lore_source_root()` walks up from the **installed** package, so it resolves only for editable (or marketplace-cache) installs → banner tracks the checked-out code, no reinstall needed.
- A plain PyPI install returns `None` → falls back to `importlib.metadata` (the only source there), unchanged behaviour.
- A corrupt/unreadable manifest degrades to metadata rather than crashing the hook.

## Verification

- Real behaviour in an editable checkout: `_lore_version()` → `0.59.0` (from the source manifest).
- 3 new tests (source wins / no source → metadata / unreadable manifest → metadata); `test_install_version_drift.py` + `test_session_banner.py` 16/16 green.
- No new lint (`hooks.py` ruff count unchanged; all findings pre-existing and outside the touched lines).
- No new test failures.