### PR TITLE
feat: unified `lore init` onboarding wizard + install.sh hardening (#194)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,8 +118,8 @@ fi
 
 if ! command -v lore >/dev/null 2>&1; then
     warn "lore is installed but not on PATH yet."
-    warn "Add ~/.local/bin (pipx) or ~/.local/share/uv/tools/bin (uv) to PATH, then run: lore install"
-    exit 0
+    warn "Add ~/.local/bin (pipx) or ~/.local/share/uv/tools/bin (uv) to PATH, then re-run this installer."
+    die "install did not leave a runnable 'lore' on PATH."
 fi
 
 # Detect first-time vs re-run: if Claude already lists lore@lore, skip the
@@ -141,6 +141,6 @@ if [ "$HAS_PLUGIN" -eq 1 ]; then
     fi
     say "Done. Restart Claude Code to load the refreshed plugin."
 else
-    say "Configuring integrations..."
-    exec lore install
+    say "Starting the lore init wizard..."
+    exec lore init
 fi

--- a/lib/lore_cli/init_cmd.py
+++ b/lib/lore_cli/init_cmd.py
@@ -1,18 +1,37 @@
-"""`lore init` — scaffold the canonical vault shape at $LORE_ROOT."""
+"""`lore init` — the single guided onboarding wizard.
+
+From "binary installed" to "notes being written" in one idempotent,
+resumable command:
+
+    vault -> wiki -> integrations -> optional first attach ->
+    automatic `lore doctor` -> handoff panel.
+
+Re-running detects existing state, collapses completed steps to a skip
+line, and thereby doubles as a repair path for a partial install. Full
+non-interactive flag parity (`--vault`, `--wiki-new/-clone/-link`,
+`--attach`, `--yes`, `--plain`) drives every step for CI and scripted
+installs; `install.sh` chains into this wizard on first install.
+"""
 
 from __future__ import annotations
 
+import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
 import typer
-from lore_core.config import get_lore_root
+from lore_core.config import get_lore_root, get_wiki_root, user_config_path
 from rich.console import Console
+from rich.panel import Panel
 
 from lore_cli._argv_compat import argv_main
 
 console = Console()
+
+# Vault -> Wiki -> Integrations -> Attach -> Doctor -> Handoff.
+TOTAL_STEPS = 6
 
 app = typer.Typer(
     add_completion=False,
@@ -25,11 +44,35 @@ app = typer.Typer(
 def _plugin_templates_dir() -> Path:
     """Backwards-compatible shim for `lore_core.templates.templates_dir`."""
     from lore_core.templates import templates_dir
+
     return templates_dir()
 
 
 def _is_interactive() -> bool:
     return sys.stdin.isatty()
+
+
+# ---------------------------------------------------------------------------
+# Step chrome
+# ---------------------------------------------------------------------------
+
+
+def _step_header(n: int, title: str) -> None:
+    console.print(f"\n[bold]Step {n}/{TOTAL_STEPS} · {title}[/bold]")
+
+
+def _skip(msg: str) -> None:
+    """A completed step collapses to one ✓ receipt line."""
+    console.print(f"  [green]✓[/green] {msg} [dim](skipped)[/dim]")
+
+
+def _done(msg: str) -> None:
+    console.print(f"  [green]✓[/green] {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Display name onboarding (unchanged; part of the vault step)
+# ---------------------------------------------------------------------------
 
 
 def _maybe_set_display_name(root: Path, display_name: str | None) -> None:
@@ -60,8 +103,14 @@ def _maybe_set_display_name(root: Path, display_name: str | None) -> None:
         console.print(f"[green]Display name set to {name!r}[/green]")
 
 
+# ---------------------------------------------------------------------------
+# Vault scaffold (the deterministic primitive the wizard's step 1 wraps)
+# ---------------------------------------------------------------------------
+
+
 def init_vault(root: Path, force: bool = False, display_name: str | None = None) -> None:
-    """Create the canonical shape at `root`."""
+    """Create the canonical vault shape at `root`. Idempotent: existing
+    CLAUDE.md / templates are left untouched unless `force`."""
     root.mkdir(parents=True, exist_ok=True)
     _maybe_set_display_name(root, display_name)
 
@@ -89,19 +138,352 @@ def init_vault(root: Path, force: bool = False, display_name: str | None = None)
         claude_md.write_text((templates_src / "root-CLAUDE.md").read_text())
         console.print(f"[green]Wrote {claude_md}[/green]")
 
-    console.print()
-    console.print(f"[bold]Vault initialized at[/bold] {root}")
-    console.print()
-    console.print("Next steps:")
-    console.print(f"  1. Scaffold a wiki: [cyan]lore new-wiki <name>[/cyan]")
-    console.print(f"     Or mount existing: [cyan]ln -s <path> {root}/wiki/<name>[/cyan]")
-    console.print("  2. Run [cyan]lore lint[/cyan] to seed catalogs.")
+
+def _vault_complete(root: Path) -> bool:
+    return (
+        (root / "CLAUDE.md").exists() and (root / "templates").is_dir() and (root / "wiki").is_dir()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vault resolution + persistence
+# ---------------------------------------------------------------------------
+
+
+def _prompt_vault(vault_flag: str | None, *, interactive: bool) -> Path:
+    """Resolve the vault root the wizard will target.
+
+    Precedence: explicit ``--vault`` flag > existing ``$LORE_ROOT`` /
+    config (``get_lore_root`` already honours env then config) > the
+    ``~/lore`` default. Only prompts when interactive and no flag.
+    """
+    if vault_flag:
+        return Path(vault_flag).expanduser().resolve()
+    default = get_lore_root()
+    if interactive:
+        raw = input(f"  Vault location [{default}]: ").strip()
+        return Path(raw).expanduser().resolve() if raw else default
+    return default
+
+
+def _persist_vault(root: Path) -> None:
+    """Commit the chosen vault as the resolved LORE_ROOT for this process
+    and future ones.
+
+    Sets ``os.environ['LORE_ROOT']`` so every downstream step (wiki
+    scaffold, doctor, attach) resolves to the same vault unambiguously
+    within this run, and writes ``~/.config/lore/config.yml`` so future
+    ``lore`` invocations find it without an env export.
+    """
+    import yaml
+
+    os.environ["LORE_ROOT"] = str(root)
+    cfg = user_config_path()
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(yaml.safe_dump({"lore_root": str(root)}, sort_keys=False))
+
+
+# ---------------------------------------------------------------------------
+# Step 1 · Vault
+# ---------------------------------------------------------------------------
+
+
+def _step_vault(root: Path, *, force: bool, display_name: str | None) -> None:
+    _step_header(1, "Vault")
+    _persist_vault(root)
+    if _vault_complete(root) and not force:
+        _skip(f"Vault ready at {root}")
+        _maybe_set_display_name(root, display_name)
+        return
+    init_vault(root, force=force, display_name=display_name)
+    _done(f"Vault initialised at {root}")
+
+
+# ---------------------------------------------------------------------------
+# Step 2 · Wiki (new personal / clone team remote / link existing dir)
+# ---------------------------------------------------------------------------
+
+
+def _existing_wikis(root: Path) -> list[str]:
+    wr = root / "wiki"
+    if not wr.is_dir():
+        return []
+    return sorted(d.name for d in wr.iterdir() if d.is_dir() or d.is_symlink())
+
+
+def _clone_target_name(url: str) -> str:
+    return url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
+
+
+def _clone_wiki(url: str) -> None:
+    name = _clone_target_name(url)
+    target = get_wiki_root() / name
+    if target.exists() or target.is_symlink():
+        _skip(f"Wiki {name!r} already present")
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "clone", url, str(target)], check=True)
+    _done(f"Cloned team wiki {name!r}")
+
+
+def _link_wiki(src_path: str) -> None:
+    src = Path(src_path).expanduser().resolve()
+    name = src.name
+    target = get_wiki_root() / name
+    if target.exists() or target.is_symlink():
+        _skip(f"Wiki {name!r} already present")
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(src)
+    _done(f"Linked wiki {name!r} -> {src}")
+
+
+def _create_personal_wiki(name: str) -> None:
+    from lore_cli.wiki_cmd import scaffold_wiki
+
+    scaffold_wiki(name, mode="personal")
+    _done(f"Created personal wiki {name!r}")
+
+
+def _step_wiki(
+    root: Path,
+    *,
+    wiki_new: str | None,
+    wiki_clone: str | None,
+    wiki_link: str | None,
+    interactive: bool,
+) -> None:
+    _step_header(2, "Wiki")
+    existing = _existing_wikis(root)
+
+    if wiki_clone:
+        if _clone_target_name(wiki_clone) in existing:
+            _skip(f"Wiki {_clone_target_name(wiki_clone)!r} already present")
+        else:
+            _clone_wiki(wiki_clone)
+        return
+    if wiki_link:
+        _link_wiki(wiki_link)
+        return
+    if wiki_new:
+        if wiki_new in existing:
+            _skip(f"Wiki {wiki_new!r} already present")
+        else:
+            _create_personal_wiki(wiki_new)
+        return
+
+    # No explicit target flag.
+    if existing:
+        _skip(f"Wiki already present ({', '.join(existing)})")
+        return
+
+    if not interactive:
+        _create_personal_wiki("personal")
+        return
+
+    # Interactive: new personal / clone remote / link existing dir.
+    console.print("  How would you like to set up your first wiki?")
+    console.print("    [n] New personal wiki")
+    console.print("    [c] Clone a team wiki from a git remote")
+    console.print("    [l] Link an existing directory")
+    choice = input("  Choice [n]: ").strip().lower() or "n"
+    if choice == "c":
+        url = input("  Git remote URL: ").strip()
+        if url:
+            _clone_wiki(url)
+    elif choice == "l":
+        folder = input("  Directory path: ").strip()
+        if folder:
+            _link_wiki(folder)
+    else:
+        name = input("  Wiki name [personal]: ").strip() or "personal"
+        _create_personal_wiki(name)
+
+
+# ---------------------------------------------------------------------------
+# Step 3 · Integrations (reuse the `lore install` plumbing)
+# ---------------------------------------------------------------------------
+
+
+def _step_integrations(*, plain: bool) -> None:
+    _step_header(3, "Integrations")
+    from lore_core.install import known_integrations
+
+    from lore_cli import install_cmd
+
+    present = [h for h in known_integrations() if install_cmd._integration_present(h)]
+    if not present:
+        _skip("No Claude Code or Cursor detected on PATH — re-run `lore init` after installing one")
+        return
+    argv = ["--yes"]
+    if plain:
+        argv.append("--quiet")
+    rc = install_cmd.main(argv)
+    if rc != 0:
+        console.print(
+            "  [yellow]⚠ Integration wiring reported issues — "
+            "run [cyan]lore doctor[/cyan] to diagnose.[/yellow]"
+        )
+    if "claude" in present:
+        console.print(
+            "  [bold yellow]⚠ Restart Claude Code[/bold yellow] to load the "
+            "refreshed plugin (hooks, skills, MCP server)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 4 · Optional first attach
+# ---------------------------------------------------------------------------
+
+
+def _step_attach(root: Path, *, attach: bool, interactive: bool, cwd: Path) -> None:
+    _step_header(4, "Attach")
+    if not (cwd / ".git").is_dir():
+        _skip("Current directory is not a git repo — no first attach")
+        return
+
+    if interactive:
+        import contextlib
+
+        from lore_cli import attach_cmd
+
+        with contextlib.suppress(typer.Exit, KeyboardInterrupt, EOFError):
+            attach_cmd._interactive_wizard(cwd, root)
+        return
+
+    # Non-interactive: honour --attach by auto-accepting a checked-in
+    # offer if one exists; otherwise leave it to an explicit `lore attach`.
+    if not attach:
+        _skip("Skipping first attach (pass --attach, or run `lore attach` later)")
+        return
+    from lore_core.offer import find_lore_yml
+
+    found = find_lore_yml(cwd)
+    if found is None:
+        _skip("No .lore.yml offer to auto-accept — run `lore attach` in this repo")
+        return
+    try:
+        from lore_cli.attach_cmd import _do_accept
+
+        _do_accept(root, cwd.resolve())
+        _done(f"Attached {cwd}")
+    except Exception as exc:  # noqa: BLE001 — attach is best-effort here
+        console.print(f"  [yellow]Attach skipped: {type(exc).__name__}[/yellow]")
+
+
+# ---------------------------------------------------------------------------
+# Step 5 · Doctor (the wizard's exit code mirrors its verdict)
+# ---------------------------------------------------------------------------
+
+
+def _run_doctor(cwd: Path) -> int:
+    """Run `lore doctor` in-process and return its exit code (0 ok / 1 fail).
+
+    A thin seam over the doctor command so the wizard reuses the exact
+    diagnostics rather than reimplementing checks — and so tests can
+    substitute a deterministic verdict.
+    """
+    from lore_cli import doctor_cmd
+
+    return doctor_cmd.main(["--cwd", str(cwd)])
+
+
+def _step_doctor(cwd: Path) -> bool:
+    _step_header(5, "Doctor")
+    return _run_doctor(cwd) == 0
+
+
+# ---------------------------------------------------------------------------
+# Step 6 · Handoff
+# ---------------------------------------------------------------------------
+
+
+def _step_handoff(root: Path, *, doctor_ok: bool, plain: bool) -> None:
+    _step_header(6, "Next steps")
+    verdict = "[green]✓ passed[/green]" if doctor_ok else "[red]✗ failed — see above[/red]"
+    body = "\n".join(
+        [
+            f"Vault:  {root}",
+            f"Doctor: {verdict}",
+            "",
+            "1. Restart Claude Code to load the Lore plugin.",
+            "2. Run [cyan]lore status[/cyan] to see capture liveness.",
+            "3. In any git repo, run [cyan]lore attach[/cyan] to capture sessions.",
+        ]
+    )
+    if plain:
+        console.print(body)
+    else:
+        console.print(Panel(body, title="Lore is ready", expand=False))
+
+
+# ---------------------------------------------------------------------------
+# Wizard driver
+# ---------------------------------------------------------------------------
+
+
+def run_wizard(
+    *,
+    vault: str | None = None,
+    wiki_new: str | None = None,
+    wiki_clone: str | None = None,
+    wiki_link: str | None = None,
+    attach: bool = False,
+    yes: bool = False,
+    plain: bool = False,
+    force: bool = False,
+    display_name: str | None = None,
+    cwd: str | Path | None = None,
+) -> int:
+    """Run the full onboarding wizard. Returns the doctor exit code."""
+    wiki_targets = [t for t in (wiki_new, wiki_clone, wiki_link) if t]
+    if len(wiki_targets) > 1:
+        raise typer.BadParameter("Pass at most one of --wiki-new / --wiki-clone / --wiki-link.")
+
+    cwd_path = Path(cwd) if cwd else Path(os.getcwd())
+    interactive = _is_interactive() and not yes and not plain
+
+    root = _prompt_vault(vault, interactive=interactive)
+    _step_vault(root, force=force, display_name=display_name)
+    _step_wiki(
+        root,
+        wiki_new=wiki_new,
+        wiki_clone=wiki_clone,
+        wiki_link=wiki_link,
+        interactive=interactive,
+    )
+    _step_integrations(plain=plain)
+    _step_attach(root, attach=attach, interactive=interactive, cwd=cwd_path)
+    doctor_ok = _step_doctor(cwd_path)
+    _step_handoff(root, doctor_ok=doctor_ok, plain=plain)
+    return 0 if doctor_ok else 1
 
 
 @app.callback(invoke_without_command=True)
 def init(
-    root: str = typer.Option(
-        None, "--root", help="Vault root path (defaults to $LORE_ROOT or ~/lore)"
+    vault: str = typer.Option(
+        None,
+        "--vault",
+        "--root",
+        help="Vault location (default: $LORE_ROOT or ~/lore).",
+    ),
+    wiki_new: str = typer.Option(
+        None, "--wiki-new", help="Scaffold a new personal wiki with this name."
+    ),
+    wiki_clone: str = typer.Option(
+        None, "--wiki-clone", help="Clone a team wiki from this git remote URL."
+    ),
+    wiki_link: str = typer.Option(
+        None, "--wiki-link", help="Link an existing directory as a wiki."
+    ),
+    attach: bool = typer.Option(
+        False, "--attach", help="Attach the current git repo (auto-accepts a .lore.yml offer)."
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Non-interactive; accept defaults for every step."
+    ),
+    plain: bool = typer.Option(
+        False, "--plain", help="Degrade prompts to plain stdin; no Rich panels."
     ),
     force: bool = typer.Option(
         False, "--force", help="Overwrite existing CLAUDE.md and templates/."
@@ -112,9 +494,20 @@ def init(
         help="Personal display name for session notes/briefings (skips the prompt).",
     ),
 ) -> None:
-    """Scaffold the canonical vault shape at $LORE_ROOT."""
-    target = Path(root).expanduser().resolve() if root else get_lore_root()
-    init_vault(target, force=force, display_name=display_name)
+    """Run the unified onboarding wizard (idempotent and resumable)."""
+    rc = run_wizard(
+        vault=vault,
+        wiki_new=wiki_new,
+        wiki_clone=wiki_clone,
+        wiki_link=wiki_link,
+        attach=attach,
+        yes=yes,
+        plain=plain,
+        force=force,
+        display_name=display_name,
+    )
+    if rc != 0:
+        raise typer.Exit(code=rc)
 
 
 main = argv_main(app)

--- a/lib/lore_cli/install_cmd.py
+++ b/lib/lore_cli/install_cmd.py
@@ -385,110 +385,6 @@ def _is_interactive(args: SimpleNamespace) -> bool:
     return sys.stdin.isatty() and not args.yes and not args.json and not args.quiet
 
 
-def _post_install_setup() -> None:
-    """Interactive vault + wiki scaffolding after a successful integration install.
-
-    Only called in interactive mode for fresh installs. Skipped silently
-    if the vault already exists and has wikis.
-    """
-    from lore_core.config import get_lore_root
-
-    # --- Vault setup ---------------------------------------------------
-    try:
-        lore_root = get_lore_root()
-        has_vault = (lore_root / "wiki").is_dir()
-    except Exception:
-        has_vault = False
-
-    if has_vault:
-        wiki_root = lore_root / "wiki"
-        existing_wikis = [
-            d.name for d in wiki_root.iterdir() if d.is_dir()
-        ]
-        if existing_wikis:
-            # Vault exists and has wikis — nothing to do
-            return
-
-    console.print()
-    console.print("[bold]Vault setup[/bold]", markup=True)
-
-    default_root = Path.home() / "lore"
-    vault_input = input(
-        f"  Where to store your vault? [{default_root}]: "
-    ).strip()
-    vault_path = Path(vault_input).expanduser().resolve() if vault_input else default_root
-
-    from lore_cli.init_cmd import init_vault  # lazy to avoid circular imports
-
-    init_vault(vault_path, force=False)
-
-    # --- Wiki setup ----------------------------------------------------
-    wiki_root = vault_path / "wiki"
-    existing_wikis = (
-        [d.name for d in wiki_root.iterdir() if d.is_dir()]
-        if wiki_root.exists()
-        else []
-    )
-
-    if not existing_wikis:
-        console.print()
-        console.print("  Do you have a team wiki to connect?")
-        console.print("    [g] Clone from GitHub URL")
-        console.print("    [f] Link existing folder")
-        console.print("    [s] Skip — create a personal wiki only")
-        team_choice = input("  Choice [s]: ").strip().lower() or "s"
-
-        if team_choice == "g":
-            url = input("  GitHub URL: ").strip()
-            if url:
-                import subprocess as _sp
-
-                wiki_name = (
-                    url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
-                )
-                target = wiki_root / wiki_name
-                _sp.run(["git", "clone", url, str(target)], check=True)
-                console.print(
-                    f"  [green]✓[/green] Team wiki '{rich_escape(wiki_name)}' cloned",
-                    markup=True,
-                )
-        elif team_choice == "f":
-            folder = input("  Folder path: ").strip()
-            if folder:
-                source = Path(folder).expanduser().resolve()
-                wiki_name = source.name
-                target = wiki_root / wiki_name
-                target.symlink_to(source)
-                console.print(
-                    f"  [green]✓[/green] Wiki '{rich_escape(wiki_name)}' linked",
-                    markup=True,
-                )
-
-        # Personal wiki
-        personal = input("  Create a personal wiki too? [Y/n]: ").strip().lower()
-        if personal != "n":
-            name = input("  Personal wiki name [personal]: ").strip() or "personal"
-            from lore_cli.new_wiki_cmd import scaffold_wiki  # lazy import
-
-            scaffold_wiki(name, mode="personal")
-            console.print(
-                f"  [green]✓[/green] Wiki '{rich_escape(name)}' created",
-                markup=True,
-            )
-
-    # --- Final handoff -------------------------------------------------
-    console.print()
-    console.print(
-        "  [bold]Next:[/bold] run [cyan]lore attach[/cyan] in any repo "
-        "to start capturing sessions.",
-        markup=True,
-    )
-    console.print(
-        "  [bold]Verify:[/bold] [cyan]lore doctor[/cyan]",
-        markup=True,
-    )
-
-
 _INSTALL_SH_URL = "https://raw.githubusercontent.com/buchbend/lore/main/install.sh"
 
 
@@ -542,6 +438,34 @@ def _run_self_upgrade(*, quiet: bool) -> int:
         return 1
 
 
+def _loud_plugin_cache_failure(detail: str) -> None:
+    """Plugin-cache refresh failed — never silent.
+
+    A stale cache means hooks, skills, and the MCP server keep serving the
+    previous manifest with no error at all (exactly the silent-failure
+    class this epic targets), so surface it loudly and name the manual
+    fix plus the required Claude Code restart. Printed even under
+    ``--quiet``: this is an error, not a per-action line.
+    """
+    from rich.panel import Panel
+
+    console.print(
+        Panel(
+            "Claude's plugin cache was NOT refreshed:\n"
+            f"  {detail}\n\n"
+            "Hooks, skills, and the MCP server may keep serving the old "
+            "version.\n"
+            "If Lore isn't installed as a plugin yet, add it via /plugin.\n"
+            "Otherwise fix it manually, then restart Claude Code:\n"
+            "  claude plugin update lore@lore",
+            title="plugin cache stale — restart Claude Code",
+            border_style="red",
+            expand=False,
+        ),
+        markup=False,
+    )
+
+
 def _refresh_claude_plugin_cache(*, quiet: bool) -> None:
     """Run `claude plugin update lore@lore` so Claude re-fetches the manifest.
 
@@ -581,24 +505,13 @@ def _refresh_claude_plugin_cache(*, quiet: bool) -> None:
             timeout=60,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
-        if not quiet:
-            console.print(
-                f"  [yellow]claude plugin update failed: {exc}[/yellow] "
-                "Run [cyan]claude plugin update lore@lore[/cyan] manually.",
-                markup=True,
-            )
+        _loud_plugin_cache_failure(str(exc))
         return
 
     if result.returncode != 0:
-        if not quiet:
-            stderr = (result.stderr or result.stdout or "").strip().splitlines()
-            tail = stderr[-1] if stderr else f"exit {result.returncode}"
-            console.print(
-                f"  [yellow]claude plugin update lore@lore: {rich_escape(tail)}[/yellow]\n"
-                "  If the plugin isn't installed yet, add it from the Claude "
-                "marketplace via [cyan]/plugin[/cyan].",
-                markup=True,
-            )
+        stderr = (result.stderr or result.stdout or "").strip().splitlines()
+        tail = stderr[-1] if stderr else f"exit {result.returncode}"
+        _loud_plugin_cache_failure(tail)
         return
 
     if not quiet:
@@ -719,21 +632,11 @@ def _cmd_install(args: SimpleNamespace, mode: str) -> int:
         # Claude integration was actually part of the run.
         if any(name == "claude" for name, _ in plans) and not args.json:
             _refresh_claude_plugin_cache(quiet=args.quiet)
-        if interactive:
-            try:
-                _post_install_setup()
-            except (KeyboardInterrupt, EOFError):
-                console.print(
-                    "\n\n  [yellow]Setup interrupted.[/yellow] "
-                    "Run [cyan]lore init[/cyan] later to finish vault setup.",
-                    markup=True,
-                )
-        else:
-            console.print(
-                "\n[bold]Next:[/bold] run [cyan]lore init[/cyan] to scaffold "
-                "your vault.",
-                markup=True,
-            )
+        console.print(
+            "\n[bold]Next:[/bold] run [cyan]lore init[/cyan] to scaffold "
+            "your vault and finish onboarding.",
+            markup=True,
+        )
     return 0 if overall_failures == 0 else 1
 
 

--- a/lib/lore_cli/wiki_cmd.py
+++ b/lib/lore_cli/wiki_cmd.py
@@ -36,6 +36,26 @@ class WikiMode(str, Enum):
 
 SUBDIRS = ("projects", "concepts", "decisions", "sessions", "inbox")
 
+# Seeded on wiki creation. Fully commented so `load_scopes_yml` parses it
+# to an empty tree — a starting point, never a phantom scope. The shape
+# mirrors what `lore_core.scopes.walk_scope_leaves` reads: a top-level
+# `scopes:` map whose leaves carry a `repo:` and may nest via `children:`.
+_SCOPES_YML_TEMPLATE = """\
+# _scopes.yml — declare which repos live under which scope path.
+#
+# Scopes are colon-separated and hierarchical
+# (e.g. ccat:data-center:data-transfer). Each leaf with a `repo:` maps a
+# git repo slug (owner/name) onto a scope path; nest deeper with
+# `children:`. Uncomment and adapt the example below to get started.
+#
+# scopes:
+#   my-project:
+#     repo: your-org/my-project
+#     children:
+#       backend:
+#         repo: your-org/my-project-backend
+"""
+
 
 def _plugin_templates_dir() -> Path:
     from lore_core.templates import templates_dir
@@ -66,6 +86,13 @@ def scaffold_wiki(
         claude_md.write_text((templates_src / "wiki-CLAUDE.md").read_text())
         (target / "templates").mkdir(exist_ok=True)
         shutil.copy(templates_src / "session.md", target / "templates" / "session.md")
+
+        # Seed a commented `_scopes.yml` so the scope registry has an
+        # obvious home the moment the wiki exists (never overwrite one a
+        # cloned/linked wiki already carries).
+        scopes_yml = target / "_scopes.yml"
+        if not scopes_yml.exists():
+            scopes_yml.write_text(_SCOPES_YML_TEMPLATE)
 
         (target / "_index.txt").write_text(
             f"# {name.upper()} Knowledge Index\n\n"

--- a/tests/test_cli_wiki.py
+++ b/tests/test_cli_wiki.py
@@ -34,3 +34,16 @@ def test_lore_new_wiki_legacy_form_is_gone(lore_root: Path) -> None:
     """`lore new-wiki <name>` no longer exists; only `lore wiki new` remains."""
     result = runner.invoke(app, ["new-wiki", "test-wiki"])
     assert result.exit_code != 0
+
+
+def test_scaffold_wiki_writes_commented_scopes_yml(lore_root: Path) -> None:
+    """A new wiki gets a `_scopes.yml` seeded with a commented example — a
+    starting point that parses to an empty tree (no phantom scopes)."""
+    from lore_cli.wiki_cmd import scaffold_wiki
+    from lore_core.scopes import load_scopes_yml
+
+    target = scaffold_wiki("mywiki", mode="personal")
+    scopes = target / "_scopes.yml"
+    assert scopes.exists()
+    assert "scopes:" in scopes.read_text()  # example present (commented)
+    assert load_scopes_yml(target) == {}  # commented-only → empty tree

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -1,59 +1,259 @@
-"""Tests for `lore init` — display-name onboarding prompt."""
+"""Tests for `lore init` — vault scaffold + the unified onboarding wizard.
+
+The wizard is the single guided path from "binary installed" to "notes
+being written": vault -> wiki -> integrations -> optional attach ->
+automatic doctor -> handoff. It is idempotent and resumable, so
+re-running repairs a partial install.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
+import os
+import subprocess
 
-from lore_cli.init_cmd import app, init_vault
+import pytest
+import typer
+from lore_cli import init_cmd
+from lore_cli.init_cmd import app, init_vault, run_wizard
 from lore_core.root_config import load_root_config
 from typer.testing import CliRunner
 
 runner = CliRunner()
 
 
-def test_init_vault_noninteractive_leaves_display_name_unset(tmp_path: Path):
+@pytest.fixture(autouse=True)
+def _restore_lore_root_env():
+    """The wizard commits its chosen vault to ``os.environ['LORE_ROOT']``
+    for the running process; snapshot + restore so it never leaks across
+    tests."""
+    saved = os.environ.get("LORE_ROOT")
+    yield
+    if saved is None:
+        os.environ.pop("LORE_ROOT", None)
+    else:
+        os.environ["LORE_ROOT"] = saved
+
+
+@pytest.fixture()
+def no_integrations(monkeypatch):
+    """Neutralise the integration-wiring step so tests never touch a real
+    Claude Code / Cursor install (the dev host has ``claude`` on PATH)."""
+    monkeypatch.setattr(init_cmd, "_step_integrations", lambda **kw: None)
+
+
+# --------------------------------------------------------------------------
+# init_vault unit — display-name onboarding (unchanged behaviour)
+# --------------------------------------------------------------------------
+
+
+def test_init_vault_noninteractive_leaves_display_name_unset(tmp_path):
     init_vault(tmp_path)
     assert load_root_config(tmp_path).user.display_name == ""
 
 
-def test_init_vault_display_name_arg_persists(tmp_path: Path):
+def test_init_vault_display_name_arg_persists(tmp_path):
     init_vault(tmp_path, display_name="Christof")
     assert load_root_config(tmp_path).user.display_name == "Christof"
 
 
-def test_init_vault_already_configured_not_reprompted(tmp_path: Path, monkeypatch):
-    """Re-running init (e.g. --force) must not clobber an existing name."""
+def test_init_vault_already_configured_not_reprompted(tmp_path, monkeypatch):
     from lore_core.root_config import set_field
 
     set_field(tmp_path, "user.display_name", "Christof")
-    monkeypatch.setattr("lore_cli.init_cmd._is_interactive", lambda: True)
+    monkeypatch.setattr(init_cmd, "_is_interactive", lambda: True)
     init_vault(tmp_path, force=True)
     assert load_root_config(tmp_path).user.display_name == "Christof"
 
 
-def test_init_cli_interactive_prompts_and_persists(tmp_path: Path, monkeypatch):
-    monkeypatch.setattr("lore_cli.init_cmd._is_interactive", lambda: True)
-    result = runner.invoke(app, ["--root", str(tmp_path)], input="Christof\n")
+# --------------------------------------------------------------------------
+# Vault resolution / persistence
+# --------------------------------------------------------------------------
+
+
+def test_prompt_vault_flag_wins(tmp_path, monkeypatch):
+    monkeypatch.delenv("LORE_ROOT", raising=False)
+    got = init_cmd._prompt_vault(str(tmp_path / "v"), interactive=False)
+    assert got == (tmp_path / "v").resolve()
+
+
+def test_prompt_vault_honors_existing_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path / "envvault"))
+    got = init_cmd._prompt_vault(None, interactive=False)
+    assert got == (tmp_path / "envvault").resolve()
+
+
+# --------------------------------------------------------------------------
+# Wizard end-to-end (--yes, CI-runnable)
+# --------------------------------------------------------------------------
+
+
+def test_wizard_yes_creates_vault_wiki_scopes(tmp_path, monkeypatch, no_integrations):
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    rc = run_wizard(vault=str(vault), yes=True, cwd=tmp_path)
+
+    assert (vault / "CLAUDE.md").exists()
+    assert (vault / "templates").is_dir()
+    wikis = [d for d in (vault / "wiki").iterdir() if d.is_dir()]
+    assert wikis, "wizard must scaffold a wiki by default"
+    assert (wikis[0] / "_scopes.yml").exists()
+
+    # Exit code mirrors a direct doctor run on the same state.
+    from lore_cli import doctor_cmd
+
+    expected = doctor_cmd.main(["--cwd", str(tmp_path)])
+    assert rc == expected
+
+
+def test_wizard_yes_display_name(tmp_path, monkeypatch, no_integrations):
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+    run_wizard(vault=str(vault), yes=True, display_name="Christof", cwd=tmp_path)
+    assert load_root_config(vault).user.display_name == "Christof"
+
+
+# --------------------------------------------------------------------------
+# Exit code reflects the doctor result
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("doctor_rc", [0, 1])
+def test_wizard_exit_reflects_doctor(tmp_path, monkeypatch, no_integrations, doctor_rc):
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: doctor_rc)
+    rc = run_wizard(vault=str(vault), yes=True, cwd=tmp_path)
+    assert rc == doctor_rc
+
+
+# --------------------------------------------------------------------------
+# Idempotent + resumable
+# --------------------------------------------------------------------------
+
+
+def test_wizard_idempotent_second_run(tmp_path, monkeypatch, no_integrations, capsys):
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+
+    run_wizard(vault=str(vault), yes=True, cwd=tmp_path)
+    wikis1 = sorted(p.name for p in (vault / "wiki").iterdir() if p.is_dir())
+    scopes = next((vault / "wiki").glob("*/_scopes.yml"))
+    bytes1 = scopes.read_bytes()
+    capsys.readouterr()
+
+    run_wizard(vault=str(vault), yes=True, cwd=tmp_path)
+    out = capsys.readouterr().out
+
+    wikis2 = sorted(p.name for p in (vault / "wiki").iterdir() if p.is_dir())
+    assert wikis1 == wikis2, "second run must not create a duplicate wiki"
+    assert scopes.read_bytes() == bytes1, "second run must not churn _scopes.yml"
+    assert out.count("skipped") >= 2, "vault + wiki collapse to skip lines"
+
+
+def test_wizard_repairs_one_deleted_artifact(tmp_path, monkeypatch, no_integrations, capsys):
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+
+    run_wizard(vault=str(vault), yes=True, cwd=tmp_path)
+    (vault / "CLAUDE.md").unlink()  # break exactly one vault artifact
+    capsys.readouterr()
+
+    run_wizard(vault=str(vault), yes=True, cwd=tmp_path)
+    out = capsys.readouterr().out
+
+    assert (vault / "CLAUDE.md").exists(), "vault step must repair the deletion"
+    assert "skipped" in out, "the wiki step still collapses (only vault repaired)"
+
+
+# --------------------------------------------------------------------------
+# Flag parity — wiki targets
+# --------------------------------------------------------------------------
+
+
+def test_wizard_wiki_new_names_wiki(tmp_path, monkeypatch, no_integrations):
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+    run_wizard(vault=str(vault), wiki_new="research", yes=True, cwd=tmp_path)
+    assert (vault / "wiki" / "research" / "_scopes.yml").exists()
+
+
+def test_wizard_wiki_link_symlinks_dir(tmp_path, monkeypatch, no_integrations):
+    vault = tmp_path / "vault"
+    src = tmp_path / "external-wiki"
+    src.mkdir()
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+    run_wizard(vault=str(vault), wiki_link=str(src), yes=True, cwd=tmp_path)
+    linked = vault / "wiki" / "external-wiki"
+    assert linked.is_symlink() and linked.resolve() == src.resolve()
+
+
+def test_wizard_wiki_clone_uses_git(tmp_path, monkeypatch, no_integrations):
+    srcrepo = tmp_path / "srcwiki"
+    srcrepo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=srcrepo, check=True)
+    (srcrepo / "README.md").write_text("team wiki\n")
+    subprocess.run(["git", "add", "-A"], cwd=srcrepo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init"],
+        cwd=srcrepo,
+        check=True,
+    )
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+    run_wizard(vault=str(vault), wiki_clone=str(srcrepo), yes=True, cwd=tmp_path)
+    assert (vault / "wiki" / "srcwiki" / "README.md").exists()
+
+
+def test_wizard_wiki_flags_mutually_exclusive(tmp_path, monkeypatch, no_integrations):
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+    with pytest.raises(typer.BadParameter):
+        run_wizard(vault=str(vault), wiki_new="a", wiki_link=str(tmp_path), yes=True, cwd=tmp_path)
+
+
+# --------------------------------------------------------------------------
+# Integration step reuses the `lore install` plumbing
+# --------------------------------------------------------------------------
+
+
+def test_wizard_integration_step_reuses_install(tmp_path, monkeypatch):
+    from lore_cli import install_cmd
+
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+    monkeypatch.setattr(install_cmd, "_integration_present", lambda name: name == "claude")
+    spy = []
+    monkeypatch.setattr(install_cmd, "main", lambda argv=None: spy.append(argv) or 0)
+    run_wizard(vault=str(vault), yes=True, cwd=tmp_path)
+    assert spy, "integration step must call `lore install`"
+    assert "--yes" in spy[0]
+
+
+# --------------------------------------------------------------------------
+# CLI wiring
+# --------------------------------------------------------------------------
+
+
+def test_init_cli_yes_runs_wizard(tmp_path, monkeypatch, no_integrations):
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+    result = runner.invoke(app, ["--vault", str(vault), "--yes"])
     assert result.exit_code == 0, result.output
-    assert load_root_config(tmp_path).user.display_name == "Christof"
+    assert (vault / "wiki").is_dir()
 
 
-def test_init_cli_interactive_blank_leaves_unset(tmp_path: Path, monkeypatch):
-    monkeypatch.setattr("lore_cli.init_cmd._is_interactive", lambda: True)
-    result = runner.invoke(app, ["--root", str(tmp_path)], input="\n")
+def test_init_cli_root_alias_still_accepted(tmp_path, monkeypatch, no_integrations):
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setattr(init_cmd, "_run_doctor", lambda cwd: 0)
+    result = runner.invoke(app, ["--root", str(vault), "--yes"])
     assert result.exit_code == 0, result.output
-    assert load_root_config(tmp_path).user.display_name == ""
-
-
-def test_init_cli_noninteractive_never_prompts(tmp_path: Path):
-    """No --input, no isatty patch: CliRunner stdin is not a tty, so this
-    must complete without blocking on a prompt."""
-    result = runner.invoke(app, ["--root", str(tmp_path)])
-    assert result.exit_code == 0, result.output
-    assert load_root_config(tmp_path).user.display_name == ""
-
-
-def test_init_cli_display_name_flag_noninteractive(tmp_path: Path):
-    result = runner.invoke(app, ["--root", str(tmp_path), "--display-name", "Christof"])
-    assert result.exit_code == 0, result.output
-    assert load_root_config(tmp_path).user.display_name == "Christof"

--- a/tests/test_install_sh_hardening.py
+++ b/tests/test_install_sh_hardening.py
@@ -1,0 +1,31 @@
+"""Structural guards for `install.sh` onboarding hardening (#194).
+
+install.sh is bash — exercising a full pipx round-trip in pytest is not
+worth it. These read the script and assert the two behaviours the epic
+requires: it fails loudly when `lore` is not runnable on PATH afterwards,
+and a first install chains into the unified `lore init` wizard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+INSTALL_SH = Path(__file__).resolve().parents[1] / "install.sh"
+
+
+def _path_check_block() -> str:
+    text = INSTALL_SH.read_text()
+    assert "command -v lore" in text, "install.sh must verify lore is on PATH"
+    # The ~30 lines following the PATH probe cover the not-runnable branch.
+    return text.split("command -v lore", 1)[1][:600]
+
+
+def test_install_sh_fails_when_lore_not_on_path():
+    block = _path_check_block()
+    assert ("die " in block) or ("exit 1" in block), (
+        "the not-on-PATH branch must exit non-zero, not `exit 0`"
+    )
+
+
+def test_install_sh_first_install_chains_into_lore_init():
+    assert "exec lore init" in INSTALL_SH.read_text()


### PR DESCRIPTION
Closes #194 — the onboarding capstone for epic #183 (PRD 0005).

## What

`lore init` becomes the single guided path from "binary installed" to "notes being written":

**vault → wiki → integrations → optional first attach → automatic `lore doctor` → handoff panel**

Idempotent and resumable: each step detects existing state and collapses to a `✓ … (skipped)` receipt line, so re-running completes or repairs a partial install. The wizard's exit code mirrors the doctor verdict.

## Acceptance criteria → coverage

1. **Full wizard, interactive AND flag-only (`--yes` CI-runnable).** `run_wizard` drives all six steps; flag parity: `--vault`/`--root`, `--wiki-new|--wiki-clone|--wiki-link`, `--attach`, `--yes`, `--plain`. → `test_wizard_yes_creates_vault_wiki_scopes`
2. **`_scopes.yml` scaffolded on wiki creation** (commented example, parses to empty tree — no phantom scopes). → `test_scaffold_wiki_writes_commented_scopes_yml`, `test_wizard_wiki_new_names_wiki`
3. **Idempotent + resumable.** Re-run is skip lines with no churn; deleting one artifact repairs exactly that step. → `test_wizard_idempotent_second_run`, `test_wizard_repairs_one_deleted_artifact`
4. **Doctor runs automatically; exit code reflects it.** → `test_wizard_exit_reflects_doctor` (0/1), `test_wizard_yes_creates_vault_wiki_scopes` compares against a direct doctor run
5. **`install.sh` exits non-zero when `lore` isn't runnable; first install chains into `lore init`.** → `test_install_sh_fails_when_lore_not_on_path`, `test_install_sh_first_install_chains_into_lore_init`
6. **One onboarding path.** Deleted the duplicate `_post_install_setup` vault path in `lore install` (it imported a non-existent `new_wiki_cmd` — dead **and** broken); `lore install` now points at `lore init`. → covered by full install suite staying green

Also: plugin-cache refresh failure is **loud** (bordered panel naming the manual fix + required Claude Code restart), even under `--quiet`. Reuses the merged epic pieces — #191's attach wizard, #186's doctor, the `lore install` plumbing — rather than reimplementing (`test_wizard_integration_step_reuses_install`).

## Red → green evidence

Initial run against the un-implemented API (red):

```
tests/test_init_cmd.py:18: in <module>
    from lore_cli.init_cmd import app, init_vault, run_wizard
E   ImportError: cannot import name 'run_wizard' from 'lore_cli.init_cmd'
```

After implementation (green) — the new suites:

```
tests/test_init_cmd.py .................  (init_vault + wizard)
tests/test_install_sh_hardening.py ..
tests/test_cli_wiki.py ...
23 passed in 1.72s
```

Full suite: **2762 passed, 16 skipped, 10 failed** — all 10 failures are the pre-existing ANSI-color CliRunner failures (`assert 'x' in '\x1b[...'`) in untouched modules (`test_drain_prune`, `test_core_llm_wiring`, `test_proc_cmd`, `test_log_cmd`, `test_cli_runs`, and the `test_refresh_claude_plugin_cache_runs_update_on_success` success-path relay). Each was confirmed to fail identically on `epic/183`. **Zero new failures.**

Real CLI smoke (`lore init --yes --vault … `, `claude` off PATH, non-git cwd): scaffolds vault + personal wiki + `_scopes.yml`, persists `lore_root` to `~/.config/lore/config.yml`, runs doctor automatically ("Install looks good"), renders the handoff panel, exits 0.

## Notes

- `ruff check` + `ruff format --check` clean on `init_cmd.py` and both new test files. `wiki_cmd.py`/`install_cmd.py` retain only pre-existing whole-tree ruff dirt (I001/UP042/B008 — the standard typer idioms; identical on HEAD, tracked #196, not a required check).
- Coordinates with #171 (PRD 0003) workflow scaffolding: the attach step already threads its `scaffold_workflow` opt-in, and the wizard frame is extensible for whichever lands second.
