### PR TITLE
seed-epic: lift Origin/Findings from the session note

### DIFF
--- a/lib/lore_cli/workflow_cmd.py
+++ b/lib/lore_cli/workflow_cmd.py
@@ -16,6 +16,7 @@ from lore_workflow.board_parser import BoardParseError, parse_board
 from lore_workflow.epic_policy import resolve_epic_policy
 from lore_workflow.prd_docs import create_prd
 from lore_workflow.roadmap_validator import roadmap_counts, validate_roadmap
+from lore_workflow.seed_epic import compose_seed_lift
 from rich.console import Console
 
 from lore_cli._argv_compat import argv_main
@@ -114,6 +115,32 @@ def epic_policy_cmd(
     print(
         json.dumps(
             {"target_branch": policy.target_branch, "deploy_gate": policy.deploy_gate}
+        )
+    )
+
+
+@app.command("seed-lift")
+def seed_lift_cmd(
+    note_path: Path = typer.Argument(..., help="Path to the session note to lift from."),
+    wiki_root: Path | None = typer.Option(
+        None, "--wiki-root", help="Wiki root; when given, source_note is recorded wiki-relative."
+    ),
+) -> None:
+    """Lift Origin/Findings for a seed issue from a session note.
+
+    Prints `{origin, findings, source_note}` as JSON on success. Exits 1
+    when the note is missing or too thin to say anything a freehand pass
+    wouldn't already have — the skill's signal to fall back to freehand.
+    """
+    lift = compose_seed_lift(note_path, wiki_root=wiki_root)
+    if lift is None:
+        console.print("[yellow]no usable note[/yellow]: fall back to freehand Origin/Findings")
+        raise typer.Exit(code=1)
+    # Plain (uncolored) JSON: this is machine output for the skill to parse,
+    # not a human-facing message like the other subcommands' console.print.
+    typer.echo(
+        json.dumps(
+            {"origin": lift.origin, "findings": lift.findings, "source_note": lift.source_note}
         )
     )
 

--- a/lib/lore_workflow/seed_epic.py
+++ b/lib/lore_workflow/seed_epic.py
@@ -1,0 +1,88 @@
+"""Seed-epic Origin/Findings lift — pull from the session note, not freehand.
+
+`compose_seed_lift` gives the seed-epic skill's "Write the seed(s)" step a
+deterministic Origin (from the note's linkage) and Findings (from the
+note's topic-chapter bodies) instead of a model reconstructing them from
+memory. Returns ``None`` — the caller's signal to fall back to the existing
+freehand path — when there is no note, or the note carries nothing a
+freehand pass wouldn't already have: no linkage refs and no topic-chapter
+content. Marker chapters (withheld/failed) are gate bookkeeping, not
+findings, and don't count either way.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from lore_core.note_document import DISCLAIMER, NoteView, read_note
+
+__all__ = ["SeedLift", "compose_seed_lift"]
+
+_CHAPTER_HEADER_RE = re.compile(
+    r"^<!-- lore:chapter (\d+)(?: marker:\S+)? @\d+-\d+ -->\s*$", re.MULTILINE
+)
+
+
+@dataclass(frozen=True)
+class SeedLift:
+    """Origin + Findings lifted from a session note, plus a pointer back to it."""
+
+    origin: str
+    findings: str
+    source_note: str
+
+
+def _format_origin(linkage: dict) -> str:
+    repo = linkage.get("repo") or ""
+    if not repo:
+        return ""
+    bits = [f"`{repo}`"]
+    epics = linkage.get("epics") or []
+    if epics:
+        bits.append("epic " + ", ".join(f"#{n}" for n in epics))
+    prs = linkage.get("prs") or []
+    if prs:
+        label = "PR" if len(prs) == 1 else "PRs"
+        bits.append(f"{label} " + ", ".join(f"#{n}" for n in prs))
+    return " — ".join(bits)
+
+
+def _findings(view: NoteView) -> str:
+    """Concatenate topic-chapter bodies; marker chapters carry no findings."""
+    topic_ns = {c["n"] for c in view.chapters if c.get("kind") == "topic"}
+    if not topic_ns:
+        return ""
+    body = view.body
+    if body.startswith(DISCLAIMER):
+        body = body[len(DISCLAIMER) :]
+    matches = list(_CHAPTER_HEADER_RE.finditer(body))
+    segments = []
+    for i, m in enumerate(matches):
+        if int(m.group(1)) not in topic_ns:
+            continue
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        segment = body[start:end].strip()
+        if segment:
+            segments.append(segment)
+    return "\n\n".join(segments)
+
+
+def compose_seed_lift(note_path: Path, *, wiki_root: Path | None = None) -> SeedLift | None:
+    """Lift Origin/Findings from the note at ``note_path``.
+
+    Returns ``None`` when the note is missing or too thin (no linkage refs,
+    no topic-chapter findings) — the caller's signal to fall back to the
+    existing freehand path.
+    """
+    if not note_path.exists():
+        return None
+    view = read_note(note_path)
+    origin = _format_origin(view.frontmatter.get("linkage") or {})
+    findings = _findings(view)
+    if not origin and not findings:
+        return None
+    source_note = str(note_path.relative_to(wiki_root)) if wiki_root else str(note_path)
+    return SeedLift(origin=origin, findings=findings, source_note=source_note)

--- a/lore-workflow/skills/seed-epic/SKILL.md
+++ b/lore-workflow/skills/seed-epic/SKILL.md
@@ -36,6 +36,15 @@ seeds. Trivially small, well-understood follow-ups don't need the chain — note
 filing instead. Confirm the grouping with the user before publishing.
 
 ### 3. Write the seed(s)
+First try to lift **Origin** and **Findings** from this session's note (deterministic, no
+freehand reconstruction needed): `lore workflow seed-lift <path-to-this-session's-note>
+--wiki-root <wiki-root>`. On success (exit 0), use its `origin` and `findings` JSON fields
+verbatim for those two sections, and add its `source_note` under **Pointers** as an explicit
+reference — so a cold `/lore-workflow:orient` on the seed can pull the note back via
+`lore_read`/`lore_context_pack`. On failure (exit 1: no note, or too thin), fall back to
+freehand — reconstruct Origin (the finished epic, merged PRs/commits) and Findings (hard-won
+context from this session) as before.
+
 Draft each body with the template below. Lead with intent; make the **findings** section rich —
 that is the handover value. Pointers are starting points, not gospel (they may go stale).
 

--- a/tests/test_workflow_cmd.py
+++ b/tests/test_workflow_cmd.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from lore_cli import workflow_cmd
+from lore_core import note_document as nd
+from lore_core.linkage import Linkage
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "roadmaps"
 
@@ -40,3 +43,36 @@ def test_create_prd_writes_file(tmp_path: Path) -> None:
     )
     assert rc == 0
     assert (tmp_path / "docs" / "prd" / "0001-foo.md").exists()
+
+
+def test_seed_lift_prints_json_on_usable_note(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "sessions" / "10-topic.md"
+    nd.create_note(
+        path,
+        title="Seed lift plumbing",
+        description="deterministic seed lift",
+        scope="lore",
+        created="2026-07-10",
+        linkage=Linkage(repo="buchbend/lore", epics=[229]),
+    )
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[nd.TopicBlock(lead="Findings lead.", body="Findings body.")]),
+        slice_from_turn=0,
+        slice_to_turn=5,
+    )
+
+    rc = workflow_cmd.main(["seed-lift", str(path)])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "buchbend/lore" in payload["origin"]
+    assert "Findings body." in payload["findings"]
+    assert payload["source_note"] == str(path)
+
+
+def test_seed_lift_exits_nonzero_when_note_missing(tmp_path: Path, capsys) -> None:
+    rc = workflow_cmd.main(["seed-lift", str(tmp_path / "sessions" / "nope.md")])
+
+    assert rc != 0
+    assert "fall back to freehand" in capsys.readouterr().out

--- a/tests/test_workflow_seed_epic.py
+++ b/tests/test_workflow_seed_epic.py
@@ -1,0 +1,168 @@
+"""Tests `lore_workflow.seed_epic` — Origin/Findings lift for `/lore-workflow:seed-epic`.
+
+The seed's Origin and Findings sections are lifted straight from the
+current session's note (linkage + chapter body) instead of being
+freehand-reconstructed. `compose_seed_lift` returns `None` — the signal
+callers use to fall back to the existing freehand path — when there's no
+note, or the note is too thin (no linkage provenance and no chapter
+content beyond the disclaimer) to say anything a freehand pass wouldn't.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_core import note_document as nd
+from lore_core.linkage import Linkage
+from lore_workflow.seed_epic import compose_seed_lift
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _note_path(tmp_path: Path) -> Path:
+    return tmp_path / "wiki" / "sessions" / "2026" / "07" / "10-1200-topic.md"
+
+
+def _linkage(**overrides) -> Linkage:
+    kwargs = {
+        "repo": "buchbend/lore",
+        "branch": "feat/226-seed-epic-lift",
+        "issues": [],
+        "prs": [],
+        "epics": [],
+        "author": "",
+    }
+    kwargs.update(overrides)
+    return Linkage(**kwargs)
+
+
+def _note_with_chapter(tmp_path: Path, *, linkage: Linkage | None = None) -> Path:
+    path = _note_path(tmp_path)
+    nd.create_note(
+        path,
+        title="Seed lift plumbing",
+        description="deterministic seed lift",
+        scope="lore",
+        created="2026-07-10",
+        linkage=linkage,
+    )
+    chapter = nd.Chapter(
+        blocks=[
+            nd.TopicBlock(
+                lead="The buffer-flush path drops linkage on marker chapters.",
+                body="Root-caused to `_apply_linkage` never being called from the marker path.",
+                anchor_turn=12,
+            )
+        ]
+    )
+    nd.append_chapter(path, chapter, slice_from_turn=0, slice_to_turn=12, linkage=linkage)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Note-derived path (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_compose_seed_lift_derives_origin_from_linkage(tmp_path: Path) -> None:
+    linkage = _linkage(epics=[229], prs=[235])
+    path = _note_with_chapter(tmp_path, linkage=linkage)
+
+    lift = compose_seed_lift(path)
+
+    assert lift is not None
+    assert "buchbend/lore" in lift.origin
+    assert "#229" in lift.origin
+    assert "#235" in lift.origin
+
+
+def test_compose_seed_lift_derives_findings_from_chapter_body(tmp_path: Path) -> None:
+    linkage = _linkage(epics=[229])
+    path = _note_with_chapter(tmp_path, linkage=linkage)
+
+    lift = compose_seed_lift(path)
+
+    assert lift is not None
+    assert "buffer-flush path drops linkage on marker chapters" in lift.findings
+    assert "_apply_linkage" in lift.findings
+    # Machine-written disclaimer and chapter delimiters are noise for a
+    # human-facing seed, not findings — stripped.
+    assert nd.DISCLAIMER not in lift.findings
+    assert "lore:chapter" not in lift.findings
+
+
+def test_compose_seed_lift_source_note_is_wiki_relative_when_wiki_root_given(
+    tmp_path: Path,
+) -> None:
+    path = _note_with_chapter(tmp_path, linkage=_linkage(epics=[229]))
+    wiki_root = tmp_path / "wiki"
+
+    lift = compose_seed_lift(path, wiki_root=wiki_root)
+
+    assert lift is not None
+    assert lift.source_note == "sessions/2026/07/10-1200-topic.md"
+
+
+def test_compose_seed_lift_source_note_falls_back_to_full_path_without_wiki_root(
+    tmp_path: Path,
+) -> None:
+    path = _note_with_chapter(tmp_path, linkage=_linkage(epics=[229]))
+
+    lift = compose_seed_lift(path)
+
+    assert lift is not None
+    assert lift.source_note == str(path)
+
+
+def test_compose_seed_lift_singular_pr_wording(tmp_path: Path) -> None:
+    path = _note_with_chapter(tmp_path, linkage=_linkage(prs=[100]))
+
+    lift = compose_seed_lift(path)
+
+    assert lift is not None
+    assert "PR #100" in lift.origin
+    assert "PRs #100" not in lift.origin
+
+
+# ---------------------------------------------------------------------------
+# Freehand-fallback path (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_compose_seed_lift_returns_none_when_note_is_missing(tmp_path: Path) -> None:
+    assert compose_seed_lift(tmp_path / "sessions" / "nope.md") is None
+
+
+def test_compose_seed_lift_returns_none_when_note_is_thin(tmp_path: Path) -> None:
+    # A note with no linkage refs and no chapters — just the disclaimer —
+    # carries nothing a freehand pass wouldn't already have.
+    path = _note_path(tmp_path)
+    nd.create_note(
+        path,
+        title="Empty session",
+        description="nothing happened",
+        scope="lore",
+        created="2026-07-10",
+    )
+
+    assert compose_seed_lift(path) is None
+
+
+def test_compose_seed_lift_returns_none_when_only_marker_chapters(tmp_path: Path) -> None:
+    # Withheld/failed marker chapters are procedural bookkeeping, not
+    # findings — a note with only markers and no linkage is still thin.
+    path = _note_path(tmp_path)
+    nd.create_note(
+        path,
+        title="Gate-withheld session",
+        description="publish gate withheld the chapter",
+        scope="lore",
+        created="2026-07-10",
+    )
+    nd.append_marker_chapter(
+        path, kind=nd.MARKER_WITHHELD, reason="quote mismatch", slice_from_turn=0, slice_to_turn=5
+    )
+
+    assert compose_seed_lift(path) is None


### PR DESCRIPTION
Implements #226

## Summary

`seed-epic`'s Origin/Findings sections used to be freehand-reconstructed by the model each time. This adds a deterministic lift path: `lore_workflow.seed_epic.compose_seed_lift(note_path, wiki_root=...)` reads the current session's note and returns Origin (formatted from `linkage.repo`/`epics`/`prs`) and Findings (concatenated topic-chapter bodies, disclaimer and chapter delimiters stripped). It returns `None` — the fall-back signal — when the note is missing or too thin: no linkage refs and no topic-chapter content. Marker chapters (withheld/failed) are excluded from Findings and don't count toward "thin" either way, since they're gate bookkeeping, not substance; this is done by filtering on each chapter's structured `kind` field in frontmatter rather than pattern-matching the marker boilerplate text, so it stays correct if that wording changes.

Exposed as `lore workflow seed-lift <note-path> [--wiki-root]`, printing `{origin, findings, source_note}` as plain (uncolored — this is machine output) JSON on success, exiting 1 with a "fall back to freehand" message otherwise. `source_note` is wiki-relative when `--wiki-root` is given, else the full path — this is what satisfies AC3: the seed-epic skill now embeds it under **Pointers** in the seed body, giving a cold `/orient` on the seed a deterministic pointer to pull the note back via `lore_read`/`lore_context_pack`, without needing to retroactively edit the note's own linkage (which would touch the shared `note_document.py` file that teammate #222's PR also has open).

`lore-workflow/skills/seed-epic/SKILL.md`'s "Write the seed(s)" step now tries the lift first and falls back to the existing freehand reconstruction on failure. `orchestrate-epic/SKILL.md` and `CONTEXT.md` are untouched (out of scope, owned by other sub-issues).

## Red → green

```
$ pytest tests/test_workflow_seed_epic.py -v   # before lib/lore_workflow/seed_epic.py existed
ModuleNotFoundError: No module named 'lore_workflow.seed_epic'
ERROR tests/test_workflow_seed_epic.py

$ pytest tests/test_workflow_seed_epic.py tests/test_workflow_cmd.py -v   # after
13 passed in 0.74s
```

Full suite: `2649 passed, 1 skipped, 11 failed` — all 11 failures are pre-existing ANSI/color-leaking-into-capture failures in unrelated files (`test_cli_runs.py`, `test_core_llm_wiring.py`, `test_drain_prune.py`, `test_install_dispatcher.py`, `test_log_cmd.py`, `test_proc_cmd.py`), confirmed present on `epic/229` before this branch. None of my files are among them.

## Test plan
- [x] `compose_seed_lift`: note-derived Origin from linkage, Findings from chapter body, wiki-relative vs. absolute `source_note`, singular/plural PR wording
- [x] `compose_seed_lift`: falls back to `None` on missing note, thin note (disclaimer only), and marker-chapters-only note
- [x] `lore workflow seed-lift` CLI: JSON on success, exit 1 + fallback message on missing note
- [x] `ruff check` clean on all touched files (pre-existing B008 on `create_prd_cmd`, unrelated to this change, left as-is — same idiom my new command follows)
- [x] Full `pytest -q` run, no new failures vs. `epic/229` base