### PR TITLE
feat: note-format v2 — scope-prefixed title + inline-bold lede body (#222)

### DIFF
--- a/CONTEXT-FORMAT.md
+++ b/CONTEXT-FORMAT.md
@@ -1,0 +1,57 @@
+# Session note format v2 — title and body shape
+
+Refines the note-essence voice from `CONTEXT.md`'s "The session note"
+section: same vocabulary (chapter, topic block, lead, disclaimer), two
+rendering changes that make a note's *display* title and its *skim
+layer* easier to read at a glance. Grounded in
+`lore_core/note_document.py` and `lore_curator/stub_note.py`.
+
+## Title: `scope: name`
+
+A note's frontmatter `title` is a placeholder at creation
+(`stub_note._placeholder_title`, e.g. `proj:x session — 2026-07-10`) —
+the first heartbeat fires before any chapter exists, so there's no
+topic to name yet. Once the first chapter composes, the title is
+replaced with `<scope>: <name>`:
+
+- **scope first** — the linkage scope (repo/project slug, e.g.
+  `proj:x` or `ccat:data-center`) so a list of notes sorts and scans
+  by *where*, not by an arbitrary date stamp.
+- **name second** — a compiled human-readable name taken from the
+  first chapter's opening lead (`stub_note._topic_title`, reusing
+  `_lead_for_rename`'s same source text as the filename slug — title
+  and filename always name the same topic).
+
+Example: `proj:x: Traced the flush race`.
+
+The rename happens once, on chapter 1 only
+(`note_document.append_chapter`'s `title` kwarg is a no-op past the
+first chapter) — later chapters extend the note but never rename it,
+matching the existing filename-rename behavior
+(`chapter_flush._rename_to_topic_slug`).
+
+## Body: inline lead
+
+Each topic block's bold lead sentence opens the same paragraph as its
+body prose — not a standalone bold line sitting above a blank-line
+gap:
+
+```
+**Chose an append-only note model.** We decided the note file is
+append-only until close.
+```
+
+not:
+
+```
+**Chose an append-only note model.**
+
+We decided the note file is append-only until close.
+```
+
+A reader reads the bold sentence and bails, or keeps reading the same
+paragraph for the rest of the topic — no forced stop between claim and
+support. The skim layer (bold leads read top-to-bottom, CONTEXT.md)
+is unchanged: leads are still bold, still self-sufficient, still first
+in their paragraph. Quote and `@N` anchor still follow as their own
+lines. See `note_document._render_block`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,6 +68,8 @@ kind), and a cumulative `SessionFacts` snapshot (commits, PRs,
 files touched/read, duration) that only ever grows. Nothing in
 frontmatter is re-narrated in the body.
 
+Exact title and body rendering shape: `CONTEXT-FORMAT.md`.
+
 ## Writing a note — buffer, flush, compose
 
 A session's turns accumulate in a per-transcript **buffer**

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -148,11 +148,15 @@ class NoteView:
 
 
 def _render_block(block: TopicBlock) -> str:
+    # Note-format v2 (#222): the lead sentence stays inline with its body in
+    # one paragraph — a reader reads the bold sentence and bails or reads on,
+    # instead of a standalone bold line floating above a blank-line gap.
     lead = f"Continued: {block.continued_topic}" if block.continued else block.lead
-    parts = [f"**{lead.strip()}**"]
+    lead_para = f"**{lead.strip()}**"
     body = (block.body or "").strip()
     if body:
-        parts.append(body)
+        lead_para = f"{lead_para} {body}"
+    parts = [lead_para]
     quote = (block.quote or "").strip()
     if quote:
         parts.append(f'> "{quote}"')
