### PR TITLE
Writable validated config: lore config get/set/unset/edit

### DIFF
--- a/lib/lore_cli/config_cmd.py
+++ b/lib/lore_cli/config_cmd.py
@@ -1,14 +1,16 @@
-"""`lore config` — read-only view of resolved configuration."""
+"""`lore config` — view and edit resolved configuration."""
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
+import click
 import typer
-from rich.console import Console
-
 from lore_core.config import get_lore_root, get_wiki_root
+from lore_core.config_schema import ConfigSchema
 from lore_core.timefmt import relative_time
+from rich.console import Console
 
 app = typer.Typer(
     add_completion=False,
@@ -41,7 +43,7 @@ def config(ctx: typer.Context) -> None:
         lore_root = get_lore_root()
     except Exception:
         console.print("[red]LORE_ROOT not set.[/red] Run `lore init` or export $LORE_ROOT.")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
     now = datetime.now(UTC)
 
@@ -49,7 +51,9 @@ def config(ctx: typer.Context) -> None:
 
     try:
         wiki_root = get_wiki_root()
-        wikis = sorted(d.name for d in wiki_root.iterdir() if d.is_dir()) if wiki_root.exists() else []
+        wikis = (
+            sorted(d.name for d in wiki_root.iterdir() if d.is_dir()) if wiki_root.exists() else []
+        )
     except Exception:
         wikis = []
 
@@ -61,6 +65,7 @@ def config(ctx: typer.Context) -> None:
     console.print()
 
     from lore_core.state.attachments import AttachmentsFile
+
     af = AttachmentsFile(lore_root)
     af.load()
     attachments = af.all()
@@ -70,8 +75,7 @@ def config(ctx: typer.Context) -> None:
         for a in attachments:
             rel = relative_time(a.attached_at, now=now)
             console.print(
-                f"    {_format_path(a.path):40s} -> {a.wiki}:{a.scope}  "
-                f"({a.source}, {rel})"
+                f"    {_format_path(a.path):40s} -> {a.wiki}:{a.scope}  ({a.source}, {rel})"
             )
     else:
         console.print("  Attachments: [dim]none[/dim]")
@@ -102,8 +106,8 @@ def config(ctx: typer.Context) -> None:
     console.print("  For health checks: [cyan]lore doctor[/cyan]")
     console.print("  For live activity: [cyan]lore status[/cyan]")
     console.print(
-        "  For typed config: [cyan]lore config show[/cyan] · "
-        "[cyan]get[/cyan] · [cyan]set[/cyan] · [cyan]schema[/cyan]"
+        "  For typed config: [cyan]lore config show[/cyan] · [cyan]get[/cyan] · "
+        "[cyan]set[/cyan] · [cyan]unset[/cyan] · [cyan]edit[/cyan] · [cyan]schema[/cyan]"
     )
 
 
@@ -114,6 +118,50 @@ def _format_value(v: object) -> str:
     if isinstance(v, str) and v == "":
         return '""'
     return str(v)
+
+
+def _resolve_target(wiki: str | None) -> tuple[Path, Any, Path, ConfigSchema]:
+    """Return (base_dir, module, cfg_path, schema) for root or ``--wiki`` config.
+
+    ``module`` is ``lore_core.root_config`` or ``lore_core.wiki_config`` —
+    both expose the same ``get_field``/``set_field``/``unset_field``/
+    ``walk_fields`` signatures (thin bindings over ``lore_core.config_schema``).
+    """
+    if wiki is None:
+        from lore_core import root_config as mod
+
+        try:
+            lore_root = get_lore_root()
+        except Exception:
+            console.print("[red]LORE_ROOT not set.[/red] Run `lore init` or export $LORE_ROOT.")
+            raise typer.Exit(1) from None
+        return lore_root, mod, mod.ROOT_SCHEMA.config_path_fn(lore_root), mod.ROOT_SCHEMA
+
+    from lore_core import wiki_config as mod
+
+    wiki_dir = get_wiki_root() / wiki
+    if not wiki_dir.exists():
+        console.print(f"[red]wiki not found:[/red] {wiki}")
+        raise typer.Exit(1)
+    return wiki_dir, mod, mod.WIKI_SCHEMA.config_path_fn(wiki_dir), mod.WIKI_SCHEMA
+
+
+def _build_resolved_table(rows: list):
+    from rich.table import Table
+
+    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+    table.add_column("path", overflow="fold")
+    table.add_column("value")
+    table.add_column("default")
+    table.add_column("from")
+    for r in rows:
+        value_str = _format_value(r.value)
+        default_str = _format_value(r.default)
+        if r.value != r.default:
+            value_str = f"[yellow]{value_str}[/yellow]"
+        source_label = "[green]file[/green]" if r.source == "file" else "[dim]default[/dim]"
+        table.add_row(r.path, value_str, default_str, source_label)
+    return table
 
 
 @app.command("show")
@@ -130,14 +178,13 @@ def cmd_show(
     ),
 ) -> None:
     """Show the resolved typed configuration with provenance."""
-    from rich.table import Table
     from lore_core.root_config import walk_fields
 
     try:
         lore_root = get_lore_root()
     except Exception:
         console.print("[red]LORE_ROOT not set.[/red] Run `lore init` or export $LORE_ROOT.")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
     rows = walk_fields(lore_root)
     if path_filter:
