### PR TITLE
feat: workflow mechanics — epic-policy, validate-roadmap --json, board parser (#223)

### DIFF
--- a/lib/lore_cli/workflow_cmd.py
+++ b/lib/lore_cli/workflow_cmd.py
@@ -6,12 +6,16 @@ mechanic as prose now call these subcommands and gate on their exit code.
 
 from __future__ import annotations
 
+import json
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
 import typer
+from lore_workflow.board_parser import BoardParseError, parse_board
+from lore_workflow.epic_policy import resolve_epic_policy
 from lore_workflow.prd_docs import create_prd
-from lore_workflow.roadmap_validator import validate_roadmap
+from lore_workflow.roadmap_validator import roadmap_counts, validate_roadmap
 from rich.console import Console
 
 from lore_cli._argv_compat import argv_main
@@ -31,12 +35,37 @@ def validate_roadmap_cmd(
     path: str = typer.Argument(
         "-", help="Path to the epic body Markdown, or '-' to read stdin."
     ),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine output: {ok, rows, repos, edges, problems}. "
+        "Exit code is unchanged (0 valid, 1 invalid).",
+    ),
 ) -> None:
     """Validate an epic's roadmap table: required columns, fully-qualified
     `owner/repo#n` issue refs, resolvable blocked-by edges, acyclic DAG.
     """
     text = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
     result = validate_roadmap(text)
