### PR TITLE
Flush lifecycle state machine + curator run-log onto the spine (#189)

### DIFF
--- a/lib/lore_cli/curator_cmd.py
+++ b/lib/lore_cli/curator_cmd.py
@@ -94,7 +94,7 @@ def _print_backend_label(con: Console, llm_client: object) -> None:
 def run_command(
     scope: str = typer.Option(None, "--scope", help="Filter to one scope, e.g. 'mywiki:subproject'."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Classify but don't write notes or advance ledger."),
-    trace_llm: bool = typer.Option(False, "--trace-llm", help="Capture LLM prompts/responses to runs/<id>.trace.jsonl (equivalent to LORE_TRACE_LLM=1)."),
+    trace_llm: bool = typer.Option(False, "--trace-llm", help="Emit LLM call metadata onto the event spine (equivalent to LORE_TRACE_LLM=1)."),
     backend: str = typer.Option(None, "--backend", help="LLM backend: subscription | api | openai | auto. Overrides LORE_LLM_BACKEND and curator.backend config."),
 ) -> None:
     """Run the curator: classify pending transcripts and file session notes."""

--- a/lib/lore_cli/log_cmd.py
+++ b/lib/lore_cli/log_cmd.py
@@ -86,22 +86,20 @@ def _run_end_label(rec: dict) -> str:
 def _read_run_events(
     lore_root: Path, since: datetime, *, role_filter: str | None = None,
 ) -> list[TimelineEntry]:
-    from lore_core.run_reader import iter_archival_runs, read_run
+    from lore_core.run_reader import read_curator_runs
 
     entries: list[TimelineEntry] = []
+    grouped = read_curator_runs(lore_root)
     try:
-        for run_path in iter_archival_runs(lore_root):
-            try:
-                records = read_run(run_path, strict_schema=False)
-            except Exception:
-                continue
+        for run_id in sorted(grouped.keys(), reverse=True):  # newest-first
+            records = grouped[run_id]
             if not records:
                 continue
             first_ts = _parse_ts(records[0].get("ts"))
             if first_ts and first_ts < since:
                 break
 
-            short_id = run_path.stem.split("-")[-1]
+            short_id = run_id.split("-")[-1]
             run_role: str | None = None
             for rec in records:
                 rtype = rec.get("type")

--- a/lib/lore_cli/runs_cmd.py
+++ b/lib/lore_cli/runs_cmd.py
@@ -1,4 +1,10 @@
-"""`lore runs` — inspect Curator A run logs."""
+"""`lore runs` — inspect Curator run logs (reconstructed from the event spine).
+
+Runs no longer have their own JSONL files: curator run events live on the
+unified spine (``source="curator"``), grouped by ``run_id``. This command
+reads that spine — it is superseded by ``lore trace`` (#192) for drill-down
+and slated for deprecation (#195), so it stays a thin history view.
+"""
 
 from __future__ import annotations
 
@@ -9,17 +15,21 @@ import time
 from pathlib import Path
 
 import typer
-from rich.console import Console
-from rich.panel import Panel
-
 from lore_core.run_reader import (
-    RunIdAmbiguous, RunIdNotFound, SchemaVersionTooNew,
-    read_run, resolve_run_id,
+    RunIdAmbiguous,
+    RunIdNotFound,
+    read_run_by_id,
+    resolve_run_id,
+    run_ids,
 )
 from lore_core.run_render import (
-    pick_icon_set, render_flat_log, render_summary_panel, should_use_color,
+    pick_icon_set,
+    render_flat_log,
+    render_summary_panel,
+    should_use_color,
 )
-
+from rich.console import Console
+from rich.panel import Panel
 
 app = typer.Typer(
     add_completion=False,
@@ -41,6 +51,7 @@ _IDLE_TIMEOUT_S = 30 * 60  # 30 min
 
 def _get_lore_root() -> Path:
     from lore_core.config import get_lore_root
+
     return get_lore_root()
 
 
@@ -52,12 +63,28 @@ def _complete_run_id(ctx, args, incomplete: str):
     """
     try:
         from lore_core.config import get_lore_root
-        from lore_core.run_reader import list_archival_runs
-        suffixes = [p.stem.split("-")[-1] for p in list_archival_runs(get_lore_root())]
+
+        suffixes = [rid.split("-")[-1] for rid in run_ids(get_lore_root())]
     except Exception:
         suffixes = []
     candidates = suffixes + ["latest"] + [f"^{i}" for i in range(1, 6)]
     return [c for c in candidates if c.startswith(incomplete)]
+
+
+def _run_summary_row(run_id: str, records: list[dict]) -> dict:
+    """Collapse one run's records into the fields both list views render."""
+    start = next((r for r in records if r.get("type") == "run-start"), {})
+    end = next((r for r in reversed(records) if r.get("type") == "run-end"), {})
+    return {
+        "short_id": run_id.split("-")[-1],
+        "ts": start.get("ts", ""),
+        "dur": f"{end.get('duration_ms', 0) / 1000:.1f}s",
+        "transcripts": sum(1 for r in records if r.get("type") == "transcript-start"),
+        "notes_new": end.get("notes_new", 0),
+        "notes_merged": end.get("notes_merged", 0),
+        "skipped": end.get("skipped", 0),
+        "errors": end.get("errors", 0),
+    }
 
 
 @app.command("list")
@@ -70,75 +97,71 @@ def list_runs(
     from rich.table import Table
 
     lore_root = _get_lore_root()
-
-    runs_dir = lore_root / ".lore" / "runs"
+    ids = run_ids(lore_root, limit=limit)
 
     if hooks:
         import os as _os
-        # Build combined list of (ts_str, kind, data) tuples.
-        combined: list[tuple[str, str, object]] = []
-        has_runs = False
+
         from lore_core.spine import read_spine
+
         hook_rows = read_spine(lore_root, source="hook")
         has_hook_events = bool(hook_rows)
+        has_runs = bool(ids)
 
-        # Load runs.
-        if runs_dir.exists():
-            from lore_core.run_reader import iter_archival_runs
-            archival_paths = list(iter_archival_runs(lore_root, limit=limit))
-            has_runs = bool(archival_paths)
-            for p in archival_paths:
-                records = read_run(p, strict_schema=False)
-                start = next((r for r in records if r.get("type") == "run-start"), {})
-                end = next((r for r in reversed(records) if r.get("type") == "run-end"), {})
-                ts = start.get("ts", "")
-                short_id = p.stem.split("-")[-1]
-                schema_mismatch = any(r.get("_schema_mismatch") for r in records)
-                dur = f"{end.get('duration_ms', 0) / 1000:.1f}s"
-                notes_new = end.get("notes_new", 0)
-                notes_merged = end.get("notes_merged", 0)
-                skipped = end.get("skipped", 0)
-                errors = end.get("errors", 0)
-                if notes_new == 0 and notes_merged == 0:
-                    summary = f"0 skipped ({skipped})" if skipped else "0 \u00b7 0 errors"
-                else:
-                    summary = f"{notes_new} new" + (f"+{notes_merged}m" if notes_merged else "")
-                    summary += f" \u00b7 {errors} errors"
-                combined.append((ts, "run", {
-                    "short_id": short_id,
-                    "started": _relative_time_cli(ts),
-                    "dur": dur,
-                    "summary": summary,
-                    "schema_mismatch": schema_mismatch,
-                }))
+        combined: list[tuple[str, str, object]] = []
+        for run_id in ids:
+            row = _run_summary_row(run_id, read_run_by_id(lore_root, run_id))
+            if row["notes_new"] == 0 and row["notes_merged"] == 0:
+                summary = f"0 skipped ({row['skipped']})" if row["skipped"] else "0 · 0 errors"
+            else:
+                summary = f"{row['notes_new']} new" + (
+                    f"+{row['notes_merged']}m" if row["notes_merged"] else ""
+                )
+                summary += f" · {row['errors']} errors"
+            combined.append(
+                (
+                    row["ts"],
+                    "run",
+                    {
+                        "short_id": row["short_id"],
+                        "started": _relative_time_cli(row["ts"]),
+                        "dur": row["dur"],
+                        "summary": summary,
+                    },
+                )
+            )
 
-        # Load hook events from the spine.
-        for row in hook_rows:
-            data = row.get("data") or {}
-            ts = row.get("ts", "")
+        for hrow in hook_rows:
+            data = hrow.get("data") or {}
+            ts = hrow.get("ts", "")
             cwd = data.get("cwd")
-            where = _os.path.basename(cwd) if cwd else "\u2014"
+            where = _os.path.basename(cwd) if cwd else "—"
             pid_val = data.get("pid")
-            pid = str(pid_val) if pid_val is not None else "\u2014"
-            combined.append((ts, "hook", {
-                "started": _relative_time_cli(ts),
-                "event": row.get("event", "?"),
-                "outcome": data.get("outcome", "?"),
-                "where": where,
-                "pid": pid,
-            }))
+            pid = str(pid_val) if pid_val is not None else "—"
+            combined.append(
+                (
+                    ts,
+                    "hook",
+                    {
+                        "started": _relative_time_cli(ts),
+                        "event": hrow.get("event", "?"),
+                        "outcome": data.get("outcome", "?"),
+                        "where": where,
+                        "pid": pid,
+                    },
+                )
+            )
 
         if not combined:
             console.print("[dim]No capture activity yet.[/dim]")
             return
 
-        # Sort newest first, limit total.
         combined.sort(key=lambda x: x[0], reverse=True)
         combined = combined[:limit]
 
-        # Diagnostic banner: runs without hook events means curator ran
-        # but Claude Code's capture hook never logged — strong signal
-        # that SessionStart isn't invoking `lore hook capture`.
+        # Diagnostic banner: runs without hook events means curator ran but
+        # Claude Code's capture hook never logged — strong signal that
+        # SessionStart isn't invoking `lore hook capture`.
         if has_runs and not has_hook_events:
             console.print(
                 "[yellow]! spine has no hook events — SessionStart capture "
@@ -158,21 +181,22 @@ def list_runs(
 
         for _ts, kind, data in combined:
             if kind == "run":
-                short_id = data["short_id"]  # type: ignore[index]
-                if data["schema_mismatch"]:  # type: ignore[index]
-                    id_cell = f"[dim]{short_id}[/dim]"
-                    summary = f"[dim]{data['summary']} (schema v? \u00b7 upgrade lore)[/dim]"  # type: ignore[index]
-                else:
-                    id_cell = short_id
-                    summary = data["summary"]  # type: ignore[index]
-                table.add_row(id_cell, "run", data["started"], data["dur"],  # type: ignore[index]
-                              summary, "\u2014", "\u2014")
+                table.add_row(
+                    data["short_id"],
+                    "run",
+                    data["started"],
+                    data["dur"],  # type: ignore[index]
+                    data["summary"],
+                    "—",
+                    "—",
+                )  # type: ignore[index]
             else:
                 table.add_row(
-                    f"[dim]\u2500[/dim]", "[dim]hook[/dim]",
+                    "[dim]─[/dim]",
+                    "[dim]hook[/dim]",
                     f"[dim]{data['started']}[/dim]",  # type: ignore[index]
-                    "[dim]\u2014[/dim]",
-                    f"[dim]{data['event']} \u00b7 {data['outcome']}[/dim]",  # type: ignore[index]
+                    "[dim]—[/dim]",
+                    f"[dim]{data['event']} · {data['outcome']}[/dim]",  # type: ignore[index]
                     f"[dim]{data['where']}[/dim]",  # type: ignore[index]
                     f"[dim]{data['pid']}[/dim]",  # type: ignore[index]
                 )
@@ -180,16 +204,14 @@ def list_runs(
         console.print(table)
         return
 
-    if not runs_dir.exists() or not any(runs_dir.iterdir()):
+    if not ids:
         console.print("[dim]No capture activity yet.[/dim]")
         return
 
-    from lore_core.run_reader import iter_archival_runs
-    archival = list(iter_archival_runs(lore_root, limit=limit))
-
     if json_out:
-        for p in archival:
-            sys.stdout.write(p.read_text())
+        for run_id in ids:
+            for rec in read_run_by_id(lore_root, run_id):
+                sys.stdout.write(json.dumps({"run_id": run_id, **rec}) + "\n")
         return
 
     table = Table(title=None)
@@ -201,33 +223,28 @@ def list_runs(
     table.add_column("Reason")
     table.add_column("Errors")
 
-    for p in archival:
-        records = read_run(p, strict_schema=False)
-        schema_mismatch = any(r.get("_schema_mismatch") for r in records)
-        start = next((r for r in records if r.get("type") == "run-start"), {})
-        end = next((r for r in reversed(records) if r.get("type") == "run-end"), {})
-        short_id = p.stem.split("-")[-1]
-        started = _relative_time_cli(start.get("ts", ""))
-        dur = f"{end.get('duration_ms', 0) / 1000:.1f}s"
-        t_count = sum(1 for r in records if r.get("type") == "transcript-start")
-        notes_new = end.get("notes_new", 0)
-        notes_merged = end.get("notes_merged", 0)
-        skipped = end.get("skipped", 0)
-        if notes_new == 0 and notes_merged == 0:
+    for run_id in ids:
+        row = _run_summary_row(run_id, read_run_by_id(lore_root, run_id))
+        started = _relative_time_cli(row["ts"])
+        if row["notes_new"] == 0 and row["notes_merged"] == 0:
             notes_cell = "0"
-            reason = f"all skipped ({skipped})" if skipped else "\u2014"
+            reason = f"all skipped ({row['skipped']})" if row["skipped"] else "—"
         else:
-            notes_cell = f"{notes_new} new" + (f"+{notes_merged}m" if notes_merged else "")
-            reason = "\u2014"
-        errors = str(end.get("errors", 0))
-        id_cell = short_id
-        if schema_mismatch:
-            id_cell = f"[dim]{short_id}[/dim]"
-            reason = f"[dim]{reason} (schema v? \u00b7 upgrade lore)[/dim]"
-        table.add_row(id_cell, started, dur, str(t_count), notes_cell, reason, errors)
+            notes_cell = f"{row['notes_new']} new" + (
+                f"+{row['notes_merged']}m" if row["notes_merged"] else ""
+            )
+            reason = "—"
+        table.add_row(
+            row["short_id"],
+            started,
+            row["dur"],
+            str(row["transcripts"]),
+            notes_cell,
+            reason,
+            str(row["errors"]),
+        )
 
     console.print(table)
-
 
 
 from lore_core.timefmt import relative_time as _relative_time_cli  # noqa: E402
@@ -235,15 +252,16 @@ from lore_core.timefmt import relative_time as _relative_time_cli  # noqa: E402
 
 @app.command("tail")
 def tail(
-    once: bool = typer.Option(False, "--once", help="Exit on first run-end (don't wait for next run)."),
+    once: bool = typer.Option(
+        False, "--once", help="Exit on first run-end (don't wait for next run)."
+    ),
 ) -> None:
-    """Stream runs-live.jsonl. Default: follow forever. --once: exit on run-end or 30min idle timeout."""
+    """Follow curator events on the spine. Default: forever; --once: exit on run-end."""
     lore_root = _get_lore_root()
-    live = lore_root / ".lore" / "runs-live.jsonl"
-    if not live.exists():
+    spine = lore_root / ".lore" / "spine.jsonl"
+    if not spine.exists():
         console.print(
-            "[dim]No active run. Use `lore runs show latest` "
-            "for the last completed run.[/dim]"
+            "[dim]No active run. Use `lore runs show latest` for the last completed run.[/dim]"
         )
         return
 
@@ -255,17 +273,17 @@ def tail(
 
     while True:
         try:
-            size = live.stat().st_size
+            size = spine.stat().st_size
         except FileNotFoundError:
-            console.print("[dim]live log disappeared — exiting.[/dim]")
+            console.print("[dim]spine disappeared — exiting.[/dim]")
             return
 
-        # Detect truncation (new run-start truncates runs-live.jsonl).
+        # Detect rotation (spine.jsonl replaced when it grows too large).
         if size < pos:
             pos = 0
 
         if size > pos:
-            with live.open("r") as f:
+            with spine.open("r") as f:
                 f.seek(pos)
                 chunk = f.read()
                 pos = f.tell()
@@ -273,11 +291,14 @@ def tail(
                 if not line.strip():
                     continue
                 try:
-                    record = json.loads(line)
+                    env = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                console.print(render_flat_log([record], icons=icons, use_color=use_color))
-                if record.get("type") == "run-end":
+                if env.get("source") != "curator":
+                    continue
+                rec = {**(env.get("data") or {}), "type": env.get("event"), "ts": env.get("ts")}
+                console.print(render_flat_log([rec], icons=icons, use_color=use_color))
+                if rec.get("type") == "run-end":
                     saw_run_end = True
             idle_since = time.monotonic()
 
@@ -295,14 +316,18 @@ def tail(
 
 @app.command("show")
 def show(
-    run_id: str = typer.Argument(..., help="latest | ^N | short suffix | full ID | prefix", autocompletion=_complete_run_id),
-    verbose: bool = typer.Option(False, "--verbose", help="Include LLM prompts/responses"),
-    raw: bool = typer.Option(False, "--raw", help="Disable 3-line trace truncation (requires --verbose)"),
+    run_id: str = typer.Argument(
+        ..., help="latest | ^N | short suffix | full ID | prefix", autocompletion=_complete_run_id
+    ),
+    verbose: bool = typer.Option(False, "--verbose", help="Include LLM call metadata"),
+    raw: bool = typer.Option(
+        False, "--raw", help="(retained flag; no effect since trace text is not persisted)"
+    ),
     json_out: bool = typer.Option(False, "--json", help="Print raw JSONL"),
 ) -> None:
     lore_root = _get_lore_root()
     try:
-        path = resolve_run_id(lore_root, run_id)
+        resolved = resolve_run_id(lore_root, run_id)
     except RunIdNotFound as e:
         console.print(f"[red]Run not found: {e}. Try `lore runs list`.[/red]")
         raise typer.Exit(code=1)
@@ -310,35 +335,29 @@ def show(
         console.print(f"[yellow]Ambiguous — matches:[/yellow] {', '.join(e.matches)}")
         raise typer.Exit(code=1)
 
+    records = read_run_by_id(lore_root, resolved)
+
     if json_out:
-        sys.stdout.write(path.read_text())
+        for rec in records:
+            sys.stdout.write(json.dumps(rec) + "\n")
         return
 
-    try:
-        records = read_run(path, strict_schema=True)
-    except SchemaVersionTooNew as e:
-        console.print(f"[red]{e}[/red]")
-        raise typer.Exit(code=1)
-
     if verbose:
-        trace_path = path.parent / f"{path.stem}.trace.jsonl"
-        if not trace_path.exists():
-            console.print(
-                "[yellow]LLM trace not captured for this run. "
-                "Re-run with [bold]LORE_TRACE_LLM=1 lore curator run --dry-run[/bold] "
-                "to capture.[/yellow]"
-            )
-        else:
-            trace_records = read_run(trace_path, strict_schema=True)
-            records = sorted(records + trace_records, key=lambda r: r.get("ts", ""))
+        # Full LLM prompt/response text is no longer persisted (the spine
+        # keeps call metadata only); point at the live-trace path instead.
+        console.print(
+            "[yellow]Full LLM trace text is not persisted. Re-run with "
+            "[bold]LORE_TRACE_LLM=1 lore curator run --dry-run[/bold] and watch "
+            "the live output for prompts/responses.[/yellow]"
+        )
 
     term_width = shutil.get_terminal_size((80, 20)).columns
     icons = pick_icon_set()
     use_color = should_use_color()
 
     panel_lines = render_summary_panel(records, term_width=term_width)
-    short_id = path.stem.split("-")[-1]
-    header = f"Run {short_id} ({path.stem})"
+    short_id = resolved.split("-")[-1]
+    header = f"Run {short_id} ({resolved})"
 
     if use_color and sys.stdout.isatty():
         console.print(Panel("\n".join(panel_lines), title=header, expand=False))

--- a/lib/lore_cli/status_cmd.py
+++ b/lib/lore_cli/status_cmd.py
@@ -105,30 +105,17 @@ def _last_two_zero_note_runs(lore_root: Path) -> list[str] | None:
 
     Used for the "loud-on-earning" 0-note alert. Returns None otherwise.
     """
-    from lore_core.run_reader import iter_archival_runs
+    from lore_core.run_reader import read_run_by_id, run_ids
 
     short_ids: list[str] = []
-    for path in iter_archival_runs(lore_root, limit=2):
-        try:
-            lines = path.read_text().splitlines()
-        except OSError:
-            return None
-        end = None
-        for line in reversed(lines):
-            if not line.strip():
-                continue
-            try:
-                rec = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if rec.get("type") == "run-end":
-                end = rec
-                break
+    for run_id in run_ids(lore_root, limit=2):
+        records = read_run_by_id(lore_root, run_id)
+        end = next((r for r in reversed(records) if r.get("type") == "run-end"), None)
         if end is None:
             return None
         if end.get("notes_new", 0) != 0 or end.get("notes_merged", 0) != 0:
             return None
-        short_ids.append(path.stem.split("-")[-1])
+        short_ids.append(run_id.split("-")[-1])
     return short_ids if len(short_ids) == 2 else None
 
 

--- a/lib/lore_core/capture_state.py
+++ b/lib/lore_core/capture_state.py
@@ -17,7 +17,6 @@ a single render).
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -120,25 +119,18 @@ def _last_run_summary(
     "Last note filed" walks newest→oldest runs for the first session-note
     record with action=filed.
     """
-    from lore_core.run_reader import iter_archival_runs
+    from lore_core.run_reader import read_curator_runs
 
     summary = _RunSummary(None, None, None, None, None, None)
     last_note: tuple[datetime, str] | None = None
 
-    for i, path in enumerate(iter_archival_runs(lore_root)):
-        try:
-            lines = path.read_text().splitlines()
-        except OSError:
-            continue
+    grouped = read_curator_runs(lore_root)
+    # run_id is timestamp-prefixed, so reverse-sorted keys are newest-first.
+    for i, run_id in enumerate(sorted(grouped.keys(), reverse=True)):
+        records = grouped[run_id]
 
         run_end: dict | None = None
-        for line in reversed(lines):
-            if not line.strip():
-                continue
-            try:
-                rec = json.loads(line)
-            except json.JSONDecodeError:
-                continue
+        for rec in reversed(records):
             t = rec.get("type")
             if run_end is None and t == "run-end":
                 run_end = rec
@@ -157,7 +149,7 @@ def _last_run_summary(
                 notes_merged=run_end.get("notes_merged"),
                 skipped=run_end.get("skipped"),
                 errors=run_end.get("errors"),
-                short_id=path.stem.split("-")[-1],
+                short_id=run_id.split("-")[-1],
             )
 
         if last_note is not None and i > 0:

--- a/lib/lore_core/flush_store.py
+++ b/lib/lore_core/flush_store.py
@@ -1,0 +1,290 @@
+"""Persisted flush lifecycle state machine (issue #189).
+
+Replaces the old "retry forever, or silently give up with no marker" flush
+behaviour with an explicit, queryable record. One record per flush unit —
+keyed by the buffer stem — tracks a flush through::
+
+    queued -> running -> published | withheld | dead-lettered(reason)
+
+with an attempt counter and a next-eligible-retry timestamp. A stuck flush
+is now a row you can ``list``, not an absence of evidence.
+
+The record is the source of truth for "what is in-flight right now"; the
+event *history* lives on the spine — every transition emits an envelope
+(``source="curator"``, ``event="flush-<state>"``), so a record reopened for a
+new unit never erases the trail. Slices #192 (``lore trace``) and #193
+(``lore status``) read this store, so :meth:`FlushStore.list` is a clean
+queryable API, not an internal detail.
+
+Persistence mirrors the sibling buffer store: one small JSON file per record
+under ``.lore/flushes/`` mutated under a per-record ``flocked`` lock. No
+daemon, no index — JSONL/JSON plus in-command aggregation is sufficient at
+these volumes (PRD 0005, "Out of scope").
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+
+from lore_core.lockfile import flocked
+from lore_core.spine import ErrorCode, SpineWriter
+
+SCHEMA_VERSION = 1
+
+# Bounded-retry policy. attempts counts failed runs; the MAX_ATTEMPTS-th
+# failure dead-letters instead of scheduling another retry.
+MAX_ATTEMPTS = 3
+RETRY_BASE_SECONDS = 60
+RETRY_CAP_SECONDS = 3600  # backoff ceiling — a stuck buffer retries hourly, not never
+
+
+class FlushState(StrEnum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    PUBLISHED = "published"
+    WITHHELD = "withheld"
+    DEAD_LETTERED = "dead-lettered"
+
+
+_TERMINAL: frozenset[FlushState] = frozenset(
+    {FlushState.PUBLISHED, FlushState.WITHHELD, FlushState.DEAD_LETTERED}
+)
+
+# The legal transition table — the heart of the machine. ``running -> queued``
+# is a *scheduled retry*; terminal states have no outgoing edges. Self-loops
+# are deliberately absent: an idempotent caller re-reads via ``begin`` rather
+# than re-transitioning.
+_LEGAL: dict[FlushState, frozenset[FlushState]] = {
+    FlushState.QUEUED: frozenset({FlushState.RUNNING}),
+    FlushState.RUNNING: frozenset(
+        {
+            FlushState.PUBLISHED,
+            FlushState.WITHHELD,
+            FlushState.DEAD_LETTERED,
+            FlushState.QUEUED,
+        }
+    ),
+    FlushState.PUBLISHED: frozenset(),
+    FlushState.WITHHELD: frozenset(),
+    FlushState.DEAD_LETTERED: frozenset(),
+}
+
+
+class FlushTransitionError(RuntimeError):
+    """Raised when a transition is not in :data:`_LEGAL`."""
+
+    def __init__(self, frm: FlushState, to: FlushState) -> None:
+        super().__init__(f"illegal flush transition: {frm.value} -> {to.value}")
+        self.frm = frm
+        self.to = to
+
+
+def is_legal_transition(frm: FlushState | str, to: FlushState | str) -> bool:
+    """Pure predicate over the transition table (AC1)."""
+    return FlushState(to) in _LEGAL[FlushState(frm)]
+
+
+def backoff_seconds(attempt: int) -> int:
+    """Exponential backoff, capped. ``attempt`` is 1-based (first retry == 1)."""
+    if attempt < 1:
+        return 0
+    return min(RETRY_BASE_SECONDS * (2 ** (attempt - 1)), RETRY_CAP_SECONDS)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(s: str) -> datetime | None:
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+@dataclass
+class FlushRecord:
+    """One flush unit's persisted state. ``flush_id == buffer_stem``."""
+
+    flush_id: str
+    buffer_stem: str
+    state: str = FlushState.QUEUED.value
+    attempts: int = 0
+    next_retry_at: str | None = None  # ISO-Z; set only while a retry is scheduled
+    reason: str | None = None  # ErrorCode value on dead-letter; else None
+    wiki: str = ""
+    trace_id: str | None = None  # #188 stamps this
+    created_at: str = ""
+    updated_at: str = ""
+    schema_version: int = SCHEMA_VERSION
+
+    @property
+    def is_terminal(self) -> bool:
+        return FlushState(self.state) in _TERMINAL
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> FlushRecord:
+        known = {f: d[f] for f in cls.__dataclass_fields__ if f in d}
+        return cls(**known)
+
+
+def is_retry_due(rec: FlushRecord, *, now: datetime | None = None) -> bool:
+    """True when a queued record's backoff has elapsed (retry may proceed)."""
+    if FlushState(rec.state) is not FlushState.QUEUED:
+        return False
+    if not rec.next_retry_at:
+        return True
+    due = _parse_iso(rec.next_retry_at)
+    if due is None:
+        return True
+    return (now or _now()) >= due
+
+
+class FlushStore:
+    """Queryable per-flush record store. Mutations serialise per-record.
+
+    Persistence and the spine emit are best-effort in the sense the spine
+    itself never raises; the JSON write does raise on a genuinely broken FS
+    (the caller is already inside the flush pipeline's own error handling).
+    """
+
+    def __init__(self, lore_root: Path) -> None:
+        self._lore_root = Path(lore_root)
+        self._dir = self._lore_root / ".lore" / "flushes"
+
+    # -- paths -------------------------------------------------------------
+    def _path(self, flush_id: str) -> Path:
+        return self._dir / f"{flush_id}.json"
+
+    def _lock_path(self, flush_id: str) -> Path:
+        return self._dir / f"{flush_id}.lock"
+
+    # -- read --------------------------------------------------------------
+    def get(self, flush_id: str) -> FlushRecord | None:
+        path = self._path(flush_id)
+        try:
+            return FlushRecord.from_dict(json.loads(path.read_text()))
+        except (OSError, json.JSONDecodeError, TypeError):
+            return None
+
+    def list(self, *, state: FlushState | str | None = None) -> list[FlushRecord]:
+        """All records, optionally filtered by state. Newest-updated first."""
+        if not self._dir.exists():
+            return []
+        want = FlushState(state).value if state is not None else None
+        out: list[FlushRecord] = []
+        for p in self._dir.glob("*.json"):
+            try:
+                rec = FlushRecord.from_dict(json.loads(p.read_text()))
+            except (OSError, json.JSONDecodeError, TypeError):
+                continue
+            if want is None or rec.state == want:
+                out.append(rec)
+        out.sort(key=lambda r: r.updated_at, reverse=True)
+        return out
+
+    # -- write -------------------------------------------------------------
+    def _persist(self, rec: FlushRecord) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        rec.updated_at = _iso(_now())
+        self._path(rec.flush_id).write_text(json.dumps(rec.to_dict(), default=str))
+
+    def _emit(self, rec: FlushRecord, *, level: str) -> None:
+        SpineWriter(self._lore_root).emit(
+            source="curator",
+            event=f"flush-{rec.state}",
+            level=level,
+            trace_id=rec.trace_id,
+            wiki=rec.wiki or None,
+            error_code=rec.reason,  # ErrorCode value only on dead-letter, else None
+            data={
+                "flush_id": rec.flush_id,
+                "buffer_stem": rec.buffer_stem,
+                "attempts": rec.attempts,
+                "next_retry_at": rec.next_retry_at,
+            },
+        )
+
+    def begin(
+        self, buffer_stem: str, *, wiki: str = "", trace_id: str | None = None
+    ) -> FlushRecord:
+        """Return the active record for this buffer, or open a fresh queued unit.
+
+        Idempotent while a unit is in flight (attempts preserved across retry
+        calls); a terminal record is reopened as a new queued unit so one
+        buffer's successive flushes each get their own lifecycle.
+        """
+        flush_id = buffer_stem
+        with flocked(self._lock_path(flush_id)):
+            existing = self.get(flush_id)
+            if existing is not None and not existing.is_terminal:
+                return existing
+            now = _iso(_now())
+            rec = FlushRecord(
+                flush_id=flush_id,
+                buffer_stem=buffer_stem,
+                state=FlushState.QUEUED.value,
+                wiki=wiki or (existing.wiki if existing else ""),
+                trace_id=trace_id,
+                created_at=now,
+                updated_at=now,
+            )
+            self._persist(rec)
+        self._emit(rec, level="info")
+        return rec
+
+    def transition(
+        self,
+        rec: FlushRecord,
+        to: FlushState | str,
+        *,
+        reason: ErrorCode | None = None,
+    ) -> FlushRecord:
+        """Move ``rec`` to ``to`` if the table allows it; persist and emit.
+
+        ``reason`` is required to be an :class:`ErrorCode` (never a free-form
+        string) and is only meaningful on a dead-letter transition.
+        """
+        to = FlushState(to)
+        frm = FlushState(rec.state)
+        if to not in _LEGAL[frm]:
+            raise FlushTransitionError(frm, to)
+        if reason is not None and not isinstance(reason, ErrorCode):
+            raise ValueError(f"reason must be an ErrorCode, got {reason!r}")
+        with flocked(self._lock_path(rec.flush_id)):
+            rec.state = to.value
+            if to is FlushState.DEAD_LETTERED and reason is not None:
+                rec.reason = reason.value
+            if to is not FlushState.QUEUED:
+                rec.next_retry_at = None
+            self._persist(rec)
+        level = "error" if to is FlushState.DEAD_LETTERED else "info"
+        self._emit(rec, level=level)
+        return rec
+
+    def record_failure(self, rec: FlushRecord, *, error_code: ErrorCode) -> FlushRecord:
+        """Register a failed run: schedule a backed-off retry, or dead-letter.
+
+        The caller is expected to be in ``running``. The ``MAX_ATTEMPTS``-th
+        failure dead-letters with ``error_code``; earlier failures re-queue
+        with an exponential backoff written into ``next_retry_at``.
+        """
+        rec.attempts += 1
+        if rec.attempts >= MAX_ATTEMPTS:
+            return self.transition(rec, FlushState.DEAD_LETTERED, reason=error_code)
+        # transition() persists the whole record, carrying the bumped
+        # attempt count and the backoff we set here.
+        rec.next_retry_at = _iso(_now() + timedelta(seconds=backoff_seconds(rec.attempts)))
+        return self.transition(rec, FlushState.QUEUED)

--- a/lib/lore_core/run_log.py
+++ b/lib/lore_core/run_log.py
@@ -1,26 +1,41 @@
-"""Run-log writer for curator invocations (A, B, C).
+"""Run-log producer for curator invocations (A, B, C).
 
-Two output files per run:
-  - runs/<id>.jsonl            archival
-  - runs-live.jsonl            tee of active run (truncated at run-start)
+Curator run events are emitted onto the unified event spine
+(``source="curator"``) — one envelope per decision record, keyed by
+``run_id``. There is no longer a per-run archival file or a ``runs-live``
+tee; ``lore trace`` / ``lore runs`` reconstruct a run by grouping spine
+records on ``run_id`` (see :mod:`lore_core.run_reader`).
 
-Plus an optional LLM-trace companion runs/<id>.trace.jsonl when
-LORE_TRACE_LLM=1 or --trace-llm is set.
+The :class:`RunLogger` context-manager API is unchanged, so every producer
+(``session_curator``, ``hygiene``, ``curator_cmd``) is untouched — only the
+sink moved. Two consequences of the move:
+
+* **LLM records carry metadata only.** The spine's lock-free O_APPEND
+  atomicity assumes each record stays well under ``PIPE_BUF`` (4 KB); a full
+  prompt/response would blow past that and risk interleaved writes. So
+  ``llm-prompt`` / ``llm-response`` keep ``call``/``tier``/``token_count`` and
+  drop the message bodies. Full-text LLM tracing is no longer persisted.
+* **Retention is not enforced here.** The spine self-rotates and the unified
+  janitor (#190) owns tiered retention; ``RunLogger`` no longer runs cleanup.
 """
 
 from __future__ import annotations
 
-import json
-import os
 import secrets
 import string
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable
+from typing import Any
 
+from lore_core.spine import SpineWriter
 
 _ID_ALPHABET = string.ascii_lowercase + string.digits  # 36 chars
+
+# llm records keep only these small metadata fields on the spine; the full
+# prompt / response text is intentionally dropped (see module docstring).
+_LLM_META_FIELDS: tuple[str, ...] = ("call", "tier", "token_count", "model", "latency_ms")
 
 
 def generate_run_id(*, now: datetime | None = None) -> str:
@@ -40,7 +55,7 @@ RecordCallback = Callable[[str, dict[str, Any]], None]  # (record_type, full_pay
 
 
 class RunLogger:
-    """Write a curator run's decision trace.
+    """Emit a curator run's decision trace onto the event spine.
 
     Context-manager usage:
 
@@ -48,34 +63,48 @@ class RunLogger:
             logger.emit("session-note", action="filed", path="...")
             ...
 
-    Opens `runs/<id>.jsonl` and truncates `runs-live.jsonl` at start;
-    emits run-start. On exit (normal or exception) emits run-end
-    with duration and counts, then closes files.
-
-    Writes are best-effort: OSError during emit increments
-    `_write_failures` and is swallowed.
+    Emits run-start on enter and run-end (with duration + counts) on exit;
+    an exception in the body emits an ``error`` record and then propagates.
     """
 
-    RECORD_TYPES = frozenset({
-        "run-start", "run-end", "skip", "warning", "error",
-        "llm-prompt", "llm-response",
-        # Curator A
-        "transcript-start", "redaction", "noteworthy",
-        "cascade-verdict",  # shadow-run feature-based classifier
-        "merge-check", "session-note",
-        # Buffer-and-flush curator (plan: very-good-thats-the-mossy-lobster).
-        # Lifecycle: opened -> appended* -> (cap-tripped|requested) -> spawned
-        #   -> deterministic-completed -> llm-completed | degraded
-        # Reaper / handover events are siblings.
-        "buffer-opened", "buffer-appended", "buffer-cap-tripped",
-        "flush-requested", "flush-spawned",
-        "flush-deterministic-completed", "flush-llm-completed",
-        "flush-degraded", "flush-handover-timeout",
-        "reaper-scanned", "reaper-force-flushed",
-        "dangling-ref",
-        # Hygiene pass (lore curator [--wiki] [--apply])
-        "action-applied", "action-skipped", "wiki-start",
-    })
+    RECORD_TYPES = frozenset(
+        {
+            "run-start",
+            "run-end",
+            "skip",
+            "warning",
+            "error",
+            "llm-prompt",
+            "llm-response",
+            # Curator A
+            "transcript-start",
+            "redaction",
+            "noteworthy",
+            "cascade-verdict",  # shadow-run feature-based classifier
+            "merge-check",
+            "session-note",
+            # Buffer-and-flush curator (plan: very-good-thats-the-mossy-lobster).
+            # Lifecycle: opened -> appended* -> (cap-tripped|requested) -> spawned
+            #   -> deterministic-completed -> llm-completed | degraded
+            # Reaper / handover events are siblings.
+            "buffer-opened",
+            "buffer-appended",
+            "buffer-cap-tripped",
+            "flush-requested",
+            "flush-spawned",
+            "flush-deterministic-completed",
+            "flush-llm-completed",
+            "flush-degraded",
+            "flush-handover-timeout",
+            "reaper-scanned",
+            "reaper-force-flushed",
+            "dangling-ref",
+            # Hygiene pass (lore curator [--wiki] [--apply])
+            "action-applied",
+            "action-skipped",
+            "wiki-start",
+        }
+    )
 
     def __init__(
         self,
@@ -92,8 +121,7 @@ class RunLogger:
         on_record: RecordCallback | None = None,
     ):
         self._lore_root = lore_root
-        self._dir = lore_root / ".lore"
-        self._runs_dir = self._dir / "runs"
+        self._writer = SpineWriter(lore_root)
         self._trigger = trigger
         self._role = role
         self._pending_count = pending_count
@@ -102,13 +130,13 @@ class RunLogger:
         self._trace_llm = trace_llm
         self._ledger_snapshot_hash = ledger_snapshot_hash
         self.run_id = run_id or generate_run_id()
-        self._archival = self._runs_dir / f"{self.run_id}.jsonl"
-        self._trace = self._runs_dir / f"{self.run_id}.trace.jsonl"
-        self._live = self._dir / "runs-live.jsonl"
-        self._write_failures = 0
         self._counts = {
-            "notes_new": 0, "notes_merged": 0, "skipped": 0, "errors": 0,
-            "actions_applied": 0, "actions_skipped": 0,
+            "notes_new": 0,
+            "notes_merged": 0,
+            "skipped": 0,
+            "errors": 0,
+            "actions_applied": 0,
+            "actions_skipped": 0,
         }
         self._on_record = on_record
         self._opened_at: datetime | None = None
@@ -117,41 +145,7 @@ class RunLogger:
     def trace_enabled(self) -> bool:
         return self._trace_llm
 
-    def __enter__(self) -> "RunLogger":
-        # Best-effort setup — NEVER raise. Observability must not break
-        # the pipeline. If mkdir or collision-retry fails, subsequent
-        # emit()s will no-op on the missing/locked file and surface via
-        # _write_failures in run-end.
-        try:
-            self._runs_dir.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            self._write_failures += 1
-
-        # Init invariant — suffix collision guard. If BOTH attempts land
-        # on existing files, fall back to a failure-marked state rather
-        # than raising.
-        try:
-            if self._archival.exists():
-                self.run_id = generate_run_id()
-                self._archival = self._runs_dir / f"{self.run_id}.jsonl"
-                self._trace = self._runs_dir / f"{self.run_id}.trace.jsonl"
-                if self._archival.exists():
-                    # Extremely unlikely (clock frozen + 36^6 collision).
-                    # Count as a write failure, set paths to /dev/null so
-                    # emit() no-ops safely.
-                    self._write_failures += 1
-                    self._archival = Path(os.devnull)
-                    self._trace = Path(os.devnull)
-        except OSError:
-            self._write_failures += 1
-
-        # Truncate live-tee.
-        try:
-            self._live.parent.mkdir(parents=True, exist_ok=True)
-            self._live.write_text("")
-        except OSError:
-            self._write_failures += 1
-
+    def __enter__(self) -> RunLogger:
         self._opened_at = datetime.now(UTC)
         self.emit(
             "run-start",
@@ -176,11 +170,7 @@ class RunLogger:
                 exc_message = str(exc)
             except Exception:
                 exc_message = "<exception __str__ raised>"
-            self.emit(
-                "error",
-                exception=type(exc).__name__,
-                message=exc_message,
-            )
+            self.emit("error", exception=type(exc).__name__, message=exc_message)
         duration_ms = 0
         if self._opened_at is not None:
             duration_ms = int((datetime.now(UTC) - self._opened_at).total_seconds() * 1000)
@@ -190,43 +180,50 @@ class RunLogger:
             role=self._role,
             **self._counts,
             dry_run=self._dry_run,
-            log_write_failures=self._write_failures,
         )
-        # Lazy retention — best-effort, must not raise.
-        try:
-            from lore_core.run_retention import enforce_retention
-            from lore_core.root_config import load_root_config
-            cfg = load_root_config(self._lore_root).observability.runs
-            enforce_retention(
-                self._lore_root,
-                keep=cfg.keep,
-                max_total_mb=cfg.max_total_mb,
-                keep_trace=cfg.keep_trace,
-            )
-        except Exception:
-            pass
+        # Retention is not enforced here: the spine self-rotates and the
+        # unified janitor (#190) owns tiered retention.
 
     def emit(self, record_type: str, **fields: Any) -> None:
-        """Emit one decision record. Never raises."""
+        """Emit one decision record onto the spine. Never raises."""
         if record_type not in self.RECORD_TYPES:
             fields = {"unknown_type": record_type, **fields}
             record_type = "warning"
-        payload = {
-            **fields,
-            "type": record_type,
-            "schema_version": 1,
-            "ts": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-        }
+        ts = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        payload = {**fields, "type": record_type, "schema_version": 1, "ts": ts}
         self._counters_bookkeeping(record_type, fields)
         if self._on_record is not None:
             try:
                 self._on_record(record_type, payload)
             except Exception:
                 pass
-        self._write(self._archival, payload, mode="a")
-        self._write(self._live, {"run_id": self.run_id, **payload}, mode="a")
-        if self._trace_llm and record_type in ("llm-prompt", "llm-response"):
-            self._write(self._trace, payload, mode="a")
+        self._writer.emit(
+            source="curator",
+            event=record_type,
+            level=self._level(record_type),
+            run_id=self.run_id,
+            trace_id=None,  # #188 stamps this
+            wiki=fields.get("wiki"),
+            scope=fields.get("scope") if isinstance(fields.get("scope"), str) else None,
+            data=self._spine_data(record_type, fields),
+        )
+
+    @staticmethod
+    def _level(record_type: str) -> str:
+        # "error" and "warning" are the producer's explicit error/warn channels;
+        # everything else is informational.
+        if record_type == "error":
+            return "error"
+        if record_type == "warning":
+            return "warn"
+        return "info"
+
+    @staticmethod
+    def _spine_data(record_type: str, fields: dict[str, Any]) -> dict[str, Any]:
+        if record_type in ("llm-prompt", "llm-response"):
+            # Metadata only — the full prompt/response text is dropped.
+            return {k: fields[k] for k in _LLM_META_FIELDS if k in fields}
+        return dict(fields)
 
     def _counters_bookkeeping(self, record_type: str, fields: dict[str, Any]) -> None:
         if record_type == "session-note":
@@ -243,15 +240,3 @@ class RunLogger:
             self._counts["actions_applied"] += 1
         elif record_type == "action-skipped":
             self._counts["actions_skipped"] += 1
-
-    def _write(self, path: Path, payload: dict[str, Any], *, mode: str) -> None:
-        try:
-            encoded = json.dumps(payload, default=str) + "\n"
-        except (TypeError, ValueError):
-            self._write_failures += 1
-            return
-        try:
-            with path.open(mode) as f:
-                f.write(encoded)
-        except OSError:
-            self._write_failures += 1

--- a/lib/lore_core/run_reader.py
+++ b/lib/lore_core/run_reader.py
@@ -1,7 +1,11 @@
 """Read-side of the run-log subsystem.
 
-- resolve_run_id():    user identifier → archival file Path
-- read_run():          JSONL → list[dict] with tolerant parsing
+Curator runs now live on the event spine (``source="curator"``), grouped
+by ``run_id``; ``read_curator_runs`` / ``run_ids`` / ``read_run_by_id``
+reconstruct a run's legacy-shaped record list from it. ``resolve_run_id``
+maps a user identifier to a ``run_id`` (not a file path). The file-based
+``list_archival_runs`` / ``iter_archival_runs`` / ``read_run`` helpers
+remain for the retention janitor and any on-disk archives.
 """
 
 from __future__ import annotations
@@ -87,38 +91,79 @@ def iter_archival_runs(
         count += 1
 
 
-def resolve_run_id(lore_root: Path, identifier: str) -> Path:
-    """Resolve a user identifier to a run file path.
+def read_curator_runs(lore_root: Path) -> dict[str, list[dict]]:
+    """Group curator spine events by ``run_id`` into legacy-shaped records.
+
+    Each spine envelope becomes a ``{type, ts, schema_version, **data}`` record
+    (the shape the run renderers already consume); records stay in spine append
+    order, i.e. chronological within a run. Envelopes without a ``run_id`` (the
+    flush-state-machine and spawn events) are not part of any run.
+    """
+    from lore_core.spine import read_spine
+
+    grouped: dict[str, list[dict]] = {}
+    for rec in read_spine(lore_root, source="curator"):
+        rid = rec.get("run_id")
+        if not rid:
+            continue
+        legacy = dict(rec.get("data") or {})
+        legacy["type"] = rec.get("event")
+        legacy["ts"] = rec.get("ts")
+        legacy.setdefault("schema_version", 1)
+        grouped.setdefault(rid, []).append(legacy)
+    return grouped
+
+
+def run_ids(
+    lore_root: Path, *, newest_first: bool = True, limit: int | None = None
+) -> list[str]:
+    """Return run_ids seen on the spine. run_id is ts-prefixed, so lexicographic
+    order is chronological."""
+    ids = sorted(read_curator_runs(lore_root).keys())
+    if newest_first:
+        ids = list(reversed(ids))
+    if limit is not None:
+        ids = ids[:limit]
+    return ids
+
+
+def read_run_by_id(lore_root: Path, run_id: str) -> list[dict]:
+    """Return one run's reconstructed records, or [] if unknown."""
+    return read_curator_runs(lore_root).get(run_id, [])
+
+
+def resolve_run_id(lore_root: Path, identifier: str) -> str:
+    """Resolve a user identifier to a ``run_id`` from the spine.
 
     Accepts:
       - 'latest'         → most recent run
       - '^1', '^2', …    → N-th most recent (^1 == latest)
-      - full ID          → exact file
+      - full ID          → exact
       - 6-char suffix    → unique short ID (e.g. 'a1b2c3')
       - any prefix       → if unique
     """
-    runs = _list_runs(lore_root)
-    if not runs:
-        raise RunIdNotFound("no runs on disk")
+    ids = run_ids(lore_root, newest_first=False)  # chronological
+    if not ids:
+        raise RunIdNotFound("no runs on the spine")
     if identifier == "latest":
-        return runs[-1]
+        return ids[-1]
     m = _CARET_RE.match(identifier)
     if m:
         n = int(m.group(1))
-        if n < 1 or n > len(runs):
-            raise RunIdNotFound(f"^{n} out of range (have {len(runs)} runs)")
-        return runs[-n]
+        if n < 1 or n > len(ids):
+            raise RunIdNotFound(f"^{n} out of range (have {len(ids)} runs)")
+        return ids[-n]
     if re.fullmatch(r"[a-z0-9]{6}", identifier):
-        matches = [p for p in runs if p.stem.endswith(f"-{identifier}")]
+        matches = [rid for rid in ids if rid.endswith(f"-{identifier}")]
         if len(matches) == 1:
             return matches[0]
         if len(matches) > 1:
-            raise RunIdAmbiguous([p.stem for p in matches])
-    matches = [p for p in runs if p.stem.startswith(identifier)]
+            raise RunIdAmbiguous(matches)
+    matches = [rid for rid in ids if rid.startswith(identifier)]
     if not matches:
         raise RunIdNotFound(identifier)
     if len(matches) > 1:
-        raise RunIdAmbiguous([p.stem for p in matches])
+        raise RunIdAmbiguous(matches)
     return matches[0]
 
 

--- a/lib/lore_core/run_reader.py
+++ b/lib/lore_core/run_reader.py
@@ -44,8 +44,8 @@ _CARET_RE = re.compile(r"^\^(\d+)$")
 def list_archival_runs(lore_root: Path) -> list[Path]:
     """Return archival run files sorted oldest → newest (chronological).
 
-    Used by ``resolve_run_id`` for prefix matching and by retention for
-    FIFO deletion. For newest-first iteration (the common case for
+    Used by the retention janitor for FIFO deletion (run *resolution* now
+    reads spine run_ids, not files). For newest-first iteration (the common case for
     renderers) use :func:`iter_archival_runs`.
 
     Excludes ``.trace.jsonl`` companions. Returns empty list if the

--- a/lib/lore_core/spine.py
+++ b/lib/lore_core/spine.py
@@ -96,6 +96,12 @@ class ErrorCode(StrEnum):
     # The spine failing to write itself — surfaced via the degrade marker,
     # never emitted onto the (unwritable) spine.
     SPINE_WRITE_FAILED = "spine-write-failed"
+    # Flush lifecycle state machine (issue #189). Dead-letter reasons —
+    # the flush pipeline's formerly-silent failure paths, now structured.
+    COMPOSE_FAILED = "compose-failed"
+    SPAWN_FAILED = "spawn-failed"
+    SIDECAR_READ_FAILED = "sidecar-read-failed"
+    CHAPTER_APPEND_FAILED = "chapter-append-failed"
 
 
 _ERROR_CODE_VALUES: frozenset[str] = frozenset(c.value for c in ErrorCode)

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -53,9 +53,11 @@ from typing import TYPE_CHECKING, Any
 from lore_adapters import Adapter, get_adapter
 from lore_core import note_document as nd
 from lore_core import publish_gate as pg
+from lore_core.flush_store import FlushState, FlushStore
 from lore_core.lockfile import LockContendedError, curator_lock
 from lore_core.publish_gate import GateResult, PublishGate
 from lore_core.session_writer import FiledNote
+from lore_core.spine import ErrorCode, SpineWriter
 from lore_core.types import TranscriptHandle, Turn
 
 from lore_curator._auto_commit import maybe_auto_commit
@@ -75,8 +77,6 @@ from lore_curator.session_note import (
     linkage_from_replay,
 )
 from lore_curator.stub_note import _lead_for_rename, _resolve_renamed_path, _topic_title
-from lore_core.flush_store import FlushState, FlushStore
-from lore_core.spine import ErrorCode, SpineWriter
 
 if TYPE_CHECKING:
     from lore_core.run_log import RunLogger
@@ -655,7 +655,7 @@ def _apply_outcome(
                     out.chapter_n = nd.append_marker_chapter(
                         note_path,
                         kind=nd.MARKER_FAILED,
-                        reason="composition failed after retries; span recorded and the buffer reset",
+                        reason="composition failed after retries; span recorded and buffer reset",
                         slice_from_turn=slice_from,
                         slice_to_turn=slice_to,
                         facts=facts,

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -75,6 +75,8 @@ from lore_curator.session_note import (
     linkage_from_replay,
 )
 from lore_curator.stub_note import _lead_for_rename, _resolve_renamed_path, _topic_title
+from lore_core.flush_store import FlushState, FlushStore
+from lore_core.spine import ErrorCode, SpineWriter
 
 if TYPE_CHECKING:
     from lore_core.run_log import RunLogger
@@ -165,19 +167,6 @@ class FlushOutcome:
 # ---------------------------------------------------------------------------
 # Cap + slice helpers
 # ---------------------------------------------------------------------------
-
-
-def _resolve_caps(wiki_root: Path) -> tuple[int, int]:
-    try:
-        from lore_core.wiki_config import load_wiki_config
-
-        cfg = load_wiki_config(wiki_root)
-        return (
-            int(cfg.curator.synthesis_buffer_cap_turns),
-            int(cfg.curator.synthesis_buffer_cap_chars),
-        )
-    except Exception:  # noqa: BLE001 - config is best-effort; defaults are safe
-        return FLUSH_DEFAULT_CAP_TURNS, FLUSH_DEFAULT_CAP_CHARS
 
 
 def _flushed_to(note_path: Path) -> int:
@@ -330,6 +319,16 @@ def flush_chapter(
     buffer = Buffer.from_sidecar_path(buffer_path)
     sidecar = buffer.read_sidecar()
     if sidecar is None:
+        # A sidecar that exists but won't parse is a read *error*, not a
+        # missing buffer — surface it loudly instead of skipping in silence.
+        if buffer.sidecar_path.exists():
+            SpineWriter(lore_root).emit(
+                source="curator",
+                event="flush-skipped",
+                level="error",
+                error_code=ErrorCode.SIDECAR_READ_FAILED,
+                data={"buffer_stem": buffer.stem, "reason": "sidecar-unreadable"},
+            )
         return FlushOutcome(buffer_stem=buffer.stem, status="skipped", skipped_reason="no-sidecar")
     if sidecar.state == "closed":
         return FlushOutcome(
@@ -339,7 +338,6 @@ def flush_chapter(
             skipped_reason="already-closed",
         )
 
-    caps = _resolve_caps(wiki_root)
 
     # ---- Snapshot under the flock: note path, note-so-far, slice bounds -
     with buffer.with_lock():
@@ -449,7 +447,6 @@ def flush_chapter(
             slice_from=slice_from,
             slice_to=slice_to,
             rb=rb,
-            caps=caps,
             close=close,
             state_before=state_before,
             wiki_root=wiki_root,
@@ -510,7 +507,6 @@ def _apply_outcome(
     slice_from: int,
     slice_to: int,
     rb: ReplayedBuffer,
-    caps: tuple[int, int],
     close: bool,
     state_before: str,
     wiki_root: Path,
@@ -539,23 +535,42 @@ def _apply_outcome(
 
     status = compose_result.status if compose_result is not None else ComposeStatus.FAILED
 
+    # Track this flush as an explicit, queryable state machine: begin (queued)
+    # -> running for this attempt, then a terminal published / withheld /
+    # dead-lettered transition below. The record is the source of truth for
+    # "what is in-flight right now"; every transition also emits a spine event.
+    store = FlushStore(lore_root)
+    flush_rec = store.begin(buffer.stem, wiki=sidecar.wiki)
+    if FlushState(flush_rec.state) is FlushState.QUEUED:
+        flush_rec = store.transition(flush_rec, FlushState.RUNNING)
+
     if status is ComposeStatus.COMPOSED:
-        out.chapter_n = nd.append_chapter(
-            note_path,
-            compose_result.chapter,
-            slice_from_turn=slice_from,
-            slice_to_turn=slice_to,
-            facts=facts,
-            linkage=linkage,
-            wiki_root=wiki_root,
-            title=_topic_title(sidecar.scope, compose_result.chapter),
-        )
+        try:
+            out.chapter_n = nd.append_chapter(
+                note_path,
+                compose_result.chapter,
+                slice_from_turn=slice_from,
+                slice_to_turn=slice_to,
+                facts=facts,
+                linkage=linkage,
+                wiki_root=wiki_root,
+                title=_topic_title(sidecar.scope, compose_result.chapter),
+            )
+        except OSError:
+            # A note write that fails on disk is a dead-letter, not a crash:
+            # record it and stop writing to a failing filesystem.
+            store.transition(
+                flush_rec, FlushState.DEAD_LETTERED, reason=ErrorCode.CHAPTER_APPEND_FAILED
+            )
+            out.status = "failed"
+            return out
         if out.chapter_n == 1:
             note_path = _rename_to_topic_slug(buffer, note_path, compose_result.chapter)
             out.note_path = note_path
             out.wikilink = f"[[{note_path.stem}]]"
         out.status = "composed"
         _clear_after_progress(buffer, close=close)
+        store.transition(flush_rec, FlushState.PUBLISHED)
     elif status is ComposeStatus.EMPTY:
         out.status = "empty"
         if close:
@@ -578,6 +593,8 @@ def _apply_outcome(
                 transcript_id=sidecar.transcript_id,
                 discarded=out.discarded,
             )
+        # "Nothing of substance" is a completed flush, not a failure.
+        store.transition(flush_rec, FlushState.PUBLISHED)
     elif status is ComposeStatus.WITHHELD:
         verdict = GateResult.withheld(
             compose_result.withheld_category,
@@ -602,57 +619,68 @@ def _apply_outcome(
                 transcript_id=sidecar.transcript_id,
                 category=verdict.category,
             )
+        store.transition(flush_rec, FlushState.WITHHELD)
     else:  # FAILED
         if close:
-            out.chapter_n = nd.append_marker_chapter(
-                note_path,
-                kind=nd.MARKER_FAILED,
-                reason="composition failed at session end",
-                slice_from_turn=slice_from,
-                slice_to_turn=slice_to,
-                facts=facts,
-                linkage=linkage,
-                wiki_root=wiki_root,
-            )
-            out.status = "failed"
-        elif _is_give_up(sidecar, rb, caps):
-            out.chapter_n = nd.append_marker_chapter(
-                note_path,
-                kind=nd.MARKER_FAILED,
-                reason="composition failed after retries; span recorded and the buffer reset",
-                slice_from_turn=slice_from,
-                slice_to_turn=slice_to,
-                facts=facts,
-                linkage=linkage,
-                wiki_root=wiki_root,
-            )
-            _reset_buffer_fresh(buffer)
-            out.status = "gave-up"
-            if logger is not None:
-                logger.emit(
-                    "flush-gave-up",
-                    buffer_stem=buffer.stem,
-                    transcript_id=sidecar.transcript_id,
-                    turn_count=rb.turn_count,
-                    prompt_chars=rb.prompt_chars,
+            with contextlib.suppress(OSError):
+                out.chapter_n = nd.append_marker_chapter(
+                    note_path,
+                    kind=nd.MARKER_FAILED,
+                    reason="composition failed at session end",
+                    slice_from_turn=slice_from,
+                    slice_to_turn=slice_to,
+                    facts=facts,
+                    linkage=linkage,
+                    wiki_root=wiki_root,
                 )
+            out.status = "failed"
+            store.transition(
+                flush_rec, FlushState.DEAD_LETTERED, reason=ErrorCode.COMPOSE_FAILED
+            )
         else:
-            # Silent defer: no marker while a retry chance remains. Remember
-            # the failed attempt (drives the give-up bound) and re-open the
-            # request slot so the next trigger retries the grown slice.
+            # Bounded retry with backoff replaces the old silent-defer /
+            # give-up-at-2x-cap heuristic. record_failure() re-queues with a
+            # scheduled next-eligible-retry (emitting a spine event — never
+            # silent) until MAX_ATTEMPTS failures, then dead-letters.
+            flush_rec = store.record_failure(flush_rec, error_code=ErrorCode.COMPOSE_FAILED)
             buffer.patch(
                 flush_attempts=sidecar.flush_attempts + 1,
                 last_error="compose-failed",
                 flush_requested=None,
             )
-            out.status = "deferred"
-            if logger is not None:
-                logger.emit(
-                    "flush-deferred",
-                    buffer_stem=buffer.stem,
-                    transcript_id=sidecar.transcript_id,
-                    flush_attempts=sidecar.flush_attempts + 1,
-                )
+            if FlushState(flush_rec.state) is FlushState.DEAD_LETTERED:
+                # Retries exhausted: record the failed span with a marker and
+                # reset the buffer — the note stays open, one session one note.
+                with contextlib.suppress(OSError):
+                    out.chapter_n = nd.append_marker_chapter(
+                        note_path,
+                        kind=nd.MARKER_FAILED,
+                        reason="composition failed after retries; span recorded and the buffer reset",
+                        slice_from_turn=slice_from,
+                        slice_to_turn=slice_to,
+                        facts=facts,
+                        linkage=linkage,
+                        wiki_root=wiki_root,
+                    )
+                _reset_buffer_fresh(buffer)
+                out.status = "gave-up"
+                if logger is not None:
+                    logger.emit(
+                        "flush-gave-up",
+                        buffer_stem=buffer.stem,
+                        transcript_id=sidecar.transcript_id,
+                        turn_count=rb.turn_count,
+                        prompt_chars=rb.prompt_chars,
+                    )
+            else:
+                out.status = "deferred"
+                if logger is not None:
+                    logger.emit(
+                        "flush-deferred",
+                        buffer_stem=buffer.stem,
+                        transcript_id=sidecar.transcript_id,
+                        flush_attempts=sidecar.flush_attempts + 1,
+                    )
 
     if close:
         if not out.discarded and not nd.is_closed(note_path):
@@ -688,13 +716,6 @@ def _clear_after_progress(buffer: Buffer, *, close: bool) -> None:
     if close:
         return
     buffer.patch(flush_attempts=0, last_error=None, flush_requested=None)
-
-
-def _is_give_up(sidecar: Sidecar, rb: ReplayedBuffer, caps: tuple[int, int]) -> bool:
-    cap_turns, cap_chars = caps
-    has_prior_failure = sidecar.flush_attempts >= 1
-    at_double_cap = rb.turn_count >= 2 * cap_turns or rb.prompt_chars >= 2 * cap_chars
-    return has_prior_failure and at_double_cap
 
 
 def _reset_buffer_fresh(buffer: Buffer) -> None:
@@ -1020,6 +1041,17 @@ def _resolve_model(wiki_root: Path) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+def _emit_spawn_failed(buffer_path: Path, lore_root: Path, exc: Exception) -> None:
+    """A detached-flush spawn that fails is no longer swallowed silently."""
+    SpineWriter(lore_root).emit(
+        source="curator",
+        event="flush-spawn-failed",
+        level="error",
+        error_code=ErrorCode.SPAWN_FAILED,
+        data={"buffer": buffer_path.name, "error": str(exc)},
+    )
+
+
 def spawn_detached_flush(buffer_path: Path, *, lore_root: Path) -> bool:
     """Fire-and-forget ``lore curator flush <buffer-path> --config-from-buffer``.
 
@@ -1062,7 +1094,9 @@ def spawn_detached_flush(buffer_path: Path, *, lore_root: Path) -> bool:
                     env=env,
                 )
                 return True
-            except (OSError, subprocess.SubprocessError):
+            except (OSError, subprocess.SubprocessError) as exc:
+                _emit_spawn_failed(buffer_path, lore_root, exc)
                 return False
-    except OSError:
+    except OSError as exc:
+        _emit_spawn_failed(buffer_path, lore_root, exc)
         return False

--- a/tests/test_auto_diagnostics_e2e.py
+++ b/tests/test_auto_diagnostics_e2e.py
@@ -193,15 +193,10 @@ def test_e2e_capture_to_runs_show(tmp_path: Path, monkeypatch) -> None:
         # ------------------------------------------------------------------
         # Step 6 — assert runs/<id>.jsonl exists with run-start / run-end
         # ------------------------------------------------------------------
-        runs_dir = lore_root / ".lore" / "runs"
-        run_files = [
-            p for p in runs_dir.glob("*.jsonl")
-            if not p.name.endswith(".trace.jsonl")
-        ]
-        assert len(run_files) == 1, f"Expected 1 run file, got {[p.name for p in run_files]}"
-
-        records = [json.loads(line) for line in run_files[0].read_text().splitlines()]
-        types = [r["type"] for r in records]
+        from lore_core.run_reader import read_curator_runs
+        runs = list(read_curator_runs(lore_root).values())
+        assert len(runs) == 1, f"Expected 1 run on the spine, got {len(runs)}"
+        types = [r["type"] for r in runs[0]]
         assert types[0] == "run-start", f"First record type: {types[0]}"
         assert types[-1] == "run-end", f"Last record type: {types[-1]}"
 

--- a/tests/test_breadcrumb.py
+++ b/tests/test_breadcrumb.py
@@ -277,14 +277,19 @@ def test_banner_all_skips_is_silent(tmp_path: Path) -> None:
 
     lore_dir = tmp_path / ".lore"
     lore_dir.mkdir(parents=True)
-    runs = lore_dir / "runs"
-    runs.mkdir(parents=True)
-    (runs / "2026-04-20T14-32-05-skipsr.jsonl").write_text(
-        json.dumps({"type": "run-start", "ts": "2026-04-20T14:32:05Z", "trigger": "hook"}) + "\n"
-        + json.dumps({"type": "run-end", "ts": "2026-04-20T14:32:09Z",
-                      "duration_ms": 4000, "notes_new": 0, "notes_merged": 0,
-                      "skipped": 3, "errors": 0}) + "\n"
-    )
+    run_id = "2026-04-20T14-32-05-skipsr"
+
+    def _env(rec):
+        data = {k: v for k, v in rec.items() if k not in ("type", "ts")}
+        return {"ts": rec["ts"], "v": 1, "source": "curator", "event": rec["type"],
+                "level": "info", "trace_id": None, "session_id": None, "run_id": run_id,
+                "wiki": None, "scope": None, "error_code": None, "data": data}
+
+    (lore_dir / "spine.jsonl").write_text("\n".join(json.dumps(_env(r)) for r in [
+        {"type": "run-start", "ts": "2026-04-20T14:32:05Z", "trigger": "hook"},
+        {"type": "run-end", "ts": "2026-04-20T14:32:09Z", "duration_ms": 4000,
+         "notes_new": 0, "notes_merged": 0, "skipped": 3, "errors": 0},
+    ]) + "\n")
     from lore_cli.breadcrumb import render_banner
     now = datetime(2026, 4, 20, 15, 0, 0, tzinfo=UTC)
     scope = Scope(
@@ -315,14 +320,19 @@ def test_banner_last_run_error_prefix(tmp_path: Path) -> None:
 
     lore_dir = tmp_path / ".lore"
     lore_dir.mkdir(parents=True)
-    runs = lore_dir / "runs"
-    runs.mkdir(parents=True)
-    (runs / "2026-04-20T14-32-05-errrun.jsonl").write_text(
-        json.dumps({"type": "run-start", "ts": "2026-04-20T14:32:05Z", "trigger": "hook"}) + "\n"
-        + json.dumps({"type": "run-end", "ts": "2026-04-20T14:32:09Z",
-                      "duration_ms": 4000, "notes_new": 0, "notes_merged": 0,
-                      "skipped": 0, "errors": 2}) + "\n"
-    )
+    run_id = "2026-04-20T14-32-05-errrun"
+
+    def _env(rec):
+        data = {k: v for k, v in rec.items() if k not in ("type", "ts")}
+        return {"ts": rec["ts"], "v": 1, "source": "curator", "event": rec["type"],
+                "level": "info", "trace_id": None, "session_id": None, "run_id": run_id,
+                "wiki": None, "scope": None, "error_code": None, "data": data}
+
+    (lore_dir / "spine.jsonl").write_text("\n".join(json.dumps(_env(r)) for r in [
+        {"type": "run-start", "ts": "2026-04-20T14:32:05Z", "trigger": "hook"},
+        {"type": "run-end", "ts": "2026-04-20T14:32:09Z", "duration_ms": 4000,
+         "notes_new": 0, "notes_merged": 0, "skipped": 0, "errors": 2},
+    ]) + "\n")
     from lore_cli.breadcrumb import render_banner
     now = datetime(2026, 4, 20, 15, 0, 0, tzinfo=UTC)
     scope = Scope(

--- a/tests/test_capture_state.py
+++ b/tests/test_capture_state.py
@@ -36,25 +36,41 @@ def _seed_lore_root(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _append_spine(lore_root: Path, envelopes: list[dict]) -> None:
+    path = lore_root / ".lore" / "spine.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        for e in envelopes:
+            f.write(json.dumps(e) + "\n")
+
+
+def _curator_env(record: dict, run_id: str) -> dict:
+    data = {k: v for k, v in record.items() if k not in ("type", "ts", "schema_version")}
+    return {
+        "ts": record.get("ts"), "v": 1, "source": "curator", "event": record.get("type"),
+        "level": "info", "trace_id": None, "session_id": None, "run_id": run_id,
+        "wiki": None, "scope": None, "error_code": None, "data": data,
+    }
+
+
 def _write_runs(
     lore_root: Path,
     records_per_run: list[list[dict]],
     ts_start: datetime | None = None,
-) -> list[Path]:
-    """Write synthetic archival run files. Returns paths (newest last)."""
-    runs_dir = lore_root / ".lore" / "runs"
-    runs_dir.mkdir(parents=True, exist_ok=True)
+) -> list[str]:
+    """Seed curator runs onto the event spine. Returns run_ids (newest last)."""
     if ts_start is None:
         ts_start = _NOW - timedelta(hours=len(records_per_run))
-    paths: list[Path] = []
+    run_ids: list[str] = []
+    envs: list[dict] = []
     for i, records in enumerate(records_per_run):
         file_ts = ts_start + timedelta(minutes=i)
         short = f"{chr(ord('a') + i)}{chr(ord('a') + i)}{chr(ord('a') + i)}111"
-        stem = file_ts.strftime("%Y-%m-%dT%H-%M-%S") + f"-{short}"
-        path = runs_dir / f"{stem}.jsonl"
-        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
-        paths.append(path)
-    return paths
+        run_id = file_ts.strftime("%Y-%m-%dT%H-%M-%S") + f"-{short}"
+        run_ids.append(run_id)
+        envs.extend(_curator_env(r, run_id) for r in records)
+    _append_spine(lore_root, envs)
+    return run_ids
 
 
 def _spine_env(row: dict) -> dict:
@@ -70,10 +86,9 @@ def _spine_env(row: dict) -> dict:
 
 
 def _write_hook_events(lore_root: Path, events: list[dict]) -> Path:
-    path = lore_root / ".lore" / "spine.jsonl"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(json.dumps(_spine_env(e)) for e in events) + "\n")
-    return path
+    # Append so seeded curator runs on the same spine are preserved.
+    _append_spine(lore_root, [_spine_env(e) for e in events])
+    return lore_root / ".lore" / "spine.jsonl"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chapter_flush.py
+++ b/tests/test_chapter_flush.py
@@ -444,7 +444,7 @@ def test_same_minute_rename_collision_gets_numeric_suffix(tmp_path, monkeypatch)
 # ---------------------------------------------------------------------------
 
 
-def test_failed_midsession_flush_defers_silently(tmp_path):
+def test_failed_midsession_flush_defers_without_marker(tmp_path):
     lore_root = _lore_root(tmp_path)
     wiki_root = lore_root / "wiki" / "private"
     all_turns = _turns(0, 2)
@@ -467,6 +467,8 @@ def test_failed_midsession_flush_defers_silently(tmp_path):
     sidecar = buf.read_sidecar()
     assert sidecar.state == "accumulating"
     assert sidecar.flush_attempts == 1  # the failed attempt is remembered
+    # No marker while a retry chance remains, but no longer silent: a queued
+    # flush record + spine event are asserted in test_flush_silent_paths.py.
     assert sidecar.flush_requested is None  # request slot re-opened for next trigger
 
 
@@ -510,41 +512,35 @@ def test_next_trigger_retries_with_accumulated_slice(tmp_path):
     assert buf.read_sidecar().flush_attempts == 0  # progress cleared the memory
 
 
-def test_give_up_at_double_cap_writes_marker_and_fresh_buffer(tmp_path):
-    lore_root = _lore_root(tmp_path, cap_turns=2)  # 2x cap == 4 turns
+def test_give_up_after_max_attempts_writes_marker_and_fresh_buffer(tmp_path):
+    from lore_core.flush_store import MAX_ATTEMPTS
+
+    lore_root = _lore_root(tmp_path)
     wiki_root = lore_root / "wiki" / "private"
-    all_turns = _turns(0, 3)  # 4 turns -> at 2x cap
+    all_turns = _turns(0, 2)
     buf = _append(lore_root, all_turns)
     adapter = _Adapter(all_turns)
 
-    # First flush fails -> deferred (flush_attempts -> 1).
-    synth_in_place(
-        buf.sidecar_path,
-        lore_root=lore_root,
-        wiki_root=wiki_root,
-        llm_client=_Client([None, None]),
-        model="m",
-        adapter_lookup=_lookup(adapter),
-        auto_commit=False,
-    )
-    assert buf.read_sidecar().flush_attempts == 1
-
-    # Second flush at 2x cap with a prior failure -> give up.
-    outcome = synth_in_place(
-        buf.sidecar_path,
-        lore_root=lore_root,
-        wiki_root=wiki_root,
-        llm_client=_Client([None, None]),
-        model="m",
-        adapter_lookup=_lookup(adapter),
-        auto_commit=False,
-    )
+    # Bounded retries with backoff replace the old give-up-at-2x-cap rule:
+    # each failed flush re-queues; the MAX_ATTEMPTS-th failure dead-letters.
+    outcome = None
+    for _ in range(MAX_ATTEMPTS):
+        assert buf.read_sidecar().state == "accumulating"
+        outcome = synth_in_place(
+            buf.sidecar_path,
+            lore_root=lore_root,
+            wiki_root=wiki_root,
+            llm_client=_Client([None, None]),
+            model="m",
+            adapter_lookup=_lookup(adapter),
+            auto_commit=False,
+        )
     assert outcome.status == "gave-up"
 
     view = nd.read_note(outcome.note_path)
     markers = [c for c in view.chapters if c.get("kind") == "marker"]
     assert len(markers) == 1 and markers[0]["marker"] == nd.MARKER_FAILED
-    assert markers[0]["to_turn"] == 3
+    assert markers[0]["to_turn"] == 2
     # Fresh buffer: log truncated + counters reset, still accumulating, one note.
     sidecar = buf.read_sidecar()
     assert sidecar.state == "accumulating"

--- a/tests/test_cli_runs.py
+++ b/tests/test_cli_runs.py
@@ -1,57 +1,108 @@
+"""`lore runs` reads curator runs reconstructed from the event spine (#189).
+
+There are no per-run files any more; a run is a group of ``source="curator"``
+spine envelopes sharing a ``run_id``. Seeding writes envelopes onto the spine.
+"""
+
 import json
+import re
 from pathlib import Path
 
+from lore_core.spine import SpineWriter
 from typer.testing import CliRunner
 
+_RUN_ID = "2026-04-20T14-32-05-a1b2c3"
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
-def _seed_run(tmp_path: Path):
-    runs = tmp_path / ".lore" / "runs"
-    runs.mkdir(parents=True)
-    path = runs / "2026-04-20T14-32-05-a1b2c3.jsonl"
-    path.write_text(
-        json.dumps({"type": "run-start", "schema_version": 1, "ts": "2026-04-20T14:32:05Z",
-                    "run_id": "2026-04-20T14-32-05-a1b2c3", "trigger": "hook"}) + "\n" +
-        json.dumps({"type": "transcript-start", "schema_version": 1, "ts": "2026-04-20T14:32:06Z",
-                    "transcript_id": "t1", "new_turns": 10, "hash_before": "abc"}) + "\n" +
-        json.dumps({"type": "noteworthy", "schema_version": 1, "ts": "2026-04-20T14:32:07Z",
-                    "transcript_id": "t1", "verdict": True, "reason": "worthy",
-                    "tier": "middle", "latency_ms": 500}) + "\n" +
-        json.dumps({"type": "session-note", "schema_version": 1, "ts": "2026-04-20T14:32:08Z",
-                    "transcript_id": "t1", "action": "filed",
-                    "path": "p.md", "wikilink": "[[2026-04-20-test]]"}) + "\n" +
-        json.dumps({"type": "run-end", "schema_version": 1, "ts": "2026-04-20T14:32:09Z",
-                    "duration_ms": 4000, "notes_new": 1, "notes_merged": 0,
-                    "skipped": 0, "errors": 0}) + "\n"
+
+def _plain(s: str) -> str:
+    """Strip ANSI so number/path highlighting doesn't split substrings."""
+    return _ANSI.sub("", s)
+
+
+def _seed_run(tmp_path: Path, run_id: str = _RUN_ID) -> str:
+    w = SpineWriter(tmp_path)
+    w.emit(source="curator", event="run-start", run_id=run_id, data={"trigger": "hook"})
+    w.emit(
+        source="curator",
+        event="transcript-start",
+        run_id=run_id,
+        data={"transcript_id": "t1", "new_turns": 10, "hash_before": "abc"},
     )
-    return path
+    w.emit(
+        source="curator",
+        event="noteworthy",
+        run_id=run_id,
+        data={
+            "transcript_id": "t1",
+            "verdict": True,
+            "reason": "worthy",
+            "tier": "middle",
+            "latency_ms": 500,
+        },
+    )
+    w.emit(
+        source="curator",
+        event="session-note",
+        run_id=run_id,
+        data={
+            "transcript_id": "t1",
+            "action": "filed",
+            "path": "p.md",
+            "wikilink": "[[2026-04-20-test]]",
+        },
+    )
+    w.emit(
+        source="curator",
+        event="run-end",
+        run_id=run_id,
+        data={"duration_ms": 4000, "notes_new": 1, "notes_merged": 0, "skipped": 0, "errors": 0},
+    )
+    return run_id
+
+
+def _seed_hook_events(tmp_path: Path, rows: list[dict]) -> None:
+    w = SpineWriter(tmp_path)
+    for row in rows:
+        data = {k: v for k, v in row.items() if k not in ("ts", "event", "schema_version")}
+        w.emit(source="hook", event=row.get("event"), data=data)
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
 
 
 def test_runs_show_latest(tmp_path, monkeypatch):
     from lore_cli import runs_cmd
+
     _seed_run(tmp_path)
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     result = runner.invoke(runs_cmd.app, ["show", "latest"])
     assert result.exit_code == 0, result.output
-    assert "2026-04-20-test" in result.stdout
-    assert "1 new" in result.stdout
-    assert "worthy" in result.stdout
+    out = _plain(result.stdout)
+    assert "2026-04-20-test" in out
+    assert "1 new" in out
+    assert "worthy" in out
 
 
 def test_runs_show_json_mode(tmp_path, monkeypatch):
     from lore_cli import runs_cmd
+
     _seed_run(tmp_path)
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     result = runner.invoke(runs_cmd.app, ["show", "a1b2c3", "--json"])
     assert result.exit_code == 0
-    lines = [l for l in result.stdout.splitlines() if l.strip()]
-    for l in lines:
-        json.loads(l)  # must be valid JSON
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    for ln in lines:
+        json.loads(ln)  # must be valid JSON
 
 
-def test_runs_show_verbose_without_companion_prints_message(tmp_path, monkeypatch):
+def test_runs_show_verbose_notes_trace_not_persisted(tmp_path, monkeypatch):
     from lore_cli import runs_cmd
+
     _seed_run(tmp_path)
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
@@ -62,7 +113,7 @@ def test_runs_show_verbose_without_companion_prints_message(tmp_path, monkeypatc
 
 def test_runs_show_not_found(tmp_path, monkeypatch):
     from lore_cli import runs_cmd
-    (tmp_path / ".lore" / "runs").mkdir(parents=True)
+
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     result = runner.invoke(runs_cmd.app, ["show", "zzzzzz"])
@@ -70,23 +121,14 @@ def test_runs_show_not_found(tmp_path, monkeypatch):
     assert "not found" in result.output.lower() or "no runs" in result.output.lower()
 
 
-def test_runs_show_schema_too_new_refuses(tmp_path, monkeypatch):
-    from lore_cli import runs_cmd
-    runs = tmp_path / ".lore" / "runs"
-    runs.mkdir(parents=True)
-    (runs / "2026-04-20T10-00-00-aaaaaa.jsonl").write_text(
-        '{"type":"run-start","schema_version":2}\n'
-        '{"type":"run-end","schema_version":2}\n'
-    )
-    runner = CliRunner()
-    monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
-    result = runner.invoke(runs_cmd.app, ["show", "latest"])
-    assert result.exit_code == 1
-    assert "schema" in result.output.lower() or "upgrade" in result.output.lower()
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
 
 
 def test_runs_list_empty(tmp_path, monkeypatch):
     from lore_cli import runs_cmd
+
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     result = runner.invoke(runs_cmd.app, ["list"])
@@ -96,146 +138,97 @@ def test_runs_list_empty(tmp_path, monkeypatch):
 
 def test_runs_list_shows_seeded_run(tmp_path, monkeypatch):
     from lore_cli import runs_cmd
+
     _seed_run(tmp_path)
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     result = runner.invoke(runs_cmd.app, ["list"])
     assert result.exit_code == 0
-    assert "a1b2c3" in result.stdout          # short suffix
-    assert "1 new" in result.stdout          # notes cell
+    assert "a1b2c3" in result.stdout  # short suffix
+    assert "1 new" in result.stdout  # notes cell
 
 
 def test_runs_list_json(tmp_path, monkeypatch):
     from lore_cli import runs_cmd
+
     _seed_run(tmp_path)
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     result = runner.invoke(runs_cmd.app, ["list", "--json"])
     assert result.exit_code == 0
-    # Each non-empty line is valid JSON.
     for line in result.stdout.splitlines():
         line = line.strip()
         if line:
             json.loads(line)
 
 
-def test_runs_list_schema_mismatch_dimmed(tmp_path, monkeypatch):
-    from lore_cli import runs_cmd
-    runs = tmp_path / ".lore" / "runs"
-    runs.mkdir(parents=True)
-    (runs / "2026-04-20T10-00-00-xxxxxx.jsonl").write_text(
-        '{"type":"run-start","schema_version":2}\n'
-        '{"type":"run-end","schema_version":2,"notes_new":0,"notes_merged":0,"skipped":0,"errors":0,"duration_ms":0}\n'
-    )
-    runner = CliRunner()
-    monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
-    result = runner.invoke(runs_cmd.app, ["list"])
-    assert result.exit_code == 0, result.output
-    # List should render the row, with a schema mismatch note.
-    assert "xxxxxx" in result.stdout
-    assert ("schema" in result.stdout.lower() or "v2" in result.stdout.lower()
-            or "upgrade" in result.stdout.lower())
-
-
-def _spine_env(row: dict) -> dict:
-    """Wrap an old-style hook row as a spine envelope."""
-    data = {k: v for k, v in row.items() if k not in ("ts", "event", "schema_version")}
-    outcome = data.get("outcome")
-    return {
-        "ts": row.get("ts"), "v": 1, "source": "hook", "event": row.get("event"),
-        "level": "error" if outcome == "error" else "info",
-        "trace_id": None, "session_id": None, "run_id": None,
-        "wiki": None, "scope": None, "error_code": None, "data": data,
-    }
-
-
-def _seed_hook_events(tmp_path: Path, rows: list):
-    """Write spine hook records to tmp_path."""
-    events = tmp_path / ".lore" / "spine.jsonl"
-    events.parent.mkdir(parents=True, exist_ok=True)
-    events.write_text("\n".join(json.dumps(_spine_env(r)) for r in rows) + "\n")
-    return events
+# ---------------------------------------------------------------------------
+# list --hooks
+# ---------------------------------------------------------------------------
 
 
 def test_runs_list_hooks_interleaved_run_and_hook(tmp_path, monkeypatch):
-    """--hooks interleaves run rows and hook rows in a single table."""
     _seed_run(tmp_path)
-    _seed_hook_events(tmp_path, [
-        {
-            "schema_version": 2,
-            "ts": "2026-04-20T14:32:04Z",  # just before the run
-            "event": "session-end",
-            "outcome": "spawned-curator",
-            "pid": 12345,
-            "cwd": "/home/user/myproject",
-        }
-    ])
+    _seed_hook_events(
+        tmp_path,
+        [
+            {
+                "event": "session-end",
+                "outcome": "spawned-curator",
+                "pid": 12345,
+                "cwd": "/home/user/myproject",
+            },
+        ],
+    )
     from lore_cli import runs_cmd
-    from typer.testing import CliRunner
+
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     runner = CliRunner()
     result = runner.invoke(runs_cmd.app, ["list", "--hooks"])
     assert result.exit_code == 0, result.output
-    # Run row present
     assert "a1b2c3" in result.stdout
-    # Hook row marker and event present
-    assert "\u2500" in result.stdout           # ─ hook marker
+    assert "─" in result.stdout  # ─ hook marker
     assert "session-end" in result.stdout
-    # Where and PID columns present
     assert "myproject" in result.stdout
     assert "12345" in result.stdout
 
 
 def test_runs_list_hooks_only_hook_events_no_runs(tmp_path, monkeypatch):
-    """--hooks with ONLY hook events (no runs) renders just hook rows."""
-    _seed_hook_events(tmp_path, [
-        {
-            "schema_version": 1,
-            "ts": "2026-04-20T14:32:05Z",
-            "event": "session-start",
-            "outcome": "below-threshold",
-        }
-    ])
+    _seed_hook_events(
+        tmp_path,
+        [
+            {"event": "session-start", "outcome": "below-threshold"},
+        ],
+    )
     from lore_cli import runs_cmd
-    from typer.testing import CliRunner
+
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     runner = CliRunner()
     result = runner.invoke(runs_cmd.app, ["list", "--hooks"])
     assert result.exit_code == 0, result.output
     assert "session-start" in result.stdout
-    assert "\u2500" in result.stdout           # ─ hook marker
+    assert "─" in result.stdout
 
 
 def test_runs_list_hooks_only_runs_no_hook_events(tmp_path, monkeypatch):
-    """--hooks with runs but NO hook-events.jsonl renders the run rows AND
-    a warning line above the table.
-
-    This is the exact pattern when Claude Code's capture hook never fires
-    (e.g. plugin not installed, or silently-failing scope resolution).
-    Without the warning, the user sees a table full of empty runs and
-    has no signal that the hook pipeline itself is broken.
-    """
+    """--hooks with runs but no hook events renders the runs AND a diagnostic
+    banner (the exact pattern when Claude Code's capture hook never fires)."""
     _seed_run(tmp_path)
     from lore_cli import runs_cmd
-    from typer.testing import CliRunner
+
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     runner = CliRunner()
     result = runner.invoke(runs_cmd.app, ["list", "--hooks"])
     assert result.exit_code == 0, result.output
     assert "a1b2c3" in result.stdout
     assert "1 new" in result.stdout
-    # New: diagnostic banner when the spine has no hook events.
     assert "spine" in result.output.lower()
     assert "may not be firing" in result.output.lower()
 
 
 def test_runs_list_hooks_no_runs_no_events_no_warning(tmp_path, monkeypatch):
-    """Fresh vault: no runs AND no hook events → the empty-state copy,
-    not the "hooks aren't firing" warning (which only makes sense when
-    runs are actually appearing)."""
-    (tmp_path / ".lore" / "runs").mkdir(parents=True)
     from lore_cli import runs_cmd
-    from typer.testing import CliRunner
+
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     runner = CliRunner()
     result = runner.invoke(runs_cmd.app, ["list", "--hooks"])
@@ -244,48 +237,27 @@ def test_runs_list_hooks_no_runs_no_events_no_warning(tmp_path, monkeypatch):
     assert "may not be firing" not in result.output.lower()
 
 
-def test_runs_list_hooks_v1_no_crash(tmp_path, monkeypatch):
-    """--hooks renders schema v1 hook records without crashing (no Where/PID)."""
-    _seed_hook_events(tmp_path, [
-        {
-            "schema_version": 1,
-            "ts": "2026-04-20T14:32:05Z",
-            "event": "session-end",
-            "outcome": "spawned-curator",
-        }
-    ])
-    from lore_cli import runs_cmd
-    from typer.testing import CliRunner
-    monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
-    runner = CliRunner()
-    result = runner.invoke(runs_cmd.app, ["list", "--hooks"])
-    assert result.exit_code == 0, result.output
-    assert "session-end" in result.stdout
+# ---------------------------------------------------------------------------
+# tail (follows the spine's curator events)
+# ---------------------------------------------------------------------------
 
 
 def test_runs_tail_once_reads_to_run_end(tmp_path, monkeypatch):
     from lore_cli import runs_cmd
-    live = tmp_path / ".lore" / "runs-live.jsonl"
-    live.parent.mkdir(parents=True)
-    live.write_text(
-        json.dumps({"type": "run-start", "ts": "2026-04-20T14:32:05Z",
-                    "run_id": "r1", "trigger": "hook"}) + "\n" +
-        json.dumps({"type": "run-end", "ts": "2026-04-20T14:32:09Z",
-                    "duration_ms": 4000, "notes_new": 1, "notes_merged": 0,
-                    "skipped": 0, "errors": 0}) + "\n"
-    )
+
+    _seed_run(tmp_path)
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     monkeypatch.setattr(runs_cmd, "_POLL_INTERVAL_S", 0.01)
     result = runner.invoke(runs_cmd.app, ["tail", "--once"])
     assert result.exit_code == 0
-    # The flat log contains both the start-run and the end record.
     assert "start-run" in result.stdout or "trigger" in result.stdout
     assert "end" in result.stdout
 
 
-def test_runs_tail_missing_live_file(tmp_path, monkeypatch):
+def test_runs_tail_missing_spine(tmp_path, monkeypatch):
     from lore_cli import runs_cmd
+
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     result = runner.invoke(runs_cmd.app, ["tail", "--once"])
@@ -293,46 +265,18 @@ def test_runs_tail_missing_live_file(tmp_path, monkeypatch):
     assert "no active" in result.stdout.lower() or "no run" in result.stdout.lower()
 
 
-def test_runs_tail_handles_truncation_across_runs(tmp_path, monkeypatch):
-    """runs-live.jsonl is truncated on each new run-start; tail should see
-    the new run's records, not silently skip them."""
+def test_runs_tail_ignores_non_curator_events(tmp_path, monkeypatch):
+    """A spine with only hook events yields no run output but still terminates."""
     from lore_cli import runs_cmd
 
-    live = tmp_path / ".lore" / "runs-live.jsonl"
-    live.parent.mkdir(parents=True)
-
-    # Run A — a complete, short run.
-    live.write_text(
-        json.dumps({"type": "run-start", "ts": "2026-04-20T10:00:00Z",
-                    "run_id": "runA", "trigger": "hook"}) + "\n" +
-        json.dumps({"type": "run-end", "ts": "2026-04-20T10:00:01Z",
-                    "duration_ms": 1000, "notes_new": 0, "notes_merged": 0,
-                    "skipped": 0, "errors": 0}) + "\n"
-    )
-
+    _seed_hook_events(tmp_path, [{"event": "session-start", "outcome": "ok"}])
     runner = CliRunner()
     monkeypatch.setattr(runs_cmd, "_get_lore_root", lambda: tmp_path)
     monkeypatch.setattr(runs_cmd, "_POLL_INTERVAL_S", 0.01)
-
-    # --once tail of run A.
-    result_a = runner.invoke(runs_cmd.app, ["tail", "--once"])
-    assert result_a.exit_code == 0
-    assert "end" in result_a.stdout
-
-    # Simulate run B: truncate and write new records.
-    live.write_text(
-        json.dumps({"type": "run-start", "ts": "2026-04-20T11:00:00Z",
-                    "run_id": "runB", "trigger": "manual"}) + "\n" +
-        json.dumps({"type": "run-end", "ts": "2026-04-20T11:00:02Z",
-                    "duration_ms": 2000, "notes_new": 1, "notes_merged": 0,
-                    "skipped": 0, "errors": 0}) + "\n"
-    )
-
-    # A fresh tail invocation (new process-equivalent) sees run B.
-    result_b = runner.invoke(runs_cmd.app, ["tail", "--once"])
-    assert result_b.exit_code == 0
-    # Run B contains 1 new note, not 0.
-    assert "1 new" in result_b.stdout or "manual" in result_b.stdout
+    monkeypatch.setattr(runs_cmd, "_IDLE_TIMEOUT_S", 0)  # exit immediately when idle
+    result = runner.invoke(runs_cmd.app, ["tail", "--once"])
+    assert result.exit_code == 0
+    assert "session-start" not in result.stdout  # hook events are not run records
 
 
 # ---------------------------------------------------------------------------
@@ -341,7 +285,6 @@ def test_runs_tail_handles_truncation_across_runs(tmp_path, monkeypatch):
 
 
 def test_complete_run_id_returns_candidates(tmp_path, monkeypatch):
-    """_complete_run_id returns suffix matches and static aliases."""
     from lore_cli import runs_cmd
     from lore_core import config as cfg_mod
 
@@ -357,7 +300,6 @@ def test_complete_run_id_returns_candidates(tmp_path, monkeypatch):
 
 
 def test_complete_run_id_filters_by_prefix(tmp_path, monkeypatch):
-    """_complete_run_id filters to matching prefix."""
     from lore_cli import runs_cmd
     from lore_core import config as cfg_mod
 
@@ -371,7 +313,6 @@ def test_complete_run_id_filters_by_prefix(tmp_path, monkeypatch):
 
 
 def test_complete_run_id_graceful_on_missing_root(tmp_path, monkeypatch):
-    """_complete_run_id returns only static aliases when runs dir is absent."""
     from lore_cli import runs_cmd
     from lore_core import config as cfg_mod
 

--- a/tests/test_curator_a.py
+++ b/tests/test_curator_a.py
@@ -606,7 +606,7 @@ def test_curator_a_duration_recorded(tmp_path):
 
 
 def test_run_curator_a_creates_run_log(tmp_path):
-    """After run_curator_a finishes, a runs/<id>.jsonl file exists with run-start/run-end."""
+    """After run_curator_a finishes, the spine holds a curator run with run-start/run-end."""
     import json
 
     from lore_curator.session_curator import run_curator_a
@@ -631,11 +631,10 @@ def test_run_curator_a_creates_run_log(tmp_path):
         now=_NOW,
     )
 
-    runs_dir = tmp_path / ".lore" / "runs"
-    runs = list(runs_dir.glob("*.jsonl"))
-    archival = [p for p in runs if not p.name.endswith(".trace.jsonl")]
-    assert len(archival) == 1, f"expected 1 run file, got {runs}"
-    records = [json.loads(l) for l in archival[0].read_text().splitlines()]
+    from lore_core.run_reader import read_curator_runs
+    runs = list(read_curator_runs(tmp_path).values())
+    assert len(runs) == 1, f"expected 1 run on the spine, got {len(runs)}"
+    records = runs[0]
     types = [r["type"] for r in records]
     assert types[0] == "run-start"
     assert types[-1] == "run-end"

--- a/tests/test_flush_silent_paths.py
+++ b/tests/test_flush_silent_paths.py
@@ -1,0 +1,204 @@
+"""Regression net for the formerly-silent flush failure paths (issue #189).
+
+Before this slice a failed flush "deferred silently (no marker)", a spawn
+failure returned False into the void, an unreadable sidecar skipped without a
+trace, and a chapter-append I/O error propagated with no flush-state record.
+Each now produces a spine event or a dead-letter — a stuck flush is a
+queryable row, never an absence of evidence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lore_core import note_document as nd
+from lore_core.flush_store import FlushState, FlushStore
+from lore_core.spine import ErrorCode, read_spine
+from lore_curator.chapter_flush import (
+    flush_chapter,
+    spawn_detached_flush,
+    synth_in_place,
+)
+
+# Reuse the compose-pipeline fakes from the sibling suite.
+from test_chapter_flush import (  # noqa: E402
+    _Adapter,
+    _append,
+    _chapter_payload,
+    _Client,
+    _lookup,
+    _lore_root,
+    _turns,
+)
+
+
+@pytest.fixture(autouse=True)
+def _patch_collectors(monkeypatch):
+    monkeypatch.setattr("lore_curator.session_activity.collect_commits_by_sha", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_issues_in_window", lambda *a, **k: ([], [])
+    )
+    monkeypatch.setattr(
+        "lore_curator.session_activity.collect_projects_for_session", lambda **k: []
+    )
+    monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
+    monkeypatch.setattr("lore_core.git.current_repo", lambda cwd: "")
+
+
+def _curator_events(lore_root: Path) -> list[dict]:
+    return read_spine(lore_root, source="curator")
+
+
+# ---------------------------------------------------------------------------
+# The silent defer is gone: a failed mid-session flush now leaves evidence.
+# ---------------------------------------------------------------------------
+
+
+def test_failed_midsession_flush_leaves_a_queryable_queued_record(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    all_turns = _turns(0, 2)
+    buf = _append(lore_root, all_turns)
+
+    outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client([None, None]),  # both compose attempts fail
+        model="m",
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+        auto_commit=False,
+    )
+    assert outcome.status == "deferred"
+    # No marker while a retry chance remains — but no longer SILENT:
+    assert nd.read_note(outcome.note_path).chapters == []
+
+    store = FlushStore(lore_root)
+    queued = store.list(state=FlushState.QUEUED)
+    assert [r.buffer_stem for r in queued] == [buf.stem]
+    assert queued[0].attempts == 1
+    assert queued[0].next_retry_at is not None  # backoff scheduled
+
+    events = [e["event"] for e in _curator_events(lore_root)]
+    assert "flush-queued" in events  # the defer emitted a spine event
+
+
+def test_repeated_failures_dead_letter_with_structured_reason(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    all_turns = _turns(0, 2)
+    buf = _append(lore_root, all_turns)
+    adapter = _Adapter(all_turns)
+
+    from lore_core.flush_store import MAX_ATTEMPTS
+
+    outcome = None
+    for _ in range(MAX_ATTEMPTS):
+        outcome = synth_in_place(
+            buf.sidecar_path,
+            lore_root=lore_root,
+            wiki_root=wiki_root,
+            llm_client=_Client([None, None]),
+            model="m",
+            adapter_lookup=_lookup(adapter),
+            auto_commit=False,
+        )
+
+    assert outcome.status == "gave-up"
+    # Terminal dead-letter is listable and carries a structured reason.
+    dead = FlushStore(lore_root).list(state=FlushState.DEAD_LETTERED)
+    assert [r.buffer_stem for r in dead] == [buf.stem]
+    assert dead[0].reason == ErrorCode.COMPOSE_FAILED.value
+    # Failed marker written; buffer reset (one session stays one note).
+    markers = [c for c in nd.read_note(outcome.note_path).chapters if c.get("kind") == "marker"]
+    assert len(markers) == 1 and markers[0]["marker"] == nd.MARKER_FAILED
+    assert buf.read_sidecar().state == "accumulating"
+    # Error-level spine event with the closed error code.
+    dl = [e for e in _curator_events(lore_root) if e["event"] == "flush-dead-lettered"]
+    assert dl and dl[-1]["level"] == "error"
+    assert dl[-1]["error_code"] == ErrorCode.COMPOSE_FAILED.value
+
+
+# ---------------------------------------------------------------------------
+# Buffer sidecar read error — corrupt sidecar no longer skips in silence.
+# ---------------------------------------------------------------------------
+
+
+def test_unreadable_sidecar_emits_error_event(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    buf = _append(lore_root, _turns(0, 2))
+    # Corrupt the sidecar so read_sidecar() returns None despite the file
+    # existing — the "read error" case, distinct from a missing buffer.
+    buf.sidecar_path.write_text("{ this is not json")
+
+    outcome = flush_chapter(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        close=False,
+    )
+    assert outcome.status == "skipped"  # still short-circuits, but now loudly
+    errs = [
+        e
+        for e in _curator_events(lore_root)
+        if e.get("error_code") == ErrorCode.SIDECAR_READ_FAILED.value
+    ]
+    assert errs, "an unreadable sidecar must emit an error-level spine event"
+    assert errs[-1]["level"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Subprocess spawn failure — Popen OSError no longer vanishes.
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_failure_emits_event(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    buf = _append(lore_root, _turns(0, 2))
+
+    def boom(*a, **k):
+        raise OSError("no fork")
+
+    monkeypatch.setattr("subprocess.Popen", boom)
+    ok = spawn_detached_flush(buf.sidecar_path, lore_root=lore_root)
+    assert ok is False
+    errs = [
+        e for e in _curator_events(lore_root) if e.get("error_code") == ErrorCode.SPAWN_FAILED.value
+    ]
+    assert errs, "a spawn failure must emit a spine event"
+
+
+# ---------------------------------------------------------------------------
+# Chapter-append I/O error — a write failure dead-letters instead of crashing.
+# ---------------------------------------------------------------------------
+
+
+def test_chapter_append_ioerror_dead_letters(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    all_turns = _turns(0, 2)
+    buf = _append(lore_root, all_turns)
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(nd, "append_chapter", boom)
+
+    # A good compose that would normally append a chapter.
+    outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=_Client([_chapter_payload("Lead", "prose.", 0)]),
+        model="m",
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+        auto_commit=False,
+    )
+    # No crash; the flush is a dead-letter with the append error code.
+    assert outcome.status == "failed"
+    dead = FlushStore(lore_root).list(state=FlushState.DEAD_LETTERED)
+    assert [r.reason for r in dead] == [ErrorCode.CHAPTER_APPEND_FAILED.value]
+    dl = [e for e in _curator_events(lore_root) if e["event"] == "flush-dead-lettered"]
+    assert dl and dl[-1]["error_code"] == ErrorCode.CHAPTER_APPEND_FAILED.value

--- a/tests/test_flush_store.py
+++ b/tests/test_flush_store.py
@@ -1,0 +1,242 @@
+"""Flush lifecycle state machine tests (issue #189).
+
+The transition table (legal AND illegal) and the bounded-retry / dead-letter
+scheduling are the heart of the slice — a stuck flush must be a queryable
+row, never an absence of evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from lore_core.flush_store import (
+    MAX_ATTEMPTS,
+    RETRY_CAP_SECONDS,
+    FlushRecord,
+    FlushState,
+    FlushStore,
+    FlushTransitionError,
+    backoff_seconds,
+    is_legal_transition,
+    is_retry_due,
+)
+from lore_core.spine import ErrorCode, read_spine, validate_envelope
+
+
+def _spine(lore_root: Path) -> list[dict]:
+    return read_spine(lore_root, source="curator")
+
+
+# ---------------------------------------------------------------------------
+# AC1 — transition table (legal AND illegal)
+# ---------------------------------------------------------------------------
+
+_LEGAL_PAIRS = [
+    (FlushState.QUEUED, FlushState.RUNNING),
+    (FlushState.RUNNING, FlushState.PUBLISHED),
+    (FlushState.RUNNING, FlushState.WITHHELD),
+    (FlushState.RUNNING, FlushState.DEAD_LETTERED),
+    (FlushState.RUNNING, FlushState.QUEUED),  # scheduled retry
+]
+
+# Every ordered pair not in the legal set must be illegal — including
+# self-loops and any transition out of a terminal state.
+_ALL_STATES = list(FlushState)
+_ILLEGAL_PAIRS = [(a, b) for a in _ALL_STATES for b in _ALL_STATES if (a, b) not in _LEGAL_PAIRS]
+
+
+@pytest.mark.parametrize("frm,to", _LEGAL_PAIRS)
+def test_legal_transitions_accepted(frm, to):
+    assert is_legal_transition(frm, to) is True
+
+
+@pytest.mark.parametrize("frm,to", _ILLEGAL_PAIRS)
+def test_illegal_transitions_rejected(frm, to):
+    assert is_legal_transition(frm, to) is False
+
+
+def test_store_transition_raises_on_illegal(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101", wiki="private")
+    store.transition(rec, FlushState.RUNNING)
+    store.transition(rec, FlushState.PUBLISHED)
+    # published is terminal — any further transition is illegal.
+    with pytest.raises(FlushTransitionError):
+        store.transition(rec, FlushState.RUNNING)
+
+
+def test_store_transition_happy_path_persists(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101", wiki="private")
+    assert rec.state == FlushState.QUEUED.value
+    store.transition(rec, FlushState.RUNNING)
+    store.transition(rec, FlushState.PUBLISHED)
+    reloaded = store.get(rec.flush_id)
+    assert reloaded is not None
+    assert reloaded.state == FlushState.PUBLISHED.value
+    assert reloaded.is_terminal
+
+
+# ---------------------------------------------------------------------------
+# AC1 — the record shape: attempt counter + next-eligible-retry timestamp
+# ---------------------------------------------------------------------------
+
+
+def test_record_has_attempt_counter_and_next_retry(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101")
+    assert rec.attempts == 0
+    assert rec.next_retry_at is None
+    assert rec.trace_id is None  # #188 fills this
+
+
+def test_persisted_json_round_trips(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101", wiki="private")
+    raw = json.loads((tmp_path / ".lore" / "flushes" / f"{rec.flush_id}.json").read_text())
+    assert raw["buffer_stem"] == "t1__20260101"
+    assert raw["state"] == "queued"
+    assert raw["attempts"] == 0
+
+
+# ---------------------------------------------------------------------------
+# AC2 — bounded retries with backoff; exhaustion -> dead-letter (structured)
+# ---------------------------------------------------------------------------
+
+
+def test_backoff_is_exponential_and_capped():
+    assert backoff_seconds(1) == 60
+    assert backoff_seconds(2) == 120
+    assert backoff_seconds(3) == 240
+    # Never exceeds the cap however large the attempt.
+    assert backoff_seconds(999) == RETRY_CAP_SECONDS
+
+
+def test_record_failure_schedules_retry_before_exhaustion(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101")
+    store.transition(rec, FlushState.RUNNING)
+    rec = store.record_failure(rec, error_code=ErrorCode.COMPOSE_FAILED)
+    # First failure: retry scheduled, not dead-lettered.
+    assert rec.state == FlushState.QUEUED.value
+    assert rec.attempts == 1
+    assert rec.next_retry_at is not None
+    assert rec.reason is None
+
+
+def test_record_failure_dead_letters_on_exhaustion(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101")
+    for _ in range(MAX_ATTEMPTS):
+        store.transition(rec, FlushState.RUNNING)
+        rec = store.record_failure(rec, error_code=ErrorCode.COMPOSE_FAILED)
+    assert rec.state == FlushState.DEAD_LETTERED.value
+    assert rec.attempts == MAX_ATTEMPTS
+    # Structured reason from the closed enum — never a free-form string.
+    assert rec.reason == ErrorCode.COMPOSE_FAILED.value
+    assert rec.reason in {c.value for c in ErrorCode}
+
+
+def test_dead_letter_reason_must_be_enum(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101")
+    store.transition(rec, FlushState.RUNNING)
+    with pytest.raises(ValueError):
+        store.transition(rec, FlushState.DEAD_LETTERED, reason="free-form-string")
+
+
+# ---------------------------------------------------------------------------
+# AC1/AC2 — every transition emits a well-formed spine event
+# ---------------------------------------------------------------------------
+
+
+def test_transitions_emit_spine_events(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101", wiki="private")
+    store.transition(rec, FlushState.RUNNING)
+    store.transition(rec, FlushState.WITHHELD)
+    events = [r["event"] for r in _spine(tmp_path)]
+    assert "flush-queued" in events
+    assert "flush-running" in events
+    assert "flush-withheld" in events
+    for r in _spine(tmp_path):
+        validate_envelope(r)  # closed source/level/error_code sets
+
+
+def test_dead_letter_event_carries_error_code(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101")
+    for _ in range(MAX_ATTEMPTS):
+        store.transition(rec, FlushState.RUNNING)
+        rec = store.record_failure(rec, error_code=ErrorCode.COMPOSE_FAILED)
+    dl = [r for r in _spine(tmp_path) if r["event"] == "flush-dead-lettered"]
+    assert dl, "a dead-letter must emit an error-level spine event"
+    assert dl[-1]["level"] == "error"
+    assert dl[-1]["error_code"] == ErrorCode.COMPOSE_FAILED.value
+
+
+# ---------------------------------------------------------------------------
+# AC5 — queued / running / dead-lettered flushes are listable
+# ---------------------------------------------------------------------------
+
+
+def test_list_by_state(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    store.begin("q__20260101")  # stays queued
+    r = store.begin("r__20260101")
+    store.transition(r, FlushState.RUNNING)
+    d = store.begin("d__20260101")
+    for _ in range(MAX_ATTEMPTS):
+        store.transition(d, FlushState.RUNNING)
+        d = store.record_failure(d, error_code=ErrorCode.SPAWN_FAILED)
+
+    assert {x.buffer_stem for x in store.list(state=FlushState.QUEUED)} == {"q__20260101"}
+    assert {x.buffer_stem for x in store.list(state=FlushState.RUNNING)} == {"r__20260101"}
+    assert {x.buffer_stem for x in store.list(state=FlushState.DEAD_LETTERED)} == {"d__20260101"}
+    # No filter -> all records.
+    assert len(store.list()) == 3
+
+
+# ---------------------------------------------------------------------------
+# begin() lifecycle: idempotent while active, reopens after terminal
+# ---------------------------------------------------------------------------
+
+
+def test_begin_returns_active_record_preserving_attempts(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101")
+    store.transition(rec, FlushState.RUNNING)
+    rec = store.record_failure(rec, error_code=ErrorCode.COMPOSE_FAILED)  # attempts=1, queued
+    again = store.begin("t1__20260101")
+    assert again.flush_id == rec.flush_id
+    assert again.attempts == 1  # not reset while still active
+
+
+def test_begin_reopens_after_terminal(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("t1__20260101")
+    store.transition(rec, FlushState.RUNNING)
+    store.transition(rec, FlushState.PUBLISHED)
+    reopened = store.begin("t1__20260101")
+    assert reopened.state == FlushState.QUEUED.value
+    assert reopened.attempts == 0  # fresh unit
+
+
+# ---------------------------------------------------------------------------
+# next-eligible-retry gating
+# ---------------------------------------------------------------------------
+
+
+def test_is_retry_due(tmp_path: Path):
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    future = (now + timedelta(seconds=120)).isoformat().replace("+00:00", "Z")
+    past = (now - timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+    queued_future = FlushRecord(flush_id="x", buffer_stem="x", state="queued", next_retry_at=future)
+    queued_past = FlushRecord(flush_id="x", buffer_stem="x", state="queued", next_retry_at=past)
+    running = FlushRecord(flush_id="x", buffer_stem="x", state="running")
+    assert is_retry_due(queued_future, now=now) is False
+    assert is_retry_due(queued_past, now=now) is True
+    assert is_retry_due(running, now=now) is False  # only queued records are retry-eligible

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -216,10 +216,10 @@ def test_skip_lock_held_includes_holder(tmp_path):
             adapter_lookup=lambda h: None,
         )
 
-    runs = list((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    archival = [p for p in runs if not p.name.endswith(".trace.jsonl")]
-    assert archival, "Expected at least one run log"
-    records = [json.loads(l) for l in archival[0].read_text().splitlines() if l.strip()]
+    from lore_core.run_reader import read_curator_runs
+    runs = list(read_curator_runs(tmp_path).values())
+    assert runs, "Expected at least one run on the spine"
+    records = runs[0]
     skip_records = [
         r for r in records
         if r.get("type") == "skip" and r.get("reason") == "lock-held"

--- a/tests/test_log_cmd.py
+++ b/tests/test_log_cmd.py
@@ -44,19 +44,29 @@ def _seed_hook_events(lore_root: Path, events: list[dict]) -> None:
     p.write_text("\n".join(json.dumps(_spine_env(e)) for e in events) + "\n")
 
 
+def _curator_env(event: str, run_id: str, ts: str, data: dict) -> dict:
+    """A curator spine envelope with a controlled timestamp."""
+    return {
+        "ts": ts, "v": 1, "source": "curator", "event": event, "level": "info",
+        "trace_id": None, "session_id": None, "run_id": run_id,
+        "wiki": None, "scope": None, "error_code": None, "data": data,
+    }
+
+
 def _seed_run(lore_root: Path, *, ago: timedelta, notes_new: int = 1, suffix: str = "abc123") -> None:
+    # Curator runs live on the spine now (role omitted -> log defaults to a).
     run_ts = _NOW - ago
-    runs_dir = lore_root / ".lore" / "runs"
-    runs_dir.mkdir(parents=True, exist_ok=True)
-    stem = run_ts.strftime("%Y-%m-%dT%H-%M-%S") + f"-{suffix}"
-    records = [
-        {"type": "run-start", "ts": _iso(run_ts), "schema_version": 1, "run_id": stem},
-        {"type": "run-end", "ts": _iso(run_ts + timedelta(seconds=15)), "schema_version": 1,
-         "notes_new": notes_new, "notes_merged": 0, "duration_ms": 15000, "errors": 0},
+    run_id = run_ts.strftime("%Y-%m-%dT%H-%M-%S") + f"-{suffix}"
+    envs = [
+        _curator_env("run-start", run_id, _iso(run_ts), {"trigger": "hook"}),
+        _curator_env("run-end", run_id, _iso(run_ts + timedelta(seconds=15)),
+                     {"notes_new": notes_new, "notes_merged": 0, "duration_ms": 15000, "errors": 0}),
     ]
-    (runs_dir / f"{stem}.jsonl").write_text(
-        "\n".join(json.dumps(r) for r in records) + "\n"
-    )
+    spine = lore_root / ".lore" / "spine.jsonl"
+    spine.parent.mkdir(parents=True, exist_ok=True)
+    with spine.open("a") as f:
+        for e in envs:
+            f.write(json.dumps(e) + "\n")
 
 
 def _invoke(lore_root: Path, *extra: str, monkeypatch) -> str:

--- a/tests/test_run_log.py
+++ b/tests/test_run_log.py
@@ -1,11 +1,27 @@
-import json
+"""RunLogger emits curator run events onto the event spine (issue #189).
+
+The archival ``runs/<id>.jsonl`` file and the ``runs-live.jsonl`` tee are gone;
+every record is one ``source="curator"`` spine envelope keyed by ``run_id``.
+"""
+
 import re
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
-
 from lore_core.run_log import RunLogger, generate_run_id
+from lore_core.run_reader import read_curator_runs
+from lore_core.spine import read_spine, validate_envelope
+
+
+def _events(lore_root: Path) -> list[dict]:
+    return read_spine(lore_root, source="curator")
+
+
+def _only_run(lore_root: Path) -> list[dict]:
+    runs = list(read_curator_runs(lore_root).values())
+    assert len(runs) == 1
+    return runs[0]
 
 
 def test_run_id_format():
@@ -19,34 +35,33 @@ def test_run_id_uniqueness():
     assert len(ids) == 1000
 
 
-def test_run_start_written_on_enter(tmp_path: Path):
+def test_run_start_and_end_land_on_the_spine(tmp_path: Path):
     with RunLogger(tmp_path, trigger="manual", pending_count=2) as logger:
         pass
-    archival_files = list((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    archival = [p for p in archival_files if not p.name.endswith(".trace.jsonl")]
-    assert len(archival) == 1
-    lines = archival[0].read_text().splitlines()
-    records = [json.loads(l) for l in lines]
-    assert records[0]["type"] == "run-start"
-    assert records[0]["trigger"] == "manual"
-    assert records[0]["pending_count"] == 2
-    assert records[-1]["type"] == "run-end"
-    live = tmp_path / ".lore" / "runs-live.jsonl"
-    live_records = [json.loads(l) for l in live.read_text().splitlines()]
-    assert all("run_id" in r for r in live_records)
-    assert live_records[0]["type"] == "run-start"
+    evs = _events(tmp_path)
+    assert evs[0]["event"] == "run-start"
+    assert evs[0]["source"] == "curator"
+    assert evs[0]["run_id"] == logger.run_id
+    assert evs[0]["data"]["trigger"] == "manual"
+    assert evs[0]["data"]["pending_count"] == 2
+    assert evs[-1]["event"] == "run-end"
+    for e in evs:
+        validate_envelope(e)  # closed source/level/error_code sets
+    # No legacy files are written any more.
+    assert not (tmp_path / ".lore" / "runs").exists()
+    assert not (tmp_path / ".lore" / "runs-live.jsonl").exists()
 
 
 def test_emit_counters_and_ordering(tmp_path: Path):
     with RunLogger(tmp_path, trigger="hook", pending_count=3) as logger:
         logger.emit("transcript-start", transcript_id="t1", new_turns=10)
         logger.emit("noteworthy", transcript_id="t1", verdict=True, reason="x", tier="middle")
-        logger.emit("session-note", transcript_id="t1", action="filed",
-                    path="p.md", wikilink="[[p]]")
+        logger.emit(
+            "session-note", transcript_id="t1", action="filed", path="p.md", wikilink="[[p]]"
+        )
         logger.emit("transcript-start", transcript_id="t2", new_turns=5)
         logger.emit("skip", transcript_id="t2", reason="noteworthy-false")
-    archival = next((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    records = [json.loads(l) for l in archival.read_text().splitlines()]
+    records = read_curator_runs(tmp_path)[logger.run_id]
     assert records[0]["type"] == "run-start"
     assert records[-1]["type"] == "run-end"
     assert records[-1]["notes_new"] == 1
@@ -54,85 +69,42 @@ def test_emit_counters_and_ordering(tmp_path: Path):
     assert records[-1]["skipped"] == 1
     assert records[-1]["errors"] == 0
     kinds = [r["type"] for r in records[1:-1]]
-    assert kinds == ["transcript-start", "noteworthy", "session-note",
-                     "transcript-start", "skip"]
+    assert kinds == ["transcript-start", "noteworthy", "session-note", "transcript-start", "skip"]
 
 
 def test_exception_emits_error_and_runend_then_propagates(tmp_path: Path):
-    with pytest.raises(ValueError, match="boom"):
-        with RunLogger(tmp_path, trigger="hook") as logger:
-            logger.emit("transcript-start", transcript_id="t1", new_turns=5)
-            raise ValueError("boom")
-    archival = next((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    records = [json.loads(l) for l in archival.read_text().splitlines()]
+    with pytest.raises(ValueError, match="boom"), RunLogger(tmp_path, trigger="hook") as logger:
+        logger.emit("transcript-start", transcript_id="t1", new_turns=5)
+        raise ValueError("boom")
+    records = _only_run(tmp_path)
     types = [r["type"] for r in records]
     assert "error" in types
     assert types[-1] == "run-end"
     assert records[-1]["errors"] >= 1
+    # The error record is emitted at error level on the spine.
+    err = next(e for e in _events(tmp_path) if e["event"] == "error")
+    assert err["level"] == "error"
 
 
-def test_write_failure_increments_counter(tmp_path: Path, monkeypatch):
-    real_open = Path.open
-
-    def faulty_open(self, *args, **kwargs):
-        if "runs" in str(self) and not str(self).endswith("runs"):
-            raise OSError("disk full")
-        return real_open(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "open", faulty_open)
-    with RunLogger(tmp_path, trigger="hook") as logger:
-        logger.emit("transcript-start", transcript_id="t1", new_turns=5)
-    # No raise despite every write failing.
-
-
-def test_trace_llm_writes_companion(tmp_path: Path):
+def test_llm_records_carry_metadata_only(tmp_path: Path):
+    """Full prompt/response text must never hit the spine — the O_APPEND
+    atomicity budget (< PIPE_BUF) assumes small records."""
     with RunLogger(tmp_path, trigger="dry-run", trace_llm=True) as logger:
-        logger.emit("llm-prompt", call="noteworthy", tier="middle",
-                    token_count=100, messages=[{"role": "user", "content": "hi"}])
-        logger.emit("llm-response", call="noteworthy", token_count=5, body="yes")
-    trace_files = list((tmp_path / ".lore" / "runs").glob("*.trace.jsonl"))
-    assert len(trace_files) == 1
-    lines = trace_files[0].read_text().splitlines()
-    types = [json.loads(l)["type"] for l in lines]
-    assert "llm-prompt" in types
-    assert "llm-response" in types
-
-
-def test_trace_llm_off_no_companion(tmp_path: Path):
-    with RunLogger(tmp_path, trigger="hook", trace_llm=False) as logger:
-        logger.emit("llm-prompt", call="noteworthy", tier="middle",
-                    token_count=100, messages=[])
-    assert not list((tmp_path / ".lore" / "runs").glob("*.trace.jsonl"))
-
-
-def test_log_write_failures_surface_in_run_end(tmp_path: Path, monkeypatch):
-    real_open = Path.open
-
-    def faulty_open(self, *args, **kwargs):
-        if str(self).endswith(".jsonl"):
-            raise OSError("disk full")
-        return real_open(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "open", faulty_open)
-    # All writes fail; run still completes.
-    with RunLogger(tmp_path, trigger="hook") as logger:
-        logger.emit("transcript-start", transcript_id="t1", new_turns=5)
-    # The archival file was never written (OSError). But we can verify the
-    # counter bookkeeping by writing one record manually and checking.
-    # Since every write fails, there's no file to read. So instead test
-    # that the counter is non-zero by probing the logger attribute:
-    logger2 = RunLogger(tmp_path, trigger="hook")
-    # Pre-seed failure
-    logger2._write_failures = 3
-    # The run-end record will include log_write_failures=3; verify via
-    # unit-level check of the emit pathway by writing through logger2's
-    # fresh context:
-    monkeypatch.undo()  # restore real Path.open
-    with logger2 as l:
-        pass
-    archival = next((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    records = [json.loads(ln) for ln in archival.read_text().splitlines()]
-    assert records[-1]["log_write_failures"] == 3
+        logger.emit(
+            "llm-prompt",
+            call="noteworthy",
+            tier="middle",
+            token_count=100,
+            messages=[{"role": "user", "content": "a very long secret prompt"}],
+        )
+        logger.emit("llm-response", call="noteworthy", token_count=5, body="a long body")
+    evs = _events(tmp_path)
+    prompt = next(e for e in evs if e["event"] == "llm-prompt")
+    assert prompt["data"] == {"call": "noteworthy", "tier": "middle", "token_count": 100}
+    assert "messages" not in prompt["data"]
+    resp = next(e for e in evs if e["event"] == "llm-response")
+    assert "body" not in resp["data"]
+    assert resp["data"]["token_count"] == 5
 
 
 def test_emit_serializes_non_json_native_types(tmp_path: Path):
@@ -143,107 +115,75 @@ def test_emit_serializes_non_json_native_types(tmp_path: Path):
             a_path=Path("/tmp/foo"),
             a_ts=datetime(2026, 1, 1, tzinfo=UTC),
         )
-    archival = next((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    lines = archival.read_text().splitlines()
-    # The record survives — default=str stringifies the Path and datetime.
-    records = [json.loads(l) for l in lines]
-    warn = [r for r in records if r.get("type") == "warning"]
-    assert warn, "warning record should have landed"
-    assert "/tmp/foo" in warn[0]["a_path"]
-
-
-def test_enter_does_not_raise_on_readonly_fs(tmp_path, monkeypatch):
-    """__enter__ must not raise even if mkdir fails."""
-    real_mkdir = Path.mkdir
-
-    def bad_mkdir(self, *args, **kwargs):
-        if "runs" in str(self):
-            raise OSError("read-only")
-        return real_mkdir(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "mkdir", bad_mkdir)
-    # Must not raise.
-    with RunLogger(tmp_path, trigger="hook") as logger:
-        logger.emit("transcript-start", transcript_id="t1", new_turns=5)
-
-
-def test_enter_does_not_raise_on_collision_after_retry(tmp_path, monkeypatch):
-    """Double-collision in __enter__ must not raise."""
-    # Pre-create both possible run-id paths by monkeypatching generate_run_id
-    # to return the same collision id twice.
-    from lore_core import run_log as run_log_mod
-
-    fixed_id = "2026-04-20T14-32-05-aaaaaa"
-    (tmp_path / ".lore" / "runs").mkdir(parents=True)
-    (tmp_path / ".lore" / "runs" / f"{fixed_id}.jsonl").write_text("x\n")
-
-    call_count = {"n": 0}
-    def collide(*a, **kw):
-        call_count["n"] += 1
-        return fixed_id
-
-    monkeypatch.setattr(run_log_mod, "generate_run_id", collide)
-    # Must not raise despite the second generate_run_id also colliding.
-    with RunLogger(tmp_path, trigger="hook") as logger:
-        logger.emit("transcript-start", transcript_id="t1", new_turns=5)
-    # Collision was detected, _write_failures incremented
-    assert logger._write_failures >= 1
-
-
-# ---------------------------------------------------------------------------
-# Phase 1a: role field + B/C record types + counters
-# ---------------------------------------------------------------------------
+    warn = next(e for e in _events(tmp_path) if e["event"] == "warning")
+    assert "/tmp/foo" in warn["data"]["a_path"]
 
 
 def test_role_field_in_run_start_and_end(tmp_path: Path):
     with RunLogger(tmp_path, trigger="hook", role="b") as logger:
         logger.emit("skip", reason="empty")
-    archival = next((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    records = [json.loads(l) for l in archival.read_text().splitlines()]
-    assert records[0]["type"] == "run-start"
-    assert records[0]["role"] == "b"
-    assert records[-1]["type"] == "run-end"
-    assert records[-1]["role"] == "b"
+    evs = _events(tmp_path)
+    assert evs[0]["event"] == "run-start"
+    assert evs[0]["data"]["role"] == "b"
+    assert evs[-1]["event"] == "run-end"
+    assert evs[-1]["data"]["role"] == "b"
 
 
 def test_backward_compat_no_role_defaults_to_a(tmp_path: Path):
-    with RunLogger(tmp_path, trigger="hook") as logger:
+    with RunLogger(tmp_path, trigger="hook"):
         pass
-    archival = next((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    records = [json.loads(l) for l in archival.read_text().splitlines()]
-    assert records[0]["role"] == "a"
-    assert records[-1]["role"] == "a"
+    evs = _events(tmp_path)
+    assert evs[0]["data"]["role"] == "a"
+    assert evs[-1]["data"]["role"] == "a"
 
 
 def test_hygiene_pass_counters(tmp_path: Path):
-    """The retained `lore curator [--wiki] [--apply]` hygiene pass tags its
-    run-log entries role="c" and counts action-applied/action-skipped.
-    """
+    """The `lore curator [--wiki] [--apply]` hygiene pass tags role="c" and
+    counts action-applied / action-skipped."""
     with RunLogger(tmp_path, trigger="hook", role="c") as logger:
         logger.emit("wiki-start", wiki="private")
         logger.emit("action-applied", kind="review_stale", path="n.md", reason="90d")
         logger.emit("action-applied", kind="mark_superseded", path="m.md", reason="newer")
         logger.emit("action-skipped", path="x.md", reason="mtime changed")
-    archival = next((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    records = [json.loads(l) for l in archival.read_text().splitlines()]
+    records = _only_run(tmp_path)
     end = records[-1]
     assert end["actions_applied"] == 2
     assert end["actions_skipped"] == 1
-    kinds = [r["type"] for r in records[1:-1]]
-    assert "wiki-start" in kinds
+    assert "wiki-start" in [r["type"] for r in records[1:-1]]
 
 
 def test_retired_record_types_downgraded_to_warning(tmp_path: Path):
-    """Curator B/C ambition record types are gone; emitting them now falls
-    back to 'warning' rather than being written verbatim.
-    """
+    """Retired ambition record types fall back to 'warning' rather than being
+    emitted verbatim."""
     retired_types = ["cluster-formed", "surface-filed", "defrag-pass", "wiki-skip"]
     with RunLogger(tmp_path, trigger="hook", role="a") as logger:
         for rt in retired_types:
             logger.emit(rt, detail="test")
-    archival = next((tmp_path / ".lore" / "runs").glob("*.jsonl"))
-    records = [json.loads(l) for l in archival.read_text().splitlines()]
-    emitted_types = [r["type"] for r in records]
+    emitted = [e["event"] for e in _events(tmp_path)]
     for rt in retired_types:
-        assert rt not in emitted_types
-    assert emitted_types.count("warning") == len(retired_types)
+        assert rt not in emitted
+    assert emitted.count("warning") == len(retired_types)
+
+
+def test_wiki_lifts_to_envelope_field(tmp_path: Path):
+    with RunLogger(tmp_path, trigger="hook", role="c") as logger:
+        logger.emit("wiki-start", wiki="private")
+    ev = next(e for e in _events(tmp_path) if e["event"] == "wiki-start")
+    assert ev["wiki"] == "private"
+
+
+def test_emit_survives_unwritable_spine(tmp_path: Path, monkeypatch):
+    """A failing spine write degrades to a marker; RunLogger never raises."""
+    import os as _os
+
+    real_open = _os.open
+
+    def faulty(path, *a, **k):
+        if str(path).endswith("spine.jsonl"):
+            raise OSError("disk full")
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr(_os, "open", faulty)
+    with RunLogger(tmp_path, trigger="hook") as logger:
+        logger.emit("transcript-start", transcript_id="t1", new_turns=5)
+    assert (tmp_path / ".lore" / "spine-failed.marker").exists()

--- a/tests/test_run_reader.py
+++ b/tests/test_run_reader.py
@@ -20,43 +20,53 @@ def _seed(tmp_path: Path, ids: list[str]) -> Path:
     return runs
 
 
+def _seed_spine(tmp_path: Path, ids: list[str]) -> None:
+    """Seed curator run-start/run-end envelopes for the given run_ids."""
+    from lore_core.spine import SpineWriter
+
+    w = SpineWriter(tmp_path)
+    for rid in ids:
+        w.emit(source="curator", event="run-start", run_id=rid, data={"trigger": "hook"})
+        w.emit(source="curator", event="run-end", run_id=rid, data={"errors": 0})
+
+
 def test_resolve_latest(tmp_path):
-    _seed(tmp_path, [
+    _seed_spine(tmp_path, [
         "2026-04-20T10-00-00-aaaaaa",
         "2026-04-20T14-00-00-bbbbbb",
         "2026-04-20T18-00-00-cccccc",
     ])
-    assert resolve_run_id(tmp_path, "latest").name == "2026-04-20T18-00-00-cccccc.jsonl"
+    assert resolve_run_id(tmp_path, "latest") == "2026-04-20T18-00-00-cccccc"
 
 
 def test_resolve_caret_N(tmp_path):
-    _seed(tmp_path, [
+    _seed_spine(tmp_path, [
         "2026-04-20T10-00-00-aaaaaa",
         "2026-04-20T14-00-00-bbbbbb",
         "2026-04-20T18-00-00-cccccc",
     ])
-    assert resolve_run_id(tmp_path, "^1").name == "2026-04-20T18-00-00-cccccc.jsonl"
-    assert resolve_run_id(tmp_path, "^2").name == "2026-04-20T14-00-00-bbbbbb.jsonl"
+    assert resolve_run_id(tmp_path, "^1") == "2026-04-20T18-00-00-cccccc"
+    assert resolve_run_id(tmp_path, "^2") == "2026-04-20T14-00-00-bbbbbb"
 
 
 def test_resolve_short_suffix(tmp_path):
-    _seed(tmp_path, [
+    _seed_spine(tmp_path, [
         "2026-04-20T10-00-00-aaaaaa",
         "2026-04-20T14-00-00-bbbbbb",
     ])
-    assert resolve_run_id(tmp_path, "bbbbbb").name.endswith("bbbbbb.jsonl")
+    assert resolve_run_id(tmp_path, "bbbbbb").endswith("bbbbbb")
 
 
 def test_resolve_prefix(tmp_path):
-    _seed(tmp_path, [
+    _seed_spine(tmp_path, [
         "2026-04-20T10-00-00-aaaaaa",
         "2026-04-20T14-00-00-bbbbbb",
     ])
-    assert resolve_run_id(tmp_path, "2026-04-20T14").name.endswith("bbbbbb.jsonl")
+    assert resolve_run_id(tmp_path, "2026-04-20T14").endswith("bbbbbb")
 
 
 def test_resolve_ambiguous_prefix_raises(tmp_path):
-    _seed(tmp_path, [
+    _seed_spine(tmp_path, [
         "2026-04-20T10-00-00-aaaaaa",
         "2026-04-20T10-00-00-aaaaab",
     ])
@@ -65,7 +75,7 @@ def test_resolve_ambiguous_prefix_raises(tmp_path):
 
 
 def test_resolve_not_found(tmp_path):
-    _seed(tmp_path, ["2026-04-20T10-00-00-aaaaaa"])
+    _seed_spine(tmp_path, ["2026-04-20T10-00-00-aaaaaa"])
     with pytest.raises(RunIdNotFound):
         resolve_run_id(tmp_path, "zzzzzz")
 

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -156,15 +156,14 @@ def test_status_zero_notes_alert(tmp_path: Path, monkeypatch) -> None:
     lore_root, project = _seed_vault(tmp_path)
     from lore_core.ledger import WikiLedger
 
-    runs_dir = lore_root / ".lore" / "runs"
-    runs_dir.mkdir(parents=True, exist_ok=True)
+    from lore_core.spine import SpineWriter
+    w = SpineWriter(lore_root)
     for i, suffix in enumerate(["aaa111", "bbb222"]):
         run_ts = _NOW - timedelta(hours=3 - i)
-        stem = run_ts.strftime("%Y-%m-%dT%H-%M-%S") + f"-{suffix}"
-        (runs_dir / f"{stem}.jsonl").write_text(
-            json.dumps({"type": "run-start", "ts": _iso(run_ts), "schema_version": 1}) + "\n"
-            + json.dumps({"type": "run-end", "ts": _iso(run_ts), "notes_new": 0, "errors": 0}) + "\n"
-        )
+        run_id = run_ts.strftime("%Y-%m-%dT%H-%M-%S") + f"-{suffix}"
+        w.emit(source="curator", event="run-start", run_id=run_id, data={"ts": _iso(run_ts)})
+        w.emit(source="curator", event="run-end", run_id=run_id,
+               data={"notes_new": 0, "notes_merged": 0, "errors": 0})
     WikiLedger(lore_root, "private").update_last_curator("a", at=_NOW - timedelta(hours=2))
 
     out = _invoke(lore_root, project, monkeypatch=monkeypatch)
@@ -176,19 +175,25 @@ def test_status_stale_note_red_at_4d(tmp_path: Path, monkeypatch) -> None:
     """Last note 4 days ago → red alert (>3d threshold)."""
     lore_root, project = _seed_vault(tmp_path)
     run_ts = _NOW - timedelta(days=4)
-    runs_dir = lore_root / ".lore" / "runs"
-    runs_dir.mkdir(parents=True, exist_ok=True)
-    stem = run_ts.strftime("%Y-%m-%dT%H-%M-%S") + "-xxx999"
-    (runs_dir / f"{stem}.jsonl").write_text(
-        "\n".join(
-            json.dumps(r)
-            for r in [
-                {"type": "run-start", "ts": _iso(run_ts), "schema_version": 1},
-                {"type": "session-note", "ts": _iso(run_ts), "action": "filed", "wikilink": "[[stale]]"},
-                {"type": "run-end", "ts": _iso(run_ts), "notes_new": 1, "errors": 0},
-            ]
-        ) + "\n"
-    )
+    run_id = run_ts.strftime("%Y-%m-%dT%H-%M-%S") + "-xxx999"
+
+    def _env(event, data):
+        # Raw envelope with a controlled ts (SpineWriter stamps real-now).
+        return {
+            "ts": _iso(run_ts), "v": 1, "source": "curator", "event": event,
+            "level": "info", "trace_id": None, "session_id": None, "run_id": run_id,
+            "wiki": None, "scope": None, "error_code": None, "data": data,
+        }
+
+    spine = lore_root / ".lore" / "spine.jsonl"
+    spine.parent.mkdir(parents=True, exist_ok=True)
+    with spine.open("a") as f:
+        for env in [
+            _env("run-start", {}),
+            _env("session-note", {"action": "filed", "wikilink": "[[stale]]"}),
+            _env("run-end", {"notes_new": 1, "errors": 0}),
+        ]:
+            f.write(json.dumps(env) + "\n")
 
     out = _invoke(lore_root, project, monkeypatch=monkeypatch)
     # Red glyph marks the line; also an alert block at bottom.


### PR DESCRIPTION
Closes #189.

## Summary

Replaces the flush pipeline's "retry forever or silently give up (no marker)" behaviour with an explicit, **persisted, queryable state machine**, and migrates the curator run-log **producer onto the event spine**. A stuck flush is now a row you can `list`, not an absence of evidence.

## What changed

**Flush state machine — `lore_core.flush_store` (AC1, AC2, AC5)**
- One JSON record per flush unit under `.lore/flushes/` (keyed by buffer stem), states `queued → running → published | withheld | dead-lettered(reason)`, an attempt counter and a next-eligible-retry timestamp. A flock-guarded transition table rejects illegal moves (`FlushTransitionError`).
- Bounded retries with exponential backoff (`RETRY_BASE_SECONDS`, capped at `RETRY_CAP_SECONDS`) replace the old give-up-at-2×-cap heuristic; exhaustion after `MAX_ATTEMPTS` dead-letters with a **structured `ErrorCode`** from `lore_core.spine` — never a free-form string. Every transition emits a spine envelope, so a record reopened for a new unit never erases history. `FlushStore.list(state=…)` is the clean queryable API for slices #192/#193.

**Silent failures removed — `lore_curator.chapter_flush` (AC3)**
- The "flush defers silently (no marker)" branch is gone: a failed in-place flush now leaves a **queued record + spine event** (retry scheduled) or, on exhaustion, a **dead-letter** (marker + buffer reset).
- Every formerly-silent path now produces evidence: unreadable sidecar → error event (`SIDECAR_READ_FAILED`), detached-spawn `OSError` → event (`SPAWN_FAILED`), chapter-append I/O error → dead-letter (`CHAPTER_APPEND_FAILED`).

**Run-log onto the spine (AC4)**
- `RunLogger` emits every record as a `source="curator"` spine envelope keyed by `run_id`. The archival `runs/<id>.jsonl`, the `runs-live.jsonl` tee and the full-text `.trace.jsonl` are **deleted**. LLM records carry **metadata only** (full prompt/response text would break the spine's sub-`PIPE_BUF` O_APPEND atomicity). `trace_id` is written `null` so #188 can fill it without rework.
- Readers reconstruct a run by grouping spine records on `run_id` (`run_reader.read_curator_runs` / `run_ids` / `read_run_by_id`; `resolve_run_id` now returns a `run_id`). `lore runs`, `lore log`, `lore status`, the breadcrumb banner and `capture_state` all read the spine.

## Red → green evidence (strict TDD)

The transition table + per-silent-path regression tests were written first:

- `tests/test_flush_store.py` (39 tests) — initial run: `ModuleNotFoundError: No module named 'lore_core.flush_store'` → after `flush_store.py`: **39 passed**. Covers the legal/illegal transition table, backoff, dead-letter-on-exhaustion with enum reason, spine emission, and `list(state=…)`.
- `tests/test_flush_silent_paths.py` (5 tests) — initial run: **5 failed** (`assert [] == ['abc__…']`, `'deferred' == 'gave-up'`, "must emit an error-level spine event", spawn/append `OSError`) → after wiring `chapter_flush`: **5 passed**.
- Updated `test_chapter_flush.py`: the `defers_silently` test is renamed (the defer now leaves a queued record + event); `give_up_at_double_cap` → `give_up_after_max_attempts`.

## Test status

Full suite: **2765 passed, 10 failed**. The 10 failures are the pre-existing ANSI-colour CliRunner tests that fail on `epic/183` too (`test_core_llm_wiring`, `test_drain_prune`, `test_install_dispatcher`, `test_proc_cmd`, `test_log_cmd::test_log_proc_events`) — all on code this PR does not touch. **Zero new failures.** Tests that seeded run *files* for the run-log/capture-state readers were migrated to seed the spine.

`ruff check`/`format` clean on newly-authored files (remaining `B904`/`SIM105` are idioms already used across the tree; whole-tree ruff is pre-existing-dirty, tracked as #196).

## Decisions
- `flush_id == buffer_stem`: one record per buffer represents its current flush lifecycle (what a dashboard wants); the spine keeps the full event history, so reopening a terminal record for a new unit loses nothing.
- Full-text LLM tracing is dropped (metadata only) to preserve the spine's lock-free append atomicity; `lore trace` (#192) renders call metadata + error codes.
- `run_retention.py` left untouched (owned by #190); `RunLogger` simply stops calling it — the spine self-rotates.