@@ -151,51 +198,44 @@ def cmd_show(
     cfg_path = lore_root / ".lore" / "config.yml"
     console.print(f"  [dim]Source:[/dim] {_format_path(cfg_path)}")
     console.print()
-
-    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
-    table.add_column("path", overflow="fold")
-    table.add_column("value")
-    table.add_column("default")
-    table.add_column("from")
-
-    for r in rows:
-        value_str = _format_value(r.value)
-        default_str = _format_value(r.default)
-        if r.value != r.default:
-            value_str = f"[yellow]{value_str}[/yellow]"
-        source_label = "[green]file[/green]" if r.source == "file" else "[dim]default[/dim]"
-        table.add_row(r.path, value_str, default_str, source_label)
-
-    console.print(table)
+    console.print(_build_resolved_table(rows))
     console.print()
-    console.print(
-        "  [dim]Edit one field:[/dim] "
-        "[cyan]lore config set <path> <value>[/cyan]"
-    )
-    console.print(
-        "  [dim]Show schema:[/dim]    "
-        "[cyan]lore config schema[/cyan]"
-    )
+    console.print("  [dim]Edit one field:[/dim] [cyan]lore config set <path> <value>[/cyan]")
+    console.print("  [dim]Show schema:[/dim]    [cyan]lore config schema[/cyan]")
+
+
+_WIKI_OPTION = typer.Option(
+    None, "--wiki", help="Target a wiki's .lore-wiki.yml instead of the root config."
+)
 
 
 @app.command("get")
 def cmd_get(
-    path: str = typer.Argument(..., help="Dotted config path (e.g. `curator.backend`)."),
+    path: str | None = typer.Argument(
+        None,
+        help="Dotted config path (e.g. `curator.backend`). Omit to show the full "
+        "resolved config with provenance.",
+    ),
+    wiki: str | None = _WIKI_OPTION,
 ) -> None:
-    """Print one config value."""
-    from lore_core.root_config import get_field
+    """Print one config value, or the full resolved config."""
+    base_dir, mod, cfg_path, _schema = _resolve_target(wiki)
+
+    if path is None:
+        rows = mod.walk_fields(base_dir)
+        if not rows:
+            console.print("[dim]no matching fields[/dim]")
+            return
+        console.print(f"  [dim]Source:[/dim] {_format_path(cfg_path)}")
+        console.print()
+        console.print(_build_resolved_table(rows))
+        return
 
     try:
-        lore_root = get_lore_root()
-    except Exception:
-        console.print("[red]LORE_ROOT not set.[/red]")
-        raise typer.Exit(1)
-
-    try:
-        fi = get_field(lore_root, path)
+        fi = mod.get_field(base_dir, path)
     except KeyError as e:
         console.print(f"[red]{e}[/red]")
-        raise typer.Exit(2)
+        raise typer.Exit(2) from None
     console.print(_format_value(fi.value))
 
 
@@ -203,25 +243,23 @@ def cmd_get(
 def cmd_set(
     path: str = typer.Argument(..., help="Dotted config path."),
     value: str = typer.Argument(..., help="New value (parsed against the field's declared type)."),
+    wiki: str | None = _WIKI_OPTION,
 ) -> None:
-    """Persist a typed value to $LORE_ROOT/.lore/config.yml."""
-    from lore_core.root_config import set_field
+    """Persist a typed value to the target config file.
+
+    Validation happens before any write — an unknown path or a value that
+    doesn't parse as the field's declared type leaves the file untouched.
+    """
+    base_dir, mod, cfg_path, _schema = _resolve_target(wiki)
 
     try:
-        lore_root = get_lore_root()
-    except Exception:
-        console.print("[red]LORE_ROOT not set.[/red]")
-        raise typer.Exit(1)
-
-    try:
-        fi = set_field(lore_root, path, value)
+        fi = mod.set_field(base_dir, path, value)
     except KeyError as e:
         console.print(f"[red]{e}[/red]")
-        raise typer.Exit(2)
+        raise typer.Exit(2) from None
     except ValueError as e:
         console.print(f"[red]invalid value: {e}[/red]")
-        raise typer.Exit(2)
-    cfg_path = lore_root / ".lore" / "config.yml"
+        raise typer.Exit(2) from None
     console.print(
         f"  [green]✓[/green] {path} = {_format_value(fi.value)}  "
         f"[dim]→ {_format_path(cfg_path)}[/dim]"
@@ -232,11 +270,75 @@ def cmd_set(
     )
 
 
+@app.command("unset")
+def cmd_unset(
+    path: str = typer.Argument(
+        ..., help="Dotted config path to remove; the field reverts to its default."
+    ),
+    wiki: str | None = _WIKI_OPTION,
+) -> None:
+    """Remove a persisted override so a field reverts to its default."""
+    base_dir, mod, cfg_path, _schema = _resolve_target(wiki)
+
+    try:
+        fi = mod.unset_field(base_dir, path)
+    except KeyError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(2) from None
+    console.print(
+        f"  [green]✓[/green] {path} → default ({_format_value(fi.value)})  "
+        f"[dim]→ {_format_path(cfg_path)}[/dim]"
+    )
+
+
+@app.command("edit")
+def cmd_edit(wiki: str | None = _WIKI_OPTION) -> None:
+    """Open $EDITOR on the target config file; validates on close.
+
+    Refuses to save an invalid result — offers to re-edit or abort (which
+    reverts the file to its pre-edit content).
+    """
+    import yaml
+    from lore_core.config_schema import validate_raw
+
+    _base_dir, _mod, cfg_path, schema = _resolve_target(wiki)
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    if not cfg_path.exists():
+        cfg_path.write_text("")
+    original = cfg_path.read_text()
+
+    while True:
+        click.edit(filename=str(cfg_path))
+        edited = cfg_path.read_text()
+        if edited == original:
+            console.print("[dim]no changes[/dim]")
+            return
+
+        try:
+            raw = yaml.safe_load(edited) or {}
+        except yaml.YAMLError as e:
+            errors = [f"malformed YAML: {e}"]
+        else:
+            errors = validate_raw(schema.default_factory, raw)
+
+        if not errors:
+            console.print(f"  [green]✓[/green] saved [dim]→ {_format_path(cfg_path)}[/dim]")
+            return
+
+        console.print("[red]invalid config:[/red]")
+        for err in errors:
+            console.print(f"  - {err}")
+        if not typer.confirm("Re-edit?", default=True):
+            cfg_path.write_text(original)
+            console.print("[yellow]reverted[/yellow]")
+            raise typer.Exit(2)
+
+
 @app.command("schema")
 def cmd_schema() -> None:
     """Print the full RootConfig schema (paths, types, defaults)."""
-    from rich.table import Table
     from lore_core.root_config import schema_tree
+    from rich.table import Table
 
     table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
     table.add_column("path", overflow="fold")
@@ -249,7 +351,7 @@ def cmd_schema() -> None:
     console.print()
     console.print(
         "  [dim]This is the full set of typed fields stored in[/dim] "
-        f"[cyan]$LORE_ROOT/.lore/config.yml[/cyan]."
+        "[cyan]$LORE_ROOT/.lore/config.yml[/cyan]."
     )
     console.print(
         "  [dim]Credentials live in[/dim] [cyan]$LORE_ROOT/.lore/secrets.env[/cyan] "

--- a/lib/lore_core/config_schema.py
+++ b/lib/lore_core/config_schema.py
@@ -1,0 +1,349 @@
+"""Generic dataclass-schema validation over YAML-backed config files.
+
+Shared plumbing behind `lore config get/set/unset/edit` for both
+`RootConfig` (`root_config.py`) and `WikiConfig` (`wiki_config.py`).
+Everything here is generic over "some dataclass tree, loaded from
+some YAML file under some base dir" via :class:`ConfigSchema` — a
+future slice reuses `validate_raw`/`suggest` for `.lore.yml` offer
+validation without needing a third copy of this logic.
+"""
+
+from __future__ import annotations
+
+import difflib
+from collections.abc import Callable
+from dataclasses import dataclass, fields, is_dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class FieldInfo:
+    """One leaf field in a resolved config tree. See `walk_fields`."""
+
+    path: str
+    value: Any
+    default: Any
+    type_name: str
+    doc: str
+    source: str  # "file" | "default"
+
+
+@dataclass
+class ConfigSchema:
+    """Binds a dataclass config type to its on-disk file and loader.
+
+    ``load_fn`` is the existing lenient loader (warns on unknown
+    keys/malformed YAML, never raises) — reused here for read paths.
+    ``config_path_fn`` maps the base dir (lore_root or wiki_dir) to
+    the YAML file path.
+    """
+
+    default_factory: Callable[[], Any]
+    load_fn: Callable[[Path], Any]
+    config_path_fn: Callable[[Path], Path]
+
+
+def suggest(dotted_path: str, valid_paths: list[str], n: int = 3) -> list[str]:
+    """Nearest valid dotted paths to `dotted_path`, closest first."""
+    return difflib.get_close_matches(dotted_path, valid_paths, n=n)
+
+
+def _doc_for(parent_cls: type, field_name: str) -> str:
+    raw = (parent_cls.__doc__ or "").strip()
+    if not raw or raw.startswith(f"{parent_cls.__name__}("):
+        return ""
+    return raw.splitlines()[0].strip()
+
+
+def _navigate(obj: Any, parts: list[str]) -> Any:
+    cur = obj
+    for p in parts:
+        if not is_dataclass(cur):
+            raise KeyError(f"path enters a non-dataclass at {p!r}")
+        if p not in {f.name for f in fields(cur)}:
+            raise KeyError(p)
+        cur = getattr(cur, p)
+    return cur
+
+
+def _coerce_value(raw: str, target_type: type) -> Any:
+    """Coerce a CLI string to a field's declared type.
+
+    Strict — refuses values that don't parse cleanly. ``bool`` accepts
+    the usual on/off/yes/no/true/false/0/1 spellings (case-insensitive).
+    """
+    if target_type is bool:
+        s = raw.strip().lower()
+        if s in {"true", "yes", "on", "1"}:
+            return True
+        if s in {"false", "no", "off", "0"}:
+            return False
+        raise ValueError(f"cannot parse {raw!r} as bool")
+    if target_type is int:
+        try:
+            return int(raw)
+        except ValueError:
+            raise ValueError(f"cannot parse {raw!r} as int") from None
+    if target_type is float:
+        try:
+            return float(raw)
+        except ValueError:
+            raise ValueError(f"cannot parse {raw!r} as float") from None
+    if target_type is str:
+        return raw
+    raise ValueError(
+        f"unsupported type {target_type.__name__!r} — only bool/int/float/str "
+        f"are settable from the CLI today"
+    )
+
+
+def _all_leaf_paths(obj: Any, prefix: str = "") -> list[str]:
+    out: list[str] = []
+    for f in fields(obj):
+        path = f.name if not prefix else f"{prefix}.{f.name}"
+        value = getattr(obj, f.name)
+        if is_dataclass(value):
+            out.extend(_all_leaf_paths(value, path))
+        else:
+            out.append(path)
+    return out
+
+
+def _unknown_path_error(schema: ConfigSchema, dotted_path: str) -> str:
+    valid = _all_leaf_paths(schema.default_factory())
+    hint = suggest(dotted_path, valid)
+    msg = f"unknown config path: {dotted_path}"
+    if hint:
+        msg += f" — did you mean: {', '.join(hint)}?"
+    return msg
+
+
+def _walk(obj: Any, prefix: str, raw_at_path: dict | None, defaults_obj: Any) -> list[FieldInfo]:
+    out: list[FieldInfo] = []
+    cls = type(obj)
+    for f in fields(obj):
+        path = f.name if not prefix else f"{prefix}.{f.name}"
+        value = getattr(obj, f.name)
+        default_value = getattr(defaults_obj, f.name)
+        if is_dataclass(value):
+            sub_raw = None
+            if isinstance(raw_at_path, dict) and isinstance(raw_at_path.get(f.name), dict):
+                sub_raw = raw_at_path[f.name]
+            out.extend(_walk(value, path, sub_raw, default_value))
+            continue
+        present_in_file = bool(isinstance(raw_at_path, dict) and f.name in raw_at_path)
+        out.append(
+            FieldInfo(
+                path=path,
+                value=value,
+                default=default_value,
+                type_name=type(value).__name__,
+                doc=_doc_for(cls, f.name),
+                source="file" if present_in_file else "default",
+            )
+        )
+    return out
+
+
+def _read_raw(cfg_path: Path) -> dict:
+    if not cfg_path.exists():
+        return {}
+    try:
+        parsed = yaml.safe_load(cfg_path.read_text())
+    except yaml.YAMLError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def walk_fields(schema: ConfigSchema, base_dir: Path) -> list[FieldInfo]:
+    """Yield FieldInfo for every leaf in the resolved config tree."""
+    cfg = schema.load_fn(base_dir)
+    raw = _read_raw(schema.config_path_fn(base_dir))
+    return _walk(cfg, "", raw, schema.default_factory())
+
+
+def get_field(schema: ConfigSchema, base_dir: Path, dotted_path: str) -> FieldInfo:
+    """Resolve one dotted path to a FieldInfo. Raises KeyError if absent."""
+    parts = dotted_path.split(".")
+    if not parts or not all(parts):
+        raise KeyError(dotted_path)
+    for fi in walk_fields(schema, base_dir):
+        if fi.path == dotted_path:
+            return fi
+    cfg = schema.load_fn(base_dir)
+    try:
+        target = _navigate(cfg, parts)
+    except KeyError:
+        raise KeyError(_unknown_path_error(schema, dotted_path)) from None
+    if is_dataclass(target):
+        raise KeyError(f"{dotted_path!r} is a config group, not a leaf — try one of its fields")
+    raise KeyError(_unknown_path_error(schema, dotted_path))
+
+
+def set_field(schema: ConfigSchema, base_dir: Path, dotted_path: str, raw_value: str) -> FieldInfo:
+    """Persist a value to the schema's config file.
+
+    Validates ``dotted_path`` and coerces ``raw_value`` to the field's
+    declared type *before* touching the file — an unknown path or bad
+    type leaves the file on disk unchanged. Raises ``KeyError`` for
+    unknown paths, ``ValueError`` for type mismatches.
+    """
+    parts = dotted_path.split(".")
+    if not parts or not all(parts):
+        raise KeyError(dotted_path)
+    cfg = schema.load_fn(base_dir)
+    parent = _navigate(cfg, parts[:-1])
+    if not is_dataclass(parent):
+        raise KeyError(f"path enters a non-dataclass at {parts[-2]!r}")
+    field_map = {f.name: f for f in fields(type(parent))}
+    if parts[-1] not in field_map:
+        raise KeyError(_unknown_path_error(schema, dotted_path))
+    field_def = field_map[parts[-1]]
+    target_type = (
+        field_def.type if isinstance(field_def.type, type) else type(getattr(parent, parts[-1]))
+    )
+    coerced = _coerce_value(raw_value, target_type)
+
+    cfg_path = schema.config_path_fn(base_dir)
+    raw: dict[str, Any] = {}
+    if cfg_path.exists():
+        try:
+            parsed = yaml.safe_load(cfg_path.read_text())
+            if isinstance(parsed, dict):
+                raw = parsed
+        except yaml.YAMLError as exc:
+            raise RuntimeError(f"cannot parse {cfg_path}: {exc}") from exc
+    cur = raw
+    for p in parts[:-1]:
+        nxt = cur.get(p)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            cur[p] = nxt
+        cur = nxt
+    cur[parts[-1]] = coerced
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    return get_field(schema, base_dir, dotted_path)
+
+
+def unset_field(schema: ConfigSchema, base_dir: Path, dotted_path: str) -> FieldInfo:
+    """Remove a persisted override so the field reverts to its default.
+
+    Validates the path against the schema first — an unknown path
+    raises ``KeyError`` and leaves the file untouched. A path that
+    resolves but isn't currently overridden is a no-op (already at
+    default). Prunes parent mappings left empty by the removal.
+    """
+    parts = dotted_path.split(".")
+    fi = get_field(schema, base_dir, dotted_path)  # validates + suggests
+
+    cfg_path = schema.config_path_fn(base_dir)
+    if not cfg_path.exists():
+        return fi
+    raw = _read_raw(cfg_path)
+    cur = raw
+    chain: list[tuple[dict, str]] = []
+    for p in parts[:-1]:
+        nxt = cur.get(p)
+        if not isinstance(nxt, dict):
+            return fi  # not present anywhere along the path — no-op
+        chain.append((cur, p))
+        cur = nxt
+    if parts[-1] not in cur:
+        return fi  # no-op — already at default
+    del cur[parts[-1]]
+    for parent, key in reversed(chain):
+        if not parent[key]:
+            del parent[key]
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False) if raw else "")
+    return get_field(schema, base_dir, dotted_path)
+
+
+def schema_tree(schema: ConfigSchema) -> list[tuple[str, str, Any, str]]:
+    """[(dotted_path, type_name, default, group_doc), ...] — pure introspection."""
+    cfg = schema.default_factory()
+    rows: list[tuple[str, str, Any, str]] = []
+
+    def visit(obj: Any, prefix: str) -> None:
+        for f in fields(obj):
+            path = f.name if not prefix else f"{prefix}.{f.name}"
+            value = getattr(obj, f.name)
+            if is_dataclass(value):
+                visit(value, path)
+                continue
+            rows.append((path, type(value).__name__, value, _doc_for(type(obj), f.name)))
+
+    visit(cfg, "")
+    return rows
+
+
+def validate_raw(dataclass_type: type, raw: Any) -> list[str]:
+    """Strict validation for a parsed-YAML mapping against a dataclass tree.
+
+    Unlike the lenient loaders (which warn and fall back to defaults),
+    this returns every problem found — empty list means valid. Used by
+    ``lore config edit`` to refuse saving a broken file, and reusable
+    by any future writer that needs the same schema for a raw mapping.
+
+    Walks a *default instance* rather than field annotations: every
+    `*_config.py` module here uses ``from __future__ import annotations``,
+    so ``Field.type`` is a string, not a type object — the existing
+    ``set_field``/``_navigate`` code already works around this by
+    reading the type off a live default value instead, and this
+    follows the same pattern.
+    """
+    if not isinstance(raw, dict):
+        return [f"top-level must be a mapping, got {type(raw).__name__}"]
+
+    default_root = dataclass_type()
+    valid_paths = _all_leaf_paths(default_root)
+    errors: list[str] = []
+
+    def walk(obj: dict, prefix: str, default_node: Any) -> None:
+        field_names = {f.name for f in fields(default_node)}
+        for key, value in obj.items():
+            path = f"{prefix}.{key}" if prefix else key
+            if key not in field_names:
+                hint = suggest(path, valid_paths)
+                msg = f"unknown config path: {path!r}"
+                if hint:
+                    msg += f" — did you mean: {', '.join(hint)}?"
+                errors.append(msg)
+                continue
+            default_value = getattr(default_node, key)
+            if is_dataclass(default_value):
+                if isinstance(value, dict):
+                    walk(value, path, default_value)
+                else:
+                    errors.append(f"{path!r} expects a mapping, got {type(value).__name__}")
+                continue
+            errors.extend(_type_errors(path, type(default_value), value))
+
+    walk(raw, "", default_root)
+    return errors
+
+
+def _type_errors(path: str, expected_type: type, value: Any) -> list[str]:
+    """Type-check one leaf value against its declared type. bool/int are
+    kept distinct (bool is an int subclass in Python)."""
+    got = type(value).__name__
+
+    def _mismatch(expected_name: str) -> list[str]:
+        return [f"{path!r} expects {expected_name}, got {got}"]
+
+    if expected_type is bool:
+        return [] if isinstance(value, bool) else _mismatch("bool")
+    if expected_type in (int, float):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return _mismatch(expected_type.__name__)
+        return []
+    if expected_type is str:
+        return [] if isinstance(value, str) else _mismatch("str")
+    if expected_type is list:
+        return [] if isinstance(value, list) else _mismatch("list")
+    if expected_type is dict:
+        return [] if isinstance(value, dict) else _mismatch("dict")
+    return []

--- a/lib/lore_core/root_config.py
+++ b/lib/lore_core/root_config.py
@@ -14,6 +14,13 @@ from typing import Any
 
 import yaml
 
+from lore_core.config_schema import ConfigSchema, FieldInfo
+from lore_core.config_schema import get_field as _cs_get_field
+from lore_core.config_schema import schema_tree as _cs_schema_tree
+from lore_core.config_schema import set_field as _cs_set_field
+from lore_core.config_schema import unset_field as _cs_unset_field
+from lore_core.config_schema import walk_fields as _cs_walk_fields
+
 
 @dataclass
 class HookEventsConfig:
@@ -170,234 +177,48 @@ def load_root_config(lore_root: Path) -> RootConfig:
 
 
 # ---------------------------------------------------------------------------
-# Introspection helpers — backing `lore config show / get / set / schema`.
+# Introspection helpers — backing `lore config show / get / set / unset /
+# schema`. Thin bindings over lore_core.config_schema's generic dataclass
+# walker; see that module's docstring for why it's generic (wiki config and
+# a future `.lore.yml` offer-validation slice share the same plumbing).
 # ---------------------------------------------------------------------------
 
-
-@dataclass
-class FieldInfo:
-    """One leaf field in the resolved RootConfig tree.
-
-    Used by ``walk_fields`` and the ``lore config`` subcommands. ``source``
-    is one of ``"file"`` (present in the loaded YAML) or ``"default"``
-    (using the dataclass default). Env-var overrides are deliberately not
-    chased here — the per-call resolvers (e.g. ``_resolve_backend``)
-    interpret env vars and would require duplicating their logic to
-    surface them as a field source. The docstrings on each *Config
-    dataclass already document the env-var override for that field.
-    """
-
-    path: str
-    value: Any
-    default: Any
-    type_name: str
-    doc: str
-    source: str
+ROOT_SCHEMA = ConfigSchema(
+    default_factory=RootConfig,
+    load_fn=load_root_config,
+    config_path_fn=lambda lore_root: lore_root / ".lore" / "config.yml",
+)
 
 
-def _doc_for(parent_cls: type, field_name: str) -> str:
-    """Best-effort one-line docstring for a field.
-
-    Strategy: take the parent dataclass docstring if any (covers
-    nested-config groups), trimmed to one line. Field-level docs live
-    as inline ``# ...`` comments on the dataclass body which Python
-    introspection can't reach without source parsing — out of scope
-    here. Callers that need richer descriptions read the source file.
-
-    Filters out the dataclass auto-generated ``Cls(field: type = ...,)``
-    signature that appears when no explicit docstring is set.
-    """
-    raw = (parent_cls.__doc__ or "").strip()
-    if not raw:
-        return ""
-    # Auto-generated signature strings start with "<ClassName>(".
-    if raw.startswith(f"{parent_cls.__name__}("):
-        return ""
-    return raw.splitlines()[0].strip()
-
-
-def _walk(
-    obj: Any, prefix: str, raw_at_path: dict | None, defaults_obj: Any
-) -> "list[FieldInfo]":
-    out: list[FieldInfo] = []
-    cls = type(obj)
-    for f in fields(obj):
-        path = f.name if not prefix else f"{prefix}.{f.name}"
-        value = getattr(obj, f.name)
-        default_value = getattr(defaults_obj, f.name)
-        if is_dataclass(value):
-            sub_raw = None
-            if isinstance(raw_at_path, dict) and isinstance(raw_at_path.get(f.name), dict):
-                sub_raw = raw_at_path[f.name]
-            out.extend(_walk(value, path, sub_raw, default_value))
-            continue
-        present_in_file = bool(
-            isinstance(raw_at_path, dict) and f.name in raw_at_path
-        )
-        out.append(
-            FieldInfo(
-                path=path,
-                value=value,
-                default=default_value,
-                type_name=type(value).__name__,
-                doc=_doc_for(cls, f.name),
-                source="file" if present_in_file else "default",
-            )
-        )
-    return out
-
-
-def walk_fields(lore_root: Path) -> "list[FieldInfo]":
-    """Yield FieldInfo for every leaf in the resolved RootConfig.
-
-    Reads ``$LORE_ROOT/.lore/config.yml`` (if present) to mark which
-    fields were explicitly set vs. defaulted. Result is suitable for
-    rendering by ``lore config show``.
-    """
-    cfg = load_root_config(lore_root)
-    path = lore_root / ".lore" / "config.yml"
-    raw: dict | None = None
-    if path.exists():
-        try:
-            parsed = yaml.safe_load(path.read_text())
-            if isinstance(parsed, dict):
-                raw = parsed
-        except yaml.YAMLError:
-            raw = None
-    return _walk(cfg, "", raw, RootConfig())
-
-
-def _navigate(obj: Any, parts: list[str]) -> Any:
-    cur = obj
-    for p in parts:
-        if not is_dataclass(cur):
-            raise KeyError(f"path enters a non-dataclass at {p!r}")
-        if p not in {f.name for f in fields(cur)}:
-            raise KeyError(p)
-        cur = getattr(cur, p)
-    return cur
+def walk_fields(lore_root: Path) -> list[FieldInfo]:
+    """Yield FieldInfo for every leaf in the resolved RootConfig."""
+    return _cs_walk_fields(ROOT_SCHEMA, lore_root)
 
 
 def get_field(lore_root: Path, dotted_path: str) -> FieldInfo:
     """Resolve one dotted path to a FieldInfo. Raises KeyError if absent."""
-    parts = dotted_path.split(".")
-    if not parts or not all(parts):
-        raise KeyError(dotted_path)
-    for fi in walk_fields(lore_root):
-        if fi.path == dotted_path:
-            return fi
-    # Try to give a useful error: did the path navigate into the schema
-    # but stop at a dataclass (i.e. a group rather than a leaf)?
-    cfg = load_root_config(lore_root)
-    try:
-        target = _navigate(cfg, parts)
-    except KeyError:
-        raise KeyError(f"unknown config path: {dotted_path}") from None
-    if is_dataclass(target):
-        raise KeyError(
-            f"{dotted_path!r} is a config group, not a leaf — "
-            f"try one of its fields"
-        )
-    raise KeyError(f"unknown config path: {dotted_path}")
-
-
-def _coerce_value(raw: str, target_type: type) -> Any:
-    """Coerce a CLI string to the dataclass field's expected type.
-
-    Strict — refuses to set a typed field with a value that doesn't
-    parse cleanly. ``bool`` accepts the usual on/off/yes/no/true/false/0/1
-    spellings (case-insensitive); ``int`` and ``float`` use Python
-    parsers; ``str`` is pass-through.
-    """
-    if target_type is bool:
-        s = raw.strip().lower()
-        if s in {"true", "yes", "on", "1"}:
-            return True
-        if s in {"false", "no", "off", "0"}:
-            return False
-        raise ValueError(f"cannot parse {raw!r} as bool")
-    if target_type is int:
-        return int(raw)
-    if target_type is float:
-        return float(raw)
-    if target_type is str:
-        return raw
-    raise ValueError(
-        f"unsupported type {target_type.__name__!r} — only bool/int/float/str "
-        f"are settable from the CLI today"
-    )
+    return _cs_get_field(ROOT_SCHEMA, lore_root, dotted_path)
 
 
 def set_field(lore_root: Path, dotted_path: str, raw_value: str) -> FieldInfo:
     """Persist a value to ``$LORE_ROOT/.lore/config.yml``.
 
     Validates ``dotted_path`` against the schema and coerces
-    ``raw_value`` to the field's declared type before writing.
-    Existing file content is preserved at the YAML node level (other
-    keys untouched), but inline comments may be lost — PyYAML doesn't
-    round-trip them. Returns the FieldInfo for the updated value.
-
+    ``raw_value`` to the field's declared type before writing — an
+    unknown path or bad value leaves the file on disk unchanged.
     Raises ``KeyError`` for unknown paths and ``ValueError`` for type
-    mismatches (the underlying ``_coerce_value`` failure surfaces with
-    its message).
+    mismatches.
     """
-    parts = dotted_path.split(".")
-    if not parts or not all(parts):
-        raise KeyError(dotted_path)
-    # Validate the path resolves to a dataclass leaf.
-    cfg = load_root_config(lore_root)
-    parent = _navigate(cfg, parts[:-1])
-    if not is_dataclass(parent):
-        raise KeyError(f"path enters a non-dataclass at {parts[-2]!r}")
-    parent_cls = type(parent)
-    field_map = {f.name: f for f in fields(parent_cls)}
-    if parts[-1] not in field_map:
-        raise KeyError(f"unknown config path: {dotted_path}")
-    field_def = field_map[parts[-1]]
-    coerced = _coerce_value(raw_value, field_def.type if isinstance(field_def.type, type) else type(getattr(parent, parts[-1])))
-    # Read existing YAML, mutate the nested dict, write back. Missing
-    # parents are created on demand.
-    cfg_path = lore_root / ".lore" / "config.yml"
-    raw: dict[str, Any] = {}
-    if cfg_path.exists():
-        try:
-            parsed = yaml.safe_load(cfg_path.read_text())
-            if isinstance(parsed, dict):
-                raw = parsed
-        except yaml.YAMLError as exc:
-            raise RuntimeError(f"cannot parse {cfg_path}: {exc}") from exc
-    cur = raw
-    for p in parts[:-1]:
-        nxt = cur.get(p)
-        if not isinstance(nxt, dict):
-            nxt = {}
-            cur[p] = nxt
-        cur = nxt
-    cur[parts[-1]] = coerced
-    cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
-    return get_field(lore_root, dotted_path)
+    return _cs_set_field(ROOT_SCHEMA, lore_root, dotted_path, raw_value)
 
 
-def schema_tree() -> "list[tuple[str, str, Any, str]]":
+def unset_field(lore_root: Path, dotted_path: str) -> FieldInfo:
+    """Remove a persisted override so the field reverts to its default."""
+    return _cs_unset_field(ROOT_SCHEMA, lore_root, dotted_path)
+
+
+def schema_tree() -> list[tuple[str, str, Any, str]]:
     """Return [(dotted_path, type_name, default, group_doc), ...] for the
     full RootConfig schema. Pure introspection — no IO.
-
-    Group docstrings appear once per group with empty path-prefix
-    semantics: the leaf rows carry the closest enclosing group's
-    docstring as their `group_doc`. Suitable for ``lore config schema``.
     """
-    cfg = RootConfig()
-    rows: list[tuple[str, str, Any, str]] = []
-
-    def visit(obj: Any, prefix: str) -> None:
-        for f in fields(obj):
-            path = f.name if not prefix else f"{prefix}.{f.name}"
-            value = getattr(obj, f.name)
-            if is_dataclass(value):
-                visit(value, path)
-                continue
-            rows.append((path, type(value).__name__, value, _doc_for(type(obj), f.name)))
-
-    visit(cfg, "")
-    return rows
+    return _cs_schema_tree(ROOT_SCHEMA)

--- a/lib/lore_core/wiki_config.py
+++ b/lib/lore_core/wiki_config.py
@@ -9,6 +9,13 @@ from typing import Any
 
 import yaml
 
+from lore_core.config_schema import ConfigSchema, FieldInfo
+from lore_core.config_schema import get_field as _cs_get_field
+from lore_core.config_schema import schema_tree as _cs_schema_tree
+from lore_core.config_schema import set_field as _cs_set_field
+from lore_core.config_schema import unset_field as _cs_unset_field
+from lore_core.config_schema import walk_fields as _cs_walk_fields
+
 
 @dataclass
 class GitConfig:
@@ -27,7 +34,7 @@ class CuratorConfig:
     # _merge's unknown-key path and emit a deprecation warning.
     threshold_pending_turns: int = 30
     max_pending_age_s: int = 600
-    a_noteworthy_tier: str = "middle"    # middle | simple
+    a_noteworthy_tier: str = "middle"  # middle | simple
     curator_a_cooldown_s: int = 60
     # Buffer-and-flush curator (per the very-good-thats-the-mossy-lobster plan).
     # All knobs land here so a wiki using a low-capacity local LLM can shrink
@@ -37,23 +44,23 @@ class CuratorConfig:
     synthesis_buffer_cap_turns: int = 120
     synthesis_buffer_cap_chars: int = 240_000
     synthesis_flush_timeout_s: int = 25
-    synthesis_model_tier: str = "middle"   # resolves via models.<tier>
+    synthesis_model_tier: str = "middle"  # resolves via models.<tier>
     reaper_max_per_pass: int = 5
     buffer_done_retention_days: int = 14
-    liveness_stale_threshold_s: int = 1800   # 30 min
+    liveness_stale_threshold_s: int = 1800  # 30 min
 
 
 @dataclass
 class ModelsConfig:
     simple: str = "claude-haiku-4-5"
     middle: str = "claude-sonnet-4-6"
-    high: str = "claude-opus-4-7"         # or "off"
+    high: str = "claude-opus-4-7"  # or "off"
 
 
 @dataclass
 class BriefingConfig:
     auto: bool = True
-    audience: str = "personal"            # personal | team
+    audience: str = "personal"  # personal | team
     sinks: list[str] = field(default_factory=list)
 
 
@@ -61,11 +68,12 @@ class BriefingConfig:
 class HeartbeatConfig:
     enabled: bool = True
     cooldown_s: int = 120
-    push_context: bool = True             # inject additionalContext with wikilinks
+    push_context: bool = True  # inject additionalContext with wikilinks
+
 
 @dataclass
 class BreadcrumbConfig:
-    mode: str = "normal"                  # quiet | normal | verbose
+    mode: str = "normal"  # quiet | normal | verbose
     scope_filter: bool = True
 
 
@@ -124,3 +132,48 @@ def _merge(default_obj, overrides: dict[str, Any], source: Path):
         else:
             setattr(default_obj, key, val)
     return default_obj
+
+
+# ---------------------------------------------------------------------------
+# Introspection helpers — backing `lore config get/set/unset/edit --wiki`.
+# Thin bindings over lore_core.config_schema's generic dataclass walker;
+# mirrors root_config.py's bindings for the vault-root config file.
+# ---------------------------------------------------------------------------
+
+WIKI_SCHEMA = ConfigSchema(
+    default_factory=WikiConfig,
+    load_fn=load_wiki_config,
+    config_path_fn=lambda wiki_dir: wiki_dir / ".lore-wiki.yml",
+)
+
+
+def walk_fields(wiki_dir: Path) -> list[FieldInfo]:
+    """Yield FieldInfo for every leaf in the resolved WikiConfig."""
+    return _cs_walk_fields(WIKI_SCHEMA, wiki_dir)
+
+
+def get_field(wiki_dir: Path, dotted_path: str) -> FieldInfo:
+    """Resolve one dotted path to a FieldInfo. Raises KeyError if absent."""
+    return _cs_get_field(WIKI_SCHEMA, wiki_dir, dotted_path)
+
+
+def set_field(wiki_dir: Path, dotted_path: str, raw_value: str) -> FieldInfo:
+    """Persist a value to ``<wiki_dir>/.lore-wiki.yml``.
+
+    Validates ``dotted_path`` against the schema and coerces
+    ``raw_value`` to the field's declared type before writing — an
+    unknown path or bad value leaves the file on disk unchanged.
+    """
+    return _cs_set_field(WIKI_SCHEMA, wiki_dir, dotted_path, raw_value)
+
+
+def unset_field(wiki_dir: Path, dotted_path: str) -> FieldInfo:
+    """Remove a persisted override so the field reverts to its default."""
+    return _cs_unset_field(WIKI_SCHEMA, wiki_dir, dotted_path)
+
+
+def schema_tree() -> list[tuple[str, str, Any, str]]:
+    """Return [(dotted_path, type_name, default, group_doc), ...] for the
+    full WikiConfig schema. Pure introspection — no IO.
+    """
+    return _cs_schema_tree(WIKI_SCHEMA)

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -1,0 +1,219 @@
+"""Tests for `lore config get/set/unset/edit` — writable, validated config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from lore_cli.config_cmd import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _wiki_dir(lore_root: Path, name: str = "private") -> Path:
+    d = lore_root / "wiki" / name
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+def test_get_single_key_root(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    result = runner.invoke(app, ["get", "journal.enabled"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    assert "false" in result.output
+
+
+def test_get_no_path_shows_resolved_with_provenance(tmp_path: Path, monkeypatch):
+    (tmp_path / ".lore").mkdir()
+    (tmp_path / ".lore" / "config.yml").write_text("journal:\n  enabled: true\n")
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    result = runner.invoke(app, ["get"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    assert "journal.enabled" in result.output
+    assert "true" in result.output
+
+
+def test_get_single_key_wiki(tmp_path: Path, monkeypatch):
+    wiki_dir = _wiki_dir(tmp_path)
+    (wiki_dir / ".lore-wiki.yml").write_text("git:\n  auto_push: true\n")
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    result = runner.invoke(
+        app, ["get", "git.auto_push", "--wiki", "private"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert "true" in result.output
+
+
+def test_get_unknown_wiki_errors(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    result = runner.invoke(app, ["get", "git.auto_push", "--wiki", "nope"], catch_exceptions=False)
+    assert result.exit_code != 0
+    assert "nope" in result.output
+
+
+# ---------------------------------------------------------------------------
+# set
+# ---------------------------------------------------------------------------
+
+
+def test_set_root_persists(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    result = runner.invoke(app, ["set", "journal.enabled", "true"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    cfg = yaml.safe_load((tmp_path / ".lore" / "config.yml").read_text())
+    assert cfg["journal"]["enabled"] is True
+
+
+def test_set_wiki_persists(tmp_path: Path, monkeypatch):
+    wiki_dir = _wiki_dir(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    result = runner.invoke(
+        app, ["set", "git.auto_push", "true", "--wiki", "private"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    cfg = yaml.safe_load((wiki_dir / ".lore-wiki.yml").read_text())
+    assert cfg["git"]["auto_push"] is True
+
+
+def test_set_unknown_key_rejected_names_suggestion_and_leaves_file_unchanged(
+    tmp_path: Path, monkeypatch
+):
+    (tmp_path / ".lore").mkdir()
+    cfg_path = tmp_path / ".lore" / "config.yml"
+    cfg_path.write_text("journal:\n  enabled: true\n")
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    before = cfg_path.read_text()
+    result = runner.invoke(app, ["set", "journal.enabld", "true"], catch_exceptions=False)
+    assert result.exit_code != 0
+    assert "journal.enabled" in result.output  # named alternative
+    assert cfg_path.read_text() == before
+
+
+def test_set_invalid_value_rejected_names_type_and_leaves_file_unchanged(
+    tmp_path: Path, monkeypatch
+):
+    (tmp_path / ".lore").mkdir()
+    cfg_path = tmp_path / ".lore" / "config.yml"
+    cfg_path.write_text("journal:\n  enabled: true\n")
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    before = cfg_path.read_text()
+    result = runner.invoke(app, ["set", "journal.enabled", "notabool"], catch_exceptions=False)
+    assert result.exit_code != 0
+    assert "bool" in result.output
+    assert cfg_path.read_text() == before
+
+
+# ---------------------------------------------------------------------------
+# unset
+# ---------------------------------------------------------------------------
+
+
+def test_unset_root_reverts_to_default(tmp_path: Path, monkeypatch):
+    (tmp_path / ".lore").mkdir()
+    cfg_path = tmp_path / ".lore" / "config.yml"
+    cfg_path.write_text("journal:\n  enabled: true\n")
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    result = runner.invoke(app, ["unset", "journal.enabled"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    cfg = yaml.safe_load(cfg_path.read_text()) or {}
+    assert "journal" not in cfg
+
+
+def test_unset_wiki_reverts_to_default(tmp_path: Path, monkeypatch):
+    wiki_dir = _wiki_dir(tmp_path)
+    (wiki_dir / ".lore-wiki.yml").write_text("git:\n  auto_push: true\n")
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    result = runner.invoke(
+        app, ["unset", "git.auto_push", "--wiki", "private"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    cfg = yaml.safe_load((wiki_dir / ".lore-wiki.yml").read_text()) or {}
+    assert "git" not in cfg
+
+
+def test_unset_unknown_key_rejected(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    result = runner.invoke(app, ["unset", "journal.no_such_field"], catch_exceptions=False)
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# edit
+# ---------------------------------------------------------------------------
+
+
+def test_edit_no_changes_is_a_noop(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    monkeypatch.setattr("click.edit", lambda **kwargs: None)  # simulate untouched file
+    result = runner.invoke(app, ["edit"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    assert "no changes" in result.output.lower()
+
+
+def test_edit_valid_change_saves(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+
+    def fake_edit(*, filename=None, **kwargs):
+        Path(filename).write_text("journal:\n  enabled: true\n")
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    result = runner.invoke(app, ["edit"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    cfg = yaml.safe_load((tmp_path / ".lore" / "config.yml").read_text())
+    assert cfg["journal"]["enabled"] is True
+
+
+def test_edit_invalid_change_abort_reverts_file(tmp_path: Path, monkeypatch):
+    (tmp_path / ".lore").mkdir()
+    cfg_path = tmp_path / ".lore" / "config.yml"
+    cfg_path.write_text("journal:\n  enabled: true\n")
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+
+    def fake_edit(*, filename=None, **kwargs):
+        Path(filename).write_text("journal:\n  enabled: notabool\n")
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    monkeypatch.setattr("typer.confirm", lambda *a, **k: False)  # decline re-edit
+    result = runner.invoke(app, ["edit"], catch_exceptions=False)
+    assert result.exit_code != 0
+    assert cfg_path.read_text() == "journal:\n  enabled: true\n"  # reverted
+
+
+def test_edit_invalid_then_reedit_to_valid_saves(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    attempts = iter(
+        [
+            "journal:\n  enabled: notabool\n",  # first pass: invalid
+            "journal:\n  enabled: true\n",  # second pass: valid
+        ]
+    )
+
+    def fake_edit(*, filename=None, **kwargs):
+        Path(filename).write_text(next(attempts))
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    monkeypatch.setattr("typer.confirm", lambda *a, **k: True)  # accept re-edit
+    result = runner.invoke(app, ["edit"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    cfg = yaml.safe_load((tmp_path / ".lore" / "config.yml").read_text())
+    assert cfg["journal"]["enabled"] is True
+
+
+def test_edit_wiki_target(tmp_path: Path, monkeypatch):
+    wiki_dir = _wiki_dir(tmp_path)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+
+    def fake_edit(*, filename=None, **kwargs):
+        Path(filename).write_text("git:\n  auto_push: true\n")
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    result = runner.invoke(app, ["edit", "--wiki", "private"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    cfg = yaml.safe_load((wiki_dir / ".lore-wiki.yml").read_text())
+    assert cfg["git"]["auto_push"] is True

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,94 @@
+"""Tests for the generic dataclass-schema validation helpers.
+
+These back `lore config get/set/unset/edit` for both root and per-wiki
+config today; a future slice reuses `validate_raw` for `.lore.yml`
+offer validation, so the tests here use a throwaway schema rather than
+RootConfig/WikiConfig to keep the module's genericity honest.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from lore_core.config_schema import suggest, validate_raw
+
+
+@dataclass
+class _Sub:
+    count: int = 3
+    label: str = "x"
+
+
+@dataclass
+class _Dummy:
+    enabled: bool = False
+    ratio: float = 1.0
+    tags: list[str] = field(default_factory=list)
+    sub: _Sub = field(default_factory=_Sub)
+
+
+def test_suggest_finds_nearest_valid_path():
+    valid = ["enabled", "ratio", "sub.count", "sub.label"]
+    assert suggest("enabld", valid) == ["enabled"]
+
+
+def test_suggest_returns_empty_for_no_close_match():
+    valid = ["enabled", "ratio"]
+    assert suggest("zzzzzzzzzz", valid) == []
+
+
+def test_validate_raw_accepts_matching_types():
+    raw = {"enabled": True, "ratio": 2.5, "tags": ["a"], "sub": {"count": 5, "label": "y"}}
+    assert validate_raw(_Dummy, raw) == []
+
+
+def test_validate_raw_unknown_top_level_key_names_suggestion():
+    raw = {"enabld": True}
+    errors = validate_raw(_Dummy, raw)
+    assert len(errors) == 1
+    assert "enabld" in errors[0]
+    assert "enabled" in errors[0]
+
+
+def test_validate_raw_unknown_nested_key_names_suggestion():
+    raw = {"sub": {"cnt": 5}}
+    errors = validate_raw(_Dummy, raw)
+    assert len(errors) == 1
+    assert "sub.cnt" in errors[0]
+    assert "sub.count" in errors[0]
+
+
+def test_validate_raw_type_mismatch_names_expected_type():
+    raw = {"enabled": "yes"}
+    errors = validate_raw(_Dummy, raw)
+    assert len(errors) == 1
+    assert "enabled" in errors[0]
+    assert "bool" in errors[0]
+
+
+def test_validate_raw_int_accepted_for_float_field():
+    """A bare YAML int (2) for a float field is not an error -- Python/YAML
+    treat 2 as a valid float value."""
+    raw = {"ratio": 2}
+    assert validate_raw(_Dummy, raw) == []
+
+
+def test_validate_raw_bool_rejected_for_int_field():
+    """bool is a subclass of int in Python; must not silently pass as int."""
+    raw = {"sub": {"count": True}}
+    errors = validate_raw(_Dummy, raw)
+    assert len(errors) == 1
+    assert "sub.count" in errors[0]
+
+
+def test_validate_raw_non_mapping_top_level():
+    errors = validate_raw(_Dummy, ["not", "a", "mapping"])
+    assert len(errors) == 1
+    assert "mapping" in errors[0]
+
+
+def test_validate_raw_group_value_must_be_mapping():
+    raw = {"sub": "not-a-dict"}
+    errors = validate_raw(_Dummy, raw)
+    assert len(errors) == 1
+    assert "sub" in errors[0]

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -2,8 +2,8 @@ import warnings
 from pathlib import Path
 
 import pytest
-
-from lore_core.root_config import RootConfig, ObservabilityConfig, load_root_config
+import yaml
+from lore_core.root_config import load_root_config
 
 
 def test_defaults_when_file_absent(tmp_path: Path):
@@ -18,14 +18,10 @@ def test_defaults_when_file_absent(tmp_path: Path):
 def test_partial_override(tmp_path: Path):
     lore_dir = tmp_path / ".lore"
     lore_dir.mkdir()
-    (lore_dir / "config.yml").write_text(
-        "observability:\n"
-        "  runs:\n"
-        "    keep: 50\n"
-    )
+    (lore_dir / "config.yml").write_text("observability:\n  runs:\n    keep: 50\n")
     cfg = load_root_config(tmp_path)
-    assert cfg.observability.runs.keep == 50            # overridden
-    assert cfg.observability.runs.max_total_mb == 100   # default preserved
+    assert cfg.observability.runs.keep == 50  # overridden
+    assert cfg.observability.runs.max_total_mb == 100  # default preserved
     assert cfg.observability.hook_events.max_size_mb == 10  # default preserved
 
 
@@ -43,14 +39,10 @@ def test_unknown_key_warns(tmp_path: Path, recwarn):
     warnings.simplefilter("always")
     lore_dir = tmp_path / ".lore"
     lore_dir.mkdir()
-    (lore_dir / "config.yml").write_text(
-        "observability:\n"
-        "  bogus_section: 42\n"
-    )
+    (lore_dir / "config.yml").write_text("observability:\n  bogus_section: 42\n")
     cfg = load_root_config(tmp_path)
     assert cfg.observability.runs.keep == 200  # still defaults
-    assert any("bogus_section" in str(w.message) for w in recwarn), \
-        "should warn about unknown key"
+    assert any("bogus_section" in str(w.message) for w in recwarn), "should warn about unknown key"
 
 
 # ---------------------------------------------------------------------------
@@ -181,3 +173,89 @@ def test_user_display_name_round_trips_via_set_field(tmp_path: Path) -> None:
     fi = set_field(root, "user.display_name", "Christof")
     assert fi.value == "Christof"
     assert get_field(root, "user.display_name").value == "Christof"
+
+
+# ---------------------------------------------------------------------------
+# unset_field
+# ---------------------------------------------------------------------------
+
+
+def test_unset_field_reverts_to_default(tmp_path: Path) -> None:
+    from lore_core.root_config import get_field, set_field, unset_field
+
+    root = _fresh_root(tmp_path, "")
+    set_field(root, "journal.enabled", "true")
+    assert get_field(root, "journal.enabled").value is True
+
+    fi = unset_field(root, "journal.enabled")
+    assert fi.value is False
+    assert fi.source == "default"
+    assert get_field(root, "journal.enabled").value is False
+
+
+def test_unset_field_preserves_siblings(tmp_path: Path) -> None:
+    from lore_core.root_config import get_field, unset_field
+
+    root = _fresh_root(tmp_path, "curator:\n  backend: openai\njournal:\n  enabled: true\n")
+    unset_field(root, "journal.enabled")
+    assert get_field(root, "journal.enabled").value is False
+    assert get_field(root, "curator.backend").value == "openai"  # untouched
+
+
+def test_unset_field_noop_when_not_set(tmp_path: Path) -> None:
+    from lore_core.root_config import unset_field
+
+    root = _fresh_root(tmp_path, "")
+    fi = unset_field(root, "journal.enabled")
+    assert fi.value is False
+    assert fi.source == "default"
+
+
+def test_unset_field_noop_when_file_absent(tmp_path: Path) -> None:
+    from lore_core.root_config import unset_field
+
+    # No .lore/config.yml at all.
+    fi = unset_field(tmp_path, "journal.enabled")
+    assert fi.value is False
+
+
+def test_unset_field_unknown_path_raises_and_leaves_file_unchanged(tmp_path: Path) -> None:
+    from lore_core.root_config import unset_field
+
+    root = _fresh_root(tmp_path, "journal:\n  enabled: true\n")
+    cfg_path = root / ".lore" / "config.yml"
+    before = cfg_path.read_text()
+    with pytest.raises(KeyError, match="unknown config path"):
+        unset_field(root, "journal.no_such_field")
+    assert cfg_path.read_text() == before
+
+
+def test_unset_field_prunes_empty_parent_mapping(tmp_path: Path) -> None:
+    from lore_core.root_config import unset_field
+
+    root = _fresh_root(tmp_path, "journal:\n  enabled: true\n")
+    unset_field(root, "journal.enabled")
+    cfg_path = root / ".lore" / "config.yml"
+    raw = yaml.safe_load(cfg_path.read_text()) or {}
+    assert "journal" not in raw
+
+
+# ---------------------------------------------------------------------------
+# unknown-path suggestions
+# ---------------------------------------------------------------------------
+
+
+def test_get_field_unknown_path_suggests_nearest(tmp_path: Path) -> None:
+    from lore_core.root_config import get_field
+
+    root = _fresh_root(tmp_path, "")
+    with pytest.raises(KeyError, match="did you mean.*curator.backend"):
+        get_field(root, "curator.backand")
+
+
+def test_set_field_unknown_path_suggests_nearest(tmp_path: Path) -> None:
+    from lore_core.root_config import set_field
+
+    root = _fresh_root(tmp_path, "")
+    with pytest.raises(KeyError, match="did you mean.*curator.backend"):
+        set_field(root, "curator.backand", "openai")

--- a/tests/test_wiki_config.py
+++ b/tests/test_wiki_config.py
@@ -1,10 +1,8 @@
 """Tests for per-wiki config loader."""
 
-import warnings
 from pathlib import Path
 
 import pytest
-
 from lore_core.wiki_config import WikiConfig, load_wiki_config
 
 
@@ -75,7 +73,7 @@ class TestWikiConfigNestedDataclasses:
     def test_load_models_high_off_parsed(self, tmp_path: Path):
         """YAML with models.high="off" → parsed correctly."""
         config_file = tmp_path / ".lore-wiki.yml"
-        config_file.write_text("models:\n  high: \"off\"\n")
+        config_file.write_text('models:\n  high: "off"\n')
         cfg = load_wiki_config(tmp_path)
         assert cfg.models.high == "off"
         assert cfg.models.simple == "claude-haiku-4-5"  # defaults preserved
@@ -85,10 +83,7 @@ class TestWikiConfigNestedDataclasses:
         """YAML with briefing.sinks list → parsed correctly."""
         config_file = tmp_path / ".lore-wiki.yml"
         config_file.write_text(
-            "briefing:\n"
-            "  sinks:\n"
-            "    - matrix:#dev-notes\n"
-            "    - markdown:~/foo.md\n"
+            "briefing:\n  sinks:\n    - matrix:#dev-notes\n    - markdown:~/foo.md\n"
         )
         cfg = load_wiki_config(tmp_path)
         assert cfg.briefing.sinks == ["matrix:#dev-notes", "markdown:~/foo.md"]
@@ -138,3 +133,99 @@ class TestWikiConfigErrorHandling:
         with pytest.warns(UserWarning, match="top-level must be a mapping"):
             cfg = load_wiki_config(tmp_path)
         assert cfg == WikiConfig()
+
+
+# ---------------------------------------------------------------------------
+# Introspection / write-back helpers (lore config get/set/unset --wiki)
+# ---------------------------------------------------------------------------
+
+
+def _fresh_wiki(tmp_path: Path, body: str) -> Path:
+    (tmp_path / ".lore-wiki.yml").write_text(body)
+    return tmp_path
+
+
+class TestWikiConfigWriteBack:
+    def test_walk_fields_marks_file_vs_default(self, tmp_path: Path) -> None:
+        from lore_core.wiki_config import walk_fields
+
+        wiki = _fresh_wiki(tmp_path, "git:\n  auto_push: true\n")
+        fields_by_path = {fi.path: fi for fi in walk_fields(wiki)}
+        assert fields_by_path["git.auto_push"].source == "file"
+        assert fields_by_path["git.auto_push"].value is True
+        assert fields_by_path["git.auto_commit"].source == "default"
+        assert fields_by_path["git.auto_commit"].value is False
+
+    def test_get_field_returns_leaf_info(self, tmp_path: Path) -> None:
+        from lore_core.wiki_config import get_field
+
+        wiki = _fresh_wiki(tmp_path, "")
+        fi = get_field(wiki, "curator.threshold_pending_turns")
+        assert fi.value == 30
+        assert fi.source == "default"
+        assert fi.type_name == "int"
+
+    def test_get_field_unknown_path_raises_with_suggestion(self, tmp_path: Path) -> None:
+        from lore_core.wiki_config import get_field
+
+        wiki = _fresh_wiki(tmp_path, "")
+        with pytest.raises(KeyError, match="did you mean.*models.simple"):
+            get_field(wiki, "models.simpel")
+
+    def test_set_field_persists_and_round_trips(self, tmp_path: Path) -> None:
+        from lore_core.wiki_config import get_field, set_field
+
+        wiki = _fresh_wiki(tmp_path, "briefing:\n  audience: team\n")
+        fi = set_field(wiki, "git.auto_push", "true")
+        assert fi.value is True
+        assert get_field(wiki, "git.auto_push").value is True
+        assert get_field(wiki, "briefing.audience").value == "team"  # untouched
+
+    def test_set_field_rejects_bad_type_file_unchanged(self, tmp_path: Path) -> None:
+        from lore_core.wiki_config import set_field
+
+        wiki = _fresh_wiki(tmp_path, "")
+        cfg_path = wiki / ".lore-wiki.yml"
+        before = cfg_path.read_text()
+        with pytest.raises(ValueError, match="cannot parse"):
+            set_field(wiki, "git.auto_push", "notabool")
+        assert cfg_path.read_text() == before
+
+    def test_set_field_rejects_unknown_path_file_unchanged(self, tmp_path: Path) -> None:
+        from lore_core.wiki_config import set_field
+
+        wiki = _fresh_wiki(tmp_path, "git:\n  auto_push: true\n")
+        cfg_path = wiki / ".lore-wiki.yml"
+        before = cfg_path.read_text()
+        with pytest.raises(KeyError, match="unknown config path"):
+            set_field(wiki, "git.no_such_field", "true")
+        assert cfg_path.read_text() == before
+
+    def test_unset_field_reverts_to_default(self, tmp_path: Path) -> None:
+        from lore_core.wiki_config import get_field, set_field, unset_field
+
+        wiki = _fresh_wiki(tmp_path, "")
+        set_field(wiki, "curator.threshold_pending_turns", "5")
+        assert get_field(wiki, "curator.threshold_pending_turns").value == 5
+        fi = unset_field(wiki, "curator.threshold_pending_turns")
+        assert fi.value == 30
+        assert get_field(wiki, "curator.threshold_pending_turns").value == 30
+
+    def test_unset_field_noop_when_not_set(self, tmp_path: Path) -> None:
+        from lore_core.wiki_config import unset_field
+
+        wiki = _fresh_wiki(tmp_path, "")
+        fi = unset_field(wiki, "curator.threshold_pending_turns")
+        assert fi.value == 30
+
+    def test_schema_tree_covers_all_leaves(self) -> None:
+        from lore_core.wiki_config import schema_tree
+
+        paths = {p for p, _, _, _ in schema_tree()}
+        assert "git.auto_commit" in paths
+        assert "curator.threshold_pending_turns" in paths
+        assert "models.simple" in paths
+        assert "briefing.audience" in paths
+        assert "heartbeat.enabled" in paths
+        assert "breadcrumb.mode" in paths
+        assert "git" not in paths  # groups excluded, leaves only


### PR DESCRIPTION
## Summary

- Adds `lore config get/set/unset/edit`, each accepting `--wiki NAME` to target `<wiki>/.lore-wiki.yml` instead of the vault-root `.lore/config.yml`.
- Writes are validated against the existing typed config model **before** touching the file: unknown keys are rejected naming the nearest valid keys (difflib), invalid values are rejected naming the expected type. A rejection never modifies the file on disk.
- `edit` opens `$EDITOR` (via `click.edit()`) on the target file and validates on close; an invalid save offers re-edit or abort (abort reverts the file to its pre-edit content).
- `get` with no path prints the full resolved config with provenance (today's `show` behavior), scoped to root or `--wiki`.
- Config precedence (flag > env > wiki > root > default) is untouched — this is pure mutation plumbing, no resolution changes.

Closes #187

## Design

The validation/introspection logic that used to live only in `root_config.py` (walk/get/set + FieldInfo) is generalized into `lib/lore_core/config_schema.py`, parameterized over a `ConfigSchema` (default factory + loader + config-path function). `root_config.py` and `wiki_config.py` each bind their own `ROOT_SCHEMA`/`WIKI_SCHEMA` and re-export thin `walk_fields`/`get_field`/`set_field`/`unset_field`/`schema_tree` wrappers with unchanged call signatures, so existing callers (`init_cmd.py`, `test_identity.py`, etc.) needed no changes. This is the reusable unit slice 9 (`.lore.yml` offer validation) is meant to import — `validate_raw()` and `suggest()` take a plain dataclass type, no config-file coupling.

One subtlety worth flagging: every `*_config.py` module here uses `from __future__ import annotations`, so `dataclasses.Field.type` is a string, not a type object. The pre-existing `set_field`/`_navigate` code already worked around this by reading the type off a live default value instead of the annotation; `validate_raw()` follows the same pattern (walks a default *instance* tree, not `Field.type`) rather than reinventing type resolution.

## Red -> green evidence

**`config_schema.py` (new module, TDD from scratch):**
```
$ pytest tests/test_config_schema.py -q
ModuleNotFoundError: No module named 'lore_core.config_schema'
1 error during collection
```
-> after implementing: `10 passed`

**`wiki_config.py` (parity with root_config's get/set/unset/walk_fields/schema_tree):**
```
$ pytest tests/test_wiki_config.py -q
ImportError: cannot import name 'walk_fields' from 'lore_core.wiki_config' ...
ImportError: cannot import name 'get_field' from 'lore_core.wiki_config' ...
ImportError: cannot import name 'set_field' from 'lore_core.wiki_config' ...
ImportError: cannot import name 'unset_field' from 'lore_core.wiki_config' ...
ImportError: cannot import name 'schema_tree' from 'lore_core.wiki_config' ...
9 failed, 10 passed
```
-> after implementing: `19 passed`

**`config_cmd.py` CLI (`--wiki`, `unset`, `edit`):**
```
$ pytest tests/test_config_cmd.py -q
Error: No such command 'edit'.
Error: No such option: --wiki
10 failed, 6 passed
```
-> after implementing: `16 passed`

**`root_config.py` refactor + `unset_field`/suggestion additions** (behavior-preserving: existing 16 tests were green before touching the file and stayed green through the refactor; 8 new tests for `unset_field` and nearest-key suggestions added and passing): `24 passed`.

**Full regression suite:** `2703 passed, 16 skipped` — identical to the pre-existing baseline (verified via `git stash`/pop) including the same 11 unrelated pre-existing failures (ANSI-color-in-CliRunner-output assertions in `test_cli_runs.py`, `test_core_llm_wiring.py`, `test_drain_prune.py`, `test_install_dispatcher.py`, `test_log_cmd.py`, `test_proc_cmd.py` — none touch config).

## Lint

`ruff check` and `ruff format --check` both clean on every changed/new file.

## Test plan

- [x] `lore config get/set/unset/edit` work for root and `--wiki` config, writing valid YAML
- [x] Unknown key and invalid value rejected with named alternatives; file on disk unchanged after rejection
- [x] `edit` validates on editor close, refuses invalid saves (re-edit or abort-and-revert)
- [x] Existing config-precedence tests unmodified and green
- [x] Validation layer (`config_schema.validate_raw`/`suggest`) is a standalone importable module, decoupled from Root/WikiConfig specifics