### PR TITLE
feat: attach/offer hardening — schema, dry-run, write-offer, decline keying, rename report

### DIFF
--- a/lib/lore_cli/attach_cmd.py
+++ b/lib/lore_cli/attach_cmd.py
@@ -106,10 +106,14 @@ def _cwd_arg(cwd_opt: str | None) -> Path:
 def _no_applicable_offer_message(cwd_path: Path) -> None:
     """Print a diagnostic explaining why no offer applies to ``cwd_path``.
 
-    Distinguishes "no file anywhere" from "file at ancestor without
-    ``inherit: true``" so users hit by the migration get a clear hint.
+    Distinguishes "no file anywhere" from "file exists but fails schema
+    validation" from "file at ancestor without ``inherit: true``" so
+    users hit by any of these get a clear, actionable hint instead of a
+    generic "not found" (which a broken-but-present file would
+    otherwise produce, since ``parse_lore_yml`` treats malformed input
+    as absence).
     """
-    from lore_core.offer import find_lore_yml_raw
+    from lore_core.offer import find_lore_yml_raw, validate_offer_raw
 
     raw = find_lore_yml_raw(cwd_path)
     if raw is None:
@@ -118,6 +122,12 @@ def _no_applicable_offer_message(cwd_path: Path) -> None:
             "Use `lore attach manual --wiki ... --scope ...` for a repo "
             "without a checked-in offer."
         )
