### PR TITLE
Orchestrate-epic diet + supervision-on-notes (ADR 0002) — #228

### DIFF
--- a/docs/adr/0002-orchestrate-epic-supervision-state-split.md
+++ b/docs/adr/0002-orchestrate-epic-supervision-state-split.md
@@ -1,0 +1,97 @@
+# ADR 0002: Orchestrate-epic supervision-state split (board on the issue, working context on the epic note)
+
+- Status: Accepted
+- Date: 2026-07-10
+- Context: epic [#229](https://github.com/buchbend/lore/issues/229),
+  PRD [0006](../prd/0006-workflow-lightening-deepening.md), sub-issue
+  [#228](https://github.com/buchbend/lore/issues/228)
+
+## Context
+
+`/orchestrate-epic` supervises a whole epic autonomously: it plans batches, dispatches
+teammates, crosschecks every PR, and lands the epic. All of that produces *supervision
+state* — which features are merged, which teammate got which model tier, why a feature
+blocked, what a crosscheck verdict said — and that state has to survive a resume: an editor
+restart, a `/compact`, or a fresh session picking the epic back up cold.
+
+Historically the skill kept everything in one GitHub issue comment, written and re-read as
+prose, and re-derived repo facts (target branch, deploy gate) and effort bands by eyeballing
+the roadmap table. Resume re-scraped that comment with the model. Prose re-derivation is
+exactly what PRD 0006 removes: this epic moved the deterministic mechanics into
+`lore workflow` (`epic-policy`, `validate-roadmap --json`, `parse-board`), added note-format
+v2, and added a capture-suppress flag (`LORE_SUPPRESS_CAPTURE=1`) for dispatched teammates.
+
+That leaves one design question this ADR answers: **once the mechanics are deterministic,
+where does each kind of supervision state live?** Two kinds pull in different directions. The
+per-feature ledger (feature → tier/batch/state/PR) must be machine-readable, visible to
+humans and teammates on GitHub, and single/authoritative across sessions. The working
+narrative (tier rationale, dispatch and crosscheck reasoning, escalations, in-flight
+decisions) is rich, orchestrator-private, and is exactly what the lore substrate already
+captures into session notes. Forcing both into one store made the comment both unreadable and
+unparseable, and made resume a model-scraping step.
+
+## Decision
+
+Split supervision state into two durable stores, each with a single writer path, and never
+conflate them.
+
+1. **The board — per-feature ledger, on the epic issue.** One comment on the GitHub epic
+   issue, identified by the exact marker `<!-- lore-orchestrate-epic:status v1 -->` and a
+   Markdown table whose header carries the columns `Feature | Issue | Tier | Batch | State |
+   PR` (see `lore_workflow.board_parser`). The orchestrator *emits* that shape; on resume it
+   reads it back structurally via `lore workflow parse-board` — never by re-reading the
+   Markdown with the model. The board stays on the issue because humans and teammates watch it
+   there, and it is authoritative for per-feature state. The orchestrator edits the one
+   comment in place; a resumed run never opens a second.
+
+2. **The epic note — working narrative, on the orchestrator's own session note.** The
+   orchestrator works on the `epic/<issue>` branch, so deterministic linkage stamps its
+   session note with `epics: [<issue>]`; that note *is* the epic note. The orchestrator does
+   not write it through an API — it narrates its tier decisions, dispatch choices, crosscheck
+   verdicts, and escalations in-session, and capture composes them into the note. On resume,
+   `lore_context_pack` / `lore_resume` surface the epic-linked notes and carry that narrative
+   into the new session.
+
+3. **Same-session writes only.** The orchestrator writes only its *own* epic note. ADR 0001
+   (session-note reopen) permits a session to append to its own note across a resume, but
+   forbids any writer from appending to *another* session's note — so a fresh orchestrator
+   session reads prior epic notes and starts its own; it never edits theirs.
+
+4. **Teammates are capture-suppressed.** Each dispatched teammate runs with
+   `LORE_SUPPRESS_CAPTURE=1`, so it emits no standalone session note. Its outcome (PR, verdict,
+   tier deviation) is consolidated by the orchestrator into the single epic note. Without this,
+   an N-feature epic would scatter N low-signal teammate notes and no single record of the
+   supervision.
+
+## Consequences / Trade-offs
+
+- **Positive.** Per-feature state is deterministic and authoritative — a resumed run reconciles
+  from `parse-board` rows, not a prose re-read, and cannot silently misread a half-merged
+  board. The narrative is rich and epic-scoped without polluting the ledger. Capture-suppress
+  keeps the vault from filling with one fragment per teammate; the epic note is the one
+  consolidated supervision record. This matches the project's authoritative-state-over-derived
+  stance: one writeable ledger, breadcrumbs (session notes, commits) elsewhere.
+- **Negative — two stores can drift.** A board row can say `merged` while the epic note's
+  narrative lags, or vice versa. The rule is: the board is authoritative for per-feature state;
+  the epic note is advisory narrative. On any conflict, reconcile toward the board.
+- **The orchestrator is *not* capture-suppressed.** The epic note exists only because capture
+  runs for the orchestrator session. Suppressing the orchestrator too would erase the very
+  record this ADR relies on — so suppression is teammates-only, by construction.
+- **One epic note per orchestrator session, not per epic.** Across resumes the epic
+  accumulates several epic-linked notes (one per orchestrator session), all surfaced together
+  by `lore_context_pack` on the epic key. The board stays single. This is the direct
+  consequence of the same-session-writes rule and is acceptable: the notes are a lab-notebook
+  trail, not a single canonical document.
+
+## Alternatives considered
+
+- **One store — everything in the issue comment (the prior design).** Rejected: prose
+  re-derivation and model-scraping on resume are exactly what PRD 0006 removes, and a single
+  comment cannot hold a rich narrative without becoming both unreadable and unparseable.
+- **Write each teammate's outcome into its own session note and aggregate on resume.**
+  Rejected: N fragments per epic, a cross-session aggregation cost on every resume, and no
+  single consolidated record. Capture-suppress plus orchestrator consolidation is simpler and
+  yields one note.
+- **A shared canonical epic note appended by every orchestrator session across resumes.**
+  Rejected: it requires one session to write another session's note, which ADR 0001 forbids —
+  and cross-session note-appending reopens the duplication hazard ADR 0001 closed.

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -8,253 +8,161 @@ description: Supervise parallel TDD implementation of an epic tracker issue acro
 
 # Orchestrate Epic
 
-You are the **orchestrator**: you plan, dispatch, crosscheck, integrate. Teammate agents
-write the feature code; you do not. Your job is supervision and integration.
+You are the **orchestrator**: you plan, dispatch, crosscheck, integrate. Teammate agents write the feature
+code; you do not.
 
 **Input:** an epic tracker issue (number or URL), possibly spanning repos.
-**Mode:** fully autonomous — run the whole loop without asking. Stop only to report
-completion or to escalate a hard blocker (see Stop conditions).
+**Mode:** fully autonomous — run the whole loop without asking. Stop only to report completion or to escalate
+a hard blocker (see Stop conditions).
 
 ## Invariants
-- **Target branch is detected, never assumed.** Resolve the target branch once, at Map
-  time: `develop` if that branch exists on the remote, else the repo default (`main`).
-  Apply this same detection to BOTH the epic-branch cut point (cut `epic/<issue>` from
-  the detected target) AND the final PR target (the Land-stage PR lands on the detected
-  target). The workflow never creates `develop` — standing one up is a deploy-pipeline
-  decision outside this workflow's scope, and the epic branch already provides
-  integration buffering.
-- Integration target is an **epic branch** `epic/<issue>`, cut from the detected target
-  branch (`develop` if present, else `main`). Feature PRs target the epic branch; the
-  epic branch lands on the detected target branch via one final PR.
-- **Merges are pre-authorized.** Feature→epic merges and the epic→target merge are
-  pre-authorized by this skill — the orchestrator merges on a passing crosscheck and must
-  never ask the user to confirm either kind of merge. The only exception is the
-  deploy-gate marker below, which can require one human confirmation before the final
-  epic→target merge specifically.
-- **Deploy-gate marker.** A repo whose target-branch merge triggers a deployment may
-  declare, in its `AGENTS.md`, a `## Epic merge policy` section containing the line
-  `epic-merge-policy: confirm`. Marker present → the final epic→target merge (only that
-  merge; feature→epic merges stay pre-authorized regardless) requires one human
-  confirmation before merging — the deploy gate. Marker absent (the default) → fully
-  autonomous, merge without asking. Read this marker at Map time alongside target-branch
-  detection; never guess deploy semantics.
+- **Repo facts come from `lore workflow`, never re-derived in prose.** Resolve target branch and deploy gate
+  once at Map time with `lore workflow epic-policy <repo_root>` → `{target_branch, deploy_gate}`.
+  `epic/<issue>` is cut from `target_branch` and lands back on it via one final PR; feature PRs target the
+  epic branch.
+- **Merges are pre-authorized** — you merge on a passing crosscheck, never asking. Sole exception: when
+  `epic-policy` returns `deploy_gate: true`, the final epic→target merge (only that one) requires one human
+  confirmation first.
+- **Supervision state splits into two durable stores (ADR 0002), never conflated.** The **board** — one
+  comment on the epic issue, the per-feature ledger (Feature/Issue/Tier/Batch/State/PR), machine-readable via
+  `lore workflow parse-board`, kept on GitHub for humans and teammates; authoritative for per-feature state.
+  The **epic note** — your own session note, linkage `epics: [<issue>]`, composed by capture as you narrate;
+  it holds what the board can't: tier rationale, dispatch and crosscheck reasoning, escalations, in-flight
+  decisions. You write only your OWN epic note (ADR 0001 forbids writing another session's); dispatched
+  teammates run capture-suppressed, so the epic note is the single consolidated record.
 - One feature = one teammate = one worktree = one branch `feat/<sub-issue>-slug` = one PR.
-- **Compact mode narrows fan-out only.** A small epic (see Effort bands in Map) may run
-  with one teammate implementing every feature of the band sequentially in one worktree —
-  but one branch `feat/<sub-issue>-slug` and one PR per feature is unchanged, strict TDD
-  stays strict, and every PR is still crosschecked before merge (see Dispatch).
-- Strict TDD (red→green→refactor) per feature. No green PR without tests mapping to its
-  acceptance criteria.
-- Never merge on red CI.
+- **Compact mode narrows fan-out only** (see Effort bands) — the strict-TDD, one-PR-per-feature, and
+  every-PR-crosschecked invariants all still hold.
+- Strict TDD (red→green→refactor) per feature — no green PR without tests mapping its acceptance criteria.
+  Never merge on red CI.
 
 ## Loop
 
-**Map.** Read the epic with `gh ... --json` (see the repo's own conventions doc, if any). Extract roadmap
-items, per-feature acceptance criteria, dependency edges, target repo(s). If the epic was
-produced by `/lore-workflow:to-epic`, its **Roadmap** table is the canonical DAG (Feature | Issue | Repo |
-Type | Blocked by); read acceptance criteria from each linked sub-issue, and treat
-HITL-flagged features as escalation points, not auto-implemented.
+**Map.** Read the epic (`gh ... --json`): roadmap items, per-feature acceptance criteria, dependency edges,
+target repo(s). If it came from `/lore-workflow:to-epic`, its **Roadmap** table (Feature | Issue | Repo |
+Type | Blocked by) is the canonical DAG, and HITL-flagged features are escalation points, not
+auto-implemented. Resolve `lore workflow epic-policy` once per repo.
 
-**Resume.** This is the resume entry point — reached first, before the Roadmap-validator
-gate, before cutting the epic branch, before creating a fresh status comment. Three steps:
-1. **Find the status comment** — list comments on the epic issue (`gh api
-   repos/<owner>/<repo>/issues/<issue>/comments`) for one carrying this skill's per-feature
-   state table from a prior run.
-2. **Reconcile** merged/queued/blocked against the epic branch's actual state: a feature
-   already merged into `epic/<issue>` is done — skip it, never redispatch it; a feature still
-   queued or blocked is redispatched from where it left off. The epic branch itself, if it
-   already exists, is reused, never re-cut, so a resumed run never collides with half-merged
-   state.
-3. **Continue editing the same comment** — resume by editing that same existing comment in
-   place (`gh api ... -X PATCH`) for every further update; a resumed run never opens a second
-   one.
+**Resume.** The entry point — reached before the gate, before cutting the epic branch. Two reads recover a
+prior run:
+1. **Board** — fetch the epic issue's board comment and pipe it to `lore workflow parse-board` → rows
+   `{feature, issue, tier, batch, state, pr}`. Never scrape it with the model. Reconcile against the epic
+   branch's real state: a `merged` row is done (skip, never redispatch); a `queued`/`blocked` row is
+   redispatched; an existing epic branch is reused, never re-cut. Edit that same comment in place for every
+   later update; never open a second.
+2. **Working context** — `lore_resume` / `lore_context_pack` (epic-linked) surface prior orchestrator epic
+   notes: why a feature blocked, the tier rationale, the in-flight decisions the board omits.
 
-No prior status comment found → this is a fresh run; proceed to the Roadmap-validator gate
-and create the status comment as described below.
+No board comment found → fresh run; proceed to the gate.
 
-**Roadmap-validator gate.** Before dispatching any teammate, validate that roadmap table
-with the deterministic, dependency-free `lore workflow validate-roadmap` — required columns,
-fully-qualified `owner/repo#n` refs, blocked-by edges that resolve
-to rows, an acyclic DAG. **Refuse to start on a malformed or cyclic roadmap:** report the
-validator's problems and stop rather than dispatch teammates against a table it rejects.
+**Roadmap gate + effort band.** Run `lore workflow validate-roadmap --json` →
+`{ok, rows, repos, edges, problems}`. `ok: false` → refuse to start: report `problems` and stop, never
+dispatching against a malformed or cyclic roadmap. Otherwise pick the band from the counts, not by eye:
+**compact** iff `rows ≤ 2` and `repos == 1` and every `Type` is AFK with no HITL flags; **standard** otherwise
+(full batched loop, concurrency cap N). Record the band in your epic note. Then build the feature DAG, split
+into dependency-ordered batches (features in a batch are independent), and cut and push `epic/<issue>` from
+the up-to-date `target_branch`.
 
-**Effort bands.** Once the roadmap validates, classify the epic into an effort band from
-that same table — feature count, the `Repo` column, and `Blocked by` edge count — decided
-once, at Map time, before any dispatch. This skill runs two bands:
-- **compact** — the lowest band this skill handles: the roadmap has ≤ 2 features, one
-  repo, every row's `Type` is AFK, no HITL flags. Runs the compact dispatch path (see
-  Dispatch).
-- **standard** — everything else: the full batched Loop described here, concurrency cap N.
+**Emit the board.** One comment on the epic issue, edited in place at a few deliberate points (batch start,
+each merge, each blocker, completion) — never a second comment. It MUST carry, verbatim, the marker and
+columns `parse-board` reads:
+```
+<!-- lore-orchestrate-epic:status v1 -->
 
-Work smaller than compact — a single well-understood issue, no roadmap DAG worth cutting —
-does not enter this skill; that is the fast path (`implement-issue`, a separate skill), not
-a further-compacted band. Record the chosen band on the status comment alongside the
-per-feature state.
+| Feature | Issue | Tier | Batch | State | PR |
+|---|---|---|---|---|---|
+| <title> | owner/repo#n | <tier> | <batch> | queued | #<pr> or — |
+```
+`State` is one of queued/running/crosscheck/merged/blocked. The board is the per-feature ledger only; tier
+*rationale* and deviations belong in your epic note.
 
-Build the feature
-DAG; split into dependency-ordered batches (features in a batch are independent). Detect
-the target branch (`develop` if it exists on the remote, else `main`) and cut and push
-`epic/<issue>` from the up-to-date detected target. **The supervision trail is durable, not
-a temp file:** create one status comment on the epic issue (feature × repo × state:
-queued/running/PR/crosscheck/merged/blocked) via `gh issue comment <issue> --body ...`, then
-edit that same comment in place — `gh api repos/<owner>/<repo>/issues/comments/<id> -X PATCH
--f body=...` — never opening a new one. Edit points are deliberately few, not one per
-intermediate transition: at batch start, on each merge, on each blocker, and at epic
-completion. Record tier decisions and deviations there as they happen.
-
-**Context pack (built once at Map time, reused by every teammate).** Assemble one
-short context pack now, so codebase discovery happens once for the whole epic
-instead of once per teammate. Source it from `lore codemap` (or the `lore_codemap`
-MCP tool for bounded, queryable slices): rank the map's symbols
-against this epic's shared touchpoints and pull only the top **token-budgeted
-excerpts (~1k tokens)** — never paste the whole map, which would swamp every
-brief. Shape the pack as Anthropic's four-part subagent brief checklist — their
-documented fix for subagents duplicating each other's searches — so every
-teammate reads the same framing:
+**Codemap excerpt (built once at Map time, reused by every teammate).** So codebase discovery happens once for
+the whole epic, not once per teammate: from `lore codemap` (or the `lore_codemap` MCP tool for bounded
+slices), rank the map's symbols against this epic's shared touchpoints and pull only the top **~1k-token
+excerpts** — never the whole map. Shape it as the four-part subagent brief every teammate reads unchanged:
 - **Objective** — the epic's shared goal and how each feature slices through it.
-- **Expected output format** — one branch `feat/<n>-slug` and one PR per feature,
-  strict TDD with red→green evidence.
-- **Tool/source guidance** — the ranked code-map excerpts (files, key symbols,
-  conventions), `lore codemap` / `lore_codemap` to widen from, and where the domain
-  language lives (CONTEXT.md / glossary, `docs/adr`).
-- **Task boundaries** — the scope fence and the shared-file touchpoints to stay
-  clear of.
-Paste this same pack, unchanged, into every teammate brief below.
+- **Expected output format** — one branch `feat/<n>-slug`, one PR per feature, red→green TDD evidence.
+- **Tool/source guidance** — the ranked codemap excerpts (files, symbols, conventions), `lore codemap` /
+  `lore_codemap` to widen from, where domain language lives (CONTEXT.md / glossary, `docs/adr`).
+- **Task boundaries** — the scope fence and shared-file touchpoints to stay clear of.
 
-**Dispatch.** For each feature in the current batch, create a worktree off `epic/<issue>`
-and spawn a background teammate pinned to it (concurrency cap N, default 4). **Choose each
-teammate's model tier from the feature's assessed complexity** — a cheaper/faster tier for
-mechanical or well-scoped features, the strongest tier for architectural, ambiguous, or
-cross-cutting ones — and pass the chosen tier's resolved model (`lore tier resolve <tier>`,
-see [TIER-DELEGATION.md](../../TIER-DELEGATION.md)) in the spawn call. Fill the teammate brief below per feature.
+**Dispatch.** Per feature in the batch: worktree off `epic/<issue>`, spawn a background teammate pinned to it
+(cap N, default 4) **with `LORE_SUPPRESS_CAPTURE=1` in its environment**, so it lands its work in your epic
+note rather than scattering a standalone fragment. Choose the model tier from the feature's assessed
+complexity (cheaper for well-scoped work, strongest for cross-cutting) and pass the resolved model in the
+spawn call (`lore tier resolve <tier>`, see [TIER-DELEGATION.md](../../TIER-DELEGATION.md)); no delegation
+inherits your session model. Record the tier and its rationale in your epic note; the board carries only the
+assigned tier.
 
-_Liveness._ Liveness is event-driven, not polled: the harness's completion notification
-— fired when a background teammate finishes or sends a message — is the primary signal,
-and is acted on as it arrives rather than on a cycle. The one defined fallback: a teammate
-that has produced neither a message nor a completion notification for ~30 minutes is
-treated as silent. A silent or dead teammate is respawned once, into the same worktree
-with the same brief. A second death on the same feature is not respawned again — mark
-the feature blocked and escalate.
+_Liveness._ Event-driven, not polled: the harness's completion notification is the primary signal. Fallback:
+a teammate silent ~30 minutes is respawned once into the same worktree with the same brief; a second death on
+the same feature is not respawned — mark it blocked and escalate.
 
-_Compact mode._ When Map selected the compact band, skip the per-feature fan-out above:
-create one worktree off `epic/<issue>` and spawn one teammate pinned to it, briefed to
-implement every feature of the band sequentially — still one branch `feat/<n>-slug` and
-one PR per feature, still strict TDD per feature, and each PR is still crosschecked before
-merge exactly as in Crosscheck below (the concurrency cap does not apply — there is only
-one teammate). Optionally batch the review: one reviewer subagent, still spawned explicitly
-at the strong-tier, reviews every PR of the band in a single strong-tier pass — checking
-cross-PR consistency too — instead of one reviewer spawn per PR.
+_Compact mode._ Skip the fan-out: one worktree, one teammate, briefed to implement every feature of the band
+sequentially — still one branch and one PR per feature, still strict TDD, still each PR crosschecked below.
+Optionally batch the review: one strong-tier reviewer over the band's PRs in a single pass.
 
-**Crosscheck (delegated).** When a teammate reports its PR, you do **not** read the diff.
-Delegating the read is what keeps the orchestrator's context free for supervision as the epic
-grows. Spawn one reviewer subagent per PR at the **strong-tier** — set the spawn's model
-parameter to `lore tier resolve strong` (see
-[TIER-DELEGATION.md](../../TIER-DELEGATION.md));
-no delegation ever inherits the session model implicitly. The reviewer reads the
-diff and the linked sub-issue, runs the checks below, and returns a structured verdict. The
-orchestrator reads no diffs; it consumes only the verdict.
-
-_Reviewer contract_ — the reviewer verifies, on the PR it is handed:
-- **CI green** — the PR's required checks pass.
-- **tests map to acceptance criteria** — every acceptance criterion of the sub-issue has a
-  test that exercises it.
-- **red→green evidence present** — the report or commit history shows a failing test before
-  the fix.
-- **scope respected** — only the files this feature needs are touched; nothing outside scope.
-- **ruff clean** — `ruff check` and `ruff format --check` both pass.
-
-_Structured verdict_ — the reviewer returns exactly this, and the same text is the PR comment
-body (machine-skimmable, one check per line):
+**Crosscheck (delegated).** When a teammate reports its PR you do **not** read the diff — delegating the read
+keeps your context free as the epic grows. Spawn one reviewer subagent per PR at the **strong-tier**
+(`lore tier resolve strong`; no delegation inherits the session model). It reads the diff and the linked
+sub-issue and returns exactly this verdict, one line per check, posting the same text as the PR comment; you
+consume only the verdict and record its outcome in your epic note:
 ```
 PR #<n>
 reviewer tier: strong
 verdict: PASS | FAIL
 - CI green: pass | fail — <note>
 - tests map to acceptance criteria: pass | fail — <note>
-- red→green evidence present: pass | fail — <note>
-- scope respected: pass | fail — <note>
-- ruff clean: pass | fail — <note>
+- red→green evidence present (failing test first): pass | fail — <note>
+- scope respected (only files this feature needs): pass | fail — <note>
+- ruff clean (check + format --check): pass | fail — <note>
 fixes (only on FAIL): 1. <precise fix>  2. <precise fix>  …
 ```
-Post the verdict as a comment on the reviewed PR with `gh pr comment <n> --body …`; the verdict
-text is the comment body, so each supervision decision lives on the PR, not only in the
-orchestrator's context. On **PASS**, advance the PR to Merge. On **FAIL**, `SendMessage` the
-same teammate the numbered fix list from the verdict and re-review once it reports back —
-**max 2 fix rounds**, each driven by the next verdict. When a teammate is **stuck** — a fix
-round that fails to move the verdict — send it the `/lore-workflow:debug` skill's method rather than a
-vaguer "try again": reproduce, isolate the root cause, and heed its circuit breaker (after 3
-failed fix attempts, stop and question the architecture instead of throwing a 4th blind fix at
-the same fault). Still FAIL after the second round → mark the feature blocked and escalate.
+Post with `gh pr comment <n> --body …`. On **PASS**, advance to Merge. On **FAIL**, `SendMessage` the teammate
+the numbered fix list and re-review once it reports back — **max 2 fix rounds**. A round that doesn't move the
+verdict → send the `/lore-workflow:debug` method (reproduce, isolate root cause, heed its circuit breaker),
+not a vaguer "try again". Still FAIL after the second → mark the feature blocked and escalate. The Dispatch
+tier is advisory; a reviewer-tier deviation is allowed but recorded in your epic note (full contract:
+[TIER-DELEGATION.md](../../TIER-DELEGATION.md), `docs/model-tiers.md`).
 
-_Tier rules for this step._ The reviewer spawn carries the strong-tier's resolved model in
-its spawn call and never inherits the orchestrator's session model; the
-implementation-teammate tier the Dispatch step
-assigns is advisory — a deviation is allowed but recorded in the supervision trail. For the
-full tier contract — ordinal/collapse, fallback, and one-step escalation — see
-[TIER-DELEGATION.md](../../TIER-DELEGATION.md) and `docs/model-tiers.md`; record any tier
-escalation in the supervision trail.
+**Merge.** Merge crosscheck-passed PRs into `epic/<issue>` in dependency order; rebase later siblings on the
+updated branch and re-run their CI. A rebase conflict returns to that feature's teammate (respawned with
+conflict context if it exited) — you never resolve conflicts by hand; escalate only if the teammate can't.
+Cross-repo: merge a producer's feature and capture its commit SHA before dispatching the consumer that pins
+it. As each feature merges, close the loop: tick its roadmap checkbox (`- [ ]` → `- [x]`), close its sub-issue
+(`gh issue close <n> --comment "Merged via PR #<pr>"`), set its board row to `merged`, and record the outcome
+and any tier deviation in your epic note. When a batch is fully merged, dispatch the next; repeat to the
+roadmap's end.
 
-**Merge.** Merge crosscheck-passed PRs into `epic/<issue>` in dependency order; rebase later
-siblings on the updated epic branch and re-run their CI. If that rebase conflicts, it goes
-back to that feature's teammate — respawned with the same brief plus the conflict context if
-it has already exited — since the orchestrator never resolves merge conflicts by hand;
-escalate only if the teammate fails to resolve it. Cross-repo: merge a producer's feature and
-capture its commit SHA before dispatching the consumer feature that pins it (e.g. a consumer
-repo pins the producer library by commit SHA). **As each feature merges, close the loop on
-GitHub:** tick its roadmap checkbox in the epic issue's task list (`- [ ]` → `- [x]`), close
-its sub-issue (`gh issue close <n> --comment "Merged via PR #<pr>"`), and edit the status
-comment to mark it merged and record the teammate's tier decision and any deviation from the
-Dispatch-assigned tier.
+_Post-merge invariants._ After every merge into `epic/<issue>`, verify epic-branch CI is green before
+dispatching dependents. Where the repo carries migrations, verify a single migration head (e.g. `alembic
+heads`) — squash-merges can silently fork the migration DAG. A failed invariant blocks the batch: fix forward
+or escalate.
 
-_Post-merge invariants._ After every merge into `epic/<issue>`, verify CI is green
-on the epic branch before dispatching anything that depends on it. Where the repo
-carries migrations, also verify a single migration head (e.g. `alembic heads`) —
-squash-merges can silently drop a re-pointed revision from a parallel feature
-branch, forking the migration DAG. An invariant that fails blocks the batch: fix
-forward or escalate before advancing.
+**Land.** All features merged and epic-branch CI green → open one PR `epic/<issue> → <target_branch>` linking
+every sub-issue.
 
-**Advance.** When a batch is fully merged, dispatch the next batch. Repeat to roadmap end.
+**Whole-epic review (delegated).** Before merging that PR, spawn one strong-tier reviewer over the cumulative
+diff (`<target_branch>...epic/<issue>`). Not a per-feature re-review — scope it to cross-feature consistency
+(inconsistent naming, duplicated helpers, conflicting edits to shared files), the class that only surfaces
+once every diff lands together. Reuse the reviewer verdict shape with this cross-feature checklist; post it on
+the epic PR. It gates the merge like a crosscheck: **PASS** → merge; **FAIL** → route the fix list to the
+teammate(s) owning the affected files, re-review once, max 2 rounds, then mark the epic blocked and escalate
+rather than merge. The epic→target merge follows the deploy-gate policy: if `epic-policy` returned
+`deploy_gate: true`, record the one human confirmation in your epic note before merging. Merge, and mark the
+epic issue done with the merge SHA.
 
-**Land.** With all features merged and epic-branch CI green, open one PR
-`epic/<issue> → <detected target>` summarizing the delivered roadmap and linking every
-sub-issue.
-
-**Whole-epic review (delegated).** Before merging that PR, spawn one whole-epic
-reviewer subagent, explicitly at the strong-tier, over the cumulative epic diff
-(`<detected target>...epic/<issue>`). This is not a per-feature re-review — per-PR
-crosscheck already covers each feature in isolation. Scope it explicitly to
-cross-feature consistency: inconsistent naming, duplicated helpers, and conflicting
-edits to shared files — the class of problem that only shows up once every feature's
-diff lands together, which per-PR crosscheck structurally cannot see. Reuse the
-Crosscheck reviewer contract and structured-verdict shape (see above), substituting
-this cross-feature checklist for the per-feature one. Post the verdict as a comment
-on the epic PR with `gh pr comment <n> --body …`. Its verdict gates this PR exactly
-like a crosscheck: on **PASS**, proceed to merge; on **FAIL**, route the numbered fix
-list to the teammate(s) owning the affected files and re-review once — **max 2 fix
-rounds**, same as Crosscheck — still FAIL after the second round marks the epic
-blocked and escalates rather than merging.
-
-This epic→target merge follows the merge pre-authorization and deploy-gate policy in the
-Invariants above — comply with it, and if that repo's deploy-gate marker gates this merge,
-record the human confirmation in the supervision trail. Merge it. Mark the epic issue done
-with the merge SHA.
-
-**Cleanup.** Once the epic lands, delete every merged feature branch, local and
-remote (`git branch -d feat/<n>-<slug>`, `git push origin --delete
-feat/<n>-<slug>`), and remove its worktree (`git worktree remove`). Leave nothing
+**Cleanup.** Delete every merged feature branch (local and remote) and remove its worktree. Leave nothing
 behind but the epic branch's own history.
 
-**Document.** After the epic PR merges, invoke `document-epic` as the final automatic
-stage: it reads the merged epic, classifies each changed path into the Diátaxis four,
-writes or updates the relevant docs, opens a docs PR, and auto-merges it on green CI.
-A human reviews post-hoc and may revert if needed. Never auto-merge on red.
+**Document.** Invoke `document-epic` as the final automatic stage: it classifies changed paths into the
+Diátaxis four, opens a docs PR, and auto-merges on green CI (never on red).
 
-**Land checklist.** Before reporting completion, emit and satisfy this checklist — every item
-verified true, not merely intended:
-- [ ] every roadmap checkbox ticked in the epic issue's task list
-- [ ] every sub-issue closed
-- [ ] the epic PR merged, with its merge SHA recorded on the epic issue
-- [ ] the status comment finalized to the end state (no stale queued/running rows)
+**Land checklist.** Before reporting completion, emit and satisfy this — each item verified true, not merely
+intended:
+- [ ] every roadmap checkbox ticked and every sub-issue closed
+- [ ] the epic PR merged, its merge SHA recorded on the epic issue
+- [ ] the board finalized to the end state (no stale queued/running rows)
 - [ ] every merged feature's branch and worktree gone, local and remote
 - [ ] the docs PR opened, and merged once its CI is green
 
@@ -265,29 +173,20 @@ Report.
 > Implement **<feature title>** (sub-issue #<n>) in repo <repo>.
 > Worktree <path>, branch `feat/<n>-<slug>` off `epic/<issue>`; PR targets `epic/<issue>`.
 > Acceptance criteria: <criteria>.
-> Context pack (shared, built once at Map time — the same text for every teammate):
-> the objective, expected output format, tool/source guidance, and task boundaries,
-> carrying the ranked ~1k-token code-map excerpts from `lore codemap` (never the whole
-> map). Read it before exploring — the repo discovery is already done; widen from
-> these excerpts only as needed.
-> Method: strict TDD via the `/lore-workflow:tdd` skill — failing test first, make it pass, refactor;
-> include the failing-test output in the PR body. Before pushing, run ruff (check +
-> format) and the full suite; both clean.
-> Skip-excuses to catch yourself making — keep the discipline even when you think
-> "this is just a mechanical change" (trivial edits are exactly where a typo ships),
-> "I'll add tests after" (after-the-fact tests ratify the code you wrote, not the behavior
-> you meant; the failing test comes first), or "the skill is overkill here" (the red→green
-> loop is the floor, not ceremony reserved for hard problems). When stuck, use the `/lore-workflow:debug`
-> skill's circuit breaker instead of a 4th blind fix.
+> Codemap excerpt (shared, same text every teammate): objective, expected output format, tool/source
+> guidance, task boundaries, carrying the ranked ~1k-token codemap excerpts from `lore codemap` (never the
+> whole map). Read it before exploring — repo discovery is done; widen from it only as needed.
+> Method: strict TDD via `/lore-workflow:tdd` — failing test first, make it pass, refactor; include the
+> failing-test output in the PR body. Before pushing, run ruff (check + format) and the full suite, both
+> clean. When stuck, use the `/lore-workflow:debug` circuit breaker, not a 4th blind fix.
 > Scope fence: change only what this feature needs; no edits to shared files outside scope.
-> Sibling-write hazard: parallel teammates in separate worktrees under one session
-> can share an isolation pointer, so in-place editor writes (edit/write tools) from
-> one teammate can clobber another's. Workaround: apply file changes via shell
-> (heredoc or scripted edits) with absolute paths instead of in-place editor tools.
-> Deliver: push, open the PR linking #<n>, report the PR number, red→green evidence, and a
-> one-paragraph summary of changes and any decisions you made.
+> Sibling-write hazard: parallel teammates in separate worktrees under one session can share an isolation
+> pointer, so in-place editor writes (Edit/Write) from one can clobber another. Apply file changes via shell
+> (heredoc or scripted edits) at absolute paths instead.
+> Deliver: push, open the PR linking #<n>, report the PR number, red→green evidence, and a one-paragraph
+> summary of changes and any decisions you made.
 
 ## Stop conditions (escalate, pause that branch only)
-A feature flagged HITL (needs a human decision or design review); teammate fails crosscheck
-after 2 fix rounds; ambiguous spec needing a scientific/architectural call; unresolvable merge
-conflict; or CI-infra failure. Otherwise keep going. Emit the status table on every escalation and at completion.
+A feature flagged HITL; a teammate failing crosscheck after 2 fix rounds; an ambiguous spec needing a
+scientific/architectural call; an unresolvable merge conflict; or a CI-infra failure. Otherwise keep going.
+Emit the board on every escalation and at completion.

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -122,7 +122,7 @@ Post with `gh pr comment <n> --body …`. On **PASS**, advance to Merge. On **FA
 the numbered fix list and re-review once it reports back — **max 2 fix rounds**. A round that doesn't move the
 verdict → send the `/lore-workflow:debug` method (reproduce, isolate root cause, heed its circuit breaker),
 not a vaguer "try again". Still FAIL after the second → mark the feature blocked and escalate. The Dispatch
-tier is advisory; a reviewer-tier deviation is allowed but recorded in your epic note (full contract:
+tier is advisory; a reviewer tier deviation is allowed but recorded in your epic note (full contract:
 [TIER-DELEGATION.md](../../TIER-DELEGATION.md), `docs/model-tiers.md`).
 
 **Merge.** Merge crosscheck-passed PRs into `epic/<issue>` in dependency order; rebase later siblings on the


### PR DESCRIPTION
Implements #228.

Slims `orchestrate-epic` so it reads deterministic state from the merged `lore workflow` substrate instead of re-deriving it in skill prose, and records the supervision-state split as ADR 0002. No production code — this slice rewires the skill to call the already-merged, already-unit-tested mechanics (#222/#223/#224) and adds the ADR.

## Acceptance criteria

| AC | Where satisfied |
|----|-----------------|
| 1. target-branch + deploy-gate via `lore workflow epic-policy` (no prose re-derivation) | SKILL.md Invariants (first bullet) + **Map** ("Resolve `lore workflow epic-policy` once per repo"). The old prose deriving `develop`/`main` and the `AGENTS.md` marker is gone. |
| 2. effort-band from `validate-roadmap --json` counts | SKILL.md **Roadmap gate + effort band**: band picked from `{rows, repos, edges}`, "not by eye". |
| 3. resume reads the board via the deterministic parser; board stays on the issue | SKILL.md **Resume** step 1 (`lore workflow parse-board`, "Never scrape it with the model") + **Emit the board** (the marker `<!-- lore-orchestrate-epic:status v1 -->` and columns `Feature\|Issue\|Tier\|Batch\|State\|PR` are emitted verbatim, on the GitHub issue comment). |
| 4. working context in one epic note (linkage `epics: [<n>]`), read on resume | SKILL.md Invariants (epic-note bullet) + **Resume** step 2 (`lore_context_pack` / `lore_resume`). Narration → capture → the orchestrator's own `epic/<issue>`-branch session note. |
| 5. teammate outcomes consolidated; no per-teammate notes | SKILL.md **Dispatch**: teammates spawned `with LORE_SUPPRESS_CAPTURE=1`; outcomes recorded into the single epic note. |
| 6. "context pack" → "codemap excerpt" | SKILL.md **Codemap excerpt** section + **Teammate brief**. "context pack" now appears only as the `lore_context_pack` MCP tool (Resume step 2). |
| 7. `docs/adr/0002-*.md` records the split | `docs/adr/0002-orchestrate-epic-supervision-state-split.md` (follows the ADR 0001 format; no ADR index exists to wire). |
| 8. SKILL.md well under 200 lines | **293 → 192 lines** (−101, −34%). |

## SKILL.md line count

Before: **293**. After: **192**. (`git diff --stat`: 147 insertions, 248 deletions.)

## CLI commands exercised

Run with `PYTHONPATH=<wt>/lib /home/buchbend/.venv/default/bin/python -m lore_cli workflow ...`:

- `epic-policy .` → `{"target_branch": "main", "deploy_gate": false}`
- `validate-roadmap --json -` → `{"ok": true, "rows": 2, "repos": 1, "edges": 1, "problems": []}` (and `{"ok": false, ...}` exit 1 on a table-less body)
- `parse-board -` → `{"rows": [{"feature": ..., "issue": ..., "tier": ..., "batch": ..., "state": ..., "pr": ...}, ...]}`

## Scope

Touches only `orchestrate-epic/SKILL.md` and the new ADR — no production code, no changes to sibling skills (#225/#226), CONTEXT.md (#227), or the merged mechanics modules.