### PR TITLE
feat: lore doctor --fix — state repair, path migration, honest failing checks

### DIFF
--- a/lib/lore_cli/doctor_cmd.py
+++ b/lib/lore_cli/doctor_cmd.py
@@ -13,6 +13,12 @@ Checks:
   5. MCP server module imports (`lore mcp` would start it)
   6. lore_search index responds (FtsBackend.stats() succeeds)
   7. Current cwd's `## Lore` block parses (if attached; else skipped)
+
+`--fix` additionally repairs: rebuilds scopes.json from attachments.json,
+re-stamps drifted offer fingerprints, and migrates attachment path
+prefixes. Every repair prints what it will change and is individually
+declinable (prompt per repair, `--yes` to skip). Plain `doctor` (no
+`--fix`) never writes state — see docs/architecture/state.md.
 """
 
 from __future__ import annotations
@@ -29,7 +35,11 @@ from rich.console import Console
 
 from lore_cli._argv_compat import argv_main
 
-console = Console()
+# emoji=False: scope IDs are colon-separated (`lore:a:b`) and Rich's emoji
+# shortcode parser reads `:a:` as the letter-A emoji, silently corrupting
+# any scope chain with a single-character segment when printed. Markup
+# ([green]/[bold]/etc.) still works — only :shortcode: substitution is off.
+console = Console(emoji=False)
 
 app = typer.Typer(
     add_completion=False,
@@ -340,8 +350,9 @@ def _check_attach(cwd: str) -> Check:
 
 def _check_attachments(cwd: str) -> Check:
     """Validate every attachments.json row: path exists, wiki dir exists,