+        return
+    errors = validate_offer_raw(raw)
+    if errors:
+        err_console.print(f"[red]Invalid {raw}:[/red]")
+        for e in errors:
+            err_console.print(f"  - {e}")
         return
     err_console.print(
         f"[red]No applicable .lore.yml for[/red] {cwd_path}.\n"
@@ -267,7 +277,7 @@ def _do_accept(lore_root: Path, cwd_path: Path, scaffold_workflow: bool = False,
 
 
 def _do_decline(lore_root: Path, cwd_path: Path) -> None:
-    from lore_core.offer import find_lore_yml, offer_fingerprint
+    from lore_core.offer import find_lore_yml
     from lore_core.state.attachments import AttachmentsFile
 
     found = find_lore_yml(cwd_path)
@@ -277,11 +287,10 @@ def _do_decline(lore_root: Path, cwd_path: Path) -> None:
     offer_path, offer = found
 
     repo_root = offer_path.parent
-    fp = offer_fingerprint(offer)
 
     attachments = AttachmentsFile(lore_root)
     attachments.load()
-    attachments.decline(repo_root, fp)
+    attachments.decline(repo_root, offer.scope)
     attachments.save()
 
     console.print(
@@ -591,13 +600,14 @@ def _execute_attach(
     backend: str,
     write_offer: bool,
     scaffold_workflow: bool = False,
+    confirm_shared: bool = False,
 ) -> None:
     """Shared executor: register the attachment, optionally write a
     ``.lore.yml`` and stamp its fingerprint onto the row so the very
     next session doesn't see it as DRIFT."""
     from lore_core.offer import FILENAME
 
-    _do_manual(lore_root, resolved, wiki, scope, scaffold_workflow)
+    _do_manual(lore_root, resolved, wiki, scope, scaffold_workflow, confirm_shared)
 
     if write_offer:
         import yaml
@@ -856,11 +866,25 @@ def cmd_manual(
         "--confirm-shared",
         help="Consent to attaching to a shared (git-remote) wiki non-interactively.",
     ),
+    write_offer: bool = typer.Option(
+        False,
+        "--write-offer",
+        help="Also write a `.lore.yml` at cwd so other contributors get this config "
+             "(the non-interactive equivalent of the wizard's write-offer step).",
+    ),
+    backend: str = typer.Option(
+        "none", "--backend", help="Offer backend: github|none (used with --write-offer)."
+    ),
 ) -> None:
     """Attach ``cwd`` manually with no ``.lore.yml`` required."""
     cwd_path = _cwd_arg(cwd)
     resolved = cwd_path.resolve() if cwd_path.exists() else cwd_path.absolute()
-    _do_manual(_lore_root_or_die(), resolved, wiki, scope, scaffold_workflow, confirm_shared)
+    _execute_attach(
+        _lore_root_or_die(), resolved,
+        wiki=wiki, scope=scope, backend=backend,
+        write_offer=write_offer, scaffold_workflow=scaffold_workflow,
+        confirm_shared=confirm_shared,
+    )
 
 
 @app.command("offer")
@@ -871,6 +895,9 @@ def cmd_offer(
     wiki_source: str = typer.Option(None, "--wiki-source", help="Optional URL for clone-on-accept."),
     backend: str = typer.Option("none", "--backend", help="github|none."),
     force: bool = typer.Option(False, "--force", help="Overwrite an existing `.lore.yml`."),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print the payload that would be written; write nothing."
+    ),
 ) -> None:
     """Write a ``.lore.yml`` at ``cwd`` declaring a shareable offer."""
     import yaml
@@ -878,6 +905,16 @@ def cmd_offer(
     from lore_core.offer import FILENAME
 
     cwd_path = _cwd_arg(cwd)
+
+    payload: dict = {"wiki": wiki, "scope": scope, "backend": backend}
+    if wiki_source:
+        payload["wiki_source"] = wiki_source
+
+    if dry_run:
+        console.print(f"[dim]Dry run — would write {cwd_path / FILENAME}:[/dim]")
+        console.print(yaml.safe_dump(payload, sort_keys=False), end="")
+        return
+
     if not cwd_path.exists():
         err_console.print(f"[red]Directory does not exist:[/red] {cwd_path}")
         raise typer.Exit(1)
@@ -891,10 +928,6 @@ def cmd_offer(
             f"[red]{target} already exists.[/red] Pass --force to overwrite."
         )
         raise typer.Exit(1)
-
-    payload: dict = {"wiki": wiki, "scope": scope, "backend": backend}
-    if wiki_source:
-        payload["wiki_source"] = wiki_source
 
     target.write_text(yaml.safe_dump(payload, sort_keys=False))
     console.print(

--- a/lib/lore_cli/breadcrumb.py
+++ b/lib/lore_cli/breadcrumb.py
@@ -157,6 +157,37 @@ def render_banner(ctx: BannerContext, *, errors: list[str] | None = None) -> str
         banner = f"lore!: {state.hook_errors_24h} hook error{suffix} today (lore doctor)"
         return _prepend(session_end_line, banner)
 
+    scope_warning = _scope_drift_warning(ctx)
+    if scope_warning:
+        return _prepend(session_end_line, scope_warning)
+
     return session_end_line
+
+
+def _scope_drift_warning(ctx: BannerContext) -> str | None:
+    """Warn when this repo's checked-in ``.lore.yml`` still declares a
+    scope the registry no longer has this attachment under.
+
+    ``lore scopes rename`` rewrites vault-local state only — it never
+    edits a checked-in offer file (that file may live on a different
+    host entirely). Left uncorrected, a future ``lore attach accept``
+    re-derives the stale scope from the file and resurrects it. This
+    mirrors the fingerprint-DRIFT notice SessionStart already prints
+    for content changes, but catches the case fingerprint-matching
+    can't: the file's content hasn't changed, only the registry's
+    idea of this attachment's scope has (via rename).
+    """
+    from lore_core.offer import FILENAME, parse_lore_yml
+
+    repo_root = ctx.scope.claude_md_path.parent
+    offer = parse_lore_yml(repo_root / FILENAME)
+    if offer is None or offer.scope == ctx.scope.scope:
+        return None
+    return (
+        f"lore: {repo_root / FILENAME} still declares scope `{offer.scope}`, "
+        f"but this repo is registered under `{ctx.scope.scope}` (renamed?). "
+        f"Update the file's `scope:` field, then run "
+        f"`lore attach accept --cwd {repo_root}` to resync."
+    )
 
 

--- a/lib/lore_cli/scopes_cmd.py
+++ b/lib/lore_cli/scopes_cmd.py
@@ -335,6 +335,33 @@ def _print_rename_preview(preview: dict) -> None:
             console.print(f"  - {a.path}  [dim]({a.scope})[/dim]")
     else:
         console.print("\n[dim]No attachments reference this subtree.[/dim]")
+    _print_stale_offer_report(ats)
+
+
+def _print_stale_offer_report(affected_attachments: list) -> None:
+    """Name the checked-in `.lore.yml` files a rename leaves behind.
+
+    Rename only rewrites *this host's* vault-local state (scopes.json,
+    attachments.json, wiki frontmatter) — it never edits a `.lore.yml`
+    checked into an attached repo, which may not even be on this host.
+    Left un-updated, that file still declares the pre-rename scope; a
+    future `lore attach accept` re-derives it from the file and
+    resurrects the renamed-away scope in scopes.json.
+    """
+    from lore_core.offer import FILENAME
+
+    stale = [a.path / FILENAME for a in affected_attachments if (a.path / FILENAME).exists()]
+    if not stale:
+        return
+    console.print(
+        f"\n[yellow]Checked-in offers still reference the old scope[/yellow] ({len(stale)}):"
+    )
+    for p in stale:
+        console.print(f"  - {p}")
+    console.print(
+        "  [dim]Update each file's `scope:` field and commit — otherwise a future "
+        "`lore attach accept` will resurrect the old scope.[/dim]"
+    )
 
 
 def _apply_scope_rewrites(

--- a/lib/lore_core/consent.py
+++ b/lib/lore_core/consent.py
@@ -104,7 +104,7 @@ def classify_state(cwd: Path, attachments: AttachmentsFile) -> ConsentResult:
     repo_root = offer_path.parent
     fp = offer_fingerprint(offer)
 
-    if attachments.is_declined(repo_root, fp):
+    if attachments.is_declined(repo_root, offer.scope):
         return ConsentResult(
             state=ConsentState.DORMANT,
             offer=offer,

--- a/lib/lore_core/offer.py
+++ b/lib/lore_core/offer.py
@@ -35,8 +35,11 @@ class Offer:
     accept/decline decisions.
     """
 
-    wiki: str
-    scope: str
+    # Defaulted (not truly optional — `parse_lore_yml`/`validate_offer_raw`
+    # enforce non-empty) so `config_schema.validate_raw` can build a
+    # zero-arg default instance to walk the field tree.
+    wiki: str = ""
+    scope: str = ""
     backend: str = "none"
     wiki_source: str | None = None
     issues: str | None = None
@@ -76,6 +79,40 @@ def parse_lore_yml(path: Path) -> Offer | None:
         schema_version=int(raw.get("schema_version", 1)),
         inherit=raw.get("inherit") is True,
     )
+
+
+def validate_offer_raw(path: Path) -> list[str]:
+    """Strict schema check for a `.lore.yml` file — named-key errors.
+
+    Reuses ``config_schema.validate_raw`` (unknown keys w/ suggestions,
+    type mismatches) against the ``Offer`` field tree, same validator
+    that backs ``lore config edit``. ``validate_raw`` only checks keys
+    that are *present*; it has no notion of "required", so ``wiki``/
+    ``scope`` presence is checked here to match ``parse_lore_yml``.
+
+    Empty list means valid. Unreadable/malformed-YAML/non-mapping files
+    return ``[]`` too — ``parse_lore_yml`` already treats those as
+    "absent", and that path owns the "no offer found" message; this is
+    only for a *present, parseable, but schema-invalid* file.
+    """
+    if not path.exists() or not path.is_file():
+        return []
+    try:
+        import yaml
+        raw = yaml.safe_load(path.read_text())
+    except Exception:
+        return []
+    if not isinstance(raw, dict):
+        return []
+
+    from lore_core.config_schema import validate_raw
+
+    errors = validate_raw(Offer, raw)
+    for required in ("wiki", "scope"):
+        value = raw.get(required)
+        if not isinstance(value, str) or not value:
+            errors.append(f"{required!r} is required and must be a non-empty string")
+    return errors
 
 
 def find_lore_yml(cwd: Path, *, max_depth: int = 8) -> tuple[Path, Offer] | None:

--- a/lib/lore_core/state/attachments.py
+++ b/lib/lore_core/state/attachments.py
@@ -32,8 +32,16 @@ class Attachment:
 
 @dataclass
 class Declined:
+    """A recorded decline, keyed by ``(path, scope)`` — not by offer
+    content fingerprint. Declining is a per-scope decision: editing an
+    offer's non-routing content (or even a routing field like
+    ``wiki_source``) must not re-prompt someone who already said no,
+    but a changed ``scope`` is a materially different offer and
+    legitimately re-asks.
+    """
+
     path: Path
-    offer_fingerprint: str
+    scope: str
 
 
 class AttachmentsFile:
@@ -129,21 +137,21 @@ class AttachmentsFile:
         self._attachments = [a for a in self._attachments if a.path != normalised]
         return len(self._attachments) != before
 
-    def decline(self, path: Path, offer_fingerprint: str) -> None:
-        """Record a declined offer. Path + fingerprint pair is the key."""
+    def decline(self, path: Path, scope: str) -> None:
+        """Record a declined offer. Path + scope pair is the key."""
         self._ensure_loaded()
         normalised = _normalise_path(path)
         self._declined = [
             d for d in self._declined
-            if not (d.path == normalised and d.offer_fingerprint == offer_fingerprint)
+            if not (d.path == normalised and d.scope == scope)
         ]
-        self._declined.append(Declined(path=normalised, offer_fingerprint=offer_fingerprint))
+        self._declined.append(Declined(path=normalised, scope=scope))
 
-    def is_declined(self, path: Path, offer_fingerprint: str) -> bool:
+    def is_declined(self, path: Path, scope: str) -> bool:
         self._ensure_loaded()
         normalised = _normalise_path(path)
         return any(
-            d.path == normalised and d.offer_fingerprint == offer_fingerprint
+            d.path == normalised and d.scope == scope
             for d in self._declined
         )
 
@@ -228,11 +236,17 @@ def _attachment_from_raw(raw: dict[str, Any]) -> Attachment:
 
 
 def _declined_to_raw(d: Declined) -> dict[str, Any]:
-    return {"path": str(d.path), "offer_fingerprint": d.offer_fingerprint}
+    return {"path": str(d.path), "scope": d.scope}
 
 
 def _declined_from_raw(raw: dict[str, Any]) -> Declined:
-    return Declined(path=Path(raw["path"]), offer_fingerprint=raw["offer_fingerprint"])
+    # Pre-scope-keying records stored `offer_fingerprint` instead of
+    # `scope` — preserved verbatim (never drop a consent row) rather
+    # than migrated, since the original scope string isn't recoverable
+    # from a fingerprint. Round-trips fine; just won't match new
+    # (path, scope) lookups, so the offer re-prompts once after upgrade.
+    scope = raw.get("scope", raw.get("offer_fingerprint", ""))
+    return Declined(path=Path(raw["path"]), scope=scope)
 
 
 def _parse_dt(s: str) -> datetime:

--- a/tests/test_attachments_file.py
+++ b/tests/test_attachments_file.py
@@ -156,9 +156,9 @@ def test_decline_and_is_declined(lore_root: Path, tmp_path: Path) -> None:
     af.load()
     p = tmp_path / "repo"
     p.mkdir()
-    af.decline(p, "sha256:abc")
-    assert af.is_declined(p, "sha256:abc") is True
-    assert af.is_declined(p, "sha256:xyz") is False
+    af.decline(p, "a:b")
+    assert af.is_declined(p, "a:b") is True
+    assert af.is_declined(p, "a:c") is False
 
 
 def test_decline_is_upsert(lore_root: Path, tmp_path: Path) -> None:
@@ -166,14 +166,14 @@ def test_decline_is_upsert(lore_root: Path, tmp_path: Path) -> None:
     af.load()
     p = tmp_path / "repo"
     p.mkdir()
-    af.decline(p, "sha256:abc")
-    af.decline(p, "sha256:abc")  # same key — no duplicate
+    af.decline(p, "a:b")
+    af.decline(p, "a:b")  # same key — no duplicate
     af.save()
 
     af2 = AttachmentsFile(lore_root)
     af2.load()
-    # Different fingerprint doesn't invalidate the first
-    assert af2.is_declined(p, "sha256:abc") is True
+    # Re-declining the same scope doesn't invalidate the first
+    assert af2.is_declined(p, "a:b") is True
 
 
 def test_decline_survives_save_load(lore_root: Path, tmp_path: Path) -> None:
@@ -181,12 +181,36 @@ def test_decline_survives_save_load(lore_root: Path, tmp_path: Path) -> None:
     af.load()
     p = tmp_path / "repo"
     p.mkdir()
-    af.decline(p, "sha256:foo")
+    af.decline(p, "a:b")
     af.save()
 
     af2 = AttachmentsFile(lore_root)
     af2.load()
-    assert af2.is_declined(p, "sha256:foo") is True
+    assert af2.is_declined(p, "a:b") is True
+
+
+def test_decline_legacy_fingerprint_record_round_trips(lore_root: Path, tmp_path: Path) -> None:
+    """A pre-scope-keying record (``offer_fingerprint`` instead of
+    ``scope``) is never dropped on load/save, even though it won't
+    match new ``(path, scope)`` lookups — the original scope string
+    isn't recoverable from a fingerprint."""
+    import json
+
+    p = tmp_path / "repo"
+    p.mkdir()
+    raw = {
+        "attachments": [],
+        "declined": [{"path": str(p), "offer_fingerprint": "sha256:legacy"}],
+    }
+    (lore_root / ".lore" / "attachments.json").write_text(json.dumps(raw))
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    assert af.is_declined(p, "a:b") is False  # doesn't match any real scope
+    af.save()
+
+    saved = json.loads((lore_root / ".lore" / "attachments.json").read_text())
+    assert len(saved["declined"]) == 1  # row preserved, not dropped
 
 
 def test_get_exact_match(lore_root: Path, tmp_path: Path) -> None:

--- a/tests/test_breadcrumb.py
+++ b/tests/test_breadcrumb.py
@@ -493,6 +493,70 @@ def test_render_banner_prepends_session_end_error(tmp_path: Path) -> None:
     assert "capture error" in banner
 
 
+# ---------------------------------------------------------------------------
+# 15. Scope-drift warning — checked-in `.lore.yml` vs registry scope
+# ---------------------------------------------------------------------------
+
+
+def test_banner_no_scope_drift_when_offer_matches(
+    lore_root: Path, wiki_config_normal: WikiConfig,
+) -> None:
+    """Checked-in offer's scope agrees with the registry — silent."""
+    (lore_root / ".lore.yml").write_text("wiki: private\nscope: private:root\n")
+    scope = Scope(
+        wiki="private", scope="private:root", backend="none",
+        claude_md_path=lore_root / "CLAUDE.md",
+    )
+    now = datetime(2026, 4, 18, 10, 0, 0, tzinfo=UTC)
+    ctx = BannerContext(lore_root=lore_root, scope=scope, wiki_config=wiki_config_normal, now=now)
+    assert render_banner(ctx) is None
+
+
+def test_banner_no_scope_drift_when_no_checked_in_file(
+    lore_root: Path, wiki_config_normal: WikiConfig, scope: Scope,
+) -> None:
+    """No `.lore.yml` on disk (e.g. a manual attachment) — nothing to warn about."""
+    now = datetime(2026, 4, 18, 10, 0, 0, tzinfo=UTC)
+    ctx = BannerContext(lore_root=lore_root, scope=scope, wiki_config=wiki_config_normal, now=now)
+    assert render_banner(ctx) is None
+
+
+def test_banner_warns_on_scope_drift_after_rename(
+    lore_root: Path, wiki_config_normal: WikiConfig,
+) -> None:
+    """`lore scopes rename` moved this attachment to a new scope, but the
+    checked-in `.lore.yml` (this repo's attachment root == lore_root in
+    this fixture) still declares the old one — the exact residue a
+    rename leaves behind since it never edits attached repos' files."""
+    (lore_root / ".lore.yml").write_text("wiki: private\nscope: old:scope\n")
+    scope = Scope(
+        wiki="private", scope="new:scope", backend="none",
+        claude_md_path=lore_root / "CLAUDE.md",
+    )
+    now = datetime(2026, 4, 18, 10, 0, 0, tzinfo=UTC)
+    ctx = BannerContext(lore_root=lore_root, scope=scope, wiki_config=wiki_config_normal, now=now)
+    banner = render_banner(ctx)
+    assert banner is not None
+    assert "old:scope" in banner
+    assert "new:scope" in banner
+    assert "lore attach accept" in banner
+
+
+def test_banner_scope_drift_suppressed_in_quiet_mode(
+    lore_root: Path, wiki_config_quiet: WikiConfig,
+) -> None:
+    """Same tier as the hook-error count: quiet mode suppresses it too —
+    only the last-run-error prefix bypasses quiet."""
+    (lore_root / ".lore.yml").write_text("wiki: private\nscope: old:scope\n")
+    scope = Scope(
+        wiki="private", scope="new:scope", backend="none",
+        claude_md_path=lore_root / "CLAUDE.md",
+    )
+    now = datetime(2026, 4, 18, 10, 0, 0, tzinfo=UTC)
+    ctx = BannerContext(lore_root=lore_root, scope=scope, wiki_config=wiki_config_quiet, now=now)
+    assert render_banner(ctx) is None
+
+
 def test_render_banner_quiet_with_session_end_error(tmp_path: Path) -> None:
     """Quiet mode still surfaces error breadcrumbs."""
     lore_dir = tmp_path / ".lore"

--- a/tests/test_cli_attach_matrix.py
+++ b/tests/test_cli_attach_matrix.py
@@ -70,6 +70,31 @@ def test_accept_after_decline_fails(lore_root: Path, tmp_path: Path) -> None:
     assert result.exit_code == 1
 
 
+def test_accept_invalid_offer_names_bad_key(lore_root: Path, tmp_path: Path) -> None:
+    """A present-but-schema-invalid `.lore.yml` gets a named-key error at
+    attach time, not the generic 'no offer found' message — that message
+    is what `parse_lore_yml`'s lenient absence-on-failure would otherwise
+    produce, hiding the actual typo from the user."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / FILENAME).write_text("wiki: team-alpha\nscoep: ccat:ds\n")  # typo'd key
+    result = runner.invoke(app, ["attach", "accept", "--cwd", str(repo)])
+    assert result.exit_code == 1
+    assert "scoep" in result.stderr
+    assert "Invalid" in result.stderr
+
+    af = AttachmentsFile(lore_root); af.load()
+    assert af.all() == []
+
+
+def test_accept_valid_offer_unaffected_by_validation(lore_root: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_offer(repo)
+    result = runner.invoke(app, ["attach", "accept", "--cwd", str(repo)])
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+
 def test_accept_scope_conflict_surfaces_options(lore_root: Path, tmp_path: Path) -> None:
     """Root `ccat` already assigned to one wiki; new offer with `ccat:...`
     but different wiki should fail with a helpful conflict message."""
@@ -87,18 +112,17 @@ def test_accept_scope_conflict_surfaces_options(lore_root: Path, tmp_path: Path)
 
 # ---- decline ----
 
-def test_decline_records_fingerprint(lore_root: Path, tmp_path: Path) -> None:
+def test_decline_records_scope(lore_root: Path, tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     _write_offer(repo)
     offer = parse_lore_yml(repo / FILENAME)
-    fp = offer_fingerprint(offer)
 
     result = runner.invoke(app, ["attach", "decline", "--cwd", str(repo)])
     assert result.exit_code == 0
 
     af = AttachmentsFile(lore_root); af.load()
-    assert af.is_declined(repo, fp)
+    assert af.is_declined(repo, offer.scope)
 
 
 def test_decline_no_offer_fails(lore_root: Path, tmp_path: Path) -> None:
@@ -127,6 +151,43 @@ def test_manual_attach(lore_root: Path, tmp_path: Path) -> None:
 
     sf = ScopesFile(lore_root); sf.load()
     assert sf.get("a:b") is not None
+
+
+def test_manual_write_offer_writes_lore_yml(lore_root: Path, tmp_path: Path) -> None:
+    """Non-interactive parity: `manual --write-offer` closes the gap where
+    the CLI path used to silently skip the wizard's write-offer step."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        ["attach", "manual", "--wiki", "w", "--scope", "a:b",
+         "--cwd", str(repo), "--write-offer", "--backend", "github"],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+    offer = parse_lore_yml(repo / FILENAME)
+    assert offer is not None
+    assert offer.wiki == "w"
+    assert offer.scope == "a:b"
+    assert offer.backend == "github"
+
+    # Fingerprint stamped onto the row — next SessionStart must not see
+    # this as DRIFT just because the wizard-equivalent wrote the file.
+    af = AttachmentsFile(lore_root); af.load()
+    row = af.get(repo)
+    assert row is not None
+    assert row.offer_fingerprint == offer_fingerprint(offer)
+
+
+def test_manual_without_write_offer_writes_no_file(lore_root: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        ["attach", "manual", "--wiki", "w", "--scope", "a:b", "--cwd", str(repo)],
+    )
+    assert result.exit_code == 0
+    assert not (repo / FILENAME).exists()
 
 
 def test_manual_scope_conflict(lore_root: Path, tmp_path: Path) -> None:
@@ -174,6 +235,35 @@ def test_offer_refuses_overwrite(lore_root: Path, tmp_path: Path) -> None:
     )
     assert result.exit_code == 1
     # Original preserved
+    assert (repo / FILENAME).read_text() == "wiki: existing\nscope: e:s\n"
+
+
+def test_offer_dry_run_writes_nothing(lore_root: Path, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = runner.invoke(
+        app,
+        ["attach", "offer", "--wiki", "team-beta", "--scope", "proj:mod",
+         "--cwd", str(repo), "--dry-run"],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert not (repo / FILENAME).exists()
+    assert "wiki: team-beta" in result.stdout
+    assert "scope: proj:mod" in result.stdout
+
+
+def test_offer_dry_run_ignores_existing_file(lore_root: Path, tmp_path: Path) -> None:
+    """Dry run previews the payload even when a `.lore.yml` already exists
+    and `--force` wasn't passed — it never touches disk either way."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / FILENAME).write_text("wiki: existing\nscope: e:s\n")
+    result = runner.invoke(
+        app,
+        ["attach", "offer", "--wiki", "new", "--scope", "n:s",
+         "--cwd", str(repo), "--dry-run"],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
     assert (repo / FILENAME).read_text() == "wiki: existing\nscope: e:s\n"
 
 

--- a/tests/test_cli_scopes.py
+++ b/tests/test_cli_scopes.py
@@ -95,6 +95,44 @@ def test_rename_propagates_to_attachments(lore_root: Path, tmp_path: Path) -> No
     assert entries[0].scope == "ccat:infra:computers"
 
 
+def test_rename_reports_stale_checked_in_offer(lore_root: Path, tmp_path: Path) -> None:
+    """Rename never edits files inside an attached repo — it should name
+    the checked-in `.lore.yml` that's now left declaring the old scope,
+    since a future `lore attach accept` there would otherwise resurrect
+    the renamed-away scope."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".lore.yml").write_text("wiki: team-alpha\nscope: ccat:data-center\n")
+    _seed_scope(lore_root, "ccat:data-center", "team-alpha")
+    _seed_attachment(lore_root, repo, wiki="team-alpha", scope="ccat:data-center")
+
+    result = runner.invoke(
+        app,
+        ["scopes", "rename", "ccat:data-center", "ccat:infra", "--yes"],
+    )
+    assert result.exit_code == 0
+    assert "still reference the old scope" in result.stdout
+    # Rich's path highlighter splits dir/filename into separate ANSI
+    # spans, so match the filename token rather than the full string.
+    assert "repo" in result.stdout
+    assert ".lore.yml" in result.stdout
+
+
+def test_rename_no_stale_report_without_checked_in_file(lore_root: Path, tmp_path: Path) -> None:
+    """A manual attachment (no `.lore.yml` on disk) has nothing to report."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _seed_scope(lore_root, "ccat:data-center", "team-alpha")
+    _seed_attachment(lore_root, repo, wiki="team-alpha", scope="ccat:data-center")
+
+    result = runner.invoke(
+        app,
+        ["scopes", "rename", "ccat:data-center", "ccat:infra", "--yes"],
+    )
+    assert result.exit_code == 0
+    assert "still reference the old scope" not in result.stdout
+
+
 def test_rename_missing_scope_fails(lore_root: Path) -> None:
     result = runner.invoke(app, ["scopes", "rename", "nope", "other", "--yes"])
     assert result.exit_code == 1

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -124,31 +124,73 @@ def test_attached(lore_root: Path, tmp_path: Path, now: datetime) -> None:
 # ---- DORMANT ----
 
 def test_dormant(lore_root: Path, tmp_path: Path) -> None:
-    """Offer + decline entry with matching fingerprint → DORMANT."""
+    """Offer + decline entry with matching scope → DORMANT."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    _write_offer(repo)
-    offer = parse_lore_yml(repo / FILENAME)
-    fp = offer_fingerprint(offer)
+    _write_offer(repo, scope="a:b")
 
     af = AttachmentsFile(lore_root)
     af.load()
-    af.decline(repo, fp)
+    af.decline(repo, "a:b")
 
     r = classify_state(repo, af)
     assert r.state is ConsentState.DORMANT
 
 
-def test_dormant_decline_for_different_fingerprint_does_not_suppress(
+def test_dormant_decline_for_different_scope_does_not_suppress(
     lore_root: Path, tmp_path: Path,
 ) -> None:
-    """An old decline for a different fingerprint doesn't suppress a new offer."""
+    """An old decline for a different scope doesn't suppress a new offer."""
     repo = tmp_path / "repo"
     repo.mkdir()
     _write_offer(repo, wiki="new-wiki", scope="new:scope")
     af = AttachmentsFile(lore_root)
     af.load()
-    af.decline(repo, "sha256:old-fingerprint")     # stale decline, different offer
+    af.decline(repo, "old:scope")     # stale decline, different offer
+    r = classify_state(repo, af)
+    assert r.state is ConsentState.OFFERED
+
+
+def test_dormant_survives_content_edit_that_changes_fingerprint(
+    lore_root: Path, tmp_path: Path,
+) -> None:
+    """Editing an offer's `wiki_source` (a fingerprint field) after a
+    decline must NOT re-prompt — decline is keyed on (path, scope), not
+    on the content fingerprint that changed."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_offer(repo, wiki="w", scope="a:b")
+    fp_before = offer_fingerprint(parse_lore_yml(repo / FILENAME))
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.decline(repo, "a:b")
+    r = classify_state(repo, af)
+    assert r.state is ConsentState.DORMANT
+
+    # Edit content only — scope unchanged, but wiki_source is a
+    # fingerprint field, so the fingerprint DOES change here.
+    _write_offer(repo, wiki="w", scope="a:b", wiki_source="git@example.com:x.git")
+    fp_after = offer_fingerprint(parse_lore_yml(repo / FILENAME))
+    assert fp_before != fp_after  # sanity: the edit is not a no-op
+
+    r2 = classify_state(repo, af)
+    assert r2.state is ConsentState.DORMANT
+
+
+def test_dormant_reprompts_on_scope_change(lore_root: Path, tmp_path: Path) -> None:
+    """A changed scope IS a materially different offer — re-asks even
+    though the decline for the old scope is still on file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_offer(repo, wiki="w", scope="a:b")
+
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.decline(repo, "a:b")
+    assert classify_state(repo, af).state is ConsentState.DORMANT
+
+    _write_offer(repo, wiki="w", scope="a:c")  # scope changed
     r = classify_state(repo, af)
     assert r.state is ConsentState.OFFERED
 

--- a/tests/test_hooks_session_start_offer.py
+++ b/tests/test_hooks_session_start_offer.py
@@ -77,11 +77,10 @@ def test_returns_none_dormant(lore_root: Path, tmp_path: Path) -> None:
     repo.mkdir()
     _write_offer(repo)
     offer = parse_lore_yml(repo / FILENAME)
-    fp = offer_fingerprint(offer)
 
     af = AttachmentsFile(lore_root)
     af.load()
-    af.decline(repo, fp)
+    af.decline(repo, offer.scope)
     af.save()
 
     assert _offer_notice_line(repo) is None

--- a/tests/test_offer.py
+++ b/tests/test_offer.py
@@ -13,6 +13,7 @@ from lore_core.offer import (
     find_lore_yml_raw,
     offer_fingerprint,
     parse_lore_yml,
+    validate_offer_raw,
 )
 
 
@@ -204,3 +205,42 @@ def test_fingerprint_changes_on_wiki_source_change() -> None:
     a = Offer(wiki="w", scope="a:b", wiki_source="url1")
     b = Offer(wiki="w", scope="a:b", wiki_source="url2")
     assert offer_fingerprint(a) != offer_fingerprint(b)
+
+
+# ---- validate_offer_raw ----
+
+def test_validate_offer_raw_valid_is_empty(tmp_path: Path) -> None:
+    (tmp_path / FILENAME).write_text("wiki: w\nscope: a:b\nbackend: github\n")
+    assert validate_offer_raw(tmp_path / FILENAME) == []
+
+
+def test_validate_offer_raw_unknown_key_names_it(tmp_path: Path) -> None:
+    (tmp_path / FILENAME).write_text("wiki: w\nscope: a:b\nbakcend: github\n")
+    errors = validate_offer_raw(tmp_path / FILENAME)
+    assert len(errors) == 1
+    assert "bakcend" in errors[0]
+    assert "backend" in errors[0]  # suggestion
+
+
+def test_validate_offer_raw_type_mismatch(tmp_path: Path) -> None:
+    (tmp_path / FILENAME).write_text("wiki: w\nscope: a:b\ninherit: not-a-bool\n")
+    errors = validate_offer_raw(tmp_path / FILENAME)
+    assert len(errors) == 1
+    assert "inherit" in errors[0]
+
+
+def test_validate_offer_raw_missing_wiki(tmp_path: Path) -> None:
+    (tmp_path / FILENAME).write_text("scope: a:b\n")
+    errors = validate_offer_raw(tmp_path / FILENAME)
+    assert any("wiki" in e for e in errors)
+
+
+def test_validate_offer_raw_missing_file_is_empty(tmp_path: Path) -> None:
+    """Absence is `parse_lore_yml`'s job to report — not a validation error."""
+    assert validate_offer_raw(tmp_path / FILENAME) == []
+
+
+def test_validate_offer_raw_malformed_yaml_is_empty(tmp_path: Path) -> None:
+    """Malformed YAML is treated as absence, same as `parse_lore_yml`."""
+    (tmp_path / FILENAME).write_text("wiki: [unclosed\n")
+    assert validate_offer_raw(tmp_path / FILENAME) == []


### PR DESCRIPTION
Closes #191

## Summary

Hardens the `.lore.yml` attach/offer surface: `.lore.yml` gets real schema
validation before it's trusted, `attach offer` supports a dry-run preview,
`attach manual` can write a shareable offer non-interactively (parity with
the wizard), declines survive content edits but re-ask on scope changes,
and `scopes rename` reports the checked-in offer files it leaves stale.

- **AC1 — schema validation.** `.lore.yml` gets strict validation at attach
  time via `lore_core.offer.validate_offer_raw()`, which reuses
  `config_schema.validate_raw()`/`suggest()` from #187 against the `Offer`
  field tree (no reinvented validator). `Offer.wiki`/`scope` are now
  defaulted (`""`) so `validate_raw` can build its zero-arg default
  instance — the required-non-empty check itself still lives in
  `validate_offer_raw`, since `validate_raw` only checks keys that are
  *present*. A present-but-invalid file now surfaces a named-key error at
  `lore attach accept`/`decline` instead of the generic "no offer found"
  message that `parse_lore_yml`'s lenient-absence-on-failure produced.
- **AC2 — dry-run.** `lore attach offer --dry-run` prints the exact YAML
  payload and returns before any filesystem check or write.
- **AC3 — write-offer parity.** `lore attach manual --write-offer
  [--backend ...]` now routes through the same `_execute_attach` helper
  the wizard's one-click-accept path uses, so it writes `.lore.yml` and
  stamps the fingerprint onto the attachment row (closing the gap where
  the CLI path silently skipped that step).
- **AC4 — scope-keyed declines.** `AttachmentsFile.decline`/`is_declined`
  (and `Declined`) are now keyed on `(path, scope)` instead of content
  fingerprint. Editing an offer's `wiki_source` (a fingerprint field) no
  longer un-suppresses a decline; changing `scope` legitimately does.
  Legacy fingerprint-keyed rows round-trip losslessly on load/save (never
  dropped — consent records are non-regenerable) but won't match new
  lookups, since the original scope string isn't recoverable from a
  fingerprint hash.
- **AC5 — rename leaves a report; SessionStart warns.** `lore scopes
  rename`/`reparent` only rewrite vault-local state (scopes.json,
  attachments.json, wiki frontmatter) — they've never touched a
  checked-in `.lore.yml`, which may live in a repo not even on this host.
  The preview now names every affected attachment whose checked-in offer
  file still declares the pre-rename scope, since a later `lore attach
  accept` there would otherwise resurrect the renamed-away scope.
  `breadcrumb.render_banner` gets a matching, additive check: when the
  current repo's checked-in offer scope diverges from what the registry
  has it under, SessionStart names `lore attach accept --cwd <path>` as
  the fix (after the file itself is corrected) — same priority tier as
  the hook-error count, suppressed in quiet mode like it is.

## Test plan

Strict TDD — implementation + test written together per AC, then the
implementation was set aside (`git stash` on just the impl files, tests
kept) to capture authentic red output before restoring:

**Red** (new/changed tests against the pre-change implementation):
```
tests/test_offer.py: ImportError: cannot import name 'validate_offer_raw'
tests/test_cli_attach_matrix.py: 5 failed, 12 passed
  test_accept_invalid_offer_names_bad_key
  test_decline_records_scope
  test_manual_write_offer_writes_lore_yml
  test_offer_dry_run_writes_nothing
  test_offer_dry_run_ignores_existing_file
tests/test_consent.py: 3 failed, 11 passed
  test_dormant
  test_dormant_survives_content_edit_that_changes_fingerprint
  test_dormant_reprompts_on_scope_change
tests/test_hooks_session_start_offer.py: 1 failed, 10 passed
  test_returns_none_dormant
tests/test_cli_scopes.py: 1 failed, 12 passed
  test_rename_reports_stale_checked_in_offer
tests/test_breadcrumb.py: 1 failed, 25 passed
  test_banner_warns_on_scope_drift_after_rename
tests/test_attachments_file.py: 20 passed (pure string-key tests still passed mechanically; renamed to `scope`-flavored values for honesty, not because they broke)
```

**Green** (full repo suite after restoring the implementation):
```
$ pytest tests/ -q
11 failed, 2747 passed, 16 skipped
```
The 11 failures are the pre-existing ANSI-color `CliRunner` artifacts in
`test_cli_runs` / `test_core_llm_wiring` / `test_drain_prune` /
`test_install_dispatcher` / `test_log_cmd` / `test_proc_cmd` — present on
`epic/183` before this branch, none in files this PR touches. Confirmed
zero new failures.

`ruff check`/`ruff format --check` verified against each touched file's
pre-edit (`git show HEAD:<file>`) baseline: every file's finding *count*
is identical to baseline except `tests/test_cli_attach_matrix.py` (+2
`E702`), which are two new instances of the `x = Foo(...); x.load()`
one-liner already used in 7+ other tests in that same file — matching, not
introducing, its dominant existing style. `ruff format --check` fails
tree-wide pre-existing (verified against baseline too, tracked in #196),
not something this PR introduces.

- [x] AC1: invalid `.lore.yml` → named-key error at attach time; valid offers unaffected
- [x] AC2: `--dry-run` prints payload, writes nothing
- [x] AC3: `manual --write-offer` writes a valid, fingerprint-stamped offer
- [x] AC4: decline survives content edit (wiki_source), re-asks on scope change; legacy rows preserved
- [x] AC5: rename reports stale checked-in offers; SessionStart breadcrumb warns and names `lore attach accept`