### PR TITLE
docs: epic #229 how-to catch-up (deterministic board + epic note)

### DIFF
--- a/docs/how-to/resume-a-broken-epic.md
+++ b/docs/how-to/resume-a-broken-epic.md
@@ -22,7 +22,11 @@ comment — precisely so a second run heals rather than duplicates.
    a fresh session at the epic and run it exactly as you did the first time.
 2. **It finds the prior run's supervision trail.** It lists the epic issue's
    comments and looks for the status comment carrying its per-feature state
-   table from the earlier run.
+   table from the earlier run. That table is written in a machine-readable
+   format (a marked table with fixed columns), so the resume reads it
+   deterministically with `lore workflow parse-board` rather than
+   re-interpreting it by eye — a malformed board is reported as an error,
+   never silently misread.
 3. **It reconciles against reality.** It compares that table's
    merged / queued / blocked rows against the epic branch's actual state:
    - a feature already merged into `epic/<issue>` is **done** — it is
@@ -34,6 +38,12 @@ comment — precisely so a second run heals rather than duplicates.
 4. **It continues in the same status comment.** It edits that one existing
    comment in place for every further update; a resumed run never opens a
    second status comment.
+
+The board comment carries only the durable per-feature state. The
+orchestrator's own working context — tier decisions, crosscheck verdicts,
+in-flight markers — rides a single composed **epic note** keyed to the epic,
+which the resumed run rehydrates through `lore_context_pack`. So its
+reasoning survives the interruption too, not just the feature checklist.
 
 ## If no prior run is found
 

--- a/docs/how-to/run-an-epic.md
+++ b/docs/how-to/run-an-epic.md
@@ -46,7 +46,10 @@ small, clear change, use the [fast path](use-the-fast-path.md) instead.
   (**HITL**), a crosscheck that keeps failing, or an unresolvable conflict.
 - **Read the run in the supervision trail.** The orchestrator keeps a single
   status comment on the epic issue, updated in place, recording each
-  feature's state and every tier or escalation decision.
+  feature's state in a machine-readable table. Its own working context — the
+  tier and escalation decisions, crosscheck verdicts, in-flight markers —
+  rides a separate composed epic note, so a resumed run rehydrates its
+  reasoning, not just the checklist.
 - **If the run breaks off, resume — do not restart.** See
   [Resume a broken epic](resume-a-broken-epic.md).
 


### PR DESCRIPTION
## Docs catch-up for epic #229

`document-epic` for [#229](https://github.com/buchbend/lore/issues/229) (merged via #238). Classified the cumulative diff through the Diátaxis heuristic:
- **reference** (7 source files) — satisfied in-code: every new public symbol in `epic_policy`, `board_parser`, `seed_epic`, and the extended `roadmap_validator` carries a complete docstring; the repo has no Sphinx autosummary to wire.
- **skip / self-documented** — `CONTEXT.md` glossary (#227), `CONTEXT-FORMAT.md` (#222), `docs/architecture/config.md` (the `LORE_SUPPRESS_CAPTURE` flag, #224), and the `SKILL.md` files (#225/#226/#228) were all updated within the epic.
- **excluded** — ADR 0002 (canonical record, never touched by this skill).

The one genuine staleness the epic introduced: **#228** moved the orchestrator's working context (tier decisions, crosscheck verdicts, in-flight markers) off the board comment onto a composed **epic note**, and made resume read the board **deterministically** via `lore workflow parse-board`. This PR updates the two how-tos that described the old single-comment model:
- `docs/how-to/run-an-epic.md` — supervision trail: board table + separate epic note.
- `docs/how-to/resume-a-broken-epic.md` — deterministic `parse-board` read + epic-note rehydration on resume.

Docs-only. Part of #229.
