### PR TITLE
Orient fan-out gate on lore_context_pack (+ to-epic step-2 intake)

### DIFF
--- a/lore-workflow/skills/orient/SKILL.md
+++ b/lore-workflow/skills/orient/SKILL.md
@@ -22,23 +22,33 @@ Take the user's stated goal as the seed, verbatim. Don't expand it or jump to so
 If they pass an issue reference (e.g. an epic seed from `/lore-workflow:seed-epic`), fetch and read it
 (`gh ... --json`) and treat its Intent + Findings as the seed.
 
-### 2. Explore in parallel (subagents)
-Fan out read-only `Explore` subagents concurrently — one per facet, in a single message — and
-keep only their findings here (drop the file dumps). This fan-out runs at **mid-tier
-(REQUIRED)**: resolve the tier to a concrete model with `lore tier resolve mid` and set each
-spawn's model parameter to that resolution — see
-[TIER-DELEGATION.md](../../TIER-DELEGATION.md) for the no-implicit-inherit rule this enforces.
-Default facets:
+### 2. Pull the context pack, then fan out only what's thin
+Before spawning anything, pull the deterministic context pack **once, up front**:
+`lore_context_pack` (cold-start-safe — an empty repo/vault returns a well-formed empty pack,
+never an error) plus `lore_repo_docs_list` / `lore_repo_docs_fetch` for the full ADR/PRD
+listing and any body worth reading in full. Two facets are served straight from that pull, no
+subagent:
+- **Docs & decisions** — the pack's `adr` / `prd` entries (already linked to the focus
+  issue/epic), CONTEXT.md / glossary read directly, `lore_repo_docs_list` for anything the
+  pack's focus filter missed.
+- **Prior art** — the pack's `sessions` (recent related session notes) and `epic_state`
+  (linked issue/epic status) as the trace of related work.
+
+Spawn a facet's `Explore` subagent only when the pack came back thin or empty for it (no
+matching ADR/PRD, no matching sessions) — it then searches beyond what the deterministic join
+found. The remaining facets fan out unconditionally, as before:
 - **Code map** — where this touches the codebase: key modules, interfaces, current behavior,
   relevant tests. Start from `lore codemap` (or the `lore_codemap` MCP tool) for a ranked,
   deterministic index instead of a blind directory walk.
-- **Docs & decisions** — CONTEXT.md / glossary, `docs/adr`, relevant guides; what is already
-  decided or constrained.
-- **Prior art** — related issues/PRs and similar existing features.
 - **Cross-repo / external** — only when the intent plausibly spans repos or downstream consumers.
 
-Scale the fan-out to the ask: a small change may need a single Explore pass; a broad feature
-warrants all facets.
+Whatever subagents this leaves running go out concurrently, in a single message, at **mid-tier
+(REQUIRED)**: resolve the tier to a concrete model with `lore tier resolve mid` and set each
+spawn's model parameter to that resolution — see
+[TIER-DELEGATION.md](../../TIER-DELEGATION.md) for the no-implicit-inherit rule this enforces.
+
+Scale the fan-out to the ask: a small change may need a single Explore pass (or none, if the
+pack already covers it); a broad feature warrants all facets.
 
 ### 3. Reflect back
 Present a tight brief in the conversation:

--- a/lore-workflow/skills/to-epic/SKILL.md
+++ b/lore-workflow/skills/to-epic/SKILL.md
@@ -46,9 +46,12 @@ an epic-seed issue produced by `/lore-workflow:seed-epic` (labeled `epic-seed`) 
 (`gh ... --json`; see the repo's own conventions doc, if any).
 
 ### 2. Explore the repo(s)
-Understand the current state. Identify **every target repo** — an epic may be cross-repo.
-Use each project's domain language — its CONTEXT.md / glossary if present — and respect its
-ADRs (`docs/adr`).
+Understand the current state. Identify **every target repo** — an epic may be cross-repo. For
+each, pull `lore_context_pack` (+ `lore_repo_docs_list` / `lore_repo_docs_fetch`) up front,
+before any deeper exploration — cold-start-safe, so it costs nothing even on a repo with no
+ADRs/PRDs yet. Its `adr` / `prd` entries are the fast path into each project's domain language
+(CONTEXT.md / glossary if present) and ratified decisions (`docs/adr`); go beyond the pack only
+for what it comes back thin or missing on for this epic's scope.
 
 ### 3. Synthesize the PRD
 Condense a PRD — do NOT interview, synthesize what you already know: Problem, Solution,


### PR DESCRIPTION
Implements #225.

## Summary
- `orient` now pulls `lore_context_pack` (+ `lore_repo_docs_list` / `lore_repo_docs_fetch`) once, up front, before any subagent spawn.
- **Docs & decisions** and **Prior art** are served directly from the pack (`adr`/`prd` entries, `sessions`, `epic_state`); an `Explore` subagent for either facet is spawned only when the pack comes back thin or empty for it.
- **Code map** stays on `lore codemap` / `lore_codemap`, **Cross-repo** stays an unconditional explorer when the intent plausibly spans repos — both unchanged.
- `to-epic`'s step 2 repo-exploration intake mirrors the same pack-first pattern per target repo.
- Tool names (`lore_context_pack`, `lore_repo_docs_list`, `lore_repo_docs_fetch`, `lore_codemap`) are referenced explicitly so the deterministic path is unambiguous in the prose.

This is a skill-prose-only change — `git diff --stat` against `epic/229` shows only the two `SKILL.md` files, no code.

## Test plan
- [x] `git diff --stat` confirms only `lore-workflow/skills/orient/SKILL.md` and `lore-workflow/skills/to-epic/SKILL.md` changed
- N/A — no code changes; correctness rests on `lore_context_pack`, which is already covered by existing context-pack tests