@@ -353,8 +357,14 @@ def append_chapter(
     facts: SessionFacts | None = None,
     linkage: Linkage | None = None,
     wiki_root: Path | None = None,
+    title: str | None = None,
 ) -> int:
     """Append a chapter of topic blocks; record its slice turn range.
+
+    ``title``, if given, replaces the placeholder frontmatter title — but
+    only on chapter 1 (note-format v2, #222). The LLM never composes a
+    title; the flush derives one deterministically from the first chapter's
+    lead and passes it here.
 
     Returns the 1-based chapter number. Raises :class:`NoteClosedError`
     if the note is closed — the file is left untouched in that case.
@@ -363,6 +373,8 @@ def append_chapter(
     _guard_open(fm, path)
 
     n = _next_chapter_n(fm)
+    if title and n == 1:
+        fm["title"] = title
     segment = _render_topic_chapter(n, chapter, slice_from_turn, slice_to_turn)
     new_body = f"{body.rstrip()}\n\n{segment}"
 

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -74,7 +74,7 @@ from lore_curator.session_note import (
     facts_from_replay,
     linkage_from_replay,
 )
-from lore_curator.stub_note import _lead_for_rename, _resolve_renamed_path
+from lore_curator.stub_note import _lead_for_rename, _resolve_renamed_path, _topic_title
 
 if TYPE_CHECKING:
     from lore_core.run_log import RunLogger
@@ -548,6 +548,7 @@ def _apply_outcome(
             facts=facts,
             linkage=linkage,
             wiki_root=wiki_root,
+            title=_topic_title(sidecar.scope, compose_result.chapter),
         )
         if out.chapter_n == 1:
             note_path = _rename_to_topic_slug(buffer, note_path, compose_result.chapter)

--- a/lib/lore_curator/stub_note.py
+++ b/lib/lore_curator/stub_note.py
@@ -156,6 +156,22 @@ def _lead_for_rename(chapter: Chapter) -> str:
     return lead.strip()
 
 
+def _topic_title(scope_label: str, chapter: Chapter) -> str:
+    """Return the scope-prefixed frontmatter title for a composed chapter.
+
+    Note-format v2 (#222): `scope: name` — the linkage scope first, then a
+    compiled human-readable name from the chapter's first lead. Reuses
+    ``_lead_for_rename``'s same-source, same-fallback text so the filename
+    slug and the frontmatter title always describe the same topic. Returns
+    ``""`` under the same no-usable-lead conditions — the caller keeps the
+    placeholder title in that case.
+    """
+    lead = _lead_for_rename(chapter)
+    if not lead:
+        return ""
+    return f"{scope_label}: {lead.rstrip('.').strip()}"
+
+
 def _resolve_renamed_path(note_path: Path, slug: str) -> Path:
     """Return the rename target for ``note_path`` once ``slug`` is known.
 

--- a/tests/test_chapter_flush.py
+++ b/tests/test_chapter_flush.py
@@ -15,6 +15,7 @@ from typing import Any
 import pytest
 from lore_core import note_document as nd
 from lore_core import quarantine
+from lore_core.schema import parse_frontmatter
 from lore_core.types import Turn
 from lore_core.wiki_config import WikiConfig
 from lore_curator.buffer_append import append_chunk
@@ -328,6 +329,36 @@ def test_first_chapter_rename_reflects_topic_lead(tmp_path):
 
     reopened = Buffer.open(lore_root, transcript_id="abc", local_date="2026-05-01")
     assert reopened.read_sidecar().stub_path == str(outcome.note_path)
+
+
+def test_first_chapter_sets_scope_prefixed_title(tmp_path):
+    """Note-format v2 (#222): frontmatter title becomes `scope: name` —
+    scope first, then the composed name — and the body's lead sentence
+    stays inline with its prose rather than a standalone bold line.
+    """
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    all_turns = _turns(0, 4)
+    buf = _append(lore_root, all_turns)
+    client = _Client(
+        [_chapter_payload("Traced the flush race", "Found the race in the reaper.", 2)]
+    )
+
+    outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+        auto_commit=False,
+    )
+    assert outcome.status == "composed"
+
+    text = outcome.note_path.read_text()
+    fm = parse_frontmatter(text)
+    assert fm["title"] == "proj:x: Traced the flush race"
+    assert "**Traced the flush race** Found the race in the reaper." in text
 
 
 def test_second_chapter_does_not_rename_again(tmp_path):

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -216,6 +216,65 @@ def test_append_chapter_renders_blocks_and_records_range(tmp_path):
     ]
 
 