+    if as_json:
+        counts = roadmap_counts(result)
+        # stdout, not rich console: keep it parse-clean (no markup/wrapping).
+        print(
+            json.dumps(
+                {
+                    "ok": result.ok,
+                    "rows": counts.rows,
+                    "repos": counts.repos,
+                    "edges": counts.edges,
+                    "problems": [
+                        {"kind": p.kind, "message": p.message} for p in result.problems
+                    ],
+                }
+            )
+        )
+        if not result.ok:
+            raise typer.Exit(code=1)
+        return
     if result.ok:
         console.print(
             f"[green]roadmap OK[/green]: {len(result.rows)} feature(s), "
@@ -66,6 +95,49 @@ def create_prd_cmd(
         target or Path("."), slug=slug, title=title, epic_url=epic_url, repos=repo or []
     )
     console.print(f"[green]wrote[/green] {path}")
+
+
+@app.command("epic-policy")
+def epic_policy_cmd(
+    repo_root: str = typer.Argument(
+        ".", help="Repo root to resolve policy for (default: cwd)."
+    ),
+) -> None:
+    """Emit a repo's epic-merge policy as JSON: {target_branch, deploy_gate}.
+
+    `target_branch` is `develop` if that branch exists on `origin`, else
+    `main`. `deploy_gate` is true iff `AGENTS.md` declares
+    `epic-merge-policy: confirm` under its `## Epic merge policy` section.
+    """
+    policy = resolve_epic_policy(Path(repo_root))
+    # stdout, not rich console: keep it parse-clean for machine consumers.
+    print(
+        json.dumps(
+            {"target_branch": policy.target_branch, "deploy_gate": policy.deploy_gate}
+        )
+    )
+
+
+@app.command("parse-board")
+def parse_board_cmd(
+    path: str = typer.Argument(
+        "-", help="Path to the board comment body, or '-' to read stdin."
+    ),
+) -> None:
+    """Parse an orchestrate-epic supervision-board comment into JSON rows.
+
+    Emits {rows: [{feature, issue, tier, batch, state, pr}, ...]}. A missing
+    marker, missing columns, or a malformed row exits 1 with a clear error on
+    stderr — never a silent misread.
+    """
+    text = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    try:
+        rows = parse_board(text)
+    except BoardParseError as exc:
+        print(f"board parse error: {exc}", file=sys.stderr)
+        raise typer.Exit(code=1) from exc
+    # stdout, not rich console: keep it parse-clean for machine consumers.
+    print(json.dumps({"rows": [asdict(row) for row in rows]}))
 
 
 main = argv_main(app)

--- a/lib/lore_workflow/board_parser.py
+++ b/lib/lore_workflow/board_parser.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Parser for the supervision-board comment (peer of ``roadmap_validator.py``).
+
+``/orchestrate-epic`` keeps one durable status comment on the epic issue and
+edits it in place across a run — the supervision trail. On resume the run must
+read prior per-feature state *structurally*, not by re-reading the Markdown
+with the model (scraping is exactly the re-derivation this epic removes).
+
+This module is the machine reader, and — because feature #228 will rewire
+orchestrate-epic to EMIT the shape this reads — it is also the contract. The
+contract is three things, all explicit here so the emitter can target them:
+
+- **Marker** — the comment is identified by the exact HTML comment
+  :data:`BOARD_MARKER`. A comment without it is not a board (a v1 reader must
+  refuse a v2 marker rather than silently misread it).
+- **Columns** — a GitHub-flavoured Markdown table follows the marker whose
+  header carries at least :data:`REQUIRED_COLUMNS` (matched by name,
+  case-insensitively; extra columns are tolerated for forward-compat).
+- **Rows** — one data row per feature; each row's cell count must match the
+  header, so fields never silently misalign.
+
+Any breach raises :class:`BoardParseError` with a human-facing message —
+never a partial or misaligned parse. Standard library only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lore_workflow.roadmap_validator import _is_separator, _split_cells
+
+# The comment is identified by this exact marker. Feature #228 emits it
+# verbatim; a mismatch (including a future version bump) is "not a board".
+BOARD_MARKER = "<!-- lore-orchestrate-epic:status v1 -->"
+
+# Columns a board table must carry. Order here is the canonical emit order;
+# parsing maps by name, so an emitter may append columns without breaking us.
+REQUIRED_COLUMNS: tuple[str, ...] = ("Feature", "Issue", "Tier", "Batch", "State", "PR")
+
+# PR-cell values that mean "no PR yet" — normalised to "" so a resumed run can
+# test truthiness. Mirrors the roadmap validator's "no blocker" placeholders.
+_PLACEHOLDER = {"", "-", "–", "—"}
+
+
+class BoardParseError(ValueError):
+    """Raised when a board comment is missing, unmarked, or malformed."""
+
+
+@dataclass(frozen=True)
+class BoardRow:
+    """One feature's supervision state, one row of the board table."""
+
+    feature: str
+    issue: str
+    tier: str
+    batch: str
+    state: str
+    pr: str
+
+
+def _find_table_after(lines: list[str], start: int) -> tuple[list[str], list[tuple[int, str]]]:
+    """Locate the first Markdown table at or after line index *start*.
+
+    A table is a pipe header row immediately followed by a separator row, then
+    pipe data rows up to the first blank/non-pipe line. Raises if none found.
+    """
+    for i in range(start, len(lines) - 1):
+        if "|" not in lines[i] or _is_separator(lines[i]):
+            continue
+        if not _is_separator(lines[i + 1]):
+            continue
+        header = _split_cells(lines[i])
+        data: list[tuple[int, str]] = []
+        j = i + 2
+        while j < len(lines) and lines[j].strip() and "|" in lines[j]:
+            if _is_separator(lines[j]):
+                break
+            data.append((j + 1, lines[j]))
+            j += 1
+        return header, data
+    raise BoardParseError("no board table found after the status marker")
+
+
+def _column_index(header: list[str]) -> dict[str, int]:
+    """Map each required column to its position in *header* (case-insensitive).
+
+    Raises if any required column is absent, naming the missing ones.
+    """
+    lower = {cell.casefold(): idx for idx, cell in enumerate(header)}
+    missing = [col for col in REQUIRED_COLUMNS if col.casefold() not in lower]
+    if missing:
+        raise BoardParseError(
+            f"board table missing required column(s): {', '.join(missing)}; "
+            f"got header {' | '.join(header)}"
+        )
+    return {col: lower[col.casefold()] for col in REQUIRED_COLUMNS}
+
+
+def parse_board(text: str) -> list[BoardRow]:
+    """Parse a supervision-board comment into structured per-feature rows.
+
+    Raises :class:`BoardParseError` on a missing marker, a missing table,
+    missing required columns, or any row whose cell count does not match the
+    header — never a silent misread.
+    """
+    marker_at = text.find(BOARD_MARKER)
+    if marker_at < 0:
+        raise BoardParseError(
+            f"status marker {BOARD_MARKER!r} not found — not a board comment"
+        )
+
+    lines = text.splitlines()
+    # First line strictly after the marker line.
+    marker_line = text.count("\n", 0, marker_at)
+    header, data_lines = _find_table_after(lines, marker_line + 1)
+    idx = _column_index(header)
+    width = len(header)
+
+    rows: list[BoardRow] = []
+    for lineno, raw in data_lines:
+        cells = _split_cells(raw)
+        if len(cells) != width:
+            raise BoardParseError(
+                f"line {lineno}: board row has {len(cells)} cell(s), "
+                f"expected {width} to match the header"
+            )
+        pr = cells[idx["PR"]].strip()
+        rows.append(
+            BoardRow(
+                feature=cells[idx["Feature"]],
+                issue=cells[idx["Issue"]],
+                tier=cells[idx["Tier"]],
+                batch=cells[idx["Batch"]],
+                state=cells[idx["State"]],
+                pr="" if pr in _PLACEHOLDER else pr,
+            )
+        )
+    return rows

--- a/lib/lore_workflow/epic_policy.py
+++ b/lib/lore_workflow/epic_policy.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Per-repo epic-merge policy: target branch + deploy gate (peer of
+``roadmap_validator.py``).
+
+``/orchestrate-epic`` must resolve two repo facts deterministically at Map
+time — never guess them from prose:
+
+- **target_branch** — where the epic branch is cut from and where it lands.
+  ``develop`` if that branch exists on the repo's ``origin`` remote, else
+  ``main``. The workflow never stands ``develop`` up itself; its absence is a
+  deliberate "no deploy pipeline here" signal, so the default is ``main``.
+- **deploy_gate** — whether the final epic->target merge needs one human
+  confirmation before it lands. True iff the repo's ``AGENTS.md`` carries a
+  ``## Epic merge policy`` section containing the line
+  ``epic-merge-policy: confirm``. Absent (the default) → fully autonomous.
+
+Standard library + ``git`` only; no GitHub API. ``git ls-remote`` is the
+ground truth for "present on the remote"; if there is no ``origin`` or it is
+unreachable, that resolves to the safe default (``main``), matching the
+skill's documented fallback.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# Deploy-gate contract, scoped to its own section so the marker quoted
+# elsewhere in AGENTS.md prose can never trip the gate.
+_POLICY_HEADING = "## Epic merge policy"
+_DEPLOY_GATE_MARKER = "epic-merge-policy: confirm"
+
+
+@dataclass(frozen=True)
+class EpicPolicy:
+    """Resolved policy for one repo."""
+
+    target_branch: str
+    deploy_gate: bool
+
+
+def _remote_has_develop(repo_root: Path) -> bool:
+    """True iff ``develop`` exists on the ``origin`` remote. Any failure
+    (no origin, not a git repo, unreachable) is treated as absent."""
+    try:
+        proc = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", "develop"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0 and proc.stdout.strip() != ""
+
+
+def _section_has_marker(text: str) -> bool:
+    """True iff a ``## Epic merge policy`` section contains the deploy-gate
+    marker line. Scoping: from the heading until the next ``## `` heading."""
+    in_section = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            in_section = stripped.casefold() == _POLICY_HEADING.casefold()
+            continue
+        if in_section and stripped.casefold() == _DEPLOY_GATE_MARKER.casefold():
+            return True
+    return False
+
+
+def _read_deploy_gate(repo_root: Path) -> bool:
+    try:
+        text = (repo_root / "AGENTS.md").read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    return _section_has_marker(text)
+
+
+def resolve_epic_policy(repo_root: Path) -> EpicPolicy:
+    """Resolve the epic-merge policy for the repo rooted at *repo_root*."""
+    return EpicPolicy(
+        target_branch="develop" if _remote_has_develop(repo_root) else "main",
+        deploy_gate=_read_deploy_gate(repo_root),
+    )

--- a/lib/lore_workflow/roadmap_validator.py
+++ b/lib/lore_workflow/roadmap_validator.py
@@ -366,6 +366,29 @@ def validate_roadmap(markdown: str) -> ValidationResult:
     return ValidationResult(ok=not problems, problems=problems, rows=rows)
 
 
+@dataclass(frozen=True)
+class RoadmapCounts:
+    """Shape of a roadmap for planners: feature rows, distinct repos, and
+    dependency edges (blocked-by tokens). Read off already-parsed rows so
+    ``/orchestrate-epic`` sizes batches from a count, not from prose."""
+
+    rows: int
+    repos: int
+    edges: int
+
+
+def roadmap_counts(result: ValidationResult) -> RoadmapCounts:
+    """Count features, distinct repos, and blocked-by edges of a validated
+    roadmap. Uses ``result.rows`` — no second table parse. On a column-level
+    failure ``rows`` is empty, so every count is zero."""
+    rows = list(result.rows)
+    return RoadmapCounts(
+        rows=len(rows),
+        repos=len({row.repo for row in rows}),
+        edges=sum(len(row.blocked_by) for row in rows),
+    )
+
+
 def validate_roadmap_or_raise(markdown: str) -> ValidationResult:
     """Validate *markdown*, raising :class:`RoadmapError` if it is invalid.
 

--- a/tests/fixtures/boards/missing-marker.md
+++ b/tests/fixtures/boards/missing-marker.md
@@ -1,0 +1,5 @@
+No status marker here — a stray comment that must not be misread as a board.
+
+| Feature | Issue | Tier | Batch | State | PR |
+|---------|-------|------|-------|-------|-----|
+| Load the config | ccatobs/widget#12 | AFK | 1 | merged | ccatobs/widget#40 |

--- a/tests/fixtures/boards/well-formed.md
+++ b/tests/fixtures/boards/well-formed.md
@@ -1,0 +1,9 @@
+Epic #229 — supervision board. Edited in place across the run.
+
+<!-- lore-orchestrate-epic:status v1 -->
+
+| Feature | Issue | Tier | Batch | State | PR |
+|---------|-------|------|-------|-------|-----|
+| Load the config | ccatobs/widget#12 | AFK | 1 | merged | ccatobs/widget#40 |
+| Parse the manifest | ccatobs/widget#13 | AFK | 1 | running | — |
+| Export the report | ccatobs/widget#14 | HITL | 2 | queued | — |

--- a/tests/test_workflow_board_parser.py
+++ b/tests/test_workflow_board_parser.py
@@ -1,0 +1,117 @@
+"""Supervision-board comment parser (#223).
+
+The board comment is the durable supervision trail `/orchestrate-epic` edits in
+place. A resumed run must read prior state structurally, not by model-scraping
+the Markdown. This parser is the contract feature #228 will EMIT against: the
+marker, the required columns, and this fixture are that contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lore_workflow import board_parser as mod
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "boards"
+
+WELL_FORMED = (FIXTURES / "well-formed.md").read_text(encoding="utf-8")
+
+
+def test_marker_and_columns_are_exported_contract() -> None:
+    # #228 emits against these constants; keep them importable and stable.
+    assert mod.BOARD_MARKER == "<!-- lore-orchestrate-epic:status v1 -->"
+    assert mod.REQUIRED_COLUMNS == ("Feature", "Issue", "Tier", "Batch", "State", "PR")
+
+
+def test_parses_all_rows() -> None:
+    rows = mod.parse_board(WELL_FORMED)
+    assert len(rows) == 3
+
+
+def test_row_fields_mapped_by_column() -> None:
+    rows = mod.parse_board(WELL_FORMED)
+    first = rows[0]
+    assert first.feature == "Load the config"
+    assert first.issue == "ccatobs/widget#12"
+    assert first.tier == "AFK"
+    assert first.batch == "1"
+    assert first.state == "merged"
+    assert first.pr == "ccatobs/widget#40"
+
+
+def test_placeholder_pr_normalized_to_empty() -> None:
+    rows = mod.parse_board(WELL_FORMED)
+    # em-dash placeholder in the PR column means "no PR yet"
+    assert rows[1].pr == ""
+    assert rows[2].pr == ""
+
+
+def test_resumed_run_can_select_by_state() -> None:
+    rows = mod.parse_board(WELL_FORMED)
+    merged = [r.issue for r in rows if r.state == "merged"]
+    assert merged == ["ccatobs/widget#12"]
+
+
+# --- malformed inputs raise, never silently misread ------------------------
+
+
+def test_missing_marker_raises() -> None:
+    text = WELL_FORMED.replace(mod.BOARD_MARKER, "")
+    with pytest.raises(mod.BoardParseError, match="marker"):
+        mod.parse_board(text)
+
+
+def test_missing_required_column_raises() -> None:
+    text = (
+        f"{mod.BOARD_MARKER}\n\n"
+        "| Feature | Issue | Tier | Batch | PR |\n"
+        "|---|---|---|---|---|\n"
+        "| a | o/r#1 | AFK | 1 | — |\n"
+    )
+    with pytest.raises(mod.BoardParseError, match="State"):
+        mod.parse_board(text)
+
+
+def test_no_table_after_marker_raises() -> None:
+    with pytest.raises(mod.BoardParseError, match="table"):
+        mod.parse_board(f"{mod.BOARD_MARKER}\n\njust prose, no table here\n")
+
+
+def test_malformed_row_raises() -> None:
+    # A data row with too few cells must error, not drop or misalign fields.
+    text = (
+        f"{mod.BOARD_MARKER}\n\n"
+        "| Feature | Issue | Tier | Batch | State | PR |\n"
+        "|---|---|---|---|---|---|\n"
+        "| a | o/r#1 | AFK | 1 | merged |\n"  # missing PR cell
+    )
+    with pytest.raises(mod.BoardParseError, match="cell"):
+        mod.parse_board(text)
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def test_parse_board_cmd_emits_json(capsys) -> None:
+    from lore_cli import workflow_cmd
+
+    rc = workflow_cmd.main(["parse-board", str(FIXTURES / "well-formed.md")])
+    assert rc == 0
+    import json
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [r["issue"] for r in payload["rows"]] == [
+        "ccatobs/widget#12",
+        "ccatobs/widget#13",
+        "ccatobs/widget#14",
+    ]
+
+
+def test_parse_board_cmd_errors_on_malformed(capsys) -> None:
+    from lore_cli import workflow_cmd
+
+    rc = workflow_cmd.main(["parse-board", str(FIXTURES / "missing-marker.md")])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "marker" in err

--- a/tests/test_workflow_epic_policy.py
+++ b/tests/test_workflow_epic_policy.py
@@ -1,0 +1,118 @@
+"""Per-repo epic policy: target branch + deploy gate (#223).
+
+`/orchestrate-epic` resolves both facts deterministically at Map time instead
+of guessing deploy semantics. Fixture repos are built in tmp_path: a bare repo
+stands in for `origin`, AGENTS.md carries (or omits) the deploy-gate marker.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from lore_cli import workflow_cmd
+from lore_workflow import epic_policy
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args], cwd=str(root), check=True, capture_output=True, text=True
+    )
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@example.invalid")
+    _git(root, "config", "user.name", "Test")
+    (root / "README.md").write_text("x\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "init")
+
+
+def _add_bare_origin(root: Path, bare: Path, *branches: str) -> None:
+    subprocess.run(
+        ["git", "init", "--bare", str(bare)], check=True, capture_output=True, text=True
+    )
+    _git(root, "remote", "add", "origin", str(bare))
+    _git(root, "push", "origin", "main")
+    for branch in branches:
+        _git(root, "branch", branch)
+        _git(root, "push", "origin", branch)
+
+
+# --- target_branch ---------------------------------------------------------
+
+
+def test_target_main_when_remote_lacks_develop(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _add_bare_origin(repo, tmp_path / "origin.git")
+    assert epic_policy.resolve_epic_policy(repo).target_branch == "main"
+
+
+def test_target_develop_when_present_on_remote(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _add_bare_origin(repo, tmp_path / "origin.git", "develop")
+    assert epic_policy.resolve_epic_policy(repo).target_branch == "develop"
+
+
+def test_target_main_when_no_remote(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)  # no origin configured at all
+    assert epic_policy.resolve_epic_policy(repo).target_branch == "main"
+
+
+def test_target_main_when_not_a_git_repo(tmp_path: Path) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert epic_policy.resolve_epic_policy(plain).target_branch == "main"
+
+
+# --- deploy_gate -----------------------------------------------------------
+
+
+def _agents(root: Path, body: str) -> None:
+    (root / "AGENTS.md").write_text(body, encoding="utf-8")
+
+
+def test_deploy_gate_true_when_marker_in_section(tmp_path: Path) -> None:
+    _agents(
+        tmp_path,
+        "# Repo\n\n## Epic merge policy\n\nepic-merge-policy: confirm\n",
+    )
+    assert epic_policy.resolve_epic_policy(tmp_path).deploy_gate is True
+
+
+def test_deploy_gate_false_when_no_marker(tmp_path: Path) -> None:
+    _agents(tmp_path, "# Repo\n\n## Epic merge policy\n\nMerges are automatic.\n")
+    assert epic_policy.resolve_epic_policy(tmp_path).deploy_gate is False
+
+
+def test_deploy_gate_false_when_no_agents_file(tmp_path: Path) -> None:
+    assert epic_policy.resolve_epic_policy(tmp_path).deploy_gate is False
+
+
+def test_deploy_gate_false_when_marker_outside_section(tmp_path: Path) -> None:
+    # Marker appears, but under a different heading — must not trip the gate.
+    _agents(
+        tmp_path,
+        "# Repo\n\n## Notes\n\nepic-merge-policy: confirm\n\n## Epic merge policy\n\nn/a\n",
+    )
+    assert epic_policy.resolve_epic_policy(tmp_path).deploy_gate is False
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def test_epic_policy_cmd_emits_json(tmp_path: Path, capsys) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _add_bare_origin(repo, tmp_path / "origin.git", "develop")
+    _agents(repo, "## Epic merge policy\n\nepic-merge-policy: confirm\n")
+    rc = workflow_cmd.main(["epic-policy", str(repo)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"target_branch": "develop", "deploy_gate": True}

--- a/tests/test_workflow_roadmap_counts.py
+++ b/tests/test_workflow_roadmap_counts.py
@@ -1,0 +1,65 @@
+"""Machine-readable counts + `--json` output for the roadmap validator (#223).
+
+`/orchestrate-epic` reads roadmap size (feature rows, distinct repos, dependency
+edges) to plan batches; deriving it from validator prose is scraping. These
+counts come straight off the already-parsed rows — no second table parse.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lore_cli import workflow_cmd
+from lore_workflow import roadmap_validator as mod
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "roadmaps"
+
+
+def _counts(name: str) -> mod.RoadmapCounts:
+    return mod.roadmap_counts(mod.validate_roadmap((FIXTURES / name).read_text(encoding="utf-8")))
+
+
+def test_counts_well_formed() -> None:
+    # 3 features, one repo (widget), edges = 0 + 1 + 2 blocked-by tokens.
+    c = _counts("well-formed.md")
+    assert (c.rows, c.repos, c.edges) == (3, 1, 3)
+
+
+def test_counts_cross_repo() -> None:
+    # 3 features across two repos, edges = 0 + 1 + 1.
+    c = _counts("cross-repo.md")
+    assert (c.rows, c.repos, c.edges) == (3, 2, 2)
+
+
+def test_counts_empty_when_columns_bad() -> None:
+    # Wrong columns → no rows parsed → all-zero counts, no crash.
+    c = _counts("malformed-columns.md")
+    assert (c.rows, c.repos, c.edges) == (0, 0, 0)
+
+
+def test_validate_roadmap_json_ok(capsys) -> None:
+    rc = workflow_cmd.main(["validate-roadmap", "--json", str(FIXTURES / "well-formed.md")])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["rows"] == 3
+    assert payload["repos"] == 1
+    assert payload["edges"] == 3
+    assert payload["problems"] == []
+
+
+def test_validate_roadmap_json_invalid(capsys) -> None:
+    rc = workflow_cmd.main(["validate-roadmap", "--json", str(FIXTURES / "cyclic.md")])
+    assert rc != 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["problems"]
+    assert any(p["kind"] == "cycle" for p in payload["problems"])
+
+
+def test_validate_roadmap_human_path_still_works(capsys) -> None:
+    # Without --json the existing human/exit-coded path is unchanged.
+    rc = workflow_cmd.main(["validate-roadmap", str(FIXTURES / "well-formed.md")])
+    assert rc == 0
+    assert "roadmap OK" in capsys.readouterr().out


### PR DESCRIPTION
Implements #223 — the deterministic `lore workflow` mechanics that let `/orchestrate-epic` ride the lore substrate instead of re-deriving state in skill prose.

## What landed

Three primitives, each CLI-exposed under `lore workflow`, standard-library + git only (no GitHub API, no MCP twin):

1. **`epic-policy [PATH]`** → `{target_branch, deploy_gate}` for one repo, deterministically.
   - `target_branch`: `develop` if that branch exists on the `origin` remote (`git ls-remote`), else `main`. No origin / unreachable / not-a-repo → the safe default `main`.
   - `deploy_gate`: `true` iff the repo's `AGENTS.md` carries a `## Epic merge policy` section containing the line `epic-merge-policy: confirm`. Scoped to that section, so the marker quoted elsewhere in prose can't trip the gate. Absent (the default) → `false`.

2. **`validate-roadmap --json`** → emits `{ok, rows, repos, edges, problems}`. The existing human/exit-coded path is untouched; `--json` only switches the output shape (exit code stays 0 valid / 1 invalid). Counts (`roadmap_counts`) are read off the already-parsed `ValidationResult.rows` — no second table parse, per the "reuse its parsing" constraint.

3. **`parse-board [PATH]`** (backed by `board_parser`) → parses the orchestrate-epic supervision-board comment into structured rows a resumed run reads without model-scraping.

### Board format = the contract for #228 (coupling note)

Feature #228 will rewire orchestrate-epic to **emit** the shape this parser reads. That contract is made explicit here — the module docstring, three exported constants, and the fixture are the spec:
- Marker: `<!-- lore-orchestrate-epic:status v1 -->` (`board_parser.BOARD_MARKER`)
- Columns: `board_parser.REQUIRED_COLUMNS == ("Feature", "Issue", "Tier", "Batch", "State", "PR")` (matched by name, case-insensitive; extra columns tolerated for forward-compat)
- Rows: one per feature; each row's cell count must match the header.

A missing marker, missing required column, missing table, or a malformed row raises `BoardParseError` with a human-facing message and the CLI exits 1 with the error on stderr — never a partial or misaligned parse (AC4).

## Strict TDD — red → green

Each of the three features got its failing test first, watched fail, then made to pass.

**Feature A — roadmap counts + `--json`** (`tests/test_workflow_roadmap_counts.py`)
```
RED:   E   typer._click.exceptions.NoSuchOption: No such option: --json
       E   AttributeError: module 'lore_workflow.roadmap_validator' has no attribute 'RoadmapCounts'
       5 failed, 1 passed
GREEN: 6 passed
```

**Feature B — epic-policy** (`tests/test_workflow_epic_policy.py`, git fixture repos in tmp_path with a bare `origin`)
```
RED:   E   ImportError: cannot import name 'epic_policy' from 'lore_workflow'
       1 error during collection
GREEN: 9 passed
```

**Feature C — board parser** (`tests/test_workflow_board_parser.py`, fixture board comment)
```
RED:   E   ImportError: cannot import name 'board_parser' from 'lore_workflow'
       1 error during collection
GREEN: 11 passed
```

Combined new + existing workflow suites: **43 passed**.

## Verification beyond tests

Exercised every command through the real CLI entry point (`python -m lore_cli workflow ...`):
- `validate-roadmap --json` well-formed → `{"ok": true, "rows": 3, "repos": 1, "edges": 3, "problems": []}` (exit 0); cyclic → `ok:false` with the `cycle` problem (exit 1).
- `parse-board` well-formed → structured rows with placeholder PR cells normalized to `""`; missing-marker → `board parse error: status marker ... not found` on stderr (exit 1).
- `epic-policy` on this worktree (origin has no `develop`, no policy section) → `{"target_branch": "main", "deploy_gate": false}` (exit 0).

## Notes / decisions

- **Full suite:** `pytest -q` shows 11 pre-existing failures unrelated to this change (ANSI color-codes leaking into captured output in `test_drain_prune`, `test_proc_cmd`, `test_core_llm_wiring`, etc.). Confirmed they reproduce identically with my tracked edits stashed and that none import the modules I touched — they are environmental, not regressions from this PR. Everything else passes.
- **ruff:** my two new modules and all new tests are clean. `workflow_cmd.py` retains 2 pre-existing `B008` warnings on the `create-prd` command (the Typer `typer.Option` idiom the whole `lore_cli` package uses; repo is not yet ruff-clean). My additions introduce zero new violations and this change removes the file's prior `I001` import-sort error.
- **Scope:** diff is confined to `lib/lore_workflow/{epic_policy,board_parser,roadmap_validator}.py`, `lib/lore_cli/workflow_cmd.py`, and tests/fixtures. None of the epic's shared-file hazards (`note_document.py`, `CONTEXT.md`, `orchestrate-epic/SKILL.md`) are touched.
