### PR TITLE
Epic #229: workflow lightening & deepening on the lore substrate (PRD 0006)

### DIFF
--- a/CONTEXT-FORMAT.md
+++ b/CONTEXT-FORMAT.md
@@ -1,0 +1,57 @@
+# Session note format v2 — title and body shape
+
+Refines the note-essence voice from `CONTEXT.md`'s "The session note"
+section: same vocabulary (chapter, topic block, lead, disclaimer), two
+rendering changes that make a note's *display* title and its *skim
+layer* easier to read at a glance. Grounded in
+`lore_core/note_document.py` and `lore_curator/stub_note.py`.
+
+## Title: `scope: name`
+
+A note's frontmatter `title` is a placeholder at creation
+(`stub_note._placeholder_title`, e.g. `proj:x session — 2026-07-10`) —
+the first heartbeat fires before any chapter exists, so there's no
+topic to name yet. Once the first chapter composes, the title is
+replaced with `<scope>: <name>`:
+
+- **scope first** — the linkage scope (repo/project slug, e.g.
+  `proj:x` or `ccat:data-center`) so a list of notes sorts and scans
+  by *where*, not by an arbitrary date stamp.
+- **name second** — a compiled human-readable name taken from the
+  first chapter's opening lead (`stub_note._topic_title`, reusing
+  `_lead_for_rename`'s same source text as the filename slug — title
+  and filename always name the same topic).
+
+Example: `proj:x: Traced the flush race`.
+
+The rename happens once, on chapter 1 only
+(`note_document.append_chapter`'s `title` kwarg is a no-op past the
+first chapter) — later chapters extend the note but never rename it,
+matching the existing filename-rename behavior
+(`chapter_flush._rename_to_topic_slug`).
+
+## Body: inline lead
+
+Each topic block's bold lead sentence opens the same paragraph as its
+body prose — not a standalone bold line sitting above a blank-line
+gap:
+
+```
+**Chose an append-only note model.** We decided the note file is
+append-only until close.
+```
+
+not:
+
+```
+**Chose an append-only note model.**
+
+We decided the note file is append-only until close.
+```
+
+A reader reads the bold sentence and bails, or keeps reading the same
+paragraph for the rest of the topic — no forced stop between claim and
+support. The skim layer (bold leads read top-to-bottom, CONTEXT.md)
+is unchanged: leads are still bold, still self-sufficient, still first
+in their paragraph. Quote and `@N` anchor still follow as their own
+lines. See `note_document._render_block`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -209,6 +209,13 @@ not from anything injected ambiently:
   `docs/adr/` and `docs/prd/`. Ratified decisions live in the repo, not
   in the vault; Lore reads them on request instead of re-deriving them
   from session transcripts.
+- `lore_context_pack` (`lore_core/context_pack.py`) — deterministic
+  context resolver: given a scope, repo state, and issue/PR/epic, returns
+  a pointer pack — recent session notes for this scope, ADRs/PRDs that
+  bear on it, open epic state — with one-line summaries and selective
+  body pulls, zero LLM cost. Fed into orchestration skills before any
+  explorer subagent runs.
+
 
 ## Retrieval substrate
 
@@ -245,3 +252,40 @@ above:
 | SessionStart / PreCompact banner + hooks | `lore_cli/hooks.py` |
 | Freshness classification | `lore_core/freshness.py` |
 | Vault/wiki/scope resolution | `lore_core/scope_resolver.py`, `lore_core/state/` |
+
+## Glossary
+
+Terms used in the workflow layer and orchestration:
+
+- **Workflow** — a skill-bundled planning chain: `seed-epic → orient →
+  grill-with-docs → to-epic → orchestrate-epic → document-epic`. Each step
+  is a callable skill, with checkpoints between shaping (human-controlled)
+  and autonomous build. See `docs/conventions.md` for the stage vocabulary,
+  artifact homes, and tier assignments.
+- **Skill** — a callable, namespaced Claude Code automation block (e.g.,
+  `lore-workflow:orient`, `lore:verify`). Skills are registered in
+  `plugin.json` and dispatched by CLI invocation or intra-skill routing.
+  Workflow skills are bundled in the `lore-workflow` plugin.
+- **Lore context pack** — synonym for `lore_context_pack` (see above).
+- **Codemap excerpt** — a bounded, ranked slice of the `lore codemap`
+  output, token-budgeted (~1k tokens) and curated for a specific feature
+  or epic. Passed once at `orchestrate-epic` Map time and reused by every
+  teammate, instead of having each teammate discover symbols independently.
+  Distinct from a full `lore_context_pack`, which joins session notes and
+  ADRs/PRDs; the codemap excerpt is the code-navigation half only.
+- **Epic note** — a single, composed session note that records the
+  orchestration of an epic: the roadmap DAG, per-feature tier decisions,
+  crosscheck verdicts, and any escalations. Distinct from the per-feature
+  implementation notes written by teammate agents; the epic note is the
+  orchestrator's record of supervision.
+- **Handover (session)** — a working-context handover from one Claude Code
+  session to a cold session starting fresh. The source session ends with a
+  `/lore:handover` invoke, which drafts a structured note of context
+  (problem framing, attempted paths, current blockers). A cold session
+  resumes with `/lore:continue`, which loads the handover note and carries
+  its facts into the new session's work.
+- **Handover (epic seed)** — a tracker issue linking an epic seed (the
+  source of structured context for the `orient` step). Distinct from
+  session handover: the epic seed is filed in the issue tracker and is
+  one-time context for a shaped body of work, not a carry-forward between
+  sessions.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,6 +68,8 @@ kind), and a cumulative `SessionFacts` snapshot (commits, PRs,
 files touched/read, duration) that only ever grows. Nothing in
 frontmatter is re-narrated in the body.
 
+Exact title and body rendering shape: `CONTEXT-FORMAT.md`.
+
 ## Writing a note — buffer, flush, compose
 
 A session's turns accumulate in a per-transcript **buffer**