+def test_append_chapter_renders_lead_and_body_as_one_inline_paragraph(tmp_path):
+    """Note-format v2 (#222): lead sentence is inline with its body, not a
+    standalone bold line floating above a blank-line-separated paragraph.
+    """
+    path = _create(tmp_path)
+    chapter = nd.Chapter(
+        blocks=[
+            _block(
+                lead="Chose an append-only note model.",
+                body="We decided the note file is append-only until close.",
+            )
+        ]
+    )
+    nd.append_chapter(path, chapter, slice_from_turn=1, slice_to_turn=10)
+
+    body = strip_frontmatter(path.read_text())
+    assert (
+        "**Chose an append-only note model.** "
+        "We decided the note file is append-only until close."
+    ) in body
+
+
+def test_append_chapter_sets_title_only_on_first_chapter(tmp_path):
+    """Note-format v2 (#222): the LLM never composes a title, so the flush
+    passes a deterministically-derived one; only the first chapter may set
+    it (the placeholder from create_note stands until then).
+    """
+    path = _create(tmp_path, title="lore session — 2026-07-03")
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[_block(lead="First.", anchor=3)]),
+        slice_from_turn=1,
+        slice_to_turn=20,
+        title="lore: Traced the flush race",
+    )
+    fm = parse_frontmatter(path.read_text())
+    assert fm["title"] == "lore: Traced the flush race"
+
+
+def test_append_chapter_title_ignored_after_first_chapter(tmp_path):
+    path = _create(tmp_path, title="lore session — 2026-07-03")
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[_block(lead="First.", anchor=3)]),
+        slice_from_turn=1,
+        slice_to_turn=20,
+        title="lore: Traced the flush race",
+    )
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[_block(lead="Second.", anchor=44)]),
+        slice_from_turn=21,
+        slice_to_turn=60,
+        title="lore: Some later chapter's lead",
+    )
+    fm = parse_frontmatter(path.read_text())
+    assert fm["title"] == "lore: Traced the flush race"
+
+
 def test_append_multiple_chapters_are_chronological_with_ranges(tmp_path):
     path = _create(tmp_path)
     nd.append_chapter(

--- a/tests/test_stub_note.py
+++ b/tests/test_stub_note.py
@@ -22,6 +22,7 @@ from lore_curator.stub_note import (
     _claim_first_write_slot,
     _lead_for_rename,
     _resolve_renamed_path,
+    _topic_title,
     write_or_update,
 )
 
@@ -774,6 +775,20 @@ def test_lead_for_rename_empty_when_no_blocks():
 def test_lead_for_rename_empty_when_first_block_blank():
     chapter = Chapter(blocks=[TopicBlock(lead="   ", body="prose", anchor_turn=1)])
     assert _lead_for_rename(chapter) == ""
+
+
+def test_topic_title_prefixes_scope_before_composed_name():
+    """Note-format v2 (#222): frontmatter title is `scope: name` — scope
+    (the linkage repo/project slug) first, then the composed human name.
+    """
+    chapter = Chapter(
+        blocks=[TopicBlock(lead="Traced the flush race.", body="prose", anchor_turn=2)]
+    )
+    assert _topic_title("proj:x", chapter) == "proj:x: Traced the flush race"
+
+
+def test_topic_title_empty_when_no_lead():
+    assert _topic_title("proj:x", Chapter(blocks=[])) == ""
 
 
 def test_resolve_renamed_path_swaps_slug_keeps_prefix(tmp_path: Path):


### PR DESCRIPTION
Implements #222.

## Summary

Two changes to Curator-A compose output:

- **Title**: `scope: composed-name` — scope first, then the composed
  human-readable name — replacing the previous date-stamped placeholder
  slug as the displayed frontmatter title. Set once, on the first
  COMPOSED chapter, alongside the existing filename-rename seam
  (`chapter_flush.py`'s `_apply_outcome`), so title and filename derive
  from the same `compose_result.chapter` at the same point in the
  lifecycle.
- **Body**: the bold lead sentence now renders inline with its paragraph
  (`**Lead.** Body prose continues right here.`) instead of as a
  standalone bold line floating above a blank-line gap. A reader reads
  the bold sentence and bails, or keeps reading the same block.

`CONTEXT-FORMAT.md` (new) documents both shapes with before/after
examples, grounded in the `note_document.py` / `stub_note.py` symbols
that implement them. `CONTEXT.md` cross-references it.

## Red → green evidence

- `test_note_document.py`: added `test_append_chapter_renders_lead_and_body_as_one_inline_paragraph`
  (RED: old two-paragraph render; GREEN: merged `_render_block`),
  `test_append_chapter_sets_title_only_on_first_chapter` and
  `test_append_chapter_title_ignored_after_first_chapter` (RED: `TypeError`
  on missing `title` kwarg, then unset-title assertion; GREEN: new
  `title` kwarg on `append_chapter`, gated to `n == 1`).
- `test_stub_note.py`: added `test_topic_title_prefixes_scope_before_composed_name`
  and `test_topic_title_empty_when_no_lead` (RED: `ImportError` on
  missing `_topic_title`; GREEN: new helper reusing `_lead_for_rename`).
- `test_chapter_flush.py`: added `test_first_chapter_sets_scope_prefixed_title`,
  an end-to-end fixture test asserting both the `scope: name` title
  prefix and the inline-bold-lead body shape in one composed note (RED:
  title unset / old body shape; GREEN: `_apply_outcome` now passes
  `title=_topic_title(...)` into `append_chapter`).

72/72 tests pass across the three touched test files; full suite:
2645 passed, 1 skipped, 11 failed. All 11 failures are pre-existing and
unrelated — rich/ANSI color codes leaking into CLI `Result.output` in
this test environment (`test_cli_runs.py`, `test_core_llm_wiring.py`,
`test_drain_prune.py`, `test_install_dispatcher.py`, `test_log_cmd.py`,
`test_proc_cmd.py`). Verified via `git stash`/`git stash pop`: identical
11 failures reproduce on a clean checkout of this branch's base, before
any of this PR's changes.

Ruff clean on every file this PR touches. `lib/lore_curator/stub_note.py`
carries four pre-existing ruff findings (unsorted imports, one unused
import, one SIM108, one UP037) in code regions this PR never touches —
confirmed pre-existing via the same stash/pop check, left alone per
scope discipline (this file is also touched by #226 in a sibling
worktree; widening the diff here risks a messier rebase).

## Planning decisions (TDD skill, autonomous mode)

- **Interface changes**: `note_document.append_chapter` gained one
  optional kwarg, `title: str | None = None`, applied only when
  `n == 1` (first chapter) — additive, no call-site breakage elsewhere.
  New `stub_note._topic_title(scope_label, chapter) -> str` helper,
  colocated with the sibling `_lead_for_rename` it reuses.
- **Behaviors tested/prioritized**: prioritized the three acceptance
  criteria that are independently falsifiable (render shape, title
  gating, title content) plus one end-to-end fixture test tying both
  changes together through the real flush lifecycle — over exhaustive
  edge-case enumeration (e.g. empty scope, unicode scope names), which
  the existing `_lead_for_rename`/`_derive_slug` machinery this reuses
  already covers.
- **Deep module choice**: kept `note_document.py` as thin plumbing (an
  optional string slot, gated by chapter number) and put all title
  *composition* logic in `stub_note.py`'s `_topic_title`, mirroring how
  filename-slug composition already lives there — one deep module for
  "how to name this note," not two divergent ones.
- **Shared-file discipline**: `note_document.py` and `stub_note.py` are
  both touched by #226 in a sibling worktree; every edit here is
  additive (new kwarg with a default, new standalone function) with no
  changes to existing signatures or control flow outside the new code
  paths, to keep the eventual rebase low-conflict.