-    scope in scopes.json, fingerprint matches current `.lore.yml` if one
-    exists at the attachment path.
+    scope in scopes.json (and its registered wiki matches the attachment's),
+    fingerprint matches current `.lore.yml` if one exists at the
+    attachment path.
     """
     from lore_core.config import get_lore_root, get_wiki_root
     from lore_core.offer import offer_fingerprint, parse_lore_yml, FILENAME as LORE_YML
@@ -370,6 +381,13 @@ def _check_attachments(cwd: str) -> Check:
             issues.append(f"{a.path}: wiki `{a.wiki}` does not exist in {wiki_root}")
         if sf.get(a.scope) is None:
             issues.append(f"{a.path}: scope `{a.scope}` not in scopes.json")
+        else:
+            resolved_wiki = sf.resolve_wiki(a.scope)
+            if resolved_wiki != a.wiki:
+                issues.append(
+                    f"{a.path}: wiki `{a.wiki}` doesn't match scope registry "
+                    f"(scope `{a.scope}` resolves to wiki `{resolved_wiki}`)"
+                )
         # Fingerprint check — only when a .lore.yml is present at the attachment root
         if a.offer_fingerprint is not None:
             lore_yml = a.path / LORE_YML
@@ -504,6 +522,204 @@ def _check_pending(cwd: str) -> Check:
     if not parts:
         return True, "no attached-wiki pending"
     return True, " · ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# `--fix` repairs.
+#
+# Each repair is self-contained: it reads state, prints what it would
+# change, asks for consent (`typer.confirm`, skippable with `--yes`), and
+# only writes after consent. attachments.json is the non-regenerable
+# consent record (docs/architecture/state.md) — no repair here may ever
+# drop a row, only rebuild scopes.json or update fields on an existing
+# row in place.
+# ---------------------------------------------------------------------------
+
+
+def _fix_rebuild_scopes(lore_root: Path, *, yes: bool) -> bool:
+    """Rebuild scopes.json from every accepted attachment.
+
+    scopes.json is regenerable; re-derives each attachment's scope chain
+    via the same `ingest_chain` `lore attach accept` uses, additively
+    repairing missing or corrupt entries (a corrupt file parses to empty,
+    so this also self-heals a corrupt scopes.json). Mutation stays
+    in-memory until confirmed — a decline leaves the file untouched.
+
+    ponytail: additive only, doesn't prune scope entries whose attachment
+    was later removed. Add a prune pass if orphaned scopes become a
+    problem in practice.
+    """
+    from lore_core.state.attachments import AttachmentsFile
+    from lore_core.state.scopes import ScopeConflict, ScopesFile
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    attachments = af.all()
+    if not attachments:
+        return False
+
+    sf = ScopesFile(lore_root)
+    sf.load()
+    before_ids = set(sf.all_ids())
+
+    conflicts: list[str] = []
+    for a in attachments:
+        try:
+            sf.ingest_chain(a.scope, a.wiki)
+        except ScopeConflict as exc:
+            conflicts.append(str(exc))
+
+    added = sorted(set(sf.all_ids()) - before_ids)
+    if not added and not conflicts:
+        return False
+
+    console.print("\n[bold]Repair: rebuild scopes.json[/bold] from attachments.json")
+    for sid in added:
+        console.print(f"  [green]+ {sid}[/green]")
+    for c in conflicts:
+        console.print(f"  [yellow]! {c} (skipped)[/yellow]")
+
+    if not yes and not typer.confirm("Apply?", default=False):
+        console.print("  [yellow]declined — no changes written[/yellow]")
+        return False
+
+    sf.save()
+    console.print("  [green]written[/green]")
+    return True
+
+
+def _fix_restamp_fingerprints(lore_root: Path, *, yes: bool) -> bool:
+    """Re-stamp offer_fingerprint for attachments whose `.lore.yml` has
+    drifted, after showing what would change and getting consent.
+
+    Mirrors `lore attach accept`'s re-acceptance: re-parses the current
+    offer and updates wiki/scope/offer_fingerprint to match it. Never
+    drops the attachment row — only updates fields in place.
+    """
+    from lore_core.offer import FILENAME as LORE_YML
+    from lore_core.offer import offer_fingerprint, parse_lore_yml
+    from lore_core.state.attachments import Attachment, AttachmentsFile
+    from lore_core.state.scopes import ScopeConflict, ScopesFile
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    sf = ScopesFile(lore_root)
+    sf.load()
+
+    changed = False
+    for a in af.all():
+        if a.offer_fingerprint is None:
+            continue
+        lore_yml = a.path / LORE_YML
+        if not lore_yml.exists():
+            continue
+        offer = parse_lore_yml(lore_yml)
+        if offer is None:
+            continue
+        new_fp = offer_fingerprint(offer)
+        if new_fp == a.offer_fingerprint:
+            continue
+
+        console.print(f"\n[bold]Repair: re-stamp offer fingerprint[/bold] for {a.path}")
+        console.print(f"  wiki:        {a.wiki} -> {offer.wiki}")
+        console.print(f"  scope:       {a.scope} -> {offer.scope}")
+        console.print(f"  fingerprint: {a.offer_fingerprint} -> {new_fp}")
+
+        if not yes and not typer.confirm("Apply?", default=False):
+            console.print("  [yellow]declined — no changes written[/yellow]")
+            continue
+
+        try:
+            sf.ingest_chain(offer.scope, offer.wiki)
+        except ScopeConflict as exc:
+            console.print(f"  [red]scope conflict: {exc} — skipped[/red]")
+            continue
+
+        af.add(
+            Attachment(
+                path=a.path,
+                wiki=offer.wiki,
+                scope=offer.scope,
+                attached_at=a.attached_at,
+                source=a.source,
+                offer_fingerprint=new_fp,
+            )
+        )
+        changed = True
+        console.print("  [green]re-stamped[/green]")
+
+    if changed:
+        af.save()
+        sf.save()
+    return changed
+
+
+def _fix_migrate_paths(lore_root: Path, old_prefix: str, new_prefix: str, *, yes: bool) -> bool:
+    """Rewrite attachment paths after a vault/repo move.
+
+    Any attachment path under `old_prefix` is rewritten to the same
+    relative path under `new_prefix`. attachments.json is host-local and
+    not portable (docs/architecture/state.md) — this is the explicit
+    migration path when a host's paths changed but its consent records
+    should carry over.
+    """
+    from lore_core.state.attachments import Attachment, AttachmentsFile
+
+    old_path = Path(old_prefix)
+    new_path = Path(new_prefix)
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+
+    rewrites: list[tuple[Attachment, Path]] = []
+    for a in af.all():
+        try:
+            rel = a.path.relative_to(old_path)
+        except ValueError:
+            continue
+        rewrites.append((a, new_path / rel))
+
+    if not rewrites:
+        return False
+
+    console.print(f"\n[bold]Repair: migrate attachment paths[/bold] {old_prefix} -> {new_prefix}")
+    for a, new in rewrites:
+        console.print(f"  {a.path} -> {new}")
+
+    if not yes and not typer.confirm("Apply?", default=False):
+        console.print("  [yellow]declined — no changes written[/yellow]")
+        return False
+
+    for a, new in rewrites:
+        af.remove(a.path)
+        af.add(
+            Attachment(
+                path=new,
+                wiki=a.wiki,
+                scope=a.scope,
+                attached_at=a.attached_at,
+                source=a.source,
+                offer_fingerprint=a.offer_fingerprint,
+            )
+        )
+    af.save()
+    console.print("  [green]migrated[/green]")
+    return True
+
+
+def _run_repairs(*, yes: bool, migrate_path_from: str | None, migrate_path_to: str | None) -> None:
+    """Entry point for `--fix`. Runs before the check pass so a single
+    invocation both repairs and reports the post-repair state."""
+    from lore_core.config import get_lore_root
+
+    lore_root = get_lore_root()
+    if not lore_root.exists():
+        return
+
+    _fix_rebuild_scopes(lore_root, yes=yes)
+    _fix_restamp_fingerprints(lore_root, yes=yes)
+    if migrate_path_from and migrate_path_to:
+        _fix_migrate_paths(lore_root, migrate_path_from, migrate_path_to, yes=yes)
 
 
 # ---------------------------------------------------------------------------
@@ -653,10 +869,11 @@ _CHECKS: list[tuple[str, Callable[[str], Check], bool]] = [
     # upgraded pip; the message itself is the value (it tells them
     # to run /plugin update lore).
     ("plugin manifest", _check_plugin_manifest_sync, False),
-    # Advisory: catches the inverse — user ran `claude plugin update`
-    # but didn't refresh the pipx binary. Banner silently reports the
-    # old version; this names the fix command.
-    ("plugin cache", _check_claude_plugin_cache_drift, False),
+    # Failing (was advisory): catches the inverse — user ran `claude
+    # plugin update` but didn't refresh the pipx binary. Banner silently
+    # reports the old version; this names the fix command. The drift is
+    # common enough in practice that it should block a green `doctor` run.
+    ("plugin cache", _check_claude_plugin_cache_drift, True),
     # Cursor integration checks. All advisory: a Claude-only user has
     # no ~/.cursor dir and these all skip cleanly.
     ("cursor plugin", _check_cursor_plugin_dir, False),
@@ -678,9 +895,34 @@ def doctor(
         "--json",
         help="Emit JSON envelope on stdout (lore.doctor/1).",
     ),
+    fix: bool = typer.Option(
+        False,
+        "--fix",
+        help="Repair fixable issues: rebuild scopes.json, re-stamp drifted "
+        "offer fingerprints, migrate attachment paths. Prompts per repair "
+        "unless --yes.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Skip repair confirmation prompts (non-interactive --fix).",
+    ),
+    migrate_path_from: str = typer.Option(
+        None,
+        "--migrate-path-from",
+        help="Old absolute path prefix to rewrite in attachments.json (used with --fix).",
+    ),
+    migrate_path_to: str = typer.Option(
+        None,
+        "--migrate-path-to",
+        help="New absolute path prefix (used with --fix).",
+    ),
 ) -> None:
     """Walk the most common breakage points and print one line per check."""
     cwd = cwd or os.getcwd()
+
+    if fix:
+        _run_repairs(yes=yes, migrate_path_from=migrate_path_from, migrate_path_to=migrate_path_to)
 
     results: list[dict] = []
     all_ok = True

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -223,6 +223,23 @@ def test_plugin_cache_drift_unreadable_index_fails(tmp_path, monkeypatch):
     assert "unreadable" in msg
 
 
+def test_plugin_cache_drift_fails_the_overall_run(healthy_vault, tmp_path, monkeypatch, capsys):
+    """Plugin-cache drift is a *failing* check, not advisory:
+    `lore doctor`'s overall exit code must go non-zero on drift, unlike the
+    old advisory behaviour."""
+    monkeypatch.setattr(doctor_cmd.Path, "home", classmethod(lambda cls: tmp_path))
+    _write_plugin_index(tmp_path, version="0.13.1")
+    import importlib.metadata as _md
+    monkeypatch.setattr(_md, "version", lambda _name: "0.10.0")
+
+    rc = doctor_cmd.main(["--cwd", str(healthy_vault), "--json"])
+    assert rc == 1
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope["data"]["ok"] is False
+    checks = {c["check"]: c for c in envelope["data"]["checks"]}
+    assert checks["plugin cache"]["ok"] is False
+
+
 def test_doctor_capture_panel_lock_free_removed_smoke(tmp_path):
     """Placeholder so pytest collection still passes; old capture-panel
     tests for free-lock / hook-errors / marker are superseded by

--- a/tests/test_doctor_fix.py
+++ b/tests/test_doctor_fix.py
@@ -1,0 +1,336 @@
+"""Tests for `lore doctor --fix` — state repair, path migration.
+
+CRITICAL invariant under test throughout: attachments.json is the
+non-regenerable consent record (docs/architecture/state.md) — no repair
+here may ever drop an attachment row, only rebuild scopes.json or update
+fields in place after explicit consent.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from lore_cli.__main__ import app
+from lore_core.state.attachments import Attachment, AttachmentsFile
+from lore_core.state.scopes import ScopesFile
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def lore_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / ".lore").mkdir()
+    (tmp_path / "wiki" / "private").mkdir(parents=True)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def _attach(
+    path: Path, *, wiki: str = "private", scope: str = "lore:a", fp: str | None = None
+) -> Attachment:
+    return Attachment(
+        path=path,
+        wiki=wiki,
+        scope=scope,
+        attached_at=datetime(2026, 4, 22, 9, 0, tzinfo=UTC),
+        source="manual",
+        offer_fingerprint=fp,
+    )
+
+
+def _checks(result) -> dict[str, dict]:
+    payload = json.loads(result.stdout)
+    return {c["check"]: c for c in payload["data"]["checks"]}
+
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI escapes — Rich's auto-highlighter splits printed text
+    (e.g. a scope ID) across multiple style spans, so a raw substring
+    check against styled output can miss even though the text is there."""
+    return _ANSI.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# AC1 — rebuild scopes.json from accepted attachments
+# ---------------------------------------------------------------------------
+
+
+def test_fix_rebuilds_scopes_from_corrupt_json(lore_root: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.add(_attach(repo, wiki="private", scope="lore:a"))
+    af.save()
+
+    (lore_root / ".lore" / "scopes.json").write_text("{not valid json")
+
+    # Red: attachments check fails because the scope can't be found in a
+    # corrupt (empty-after-parse) scopes.json.
+    before = runner.invoke(app, ["doctor", "--json"])
+    assert _checks(before)["attachments"]["ok"] is False
+
+    result = runner.invoke(app, ["doctor", "--fix", "--yes", "--json"])
+    assert result.exit_code == 0, result.stdout
+
+    # Revalidate with a plain (non-fix) run.
+    after = runner.invoke(app, ["doctor", "--json"])
+    assert after.exit_code == 0, after.stdout
+    assert _checks(after)["attachments"]["ok"] is True
+
+    sf = ScopesFile(lore_root)
+    sf.load()
+    assert sf.get("lore:a") is not None
+    assert sf.resolve_wiki("lore:a") == "private"
+
+
+def test_fix_rebuild_scopes_is_declinable(lore_root: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.add(_attach(repo, wiki="private", scope="lore:a"))
+    af.save()
+
+    (lore_root / ".lore" / "scopes.json").write_text("{not valid json")
+
+    result = runner.invoke(app, ["doctor", "--fix", "--json"], input="n\n")
+    # The underlying corruption is declined, not fixed — the run still
+    # legitimately fails on the pre-existing "not in scopes.json" issue.
+    assert result.exit_code == 1, result.stdout
+
+    # Declined — scopes.json must be untouched (still the original corrupt bytes).
+    assert (lore_root / ".lore" / "scopes.json").read_text() == "{not valid json"
+
+
+def test_fix_rebuild_scopes_prints_diff_before_consent(lore_root: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.add(_attach(repo, wiki="private", scope="lore:a:b"))
+    af.save()
+
+    result = runner.invoke(app, ["doctor", "--fix"], input="n\n")
+    plain = _plain(result.stdout)
+    assert "lore:a:b" in plain
+    assert "Apply?" in plain
+
+
+# ---------------------------------------------------------------------------
+# AC2 — fingerprint re-stamp for drifted offers
+# ---------------------------------------------------------------------------
+
+
+def _seed_drifted_offer(lore_root: Path, repo: Path) -> str:
+    """Attachment accepted under one offer; `.lore.yml` since edited to a
+    new scope. Returns the stale fingerprint stored on the attachment."""
+    from lore_core.offer import Offer, offer_fingerprint
+
+    repo.mkdir()
+    old_offer = Offer(wiki="private", scope="lore:old")
+    old_fp = offer_fingerprint(old_offer)
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.add(_attach(repo, wiki="private", scope="lore:old", fp=old_fp))
+    af.save()
+
+    sf = ScopesFile(lore_root)
+    sf.load()
+    sf.ingest_chain("lore:old", "private")
+    sf.save()
+
+    (repo / ".lore.yml").write_text("wiki: private\nscope: lore:new\n")
+    return old_fp
+
+
+def test_fix_restamps_drifted_fingerprint_and_updates_scope(
+    lore_root: Path, tmp_path: Path
+) -> None:
+    repo = tmp_path / "repo"
+    old_fp = _seed_drifted_offer(lore_root, repo)
+
+    before = runner.invoke(app, ["doctor", "--json"])
+    assert "drift" in _checks(before)["attachments"]["message"]
+
+    result = runner.invoke(app, ["doctor", "--fix", "--yes"])
+    assert result.exit_code == 0, result.stdout
+    assert "lore:old" in result.stdout and "lore:new" in result.stdout
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    entries = af.all()
+    assert len(entries) == 1, "re-stamp must not drop or duplicate the consent record"
+    assert entries[0].scope == "lore:new"
+    assert entries[0].offer_fingerprint != old_fp
+
+    after = runner.invoke(app, ["doctor", "--json"])
+    assert _checks(after)["attachments"]["ok"] is True
+
+
+def test_fix_restamp_is_declinable(lore_root: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    old_fp = _seed_drifted_offer(lore_root, repo)
+
+    runner.invoke(app, ["doctor", "--fix"], input="n\n")
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    entries = af.all()
+    assert len(entries) == 1, "decline must not drop the consent record"
+    assert entries[0].offer_fingerprint == old_fp
+    assert entries[0].scope == "lore:old"
+
+
+# ---------------------------------------------------------------------------
+# AC3 — vault/repo path migration
+# ---------------------------------------------------------------------------
+
+
+def test_fix_migrates_attachment_path_prefix(lore_root: Path, tmp_path: Path) -> None:
+    old_home = tmp_path / "old_home"
+    new_home = tmp_path / "new_home"
+    (new_home / "repo").mkdir(parents=True)  # the repo now lives here
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.add(_attach(old_home / "repo", wiki="private", scope="lore:a"))
+    af.save()
+    sf = ScopesFile(lore_root)
+    sf.load()
+    sf.ingest_chain("lore:a", "private")
+    sf.save()
+
+    before = runner.invoke(app, ["doctor", "--json"])
+    assert "missing on disk" in _checks(before)["attachments"]["message"]
+
+    result = runner.invoke(
+        app,
+        [
+            "doctor",
+            "--fix",
+            "--yes",
+            "--migrate-path-from",
+            str(old_home),
+            "--migrate-path-to",
+            str(new_home),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    entries = af.all()
+    assert len(entries) == 1, "migration must not drop the consent record"
+    assert entries[0].path == (new_home / "repo").resolve()
+
+    after = runner.invoke(app, ["doctor", "--json"])
+    assert _checks(after)["attachments"]["ok"] is True
+
+
+def test_fix_migrate_path_no_match_is_noop(lore_root: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.add(_attach(repo, wiki="private", scope="lore:a"))
+    af.save()
+    sf = ScopesFile(lore_root)
+    sf.load()
+    sf.ingest_chain("lore:a", "private")
+    sf.save()
+
+    result = runner.invoke(
+        app,
+        [
+            "doctor",
+            "--fix",
+            "--yes",
+            "--migrate-path-from",
+            str(tmp_path / "unrelated"),
+            "--migrate-path-to",
+            str(tmp_path / "also-unrelated"),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    assert af.all()[0].path == repo.resolve()
+
+
+# ---------------------------------------------------------------------------
+# AC5 — plain `doctor` (no --fix) never writes
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_without_fix_writes_nothing_even_with_repairable_issues(
+    lore_root: Path, tmp_path: Path
+) -> None:
+    """Same broken-state fixtures as the --fix tests above, but run
+    without --fix: attachments.json and scopes.json — the two files repair
+    touches — must be byte-for-byte unchanged.
+
+    Scoped to those two files rather than all of `.lore/`: hook-events.jsonl
+    / `.lore/drain` are telemetry the SessionStart hook probe writes on
+    every invocation regardless of doctor — a pre-existing, intentional
+    always-append behaviour (docs/architecture/state.md), not part of the
+    no-write guarantee this AC covers.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.add(_attach(repo, wiki="private", scope="lore:a"))
+    af.save()
+    (lore_root / ".lore" / "scopes.json").write_text("{not valid json")
+
+    attachments_path = lore_root / ".lore" / "attachments.json"
+    scopes_path = lore_root / ".lore" / "scopes.json"
+    before = (attachments_path.read_bytes(), scopes_path.read_bytes())
+
+    result = runner.invoke(app, ["doctor", "--json"])
+    assert result.exit_code == 1  # the corrupt-registry issue still fails the run
+
+    after = (attachments_path.read_bytes(), scopes_path.read_bytes())
+    assert before == after, (
+        "plain `doctor` (no --fix) must never write attachments.json/scopes.json"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4b — attachments integrity flags a wiki/scope-registry mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_attachments_check_flags_wiki_scope_registry_mismatch(
+    lore_root: Path, tmp_path: Path
+) -> None:
+    (lore_root / "wiki" / "other").mkdir(parents=True)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    # Attachment claims wiki=other, but the scope registry says lore:a -> private.
+    af.add(_attach(repo, wiki="other", scope="lore:a"))
+    af.save()
+    sf = ScopesFile(lore_root)
+    sf.load()
+    sf.ingest_chain("lore:a", "private")
+    sf.save()
+
+    result = runner.invoke(app, ["doctor", "--json"])
+    checks = _checks(result)
+    assert checks["attachments"]["ok"] is False
+    assert "other" in checks["attachments"]["message"]
+    assert "private" in checks["attachments"]["message"]


### PR DESCRIPTION
Closes #186

## Summary

Adds `--fix` to `lore doctor`, turning it from diagnose-only into
diagnose-and-repair, plus tightens two checks per the PRD.

- **AC1 — rebuild scopes.json.** `_fix_rebuild_scopes` re-derives every
  attachment's scope chain via the same `ScopesFile.ingest_chain` that
  `lore attach accept` uses. scopes.json is regenerable
  (docs/architecture/state.md); a corrupt file parses to empty and this
  additively repairs it from attachments.json (the non-regenerable
  consent record).
- **AC2 — fingerprint re-stamp.** `_fix_restamp_fingerprints` detects
  `.lore.yml` drift against the stored `offer_fingerprint`, prints a
  wiki/scope/fingerprint diff, and only after consent updates the
  attachment row in place (mirrors `lore attach accept`'s re-acceptance).
- **AC3 — path migration.** `--migrate-path-from` / `--migrate-path-to`
  rewrite attachment paths under an old prefix to a new one (vault/repo
  move), after showing the rewrite list and getting consent.
- **AC4 — honest checks.** Plugin-cache version drift (Claude plugin
  cache vs pip) is now a *failing* check, not advisory. The attachments
  integrity check additionally verifies each attachment's `wiki` matches
  the scope registry's resolved wiki for that scope.
- **AC5 — read-only by default.** Plain `doctor` (no `--fix`) is asserted
  to never write `attachments.json`/`scopes.json`, even when the state is
  corrupt/repairable.

Every repair is self-contained, prints what it will change before
writing, and is individually declinable via `typer.confirm` (`--yes` to
skip prompts, matching the existing `scopes rename`/`reparent` pattern).
**No repair ever drops an attachment row** — only `scopes.json` gets
rebuilt; attachment rows are only added or updated in place.

### Bug found along the way

Rich's `Console` interprets `:word:` as an emoji shortcode by default —
`lore:a:b` was silently rendering as `lore🅰b` (the letter-A emoji) any
time a 3+ level scope ID hit the console. Fixed by constructing the
shared `console` with `emoji=False` (keeps `[green]`/`[bold]` markup,
disables shortcode substitution). This would have corrupted real `--fix`
diff output for any scope with a single-character segment.

## Test plan

Strict TDD — failing tests written first for every AC, confirmed red,
then implemented to green.

**Red** (8 of 9 new/modified tests failing — missing `--fix`/`--yes`/
`--migrate-path-*` options and the wiki-mismatch check; the 9th,
the read-only assertion, correctly passed pre-implementation, confirming
it was scoped right):
```
FAILED tests/test_doctor_fix.py::test_fix_rebuilds_scopes_from_corrupt_json
FAILED tests/test_doctor_fix.py::test_fix_rebuild_scopes_is_declinable
FAILED tests/test_doctor_fix.py::test_fix_rebuild_scopes_prints_diff_before_consent
FAILED tests/test_doctor_fix.py::test_fix_restamps_drifted_fingerprint_and_updates_scope
FAILED tests/test_doctor_fix.py::test_fix_migrates_attachment_path_prefix
FAILED tests/test_doctor_fix.py::test_fix_migrate_path_no_match_is_noop
FAILED tests/test_doctor_fix.py::test_attachments_check_flags_wiki_scope_registry_mismatch
FAILED tests/test_doctor.py::test_plugin_cache_drift_fails_the_overall_run
8 failed, 18 passed
```

**Green** (full doctor suite + full repo suite):
```
$ pytest tests/test_doctor_fix.py tests/test_doctor.py tests/test_cli_doctor_phase4.py \
         tests/test_doctor_no_side_effects.py tests/test_doctor_cursor.py -q
50 passed

$ pytest tests/ -q
11 failed, 2670 passed, 16 skipped
```
The 11 failures are the pre-existing ANSI-color `CliRunner` artifacts in
`test_cli_runs` / `test_core_llm_wiring` / `test_drain_prune` /
`test_install_dispatcher` / `test_log_cmd` / `test_proc_cmd` that exist on
`epic/183` before this branch — confirmed zero new failures.

`ruff check` / `ruff format --check` on every line this PR touches is
clean; remaining findings in the touched files are pre-existing (verified
against the pre-edit file content) and left alone per scope.

- [x] AC1: corrupt → `--fix --yes` → revalidate round trip
- [x] AC2: diff shown before consent, declinable, re-stamp updates wiki/scope/fingerprint
- [x] AC3: path prefix migration rewrites + revalidates; no-match is a no-op
- [x] AC4: plugin-cache drift now fails the run; wiki/scope-registry mismatch detected
- [x] AC5: plain `doctor` writes nothing, even with repairable issues present
- [x] Consent record invariant: no repair ever drops an attachment row (asserted directly in every `--fix` test)