--- a/docs/adr/0002-orchestrate-epic-supervision-state-split.md
+++ b/docs/adr/0002-orchestrate-epic-supervision-state-split.md
@@ -1,0 +1,97 @@
+# ADR 0002: Orchestrate-epic supervision-state split (board on the issue, working context on the epic note)
+
+- Status: Accepted
+- Date: 2026-07-10
+- Context: epic [#229](https://github.com/buchbend/lore/issues/229),
+  PRD [0006](../prd/0006-workflow-lightening-deepening.md), sub-issue
+  [#228](https://github.com/buchbend/lore/issues/228)
+
+## Context
+
+`/orchestrate-epic` supervises a whole epic autonomously: it plans batches, dispatches
+teammates, crosschecks every PR, and lands the epic. All of that produces *supervision
+state* — which features are merged, which teammate got which model tier, why a feature
+blocked, what a crosscheck verdict said — and that state has to survive a resume: an editor
+restart, a `/compact`, or a fresh session picking the epic back up cold.
+
+Historically the skill kept everything in one GitHub issue comment, written and re-read as
+prose, and re-derived repo facts (target branch, deploy gate) and effort bands by eyeballing
+the roadmap table. Resume re-scraped that comment with the model. Prose re-derivation is
+exactly what PRD 0006 removes: this epic moved the deterministic mechanics into
+`lore workflow` (`epic-policy`, `validate-roadmap --json`, `parse-board`), added note-format
+v2, and added a capture-suppress flag (`LORE_SUPPRESS_CAPTURE=1`) for dispatched teammates.
+
+That leaves one design question this ADR answers: **once the mechanics are deterministic,
+where does each kind of supervision state live?** Two kinds pull in different directions. The
+per-feature ledger (feature → tier/batch/state/PR) must be machine-readable, visible to
+humans and teammates on GitHub, and single/authoritative across sessions. The working
+narrative (tier rationale, dispatch and crosscheck reasoning, escalations, in-flight
+decisions) is rich, orchestrator-private, and is exactly what the lore substrate already
+captures into session notes. Forcing both into one store made the comment both unreadable and
+unparseable, and made resume a model-scraping step.
+
+## Decision
+
+Split supervision state into two durable stores, each with a single writer path, and never
+conflate them.
+
+1. **The board — per-feature ledger, on the epic issue.** One comment on the GitHub epic
+   issue, identified by the exact marker `<!-- lore-orchestrate-epic:status v1 -->` and a
+   Markdown table whose header carries the columns `Feature | Issue | Tier | Batch | State |
+   PR` (see `lore_workflow.board_parser`). The orchestrator *emits* that shape; on resume it
+   reads it back structurally via `lore workflow parse-board` — never by re-reading the
+   Markdown with the model. The board stays on the issue because humans and teammates watch it
+   there, and it is authoritative for per-feature state. The orchestrator edits the one
+   comment in place; a resumed run never opens a second.
+
+2. **The epic note — working narrative, on the orchestrator's own session note.** The
+   orchestrator works on the `epic/<issue>` branch, so deterministic linkage stamps its
+   session note with `epics: [<issue>]`; that note *is* the epic note. The orchestrator does
+   not write it through an API — it narrates its tier decisions, dispatch choices, crosscheck
+   verdicts, and escalations in-session, and capture composes them into the note. On resume,
+   `lore_context_pack` / `lore_resume` surface the epic-linked notes and carry that narrative
+   into the new session.
+
+3. **Same-session writes only.** The orchestrator writes only its *own* epic note. ADR 0001
+   (session-note reopen) permits a session to append to its own note across a resume, but
+   forbids any writer from appending to *another* session's note — so a fresh orchestrator
+   session reads prior epic notes and starts its own; it never edits theirs.
+
+4. **Teammates are capture-suppressed.** Each dispatched teammate runs with
+   `LORE_SUPPRESS_CAPTURE=1`, so it emits no standalone session note. Its outcome (PR, verdict,
+   tier deviation) is consolidated by the orchestrator into the single epic note. Without this,
+   an N-feature epic would scatter N low-signal teammate notes and no single record of the
+   supervision.
+
+## Consequences / Trade-offs
+
+- **Positive.** Per-feature state is deterministic and authoritative — a resumed run reconciles
+  from `parse-board` rows, not a prose re-read, and cannot silently misread a half-merged
+  board. The narrative is rich and epic-scoped without polluting the ledger. Capture-suppress
+  keeps the vault from filling with one fragment per teammate; the epic note is the one
+  consolidated supervision record. This matches the project's authoritative-state-over-derived
+  stance: one writeable ledger, breadcrumbs (session notes, commits) elsewhere.
+- **Negative — two stores can drift.** A board row can say `merged` while the epic note's
+  narrative lags, or vice versa. The rule is: the board is authoritative for per-feature state;
+  the epic note is advisory narrative. On any conflict, reconcile toward the board.
+- **The orchestrator is *not* capture-suppressed.** The epic note exists only because capture
+  runs for the orchestrator session. Suppressing the orchestrator too would erase the very
+  record this ADR relies on — so suppression is teammates-only, by construction.
+- **One epic note per orchestrator session, not per epic.** Across resumes the epic
+  accumulates several epic-linked notes (one per orchestrator session), all surfaced together
+  by `lore_context_pack` on the epic key. The board stays single. This is the direct
+  consequence of the same-session-writes rule and is acceptable: the notes are a lab-notebook
+  trail, not a single canonical document.
+
+## Alternatives considered
+
+- **One store — everything in the issue comment (the prior design).** Rejected: prose
+  re-derivation and model-scraping on resume are exactly what PRD 0006 removes, and a single
+  comment cannot hold a rich narrative without becoming both unreadable and unparseable.
+- **Write each teammate's outcome into its own session note and aggregate on resume.**
+  Rejected: N fragments per epic, a cross-session aggregation cost on every resume, and no
+  single consolidated record. Capture-suppress plus orchestrator consolidation is simpler and
+  yields one note.
+- **A shared canonical epic note appended by every orchestrator session across resumes.**
+  Rejected: it requires one session to write another session's note, which ADR 0001 forbids —
+  and cross-session note-appending reopens the duplication hazard ADR 0001 closed.

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -62,6 +62,7 @@ rather than silently falling back to `~/lore`.
 | `LORE_LLM_BACKEND` | `auto` \| `subscription` \| `api` \| `openai` | `auto` | `lore_curator/llm_client.py:make_llm_client` | `.lore/config.yml:curator.backend` |
 | `LORE_CURATOR_MODE` | `1` \| unset | unset | `lore_cli/hooks.py:_in_curator_mode` | (internal — set by the curator's own detached-subprocess spawns, not a user knob) |
 | `LORE_CLAUDE_TIMEOUT_S` | float seconds | `300.0` | `llm_client.py:_resolve_claude_timeout` | constructor arg |
+| `LORE_SUPPRESS_CAPTURE` | `1` \| unset | unset | `lore_cli/hooks.py:_capture_suppressed`, checked first thing in `capture()` | (dispatch contract — set by an orchestrator when it launches a teammate session whose transcript should not become its own standalone note; unset leaves capture unchanged) |
 
 #### OpenAI-compatible backend (when `LORE_LLM_BACKEND=openai`)
 

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -1066,6 +1066,13 @@ def _in_curator_mode() -> bool:
     return os.environ.get("LORE_CURATOR_MODE") == "1"
 
 
+def _capture_suppressed() -> bool:
+    """True when the dispatching orchestrator opted this session out of
+    standalone capture (e.g. a teammate whose work is meant to land in a
+    shared epic note instead of its own fragment)."""
+    return os.environ.get("LORE_SUPPRESS_CAPTURE") == "1"
+
+
 def _session_off_all() -> bool:
     """True iff `/lore:off` (scope=all) is active for the current session.
 
@@ -2327,7 +2334,7 @@ def capture(
     curator when pending work exceeds threshold. No LLM, no network,
     bounded FS walk (8 levels).
     """
-    if _in_curator_mode():
+    if _in_curator_mode() or _capture_suppressed():
         return
     _read_hook_payload()
     if _session_off_all():

--- a/lib/lore_cli/workflow_cmd.py
+++ b/lib/lore_cli/workflow_cmd.py
@@ -16,6 +16,7 @@ from lore_workflow.board_parser import BoardParseError, parse_board
 from lore_workflow.epic_policy import resolve_epic_policy
 from lore_workflow.prd_docs import create_prd
 from lore_workflow.roadmap_validator import roadmap_counts, validate_roadmap
+from lore_workflow.seed_epic import compose_seed_lift
 from rich.console import Console
 
 from lore_cli._argv_compat import argv_main
@@ -114,6 +115,32 @@ def epic_policy_cmd(
     print(
         json.dumps(
             {"target_branch": policy.target_branch, "deploy_gate": policy.deploy_gate}
+        )
+    )
+
+
+@app.command("seed-lift")
+def seed_lift_cmd(
+    note_path: Path = typer.Argument(..., help="Path to the session note to lift from."),
+    wiki_root: Path | None = typer.Option(
+        None, "--wiki-root", help="Wiki root; when given, source_note is recorded wiki-relative."
+    ),
+) -> None:
+    """Lift Origin/Findings for a seed issue from a session note.
+
+    Prints `{origin, findings, source_note}` as JSON on success. Exits 1
+    when the note is missing or too thin to say anything a freehand pass
+    wouldn't already have — the skill's signal to fall back to freehand.
+    """
+    lift = compose_seed_lift(note_path, wiki_root=wiki_root)
+    if lift is None:
+        console.print("[yellow]no usable note[/yellow]: fall back to freehand Origin/Findings")
+        raise typer.Exit(code=1)
+    # Plain (uncolored) JSON: this is machine output for the skill to parse,
+    # not a human-facing message like the other subcommands' console.print.
+    typer.echo(
+        json.dumps(
+            {"origin": lift.origin, "findings": lift.findings, "source_note": lift.source_note}
         )
     )
 

--- a/lib/lore_cli/workflow_cmd.py
+++ b/lib/lore_cli/workflow_cmd.py
@@ -6,12 +6,16 @@ mechanic as prose now call these subcommands and gate on their exit code.
 
 from __future__ import annotations
 
+import json
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
 import typer
+from lore_workflow.board_parser import BoardParseError, parse_board
+from lore_workflow.epic_policy import resolve_epic_policy
 from lore_workflow.prd_docs import create_prd
-from lore_workflow.roadmap_validator import validate_roadmap
+from lore_workflow.roadmap_validator import roadmap_counts, validate_roadmap
 from rich.console import Console
 
 from lore_cli._argv_compat import argv_main
@@ -31,12 +35,37 @@ def validate_roadmap_cmd(
     path: str = typer.Argument(
         "-", help="Path to the epic body Markdown, or '-' to read stdin."
     ),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine output: {ok, rows, repos, edges, problems}. "
+        "Exit code is unchanged (0 valid, 1 invalid).",
+    ),
 ) -> None:
     """Validate an epic's roadmap table: required columns, fully-qualified
     `owner/repo#n` issue refs, resolvable blocked-by edges, acyclic DAG.
     """
     text = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
     result = validate_roadmap(text)
+    if as_json:
+        counts = roadmap_counts(result)
+        # stdout, not rich console: keep it parse-clean (no markup/wrapping).
+        print(
+            json.dumps(
+                {
+                    "ok": result.ok,
+                    "rows": counts.rows,
+                    "repos": counts.repos,
+                    "edges": counts.edges,
+                    "problems": [
+                        {"kind": p.kind, "message": p.message} for p in result.problems
+                    ],
+                }
+            )
+        )
+        if not result.ok:
+            raise typer.Exit(code=1)
+        return
     if result.ok:
         console.print(
             f"[green]roadmap OK[/green]: {len(result.rows)} feature(s), "
@@ -66,6 +95,49 @@ def create_prd_cmd(
         target or Path("."), slug=slug, title=title, epic_url=epic_url, repos=repo or []
     )
     console.print(f"[green]wrote[/green] {path}")
+
+
+@app.command("epic-policy")
+def epic_policy_cmd(
+    repo_root: str = typer.Argument(
+        ".", help="Repo root to resolve policy for (default: cwd)."
+    ),
+) -> None:
+    """Emit a repo's epic-merge policy as JSON: {target_branch, deploy_gate}.
+
+    `target_branch` is `develop` if that branch exists on `origin`, else
+    `main`. `deploy_gate` is true iff `AGENTS.md` declares
+    `epic-merge-policy: confirm` under its `## Epic merge policy` section.
+    """
+    policy = resolve_epic_policy(Path(repo_root))
+    # stdout, not rich console: keep it parse-clean for machine consumers.
+    print(
+        json.dumps(
+            {"target_branch": policy.target_branch, "deploy_gate": policy.deploy_gate}
+        )
+    )
+
+
+@app.command("parse-board")
+def parse_board_cmd(
+    path: str = typer.Argument(
+        "-", help="Path to the board comment body, or '-' to read stdin."
+    ),
+) -> None:
+    """Parse an orchestrate-epic supervision-board comment into JSON rows.
+
+    Emits {rows: [{feature, issue, tier, batch, state, pr}, ...]}. A missing
+    marker, missing columns, or a malformed row exits 1 with a clear error on
+    stderr — never a silent misread.
+    """
+    text = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    try:
+        rows = parse_board(text)
+    except BoardParseError as exc:
+        print(f"board parse error: {exc}", file=sys.stderr)
+        raise typer.Exit(code=1) from exc
+    # stdout, not rich console: keep it parse-clean for machine consumers.
+    print(json.dumps({"rows": [asdict(row) for row in rows]}))
 
 
 main = argv_main(app)

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -148,11 +148,15 @@ class NoteView:
 
 
 def _render_block(block: TopicBlock) -> str:
+    # Note-format v2 (#222): the lead sentence stays inline with its body in
+    # one paragraph — a reader reads the bold sentence and bails or reads on,
+    # instead of a standalone bold line floating above a blank-line gap.
     lead = f"Continued: {block.continued_topic}" if block.continued else block.lead
-    parts = [f"**{lead.strip()}**"]
+    lead_para = f"**{lead.strip()}**"
     body = (block.body or "").strip()
     if body:
-        parts.append(body)
+        lead_para = f"{lead_para} {body}"
+    parts = [lead_para]
     quote = (block.quote or "").strip()
     if quote:
         parts.append(f'> "{quote}"')
@@ -353,8 +357,14 @@ def append_chapter(
     facts: SessionFacts | None = None,
     linkage: Linkage | None = None,
     wiki_root: Path | None = None,
+    title: str | None = None,
 ) -> int:
     """Append a chapter of topic blocks; record its slice turn range.
+
+    ``title``, if given, replaces the placeholder frontmatter title — but
+    only on chapter 1 (note-format v2, #222). The LLM never composes a
+    title; the flush derives one deterministically from the first chapter's
+    lead and passes it here.
 
     Returns the 1-based chapter number. Raises :class:`NoteClosedError`
     if the note is closed — the file is left untouched in that case.
@@ -363,6 +373,8 @@ def append_chapter(
     _guard_open(fm, path)
 
     n = _next_chapter_n(fm)
+    if title and n == 1:
+        fm["title"] = title
     segment = _render_topic_chapter(n, chapter, slice_from_turn, slice_to_turn)
     new_body = f"{body.rstrip()}\n\n{segment}"
 

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -74,7 +74,7 @@ from lore_curator.session_note import (
     facts_from_replay,
     linkage_from_replay,
 )
-from lore_curator.stub_note import _lead_for_rename, _resolve_renamed_path
+from lore_curator.stub_note import _lead_for_rename, _resolve_renamed_path, _topic_title
 
 if TYPE_CHECKING:
     from lore_core.run_log import RunLogger
@@ -548,6 +548,7 @@ def _apply_outcome(
             facts=facts,
             linkage=linkage,
             wiki_root=wiki_root,
+            title=_topic_title(sidecar.scope, compose_result.chapter),
         )
         if out.chapter_n == 1:
             note_path = _rename_to_topic_slug(buffer, note_path, compose_result.chapter)

--- a/lib/lore_curator/stub_note.py
+++ b/lib/lore_curator/stub_note.py
@@ -156,6 +156,22 @@ def _lead_for_rename(chapter: Chapter) -> str:
     return lead.strip()
 
 
+def _topic_title(scope_label: str, chapter: Chapter) -> str:
+    """Return the scope-prefixed frontmatter title for a composed chapter.
+
+    Note-format v2 (#222): `scope: name` — the linkage scope first, then a
+    compiled human-readable name from the chapter's first lead. Reuses
+    ``_lead_for_rename``'s same-source, same-fallback text so the filename
+    slug and the frontmatter title always describe the same topic. Returns
+    ``""`` under the same no-usable-lead conditions — the caller keeps the
+    placeholder title in that case.
+    """
+    lead = _lead_for_rename(chapter)
+    if not lead:
+        return ""
+    return f"{scope_label}: {lead.rstrip('.').strip()}"
+
+
 def _resolve_renamed_path(note_path: Path, slug: str) -> Path:
     """Return the rename target for ``note_path`` once ``slug`` is known.
 

--- a/lib/lore_workflow/board_parser.py
+++ b/lib/lore_workflow/board_parser.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Parser for the supervision-board comment (peer of ``roadmap_validator.py``).
+
+``/orchestrate-epic`` keeps one durable status comment on the epic issue and
+edits it in place across a run — the supervision trail. On resume the run must
+read prior per-feature state *structurally*, not by re-reading the Markdown
+with the model (scraping is exactly the re-derivation this epic removes).
+
+This module is the machine reader, and — because feature #228 will rewire
+orchestrate-epic to EMIT the shape this reads — it is also the contract. The
+contract is three things, all explicit here so the emitter can target them:
+
+- **Marker** — the comment is identified by the exact HTML comment
+  :data:`BOARD_MARKER`. A comment without it is not a board (a v1 reader must
+  refuse a v2 marker rather than silently misread it).
+- **Columns** — a GitHub-flavoured Markdown table follows the marker whose
+  header carries at least :data:`REQUIRED_COLUMNS` (matched by name,
+  case-insensitively; extra columns are tolerated for forward-compat).
+- **Rows** — one data row per feature; each row's cell count must match the
+  header, so fields never silently misalign.
+
+Any breach raises :class:`BoardParseError` with a human-facing message —
+never a partial or misaligned parse. Standard library only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lore_workflow.roadmap_validator import _is_separator, _split_cells
+
+# The comment is identified by this exact marker. Feature #228 emits it
+# verbatim; a mismatch (including a future version bump) is "not a board".
+BOARD_MARKER = "<!-- lore-orchestrate-epic:status v1 -->"
+
+# Columns a board table must carry. Order here is the canonical emit order;
+# parsing maps by name, so an emitter may append columns without breaking us.
+REQUIRED_COLUMNS: tuple[str, ...] = ("Feature", "Issue", "Tier", "Batch", "State", "PR")
+
+# PR-cell values that mean "no PR yet" — normalised to "" so a resumed run can
+# test truthiness. Mirrors the roadmap validator's "no blocker" placeholders.
+_PLACEHOLDER = {"", "-", "–", "—"}
+
+
+class BoardParseError(ValueError):
+    """Raised when a board comment is missing, unmarked, or malformed."""
+
+
+@dataclass(frozen=True)
+class BoardRow:
+    """One feature's supervision state, one row of the board table."""
+
+    feature: str
+    issue: str
+    tier: str
+    batch: str
+    state: str
+    pr: str
+
+
+def _find_table_after(lines: list[str], start: int) -> tuple[list[str], list[tuple[int, str]]]:
+    """Locate the first Markdown table at or after line index *start*.
+
+    A table is a pipe header row immediately followed by a separator row, then
+    pipe data rows up to the first blank/non-pipe line. Raises if none found.
+    """
+    for i in range(start, len(lines) - 1):
+        if "|" not in lines[i] or _is_separator(lines[i]):
+            continue
+        if not _is_separator(lines[i + 1]):
+            continue
+        header = _split_cells(lines[i])
+        data: list[tuple[int, str]] = []
+        j = i + 2
+        while j < len(lines) and lines[j].strip() and "|" in lines[j]:
+            if _is_separator(lines[j]):
+                break
+            data.append((j + 1, lines[j]))
+            j += 1
+        return header, data
+    raise BoardParseError("no board table found after the status marker")
+
+
+def _column_index(header: list[str]) -> dict[str, int]:
+    """Map each required column to its position in *header* (case-insensitive).
+
+    Raises if any required column is absent, naming the missing ones.
+    """
+    lower = {cell.casefold(): idx for idx, cell in enumerate(header)}
+    missing = [col for col in REQUIRED_COLUMNS if col.casefold() not in lower]
+    if missing:
+        raise BoardParseError(
+            f"board table missing required column(s): {', '.join(missing)}; "
+            f"got header {' | '.join(header)}"
+        )
+    return {col: lower[col.casefold()] for col in REQUIRED_COLUMNS}
+
+
+def parse_board(text: str) -> list[BoardRow]:
+    """Parse a supervision-board comment into structured per-feature rows.
+
+    Raises :class:`BoardParseError` on a missing marker, a missing table,
+    missing required columns, or any row whose cell count does not match the
+    header — never a silent misread.
+    """
+    marker_at = text.find(BOARD_MARKER)
+    if marker_at < 0:
+        raise BoardParseError(
+            f"status marker {BOARD_MARKER!r} not found — not a board comment"
+        )
+
+    lines = text.splitlines()
+    # First line strictly after the marker line.
+    marker_line = text.count("\n", 0, marker_at)
+    header, data_lines = _find_table_after(lines, marker_line + 1)
+    idx = _column_index(header)
+    width = len(header)
+
+    rows: list[BoardRow] = []
+    for lineno, raw in data_lines:
+        cells = _split_cells(raw)
+        if len(cells) != width:
+            raise BoardParseError(
+                f"line {lineno}: board row has {len(cells)} cell(s), "
+                f"expected {width} to match the header"
+            )
+        pr = cells[idx["PR"]].strip()
+        rows.append(
+            BoardRow(
+                feature=cells[idx["Feature"]],
+                issue=cells[idx["Issue"]],
+                tier=cells[idx["Tier"]],
+                batch=cells[idx["Batch"]],
+                state=cells[idx["State"]],
+                pr="" if pr in _PLACEHOLDER else pr,
+            )
+        )
+    return rows

--- a/lib/lore_workflow/epic_policy.py
+++ b/lib/lore_workflow/epic_policy.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Per-repo epic-merge policy: target branch + deploy gate (peer of
+``roadmap_validator.py``).
+
+``/orchestrate-epic`` must resolve two repo facts deterministically at Map
+time — never guess them from prose:
+
+- **target_branch** — where the epic branch is cut from and where it lands.
+  ``develop`` if that branch exists on the repo's ``origin`` remote, else
+  ``main``. The workflow never stands ``develop`` up itself; its absence is a
+  deliberate "no deploy pipeline here" signal, so the default is ``main``.
+- **deploy_gate** — whether the final epic->target merge needs one human
+  confirmation before it lands. True iff the repo's ``AGENTS.md`` carries a
+  ``## Epic merge policy`` section containing the line
+  ``epic-merge-policy: confirm``. Absent (the default) → fully autonomous.
+
+Standard library + ``git`` only; no GitHub API. ``git ls-remote`` is the
+ground truth for "present on the remote"; if there is no ``origin`` or it is
+unreachable, that resolves to the safe default (``main``), matching the
+skill's documented fallback.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# Deploy-gate contract, scoped to its own section so the marker quoted
+# elsewhere in AGENTS.md prose can never trip the gate.
+_POLICY_HEADING = "## Epic merge policy"
+_DEPLOY_GATE_MARKER = "epic-merge-policy: confirm"
+
+
+@dataclass(frozen=True)
+class EpicPolicy:
+    """Resolved policy for one repo."""
+
+    target_branch: str
+    deploy_gate: bool
+
+
+def _remote_has_develop(repo_root: Path) -> bool:
+    """True iff ``develop`` exists on the ``origin`` remote. Any failure
+    (no origin, not a git repo, unreachable) is treated as absent."""
+    try:
+        proc = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", "develop"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0 and proc.stdout.strip() != ""
+
+
+def _section_has_marker(text: str) -> bool:
+    """True iff a ``## Epic merge policy`` section contains the deploy-gate
+    marker line. Scoping: from the heading until the next ``## `` heading."""
+    in_section = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            in_section = stripped.casefold() == _POLICY_HEADING.casefold()
+            continue
+        if in_section and stripped.casefold() == _DEPLOY_GATE_MARKER.casefold():
+            return True
+    return False
+
+
+def _read_deploy_gate(repo_root: Path) -> bool:
+    try:
+        text = (repo_root / "AGENTS.md").read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    return _section_has_marker(text)
+
+
+def resolve_epic_policy(repo_root: Path) -> EpicPolicy:
+    """Resolve the epic-merge policy for the repo rooted at *repo_root*."""
+    return EpicPolicy(
+        target_branch="develop" if _remote_has_develop(repo_root) else "main",
+        deploy_gate=_read_deploy_gate(repo_root),
+    )

--- a/lib/lore_workflow/roadmap_validator.py
+++ b/lib/lore_workflow/roadmap_validator.py
@@ -366,6 +366,29 @@ def validate_roadmap(markdown: str) -> ValidationResult:
     return ValidationResult(ok=not problems, problems=problems, rows=rows)
 
 
+@dataclass(frozen=True)
+class RoadmapCounts:
+    """Shape of a roadmap for planners: feature rows, distinct repos, and
+    dependency edges (blocked-by tokens). Read off already-parsed rows so
+    ``/orchestrate-epic`` sizes batches from a count, not from prose."""
+
+    rows: int
+    repos: int
+    edges: int
+
+
+def roadmap_counts(result: ValidationResult) -> RoadmapCounts:
+    """Count features, distinct repos, and blocked-by edges of a validated
+    roadmap. Uses ``result.rows`` — no second table parse. On a column-level
+    failure ``rows`` is empty, so every count is zero."""
+    rows = list(result.rows)
+    return RoadmapCounts(
+        rows=len(rows),
+        repos=len({row.repo for row in rows}),
+        edges=sum(len(row.blocked_by) for row in rows),
+    )
+
+
 def validate_roadmap_or_raise(markdown: str) -> ValidationResult:
     """Validate *markdown*, raising :class:`RoadmapError` if it is invalid.
 

--- a/lib/lore_workflow/seed_epic.py
+++ b/lib/lore_workflow/seed_epic.py
@@ -1,0 +1,88 @@
+"""Seed-epic Origin/Findings lift — pull from the session note, not freehand.
+
+`compose_seed_lift` gives the seed-epic skill's "Write the seed(s)" step a
+deterministic Origin (from the note's linkage) and Findings (from the
+note's topic-chapter bodies) instead of a model reconstructing them from
+memory. Returns ``None`` — the caller's signal to fall back to the existing
+freehand path — when there is no note, or the note carries nothing a
+freehand pass wouldn't already have: no linkage refs and no topic-chapter
+content. Marker chapters (withheld/failed) are gate bookkeeping, not
+findings, and don't count either way.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from lore_core.note_document import DISCLAIMER, NoteView, read_note
+
+__all__ = ["SeedLift", "compose_seed_lift"]
+
+_CHAPTER_HEADER_RE = re.compile(
+    r"^<!-- lore:chapter (\d+)(?: marker:\S+)? @\d+-\d+ -->\s*$", re.MULTILINE
+)
+
+
+@dataclass(frozen=True)
+class SeedLift:
+    """Origin + Findings lifted from a session note, plus a pointer back to it."""
+
+    origin: str
+    findings: str
+    source_note: str
+
+
+def _format_origin(linkage: dict) -> str:
+    repo = linkage.get("repo") or ""
+    if not repo:
+        return ""
+    bits = [f"`{repo}`"]
+    epics = linkage.get("epics") or []
+    if epics:
+        bits.append("epic " + ", ".join(f"#{n}" for n in epics))
+    prs = linkage.get("prs") or []
+    if prs:
+        label = "PR" if len(prs) == 1 else "PRs"
+        bits.append(f"{label} " + ", ".join(f"#{n}" for n in prs))
+    return " — ".join(bits)
+
+
+def _findings(view: NoteView) -> str:
+    """Concatenate topic-chapter bodies; marker chapters carry no findings."""
+    topic_ns = {c["n"] for c in view.chapters if c.get("kind") == "topic"}
+    if not topic_ns:
+        return ""
+    body = view.body
+    if body.startswith(DISCLAIMER):
+        body = body[len(DISCLAIMER) :]
+    matches = list(_CHAPTER_HEADER_RE.finditer(body))
+    segments = []
+    for i, m in enumerate(matches):
+        if int(m.group(1)) not in topic_ns:
+            continue
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        segment = body[start:end].strip()
+        if segment:
+            segments.append(segment)
+    return "\n\n".join(segments)
+
+
+def compose_seed_lift(note_path: Path, *, wiki_root: Path | None = None) -> SeedLift | None:
+    """Lift Origin/Findings from the note at ``note_path``.
+
+    Returns ``None`` when the note is missing or too thin (no linkage refs,
+    no topic-chapter findings) — the caller's signal to fall back to the
+    existing freehand path.
+    """
+    if not note_path.exists():
+        return None
+    view = read_note(note_path)
+    origin = _format_origin(view.frontmatter.get("linkage") or {})
+    findings = _findings(view)
+    if not origin and not findings:
+        return None
+    source_note = str(note_path.relative_to(wiki_root)) if wiki_root else str(note_path)
+    return SeedLift(origin=origin, findings=findings, source_note=source_note)

--- a/lore-workflow/TIER-DELEGATION.md
+++ b/lore-workflow/TIER-DELEGATION.md
@@ -26,3 +26,24 @@ delegated to a subagent at all — there is no spawn to resolve. That is a
 different rule from the one above and the two are not interchangeable:
 delegation-point skills resolve a tier for a spawn; main-session skills
 simply state they don't spawn.
+
+## Workflow-specific tier choices
+
+**Implementation teammates** (`orchestrate-epic` Dispatch step): **advisory tier
+selection**. Assess each feature for complexity and choose a tier for its
+implementation teammate — `mid` for mechanical or well-scoped changes, `strong` for
+architectural, ambiguous, or cross-cutting ones. Pass the tier to `lore tier
+resolve` and set the spawn's model parameter to the resolved result (see "Resolution at spawn time"
+above). Deviations are allowed but recorded in the supervision trail; adequate
+output at mid-tier is preferred to stronger-tier cost.
+
+**Review passes** (implementation-teammate review in `implement-issue`, per-feature
+crosscheck in `orchestrate-epic`, whole-epic review in `orchestrate-epic`):
+**required strong-tier**. Reviewers carry the strong-tier's resolved model in the
+spawn call (no implicit inheritance). The implementation-teammate tier is advisory
+(see above); the review tier is not — it is always strong.
+
+**Exploration fan-out** (`orient` step 2): **required mid-tier**. Parallel
+explorers (code map, docs, cross-repo scan) run at mid; cheaper tiers skip
+the depth, frontier-tier would waste tokens on mechanical discovery.
+

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -8,253 +8,161 @@ description: Supervise parallel TDD implementation of an epic tracker issue acro
 
 # Orchestrate Epic
 
-You are the **orchestrator**: you plan, dispatch, crosscheck, integrate. Teammate agents
-write the feature code; you do not. Your job is supervision and integration.
+You are the **orchestrator**: you plan, dispatch, crosscheck, integrate. Teammate agents write the feature
+code; you do not.
 
 **Input:** an epic tracker issue (number or URL), possibly spanning repos.
-**Mode:** fully autonomous — run the whole loop without asking. Stop only to report
-completion or to escalate a hard blocker (see Stop conditions).
+**Mode:** fully autonomous — run the whole loop without asking. Stop only to report completion or to escalate
+a hard blocker (see Stop conditions).
 
 ## Invariants
-- **Target branch is detected, never assumed.** Resolve the target branch once, at Map
-  time: `develop` if that branch exists on the remote, else the repo default (`main`).
-  Apply this same detection to BOTH the epic-branch cut point (cut `epic/<issue>` from
-  the detected target) AND the final PR target (the Land-stage PR lands on the detected
-  target). The workflow never creates `develop` — standing one up is a deploy-pipeline
-  decision outside this workflow's scope, and the epic branch already provides
-  integration buffering.
-- Integration target is an **epic branch** `epic/<issue>`, cut from the detected target
-  branch (`develop` if present, else `main`). Feature PRs target the epic branch; the
-  epic branch lands on the detected target branch via one final PR.
-- **Merges are pre-authorized.** Feature→epic merges and the epic→target merge are
-  pre-authorized by this skill — the orchestrator merges on a passing crosscheck and must
-  never ask the user to confirm either kind of merge. The only exception is the
-  deploy-gate marker below, which can require one human confirmation before the final
-  epic→target merge specifically.
-- **Deploy-gate marker.** A repo whose target-branch merge triggers a deployment may
-  declare, in its `AGENTS.md`, a `## Epic merge policy` section containing the line
-  `epic-merge-policy: confirm`. Marker present → the final epic→target merge (only that
-  merge; feature→epic merges stay pre-authorized regardless) requires one human
-  confirmation before merging — the deploy gate. Marker absent (the default) → fully
-  autonomous, merge without asking. Read this marker at Map time alongside target-branch
-  detection; never guess deploy semantics.
+- **Repo facts come from `lore workflow`, never re-derived in prose.** Resolve target branch and deploy gate
+  once at Map time with `lore workflow epic-policy <repo_root>` → `{target_branch, deploy_gate}`.
+  `epic/<issue>` is cut from `target_branch` and lands back on it via one final PR; feature PRs target the
+  epic branch.
+- **Merges are pre-authorized** — you merge on a passing crosscheck, never asking. Sole exception: when
+  `epic-policy` returns `deploy_gate: true`, the final epic→target merge (only that one) requires one human
+  confirmation first.
+- **Supervision state splits into two durable stores (ADR 0002), never conflated.** The **board** — one
+  comment on the epic issue, the per-feature ledger (Feature/Issue/Tier/Batch/State/PR), machine-readable via
+  `lore workflow parse-board`, kept on GitHub for humans and teammates; authoritative for per-feature state.
+  The **epic note** — your own session note, linkage `epics: [<issue>]`, composed by capture as you narrate;
+  it holds what the board can't: tier rationale, dispatch and crosscheck reasoning, escalations, in-flight
+  decisions. You write only your OWN epic note (ADR 0001 forbids writing another session's); dispatched
+  teammates run capture-suppressed, so the epic note is the single consolidated record.
 - One feature = one teammate = one worktree = one branch `feat/<sub-issue>-slug` = one PR.
-- **Compact mode narrows fan-out only.** A small epic (see Effort bands in Map) may run
-  with one teammate implementing every feature of the band sequentially in one worktree —
-  but one branch `feat/<sub-issue>-slug` and one PR per feature is unchanged, strict TDD
-  stays strict, and every PR is still crosschecked before merge (see Dispatch).
-- Strict TDD (red→green→refactor) per feature. No green PR without tests mapping to its
-  acceptance criteria.
-- Never merge on red CI.
+- **Compact mode narrows fan-out only** (see Effort bands) — the strict-TDD, one-PR-per-feature, and
+  every-PR-crosschecked invariants all still hold.
+- Strict TDD (red→green→refactor) per feature — no green PR without tests mapping its acceptance criteria.
+  Never merge on red CI.
 
 ## Loop
 
-**Map.** Read the epic with `gh ... --json` (see the repo's own conventions doc, if any). Extract roadmap
-items, per-feature acceptance criteria, dependency edges, target repo(s). If the epic was
-produced by `/lore-workflow:to-epic`, its **Roadmap** table is the canonical DAG (Feature | Issue | Repo |
-Type | Blocked by); read acceptance criteria from each linked sub-issue, and treat
-HITL-flagged features as escalation points, not auto-implemented.
+**Map.** Read the epic (`gh ... --json`): roadmap items, per-feature acceptance criteria, dependency edges,
+target repo(s). If it came from `/lore-workflow:to-epic`, its **Roadmap** table (Feature | Issue | Repo |
+Type | Blocked by) is the canonical DAG, and HITL-flagged features are escalation points, not
+auto-implemented. Resolve `lore workflow epic-policy` once per repo.
 
-**Resume.** This is the resume entry point — reached first, before the Roadmap-validator
-gate, before cutting the epic branch, before creating a fresh status comment. Three steps:
-1. **Find the status comment** — list comments on the epic issue (`gh api
-   repos/<owner>/<repo>/issues/<issue>/comments`) for one carrying this skill's per-feature
-   state table from a prior run.
-2. **Reconcile** merged/queued/blocked against the epic branch's actual state: a feature
-   already merged into `epic/<issue>` is done — skip it, never redispatch it; a feature still
-   queued or blocked is redispatched from where it left off. The epic branch itself, if it
-   already exists, is reused, never re-cut, so a resumed run never collides with half-merged
-   state.
-3. **Continue editing the same comment** — resume by editing that same existing comment in
-   place (`gh api ... -X PATCH`) for every further update; a resumed run never opens a second
-   one.
+**Resume.** The entry point — reached before the gate, before cutting the epic branch. Two reads recover a
+prior run:
+1. **Board** — fetch the epic issue's board comment and pipe it to `lore workflow parse-board` → rows
+   `{feature, issue, tier, batch, state, pr}`. Never scrape it with the model. Reconcile against the epic
+   branch's real state: a `merged` row is done (skip, never redispatch); a `queued`/`blocked` row is
+   redispatched; an existing epic branch is reused, never re-cut. Edit that same comment in place for every
+   later update; never open a second.
+2. **Working context** — `lore_resume` / `lore_context_pack` (epic-linked) surface prior orchestrator epic
+   notes: why a feature blocked, the tier rationale, the in-flight decisions the board omits.
 
-No prior status comment found → this is a fresh run; proceed to the Roadmap-validator gate
-and create the status comment as described below.
+No board comment found → fresh run; proceed to the gate.
 
-**Roadmap-validator gate.** Before dispatching any teammate, validate that roadmap table
-with the deterministic, dependency-free `lore workflow validate-roadmap` — required columns,
-fully-qualified `owner/repo#n` refs, blocked-by edges that resolve
-to rows, an acyclic DAG. **Refuse to start on a malformed or cyclic roadmap:** report the
-validator's problems and stop rather than dispatch teammates against a table it rejects.
+**Roadmap gate + effort band.** Run `lore workflow validate-roadmap --json` →
+`{ok, rows, repos, edges, problems}`. `ok: false` → refuse to start: report `problems` and stop, never
+dispatching against a malformed or cyclic roadmap. Otherwise pick the band from the counts, not by eye:
+**compact** iff `rows ≤ 2` and `repos == 1` and every `Type` is AFK with no HITL flags; **standard** otherwise
+(full batched loop, concurrency cap N). Record the band in your epic note. Then build the feature DAG, split
+into dependency-ordered batches (features in a batch are independent), and cut and push `epic/<issue>` from
+the up-to-date `target_branch`.
 
-**Effort bands.** Once the roadmap validates, classify the epic into an effort band from
-that same table — feature count, the `Repo` column, and `Blocked by` edge count — decided
-once, at Map time, before any dispatch. This skill runs two bands:
-- **compact** — the lowest band this skill handles: the roadmap has ≤ 2 features, one
-  repo, every row's `Type` is AFK, no HITL flags. Runs the compact dispatch path (see
-  Dispatch).
-- **standard** — everything else: the full batched Loop described here, concurrency cap N.
+**Emit the board.** One comment on the epic issue, edited in place at a few deliberate points (batch start,
+each merge, each blocker, completion) — never a second comment. It MUST carry, verbatim, the marker and
+columns `parse-board` reads:
+```
+<!-- lore-orchestrate-epic:status v1 -->
 
-Work smaller than compact — a single well-understood issue, no roadmap DAG worth cutting —
-does not enter this skill; that is the fast path (`implement-issue`, a separate skill), not
-a further-compacted band. Record the chosen band on the status comment alongside the
-per-feature state.
+| Feature | Issue | Tier | Batch | State | PR |
+|---|---|---|---|---|---|
+| <title> | owner/repo#n | <tier> | <batch> | queued | #<pr> or — |
+```
+`State` is one of queued/running/crosscheck/merged/blocked. The board is the per-feature ledger only; tier
+*rationale* and deviations belong in your epic note.
 
-Build the feature
-DAG; split into dependency-ordered batches (features in a batch are independent). Detect
-the target branch (`develop` if it exists on the remote, else `main`) and cut and push
-`epic/<issue>` from the up-to-date detected target. **The supervision trail is durable, not
-a temp file:** create one status comment on the epic issue (feature × repo × state:
-queued/running/PR/crosscheck/merged/blocked) via `gh issue comment <issue> --body ...`, then
-edit that same comment in place — `gh api repos/<owner>/<repo>/issues/comments/<id> -X PATCH
--f body=...` — never opening a new one. Edit points are deliberately few, not one per
-intermediate transition: at batch start, on each merge, on each blocker, and at epic
-completion. Record tier decisions and deviations there as they happen.
-
-**Context pack (built once at Map time, reused by every teammate).** Assemble one
-short context pack now, so codebase discovery happens once for the whole epic
-instead of once per teammate. Source it from `lore codemap` (or the `lore_codemap`
-MCP tool for bounded, queryable slices): rank the map's symbols
-against this epic's shared touchpoints and pull only the top **token-budgeted
-excerpts (~1k tokens)** — never paste the whole map, which would swamp every
-brief. Shape the pack as Anthropic's four-part subagent brief checklist — their
-documented fix for subagents duplicating each other's searches — so every
-teammate reads the same framing:
+**Codemap excerpt (built once at Map time, reused by every teammate).** So codebase discovery happens once for
+the whole epic, not once per teammate: from `lore codemap` (or the `lore_codemap` MCP tool for bounded
+slices), rank the map's symbols against this epic's shared touchpoints and pull only the top **~1k-token
+excerpts** — never the whole map. Shape it as the four-part subagent brief every teammate reads unchanged:
 - **Objective** — the epic's shared goal and how each feature slices through it.
-- **Expected output format** — one branch `feat/<n>-slug` and one PR per feature,
-  strict TDD with red→green evidence.
-- **Tool/source guidance** — the ranked code-map excerpts (files, key symbols,
-  conventions), `lore codemap` / `lore_codemap` to widen from, and where the domain
-  language lives (CONTEXT.md / glossary, `docs/adr`).
-- **Task boundaries** — the scope fence and the shared-file touchpoints to stay
-  clear of.
-Paste this same pack, unchanged, into every teammate brief below.
+- **Expected output format** — one branch `feat/<n>-slug`, one PR per feature, red→green TDD evidence.
+- **Tool/source guidance** — the ranked codemap excerpts (files, symbols, conventions), `lore codemap` /
+  `lore_codemap` to widen from, where domain language lives (CONTEXT.md / glossary, `docs/adr`).
+- **Task boundaries** — the scope fence and shared-file touchpoints to stay clear of.
 
-**Dispatch.** For each feature in the current batch, create a worktree off `epic/<issue>`
-and spawn a background teammate pinned to it (concurrency cap N, default 4). **Choose each
-teammate's model tier from the feature's assessed complexity** — a cheaper/faster tier for
-mechanical or well-scoped features, the strongest tier for architectural, ambiguous, or
-cross-cutting ones — and pass the chosen tier's resolved model (`lore tier resolve <tier>`,
-see [TIER-DELEGATION.md](../../TIER-DELEGATION.md)) in the spawn call. Fill the teammate brief below per feature.
+**Dispatch.** Per feature in the batch: worktree off `epic/<issue>`, spawn a background teammate pinned to it
+(cap N, default 4) **with `LORE_SUPPRESS_CAPTURE=1` in its environment**, so it lands its work in your epic
+note rather than scattering a standalone fragment. Choose the model tier from the feature's assessed
+complexity (cheaper for well-scoped work, strongest for cross-cutting) and pass the resolved model in the
+spawn call (`lore tier resolve <tier>`, see [TIER-DELEGATION.md](../../TIER-DELEGATION.md)); no delegation
+inherits your session model. Record the tier and its rationale in your epic note; the board carries only the
+assigned tier.
 
-_Liveness._ Liveness is event-driven, not polled: the harness's completion notification
-— fired when a background teammate finishes or sends a message — is the primary signal,
-and is acted on as it arrives rather than on a cycle. The one defined fallback: a teammate
-that has produced neither a message nor a completion notification for ~30 minutes is
-treated as silent. A silent or dead teammate is respawned once, into the same worktree
-with the same brief. A second death on the same feature is not respawned again — mark
-the feature blocked and escalate.
+_Liveness._ Event-driven, not polled: the harness's completion notification is the primary signal. Fallback:
+a teammate silent ~30 minutes is respawned once into the same worktree with the same brief; a second death on
+the same feature is not respawned — mark it blocked and escalate.
 
-_Compact mode._ When Map selected the compact band, skip the per-feature fan-out above:
-create one worktree off `epic/<issue>` and spawn one teammate pinned to it, briefed to
-implement every feature of the band sequentially — still one branch `feat/<n>-slug` and
-one PR per feature, still strict TDD per feature, and each PR is still crosschecked before
-merge exactly as in Crosscheck below (the concurrency cap does not apply — there is only
-one teammate). Optionally batch the review: one reviewer subagent, still spawned explicitly
-at the strong-tier, reviews every PR of the band in a single strong-tier pass — checking
-cross-PR consistency too — instead of one reviewer spawn per PR.
+_Compact mode._ Skip the fan-out: one worktree, one teammate, briefed to implement every feature of the band
+sequentially — still one branch and one PR per feature, still strict TDD, still each PR crosschecked below.
+Optionally batch the review: one strong-tier reviewer over the band's PRs in a single pass.
 
-**Crosscheck (delegated).** When a teammate reports its PR, you do **not** read the diff.
-Delegating the read is what keeps the orchestrator's context free for supervision as the epic
-grows. Spawn one reviewer subagent per PR at the **strong-tier** — set the spawn's model
-parameter to `lore tier resolve strong` (see
-[TIER-DELEGATION.md](../../TIER-DELEGATION.md));
-no delegation ever inherits the session model implicitly. The reviewer reads the
-diff and the linked sub-issue, runs the checks below, and returns a structured verdict. The
-orchestrator reads no diffs; it consumes only the verdict.
-
-_Reviewer contract_ — the reviewer verifies, on the PR it is handed:
-- **CI green** — the PR's required checks pass.
-- **tests map to acceptance criteria** — every acceptance criterion of the sub-issue has a
-  test that exercises it.
-- **red→green evidence present** — the report or commit history shows a failing test before
-  the fix.
-- **scope respected** — only the files this feature needs are touched; nothing outside scope.
-- **ruff clean** — `ruff check` and `ruff format --check` both pass.
-
-_Structured verdict_ — the reviewer returns exactly this, and the same text is the PR comment
-body (machine-skimmable, one check per line):
+**Crosscheck (delegated).** When a teammate reports its PR you do **not** read the diff — delegating the read
+keeps your context free as the epic grows. Spawn one reviewer subagent per PR at the **strong-tier**
+(`lore tier resolve strong`; no delegation inherits the session model). It reads the diff and the linked
+sub-issue and returns exactly this verdict, one line per check, posting the same text as the PR comment; you
+consume only the verdict and record its outcome in your epic note:
 ```
 PR #<n>
 reviewer tier: strong
 verdict: PASS | FAIL
 - CI green: pass | fail — <note>
 - tests map to acceptance criteria: pass | fail — <note>
-- red→green evidence present: pass | fail — <note>
-- scope respected: pass | fail — <note>
-- ruff clean: pass | fail — <note>
+- red→green evidence present (failing test first): pass | fail — <note>
+- scope respected (only files this feature needs): pass | fail — <note>
+- ruff clean (check + format --check): pass | fail — <note>
 fixes (only on FAIL): 1. <precise fix>  2. <precise fix>  …
 ```
-Post the verdict as a comment on the reviewed PR with `gh pr comment <n> --body …`; the verdict
-text is the comment body, so each supervision decision lives on the PR, not only in the
-orchestrator's context. On **PASS**, advance the PR to Merge. On **FAIL**, `SendMessage` the
-same teammate the numbered fix list from the verdict and re-review once it reports back —
-**max 2 fix rounds**, each driven by the next verdict. When a teammate is **stuck** — a fix
-round that fails to move the verdict — send it the `/lore-workflow:debug` skill's method rather than a
-vaguer "try again": reproduce, isolate the root cause, and heed its circuit breaker (after 3
-failed fix attempts, stop and question the architecture instead of throwing a 4th blind fix at
-the same fault). Still FAIL after the second round → mark the feature blocked and escalate.
+Post with `gh pr comment <n> --body …`. On **PASS**, advance to Merge. On **FAIL**, `SendMessage` the teammate
+the numbered fix list and re-review once it reports back — **max 2 fix rounds**. A round that doesn't move the
+verdict → send the `/lore-workflow:debug` method (reproduce, isolate root cause, heed its circuit breaker),
+not a vaguer "try again". Still FAIL after the second → mark the feature blocked and escalate. The Dispatch
+tier is advisory; a reviewer tier deviation is allowed but recorded in your epic note (full contract:
+[TIER-DELEGATION.md](../../TIER-DELEGATION.md), `docs/model-tiers.md`).
 
-_Tier rules for this step._ The reviewer spawn carries the strong-tier's resolved model in
-its spawn call and never inherits the orchestrator's session model; the
-implementation-teammate tier the Dispatch step
-assigns is advisory — a deviation is allowed but recorded in the supervision trail. For the
-full tier contract — ordinal/collapse, fallback, and one-step escalation — see
-[TIER-DELEGATION.md](../../TIER-DELEGATION.md) and `docs/model-tiers.md`; record any tier
-escalation in the supervision trail.
+**Merge.** Merge crosscheck-passed PRs into `epic/<issue>` in dependency order; rebase later siblings on the
+updated branch and re-run their CI. A rebase conflict returns to that feature's teammate (respawned with
+conflict context if it exited) — you never resolve conflicts by hand; escalate only if the teammate can't.
+Cross-repo: merge a producer's feature and capture its commit SHA before dispatching the consumer that pins
+it. As each feature merges, close the loop: tick its roadmap checkbox (`- [ ]` → `- [x]`), close its sub-issue
+(`gh issue close <n> --comment "Merged via PR #<pr>"`), set its board row to `merged`, and record the outcome
+and any tier deviation in your epic note. When a batch is fully merged, dispatch the next; repeat to the
+roadmap's end.
 
-**Merge.** Merge crosscheck-passed PRs into `epic/<issue>` in dependency order; rebase later
-siblings on the updated epic branch and re-run their CI. If that rebase conflicts, it goes
-back to that feature's teammate — respawned with the same brief plus the conflict context if
-it has already exited — since the orchestrator never resolves merge conflicts by hand;
-escalate only if the teammate fails to resolve it. Cross-repo: merge a producer's feature and
-capture its commit SHA before dispatching the consumer feature that pins it (e.g. a consumer
-repo pins the producer library by commit SHA). **As each feature merges, close the loop on
-GitHub:** tick its roadmap checkbox in the epic issue's task list (`- [ ]` → `- [x]`), close
-its sub-issue (`gh issue close <n> --comment "Merged via PR #<pr>"`), and edit the status
-comment to mark it merged and record the teammate's tier decision and any deviation from the
-Dispatch-assigned tier.
+_Post-merge invariants._ After every merge into `epic/<issue>`, verify epic-branch CI is green before
+dispatching dependents. Where the repo carries migrations, verify a single migration head (e.g. `alembic
+heads`) — squash-merges can silently fork the migration DAG. A failed invariant blocks the batch: fix forward
+or escalate.
 
-_Post-merge invariants._ After every merge into `epic/<issue>`, verify CI is green
-on the epic branch before dispatching anything that depends on it. Where the repo
-carries migrations, also verify a single migration head (e.g. `alembic heads`) —
-squash-merges can silently drop a re-pointed revision from a parallel feature
-branch, forking the migration DAG. An invariant that fails blocks the batch: fix
-forward or escalate before advancing.
+**Land.** All features merged and epic-branch CI green → open one PR `epic/<issue> → <target_branch>` linking
+every sub-issue.
 
-**Advance.** When a batch is fully merged, dispatch the next batch. Repeat to roadmap end.
+**Whole-epic review (delegated).** Before merging that PR, spawn one strong-tier reviewer over the cumulative
+diff (`<target_branch>...epic/<issue>`). Not a per-feature re-review — scope it to cross-feature consistency
+(inconsistent naming, duplicated helpers, conflicting edits to shared files), the class that only surfaces
+once every diff lands together. Reuse the reviewer verdict shape with this cross-feature checklist; post it on
+the epic PR. It gates the merge like a crosscheck: **PASS** → merge; **FAIL** → route the fix list to the
+teammate(s) owning the affected files, re-review once, max 2 rounds, then mark the epic blocked and escalate
+rather than merge. The epic→target merge follows the deploy-gate policy: if `epic-policy` returned
+`deploy_gate: true`, record the one human confirmation in your epic note before merging. Merge, and mark the
+epic issue done with the merge SHA.
 
-**Land.** With all features merged and epic-branch CI green, open one PR
-`epic/<issue> → <detected target>` summarizing the delivered roadmap and linking every
-sub-issue.
-
-**Whole-epic review (delegated).** Before merging that PR, spawn one whole-epic
-reviewer subagent, explicitly at the strong-tier, over the cumulative epic diff
-(`<detected target>...epic/<issue>`). This is not a per-feature re-review — per-PR
-crosscheck already covers each feature in isolation. Scope it explicitly to
-cross-feature consistency: inconsistent naming, duplicated helpers, and conflicting
-edits to shared files — the class of problem that only shows up once every feature's
-diff lands together, which per-PR crosscheck structurally cannot see. Reuse the
-Crosscheck reviewer contract and structured-verdict shape (see above), substituting
-this cross-feature checklist for the per-feature one. Post the verdict as a comment
-on the epic PR with `gh pr comment <n> --body …`. Its verdict gates this PR exactly
-like a crosscheck: on **PASS**, proceed to merge; on **FAIL**, route the numbered fix
-list to the teammate(s) owning the affected files and re-review once — **max 2 fix
-rounds**, same as Crosscheck — still FAIL after the second round marks the epic
-blocked and escalates rather than merging.
-
-This epic→target merge follows the merge pre-authorization and deploy-gate policy in the
-Invariants above — comply with it, and if that repo's deploy-gate marker gates this merge,
-record the human confirmation in the supervision trail. Merge it. Mark the epic issue done
-with the merge SHA.
-
-**Cleanup.** Once the epic lands, delete every merged feature branch, local and
-remote (`git branch -d feat/<n>-<slug>`, `git push origin --delete
-feat/<n>-<slug>`), and remove its worktree (`git worktree remove`). Leave nothing
+**Cleanup.** Delete every merged feature branch (local and remote) and remove its worktree. Leave nothing
 behind but the epic branch's own history.
 
-**Document.** After the epic PR merges, invoke `document-epic` as the final automatic
-stage: it reads the merged epic, classifies each changed path into the Diátaxis four,
-writes or updates the relevant docs, opens a docs PR, and auto-merges it on green CI.
-A human reviews post-hoc and may revert if needed. Never auto-merge on red.
+**Document.** Invoke `document-epic` as the final automatic stage: it classifies changed paths into the
+Diátaxis four, opens a docs PR, and auto-merges on green CI (never on red).
 
-**Land checklist.** Before reporting completion, emit and satisfy this checklist — every item
-verified true, not merely intended:
-- [ ] every roadmap checkbox ticked in the epic issue's task list
-- [ ] every sub-issue closed
-- [ ] the epic PR merged, with its merge SHA recorded on the epic issue
-- [ ] the status comment finalized to the end state (no stale queued/running rows)
+**Land checklist.** Before reporting completion, emit and satisfy this — each item verified true, not merely
+intended:
+- [ ] every roadmap checkbox ticked and every sub-issue closed
+- [ ] the epic PR merged, its merge SHA recorded on the epic issue
+- [ ] the board finalized to the end state (no stale queued/running rows)
 - [ ] every merged feature's branch and worktree gone, local and remote
 - [ ] the docs PR opened, and merged once its CI is green
 
@@ -265,29 +173,20 @@ Report.
 > Implement **<feature title>** (sub-issue #<n>) in repo <repo>.
 > Worktree <path>, branch `feat/<n>-<slug>` off `epic/<issue>`; PR targets `epic/<issue>`.
 > Acceptance criteria: <criteria>.
-> Context pack (shared, built once at Map time — the same text for every teammate):
-> the objective, expected output format, tool/source guidance, and task boundaries,
-> carrying the ranked ~1k-token code-map excerpts from `lore codemap` (never the whole
-> map). Read it before exploring — the repo discovery is already done; widen from
-> these excerpts only as needed.
-> Method: strict TDD via the `/lore-workflow:tdd` skill — failing test first, make it pass, refactor;
-> include the failing-test output in the PR body. Before pushing, run ruff (check +
-> format) and the full suite; both clean.
-> Skip-excuses to catch yourself making — keep the discipline even when you think
-> "this is just a mechanical change" (trivial edits are exactly where a typo ships),
-> "I'll add tests after" (after-the-fact tests ratify the code you wrote, not the behavior
-> you meant; the failing test comes first), or "the skill is overkill here" (the red→green
-> loop is the floor, not ceremony reserved for hard problems). When stuck, use the `/lore-workflow:debug`
-> skill's circuit breaker instead of a 4th blind fix.
+> Codemap excerpt (shared, same text every teammate): objective, expected output format, tool/source
+> guidance, task boundaries, carrying the ranked ~1k-token codemap excerpts from `lore codemap` (never the
+> whole map). Read it before exploring — repo discovery is done; widen from it only as needed.
+> Method: strict TDD via `/lore-workflow:tdd` — failing test first, make it pass, refactor; include the
+> failing-test output in the PR body. Before pushing, run ruff (check + format) and the full suite, both
+> clean. When stuck, use the `/lore-workflow:debug` circuit breaker, not a 4th blind fix.
 > Scope fence: change only what this feature needs; no edits to shared files outside scope.
-> Sibling-write hazard: parallel teammates in separate worktrees under one session
-> can share an isolation pointer, so in-place editor writes (edit/write tools) from
-> one teammate can clobber another's. Workaround: apply file changes via shell
-> (heredoc or scripted edits) with absolute paths instead of in-place editor tools.
-> Deliver: push, open the PR linking #<n>, report the PR number, red→green evidence, and a
-> one-paragraph summary of changes and any decisions you made.
+> Sibling-write hazard: parallel teammates in separate worktrees under one session can share an isolation
+> pointer, so in-place editor writes (Edit/Write) from one can clobber another. Apply file changes via shell
+> (heredoc or scripted edits) at absolute paths instead.
+> Deliver: push, open the PR linking #<n>, report the PR number, red→green evidence, and a one-paragraph
+> summary of changes and any decisions you made.
 
 ## Stop conditions (escalate, pause that branch only)
-A feature flagged HITL (needs a human decision or design review); teammate fails crosscheck
-after 2 fix rounds; ambiguous spec needing a scientific/architectural call; unresolvable merge
-conflict; or CI-infra failure. Otherwise keep going. Emit the status table on every escalation and at completion.
+A feature flagged HITL; a teammate failing crosscheck after 2 fix rounds; an ambiguous spec needing a
+scientific/architectural call; an unresolvable merge conflict; or a CI-infra failure. Otherwise keep going.
+Emit the board on every escalation and at completion.

--- a/lore-workflow/skills/orient/SKILL.md
+++ b/lore-workflow/skills/orient/SKILL.md
@@ -22,23 +22,33 @@ Take the user's stated goal as the seed, verbatim. Don't expand it or jump to so
 If they pass an issue reference (e.g. an epic seed from `/lore-workflow:seed-epic`), fetch and read it
 (`gh ... --json`) and treat its Intent + Findings as the seed.
 
-### 2. Explore in parallel (subagents)
-Fan out read-only `Explore` subagents concurrently — one per facet, in a single message — and
-keep only their findings here (drop the file dumps). This fan-out runs at **mid-tier
-(REQUIRED)**: resolve the tier to a concrete model with `lore tier resolve mid` and set each
-spawn's model parameter to that resolution — see
-[TIER-DELEGATION.md](../../TIER-DELEGATION.md) for the no-implicit-inherit rule this enforces.
-Default facets:
+### 2. Pull the context pack, then fan out only what's thin
+Before spawning anything, pull the deterministic context pack **once, up front**:
+`lore_context_pack` (cold-start-safe — an empty repo/vault returns a well-formed empty pack,
+never an error) plus `lore_repo_docs_list` / `lore_repo_docs_fetch` for the full ADR/PRD
+listing and any body worth reading in full. Two facets are served straight from that pull, no
+subagent:
+- **Docs & decisions** — the pack's `adr` / `prd` entries (already linked to the focus
+  issue/epic), CONTEXT.md / glossary read directly, `lore_repo_docs_list` for anything the
+  pack's focus filter missed.
+- **Prior art** — the pack's `sessions` (recent related session notes) and `epic_state`
+  (linked issue/epic status) as the trace of related work.
+
+Spawn a facet's `Explore` subagent only when the pack came back thin or empty for it (no
+matching ADR/PRD, no matching sessions) — it then searches beyond what the deterministic join
+found. The remaining facets fan out unconditionally, as before:
 - **Code map** — where this touches the codebase: key modules, interfaces, current behavior,
   relevant tests. Start from `lore codemap` (or the `lore_codemap` MCP tool) for a ranked,
   deterministic index instead of a blind directory walk.
-- **Docs & decisions** — CONTEXT.md / glossary, `docs/adr`, relevant guides; what is already
-  decided or constrained.
-- **Prior art** — related issues/PRs and similar existing features.
 - **Cross-repo / external** — only when the intent plausibly spans repos or downstream consumers.
 
-Scale the fan-out to the ask: a small change may need a single Explore pass; a broad feature
-warrants all facets.
+Whatever subagents this leaves running go out concurrently, in a single message, at **mid-tier
+(REQUIRED)**: resolve the tier to a concrete model with `lore tier resolve mid` and set each
+spawn's model parameter to that resolution — see
+[TIER-DELEGATION.md](../../TIER-DELEGATION.md) for the no-implicit-inherit rule this enforces.
+
+Scale the fan-out to the ask: a small change may need a single Explore pass (or none, if the
+pack already covers it); a broad feature warrants all facets.
 
 ### 3. Reflect back
 Present a tight brief in the conversation:

--- a/lore-workflow/skills/seed-epic/SKILL.md
+++ b/lore-workflow/skills/seed-epic/SKILL.md
@@ -36,6 +36,15 @@ seeds. Trivially small, well-understood follow-ups don't need the chain — note
 filing instead. Confirm the grouping with the user before publishing.
 
 ### 3. Write the seed(s)
+First try to lift **Origin** and **Findings** from this session's note (deterministic, no
+freehand reconstruction needed): `lore workflow seed-lift <path-to-this-session's-note>
+--wiki-root <wiki-root>`. On success (exit 0), use its `origin` and `findings` JSON fields
+verbatim for those two sections, and add its `source_note` under **Pointers** as an explicit
+reference — so a cold `/lore-workflow:orient` on the seed can pull the note back via
+`lore_read`/`lore_context_pack`. On failure (exit 1: no note, or too thin), fall back to
+freehand — reconstruct Origin (the finished epic, merged PRs/commits) and Findings (hard-won
+context from this session) as before.
+
 Draft each body with the template below. Lead with intent; make the **findings** section rich —
 that is the handover value. Pointers are starting points, not gospel (they may go stale).
 

--- a/lore-workflow/skills/to-epic/SKILL.md
+++ b/lore-workflow/skills/to-epic/SKILL.md
@@ -46,9 +46,12 @@ an epic-seed issue produced by `/lore-workflow:seed-epic` (labeled `epic-seed`) 
 (`gh ... --json`; see the repo's own conventions doc, if any).
 
 ### 2. Explore the repo(s)
-Understand the current state. Identify **every target repo** — an epic may be cross-repo.
-Use each project's domain language — its CONTEXT.md / glossary if present — and respect its
-ADRs (`docs/adr`).
+Understand the current state. Identify **every target repo** — an epic may be cross-repo. For
+each, pull `lore_context_pack` (+ `lore_repo_docs_list` / `lore_repo_docs_fetch`) up front,
+before any deeper exploration — cold-start-safe, so it costs nothing even on a repo with no
+ADRs/PRDs yet. Its `adr` / `prd` entries are the fast path into each project's domain language
+(CONTEXT.md / glossary if present) and ratified decisions (`docs/adr`); go beyond the pack only
+for what it comes back thin or missing on for this epic's scope.
 
 ### 3. Synthesize the PRD
 Condense a PRD — do NOT interview, synthesize what you already know: Problem, Solution,

--- a/tests/fixtures/boards/missing-marker.md
+++ b/tests/fixtures/boards/missing-marker.md
@@ -1,0 +1,5 @@
+No status marker here — a stray comment that must not be misread as a board.
+
+| Feature | Issue | Tier | Batch | State | PR |
+|---------|-------|------|-------|-------|-----|
+| Load the config | ccatobs/widget#12 | AFK | 1 | merged | ccatobs/widget#40 |

--- a/tests/fixtures/boards/well-formed.md
+++ b/tests/fixtures/boards/well-formed.md
@@ -1,0 +1,9 @@
+Epic #229 — supervision board. Edited in place across the run.
+
+<!-- lore-orchestrate-epic:status v1 -->
+
+| Feature | Issue | Tier | Batch | State | PR |
+|---------|-------|------|-------|-------|-----|
+| Load the config | ccatobs/widget#12 | AFK | 1 | merged | ccatobs/widget#40 |
+| Parse the manifest | ccatobs/widget#13 | AFK | 1 | running | — |
+| Export the report | ccatobs/widget#14 | HITL | 2 | queued | — |

--- a/tests/test_chapter_flush.py
+++ b/tests/test_chapter_flush.py
@@ -15,6 +15,7 @@ from typing import Any
 import pytest
 from lore_core import note_document as nd
 from lore_core import quarantine
+from lore_core.schema import parse_frontmatter
 from lore_core.types import Turn
 from lore_core.wiki_config import WikiConfig
 from lore_curator.buffer_append import append_chunk
@@ -328,6 +329,36 @@ def test_first_chapter_rename_reflects_topic_lead(tmp_path):
 
     reopened = Buffer.open(lore_root, transcript_id="abc", local_date="2026-05-01")
     assert reopened.read_sidecar().stub_path == str(outcome.note_path)
+
+
+def test_first_chapter_sets_scope_prefixed_title(tmp_path):
+    """Note-format v2 (#222): frontmatter title becomes `scope: name` —
+    scope first, then the composed name — and the body's lead sentence
+    stays inline with its prose rather than a standalone bold line.
+    """
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    all_turns = _turns(0, 4)
+    buf = _append(lore_root, all_turns)
+    client = _Client(
+        [_chapter_payload("Traced the flush race", "Found the race in the reaper.", 2)]
+    )
+
+    outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+        auto_commit=False,
+    )
+    assert outcome.status == "composed"
+
+    text = outcome.note_path.read_text()
+    fm = parse_frontmatter(text)
+    assert fm["title"] == "proj:x: Traced the flush race"
+    assert "**Traced the flush race** Found the race in the reaper." in text
 
 
 def test_second_chapter_does_not_rename_again(tmp_path):

--- a/tests/test_hooks_capture.py
+++ b/tests/test_hooks_capture.py
@@ -1292,4 +1292,60 @@ def test_capture_emits_pending_by_wiki_in_hook_event(
     assert "pending_after" in rec
     assert "pending_by_wiki" in rec
     # Counts dict, not the full entry list.
-    assert rec["pending_by_wiki"] == {"alpha": 2, "beta": 1}
+
+
+# ---------------------------------------------------------------------------
+# Capture-suppress flag — dispatched teammate sessions
+# ---------------------------------------------------------------------------
+
+
+def test_capture_suppressed_by_env_flag_is_full_noop(
+    tmp_path: Path, fake_adapter_factory, monkeypatch
+) -> None:
+    """LORE_SUPPRESS_CAPTURE=1 short-circuits capture() before any ledger
+    write, curator spawn, or hook-event log — a dispatched teammate
+    session leaves no standalone note."""
+    project = _make_attached_project(tmp_path)
+    handle = _make_handle(project)
+    fake_adapter_factory([handle])
+
+    spawn_calls: list[Path] = []
+    monkeypatch.setattr(
+        "lore_cli.hooks._spawn_detached_curator_a",
+        lambda lore_root, **kw: (spawn_calls.append(lore_root), True)[-1],
+    )
+
+    result = runner.invoke(
+        hook_app,
+        ["capture", "--event", "session-end", "--cwd", str(project), "--integration", "fake"],
+        env={"LORE_ROOT": str(project), "LORE_SUPPRESS_CAPTURE": "1"},
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    ledger = TranscriptLedger(project)
+    assert ledger.get("fake", "t1") is None, "suppressed capture must not touch the ledger"
+    assert not spawn_calls, "suppressed capture must never spawn curator A"
+
+    events_path = project / ".lore" / "hook-events.jsonl"
+    assert not events_path.exists(), "suppressed capture must not emit hook telemetry"
+
+
+def test_capture_without_suppress_flag_is_unchanged(tmp_path: Path, fake_adapter_factory) -> None:
+    """Same setup, no LORE_SUPPRESS_CAPTURE set — default capture behaviour
+    is unaffected by the new flag's existence."""
+    project = _make_attached_project(tmp_path)
+    handle = _make_handle(project)
+    fake_adapter_factory([handle])
+
+    result = runner.invoke(
+        hook_app,
+        ["capture", "--event", "session-end", "--cwd", str(project), "--integration", "fake"],
+        env={"LORE_ROOT": str(project)},
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    ledger = TranscriptLedger(project)
+    entry = ledger.get("fake", "t1")
+    assert entry is not None, "unsuppressed capture must register the transcript as before"

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -216,6 +216,65 @@ def test_append_chapter_renders_blocks_and_records_range(tmp_path):
     ]
 
 
+def test_append_chapter_renders_lead_and_body_as_one_inline_paragraph(tmp_path):
+    """Note-format v2 (#222): lead sentence is inline with its body, not a
+    standalone bold line floating above a blank-line-separated paragraph.
+    """
+    path = _create(tmp_path)
+    chapter = nd.Chapter(
+        blocks=[
+            _block(
+                lead="Chose an append-only note model.",
+                body="We decided the note file is append-only until close.",
+            )
+        ]
+    )
+    nd.append_chapter(path, chapter, slice_from_turn=1, slice_to_turn=10)
+
+    body = strip_frontmatter(path.read_text())
+    assert (
+        "**Chose an append-only note model.** "
+        "We decided the note file is append-only until close."
+    ) in body
+
+
+def test_append_chapter_sets_title_only_on_first_chapter(tmp_path):
+    """Note-format v2 (#222): the LLM never composes a title, so the flush
+    passes a deterministically-derived one; only the first chapter may set
+    it (the placeholder from create_note stands until then).
+    """
+    path = _create(tmp_path, title="lore session — 2026-07-03")
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[_block(lead="First.", anchor=3)]),
+        slice_from_turn=1,
+        slice_to_turn=20,
+        title="lore: Traced the flush race",
+    )
+    fm = parse_frontmatter(path.read_text())
+    assert fm["title"] == "lore: Traced the flush race"
+
+
+def test_append_chapter_title_ignored_after_first_chapter(tmp_path):
+    path = _create(tmp_path, title="lore session — 2026-07-03")
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[_block(lead="First.", anchor=3)]),
+        slice_from_turn=1,
+        slice_to_turn=20,
+        title="lore: Traced the flush race",
+    )
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[_block(lead="Second.", anchor=44)]),
+        slice_from_turn=21,
+        slice_to_turn=60,
+        title="lore: Some later chapter's lead",
+    )
+    fm = parse_frontmatter(path.read_text())
+    assert fm["title"] == "lore: Traced the flush race"
+
+
 def test_append_multiple_chapters_are_chronological_with_ranges(tmp_path):
     path = _create(tmp_path)
     nd.append_chapter(

--- a/tests/test_stub_note.py
+++ b/tests/test_stub_note.py
@@ -22,6 +22,7 @@ from lore_curator.stub_note import (
     _claim_first_write_slot,
     _lead_for_rename,
     _resolve_renamed_path,
+    _topic_title,
     write_or_update,
 )
 
@@ -774,6 +775,20 @@ def test_lead_for_rename_empty_when_no_blocks():
 def test_lead_for_rename_empty_when_first_block_blank():
     chapter = Chapter(blocks=[TopicBlock(lead="   ", body="prose", anchor_turn=1)])
     assert _lead_for_rename(chapter) == ""
+
+
+def test_topic_title_prefixes_scope_before_composed_name():
+    """Note-format v2 (#222): frontmatter title is `scope: name` — scope
+    (the linkage repo/project slug) first, then the composed human name.
+    """
+    chapter = Chapter(
+        blocks=[TopicBlock(lead="Traced the flush race.", body="prose", anchor_turn=2)]
+    )
+    assert _topic_title("proj:x", chapter) == "proj:x: Traced the flush race"
+
+
+def test_topic_title_empty_when_no_lead():
+    assert _topic_title("proj:x", Chapter(blocks=[])) == ""
 
 
 def test_resolve_renamed_path_swaps_slug_keeps_prefix(tmp_path: Path):

--- a/tests/test_workflow_board_parser.py
+++ b/tests/test_workflow_board_parser.py
@@ -1,0 +1,117 @@
+"""Supervision-board comment parser (#223).
+
+The board comment is the durable supervision trail `/orchestrate-epic` edits in
+place. A resumed run must read prior state structurally, not by model-scraping
+the Markdown. This parser is the contract feature #228 will EMIT against: the
+marker, the required columns, and this fixture are that contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lore_workflow import board_parser as mod
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "boards"
+
+WELL_FORMED = (FIXTURES / "well-formed.md").read_text(encoding="utf-8")
+
+
+def test_marker_and_columns_are_exported_contract() -> None:
+    # #228 emits against these constants; keep them importable and stable.
+    assert mod.BOARD_MARKER == "<!-- lore-orchestrate-epic:status v1 -->"
+    assert mod.REQUIRED_COLUMNS == ("Feature", "Issue", "Tier", "Batch", "State", "PR")
+
+
+def test_parses_all_rows() -> None:
+    rows = mod.parse_board(WELL_FORMED)
+    assert len(rows) == 3
+
+
+def test_row_fields_mapped_by_column() -> None:
+    rows = mod.parse_board(WELL_FORMED)
+    first = rows[0]
+    assert first.feature == "Load the config"
+    assert first.issue == "ccatobs/widget#12"
+    assert first.tier == "AFK"
+    assert first.batch == "1"
+    assert first.state == "merged"
+    assert first.pr == "ccatobs/widget#40"
+
+
+def test_placeholder_pr_normalized_to_empty() -> None:
+    rows = mod.parse_board(WELL_FORMED)
+    # em-dash placeholder in the PR column means "no PR yet"
+    assert rows[1].pr == ""
+    assert rows[2].pr == ""
+
+
+def test_resumed_run_can_select_by_state() -> None:
+    rows = mod.parse_board(WELL_FORMED)
+    merged = [r.issue for r in rows if r.state == "merged"]
+    assert merged == ["ccatobs/widget#12"]
+
+
+# --- malformed inputs raise, never silently misread ------------------------
+
+
+def test_missing_marker_raises() -> None:
+    text = WELL_FORMED.replace(mod.BOARD_MARKER, "")
+    with pytest.raises(mod.BoardParseError, match="marker"):
+        mod.parse_board(text)
+
+
+def test_missing_required_column_raises() -> None:
+    text = (
+        f"{mod.BOARD_MARKER}\n\n"
+        "| Feature | Issue | Tier | Batch | PR |\n"
+        "|---|---|---|---|---|\n"
+        "| a | o/r#1 | AFK | 1 | — |\n"
+    )
+    with pytest.raises(mod.BoardParseError, match="State"):
+        mod.parse_board(text)
+
+
+def test_no_table_after_marker_raises() -> None:
+    with pytest.raises(mod.BoardParseError, match="table"):
+        mod.parse_board(f"{mod.BOARD_MARKER}\n\njust prose, no table here\n")
+
+
+def test_malformed_row_raises() -> None:
+    # A data row with too few cells must error, not drop or misalign fields.
+    text = (
+        f"{mod.BOARD_MARKER}\n\n"
+        "| Feature | Issue | Tier | Batch | State | PR |\n"
+        "|---|---|---|---|---|---|\n"
+        "| a | o/r#1 | AFK | 1 | merged |\n"  # missing PR cell
+    )
+    with pytest.raises(mod.BoardParseError, match="cell"):
+        mod.parse_board(text)
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def test_parse_board_cmd_emits_json(capsys) -> None:
+    from lore_cli import workflow_cmd
+
+    rc = workflow_cmd.main(["parse-board", str(FIXTURES / "well-formed.md")])
+    assert rc == 0
+    import json
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [r["issue"] for r in payload["rows"]] == [
+        "ccatobs/widget#12",
+        "ccatobs/widget#13",
+        "ccatobs/widget#14",
+    ]
+
+
+def test_parse_board_cmd_errors_on_malformed(capsys) -> None:
+    from lore_cli import workflow_cmd
+
+    rc = workflow_cmd.main(["parse-board", str(FIXTURES / "missing-marker.md")])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "marker" in err

--- a/tests/test_workflow_cmd.py
+++ b/tests/test_workflow_cmd.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from lore_cli import workflow_cmd
+from lore_core import note_document as nd
+from lore_core.linkage import Linkage
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "roadmaps"
 
@@ -40,3 +43,36 @@ def test_create_prd_writes_file(tmp_path: Path) -> None:
     )
     assert rc == 0
     assert (tmp_path / "docs" / "prd" / "0001-foo.md").exists()
+
+
+def test_seed_lift_prints_json_on_usable_note(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "sessions" / "10-topic.md"
+    nd.create_note(
+        path,
+        title="Seed lift plumbing",
+        description="deterministic seed lift",
+        scope="lore",
+        created="2026-07-10",
+        linkage=Linkage(repo="buchbend/lore", epics=[229]),
+    )
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[nd.TopicBlock(lead="Findings lead.", body="Findings body.")]),
+        slice_from_turn=0,
+        slice_to_turn=5,
+    )
+
+    rc = workflow_cmd.main(["seed-lift", str(path)])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "buchbend/lore" in payload["origin"]
+    assert "Findings body." in payload["findings"]
+    assert payload["source_note"] == str(path)
+
+
+def test_seed_lift_exits_nonzero_when_note_missing(tmp_path: Path, capsys) -> None:
+    rc = workflow_cmd.main(["seed-lift", str(tmp_path / "sessions" / "nope.md")])
+
+    assert rc != 0
+    assert "fall back to freehand" in capsys.readouterr().out

--- a/tests/test_workflow_epic_policy.py
+++ b/tests/test_workflow_epic_policy.py
@@ -1,0 +1,118 @@
+"""Per-repo epic policy: target branch + deploy gate (#223).
+
+`/orchestrate-epic` resolves both facts deterministically at Map time instead
+of guessing deploy semantics. Fixture repos are built in tmp_path: a bare repo
+stands in for `origin`, AGENTS.md carries (or omits) the deploy-gate marker.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from lore_cli import workflow_cmd
+from lore_workflow import epic_policy
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args], cwd=str(root), check=True, capture_output=True, text=True
+    )
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@example.invalid")
+    _git(root, "config", "user.name", "Test")
+    (root / "README.md").write_text("x\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "init")
+
+
+def _add_bare_origin(root: Path, bare: Path, *branches: str) -> None:
+    subprocess.run(
+        ["git", "init", "--bare", str(bare)], check=True, capture_output=True, text=True
+    )
+    _git(root, "remote", "add", "origin", str(bare))
+    _git(root, "push", "origin", "main")
+    for branch in branches:
+        _git(root, "branch", branch)
+        _git(root, "push", "origin", branch)
+
+
+# --- target_branch ---------------------------------------------------------
+
+
+def test_target_main_when_remote_lacks_develop(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _add_bare_origin(repo, tmp_path / "origin.git")
+    assert epic_policy.resolve_epic_policy(repo).target_branch == "main"
+
+
+def test_target_develop_when_present_on_remote(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _add_bare_origin(repo, tmp_path / "origin.git", "develop")
+    assert epic_policy.resolve_epic_policy(repo).target_branch == "develop"
+
+
+def test_target_main_when_no_remote(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)  # no origin configured at all
+    assert epic_policy.resolve_epic_policy(repo).target_branch == "main"
+
+
+def test_target_main_when_not_a_git_repo(tmp_path: Path) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert epic_policy.resolve_epic_policy(plain).target_branch == "main"
+
+
+# --- deploy_gate -----------------------------------------------------------
+
+
+def _agents(root: Path, body: str) -> None:
+    (root / "AGENTS.md").write_text(body, encoding="utf-8")
+
+
+def test_deploy_gate_true_when_marker_in_section(tmp_path: Path) -> None:
+    _agents(
+        tmp_path,
+        "# Repo\n\n## Epic merge policy\n\nepic-merge-policy: confirm\n",
+    )
+    assert epic_policy.resolve_epic_policy(tmp_path).deploy_gate is True
+
+
+def test_deploy_gate_false_when_no_marker(tmp_path: Path) -> None:
+    _agents(tmp_path, "# Repo\n\n## Epic merge policy\n\nMerges are automatic.\n")
+    assert epic_policy.resolve_epic_policy(tmp_path).deploy_gate is False
+
+
+def test_deploy_gate_false_when_no_agents_file(tmp_path: Path) -> None:
+    assert epic_policy.resolve_epic_policy(tmp_path).deploy_gate is False
+
+
+def test_deploy_gate_false_when_marker_outside_section(tmp_path: Path) -> None:
+    # Marker appears, but under a different heading — must not trip the gate.
+    _agents(
+        tmp_path,
+        "# Repo\n\n## Notes\n\nepic-merge-policy: confirm\n\n## Epic merge policy\n\nn/a\n",
+    )
+    assert epic_policy.resolve_epic_policy(tmp_path).deploy_gate is False
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def test_epic_policy_cmd_emits_json(tmp_path: Path, capsys) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _add_bare_origin(repo, tmp_path / "origin.git", "develop")
+    _agents(repo, "## Epic merge policy\n\nepic-merge-policy: confirm\n")
+    rc = workflow_cmd.main(["epic-policy", str(repo)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"target_branch": "develop", "deploy_gate": True}

--- a/tests/test_workflow_roadmap_counts.py
+++ b/tests/test_workflow_roadmap_counts.py
@@ -1,0 +1,65 @@
+"""Machine-readable counts + `--json` output for the roadmap validator (#223).
+
+`/orchestrate-epic` reads roadmap size (feature rows, distinct repos, dependency
+edges) to plan batches; deriving it from validator prose is scraping. These
+counts come straight off the already-parsed rows — no second table parse.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lore_cli import workflow_cmd
+from lore_workflow import roadmap_validator as mod
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "roadmaps"
+
+
+def _counts(name: str) -> mod.RoadmapCounts:
+    return mod.roadmap_counts(mod.validate_roadmap((FIXTURES / name).read_text(encoding="utf-8")))
+
+
+def test_counts_well_formed() -> None:
+    # 3 features, one repo (widget), edges = 0 + 1 + 2 blocked-by tokens.
+    c = _counts("well-formed.md")
+    assert (c.rows, c.repos, c.edges) == (3, 1, 3)
+
+
+def test_counts_cross_repo() -> None:
+    # 3 features across two repos, edges = 0 + 1 + 1.
+    c = _counts("cross-repo.md")
+    assert (c.rows, c.repos, c.edges) == (3, 2, 2)
+
+
+def test_counts_empty_when_columns_bad() -> None:
+    # Wrong columns → no rows parsed → all-zero counts, no crash.
+    c = _counts("malformed-columns.md")
+    assert (c.rows, c.repos, c.edges) == (0, 0, 0)
+
+
+def test_validate_roadmap_json_ok(capsys) -> None:
+    rc = workflow_cmd.main(["validate-roadmap", "--json", str(FIXTURES / "well-formed.md")])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["rows"] == 3
+    assert payload["repos"] == 1
+    assert payload["edges"] == 3
+    assert payload["problems"] == []
+
+
+def test_validate_roadmap_json_invalid(capsys) -> None:
+    rc = workflow_cmd.main(["validate-roadmap", "--json", str(FIXTURES / "cyclic.md")])
+    assert rc != 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["problems"]
+    assert any(p["kind"] == "cycle" for p in payload["problems"])
+
+
+def test_validate_roadmap_human_path_still_works(capsys) -> None:
+    # Without --json the existing human/exit-coded path is unchanged.
+    rc = workflow_cmd.main(["validate-roadmap", str(FIXTURES / "well-formed.md")])
+    assert rc == 0
+    assert "roadmap OK" in capsys.readouterr().out

--- a/tests/test_workflow_seed_epic.py
+++ b/tests/test_workflow_seed_epic.py
@@ -1,0 +1,168 @@
+"""Tests `lore_workflow.seed_epic` — Origin/Findings lift for `/lore-workflow:seed-epic`.
+
+The seed's Origin and Findings sections are lifted straight from the
+current session's note (linkage + chapter body) instead of being
+freehand-reconstructed. `compose_seed_lift` returns `None` — the signal
+callers use to fall back to the existing freehand path — when there's no
+note, or the note is too thin (no linkage provenance and no chapter
+content beyond the disclaimer) to say anything a freehand pass wouldn't.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_core import note_document as nd
+from lore_core.linkage import Linkage
+from lore_workflow.seed_epic import compose_seed_lift
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _note_path(tmp_path: Path) -> Path:
+    return tmp_path / "wiki" / "sessions" / "2026" / "07" / "10-1200-topic.md"
+
+
+def _linkage(**overrides) -> Linkage:
+    kwargs = {
+        "repo": "buchbend/lore",
+        "branch": "feat/226-seed-epic-lift",
+        "issues": [],
+        "prs": [],
+        "epics": [],
+        "author": "",
+    }
+    kwargs.update(overrides)
+    return Linkage(**kwargs)
+
+
+def _note_with_chapter(tmp_path: Path, *, linkage: Linkage | None = None) -> Path:
+    path = _note_path(tmp_path)
+    nd.create_note(
+        path,
+        title="Seed lift plumbing",
+        description="deterministic seed lift",
+        scope="lore",
+        created="2026-07-10",
+        linkage=linkage,
+    )
+    chapter = nd.Chapter(
+        blocks=[
+            nd.TopicBlock(
+                lead="The buffer-flush path drops linkage on marker chapters.",
+                body="Root-caused to `_apply_linkage` never being called from the marker path.",
+                anchor_turn=12,
+            )
+        ]
+    )
+    nd.append_chapter(path, chapter, slice_from_turn=0, slice_to_turn=12, linkage=linkage)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Note-derived path (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_compose_seed_lift_derives_origin_from_linkage(tmp_path: Path) -> None:
+    linkage = _linkage(epics=[229], prs=[235])
+    path = _note_with_chapter(tmp_path, linkage=linkage)
+
+    lift = compose_seed_lift(path)
+
+    assert lift is not None
+    assert "buchbend/lore" in lift.origin
+    assert "#229" in lift.origin
+    assert "#235" in lift.origin
+
+
+def test_compose_seed_lift_derives_findings_from_chapter_body(tmp_path: Path) -> None:
+    linkage = _linkage(epics=[229])
+    path = _note_with_chapter(tmp_path, linkage=linkage)
+
+    lift = compose_seed_lift(path)
+
+    assert lift is not None
+    assert "buffer-flush path drops linkage on marker chapters" in lift.findings
+    assert "_apply_linkage" in lift.findings
+    # Machine-written disclaimer and chapter delimiters are noise for a
+    # human-facing seed, not findings — stripped.
+    assert nd.DISCLAIMER not in lift.findings
+    assert "lore:chapter" not in lift.findings
+
+
+def test_compose_seed_lift_source_note_is_wiki_relative_when_wiki_root_given(
+    tmp_path: Path,
+) -> None:
+    path = _note_with_chapter(tmp_path, linkage=_linkage(epics=[229]))
+    wiki_root = tmp_path / "wiki"
+
+    lift = compose_seed_lift(path, wiki_root=wiki_root)
+
+    assert lift is not None
+    assert lift.source_note == "sessions/2026/07/10-1200-topic.md"
+
+
+def test_compose_seed_lift_source_note_falls_back_to_full_path_without_wiki_root(
+    tmp_path: Path,
+) -> None:
+    path = _note_with_chapter(tmp_path, linkage=_linkage(epics=[229]))
+
+    lift = compose_seed_lift(path)
+
+    assert lift is not None
+    assert lift.source_note == str(path)
+
+
+def test_compose_seed_lift_singular_pr_wording(tmp_path: Path) -> None:
+    path = _note_with_chapter(tmp_path, linkage=_linkage(prs=[100]))
+
+    lift = compose_seed_lift(path)
+
+    assert lift is not None
+    assert "PR #100" in lift.origin
+    assert "PRs #100" not in lift.origin
+
+
+# ---------------------------------------------------------------------------
+# Freehand-fallback path (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_compose_seed_lift_returns_none_when_note_is_missing(tmp_path: Path) -> None:
+    assert compose_seed_lift(tmp_path / "sessions" / "nope.md") is None
+
+
+def test_compose_seed_lift_returns_none_when_note_is_thin(tmp_path: Path) -> None:
+    # A note with no linkage refs and no chapters — just the disclaimer —
+    # carries nothing a freehand pass wouldn't already have.
+    path = _note_path(tmp_path)
+    nd.create_note(
+        path,
+        title="Empty session",
+        description="nothing happened",
+        scope="lore",
+        created="2026-07-10",
+    )
+
+    assert compose_seed_lift(path) is None
+
+
+def test_compose_seed_lift_returns_none_when_only_marker_chapters(tmp_path: Path) -> None:
+    # Withheld/failed marker chapters are procedural bookkeeping, not
+    # findings — a note with only markers and no linkage is still thin.
+    path = _note_path(tmp_path)
+    nd.create_note(
+        path,
+        title="Gate-withheld session",
+        description="publish gate withheld the chapter",
+        scope="lore",
+        created="2026-07-10",
+    )
+    nd.append_marker_chapter(
+        path, kind=nd.MARKER_WITHHELD, reason="quote mismatch", slice_from_turn=0, slice_to_turn=5
+    )
+
+    assert compose_seed_lift(path) is None


### PR DESCRIPTION
## Epic #229 — workflow lightening & deepening on the lore substrate (PRD 0006)

Lands the full roadmap: the lore workflow layer now rides the substrate (deterministic mechanics + composed notes) instead of re-deriving state in skill prose.

### Delivered
- **#222** Note-format v2 — scope-prefixed title (`scope: name`) + inline-bold lede body; documented in `CONTEXT-FORMAT.md`.
- **#223** Workflow mechanics — `lore workflow epic-policy` ({target_branch, deploy_gate}), `validate-roadmap --json` ({rows, repos, edges}), and a deterministic board-comment parser (`parse-board`).
- **#224** Capture-suppress — `LORE_SUPPRESS_CAPTURE=1` makes SessionEnd/PreCompact capture a no-op; default path unchanged.
- **#225** Orient fan-out gate — orient/to-epic pull `lore_context_pack` up front; per-facet explorers spawn only when the pack is thin.
- **#226** seed-epic lift — Origin from note linkage, Findings from note body, freehand fallback; seed records a source-note pointer.
- **#227** Glossary + CONTEXT.md sync + tier-choice review pass (docs-only).
- **#228** Orchestrate-epic diet + **ADR 0002** — skill rewired onto the merged mechanics; supervision board on the issue, working context on one composed epic note; SKILL.md 293→192 lines.

### Quality gate
Each feature: strict TDD, one PR, strong-tier crosscheck (all PASS), squash-merged into `epic/229` in dependency order. Epic-branch CI green.

Closes #222, #223, #224, #225, #226, #227, #228. Part of #229.
