### PR TITLE
trace_id propagation end-to-end + drain producer onto the event spine (#188)

### DIFF
--- a/lib/lore_cli/curator_cmd.py
+++ b/lib/lore_cli/curator_cmd.py
@@ -268,6 +268,9 @@ def flush_command(
         trigger="flush",
         pending_count=1,
         config_snapshot={"buffer_stem": buffer.stem, "mode": mode},
+        # Delivered across the process boundary by spawn_detached_flush so
+        # this run's events join the spawning session's flush (#188).
+        trace_id=os.environ.get("LORE_TRACE_ID"),
     ) as logger:
         outcome = synth_fn(
             buffer_path,

--- a/lib/lore_core/drain.py
+++ b/lib/lore_core/drain.py
@@ -1,22 +1,23 @@
 """Per-session drain store — append-only event log surfaced by `lore news`.
 
-Each Claude Code session owns a drain file at
-``<lore_root>/.lore/drain/<session-id>.jsonl`` that records what Lore
-did on its behalf since the session began. A separate `_system.jsonl`
-captures events that aren't tied to a specific session (Curator B
-surface consolidation, transcript sync, future cross-session work).
+Drain events — what Lore did on a session's behalf, surfaced by
+`lore news` — are emitted onto the unified event spine with
+``source="drain"`` (issue #188). Each event carries the resolving
+``session_id`` so per-session and ``_system`` streams stay separable on
+one shared log. There is no longer a per-session ``<session-id>.jsonl``
+writer; :class:`DrainStore` is a thin producer/reader adapter over the
+spine, keeping only the news *cursor* files under ``.lore/drain/``.
 
 Design invariants:
 
-* **Append-only.** Every entry is one line of JSON; the file is never
-  rewritten. Crash-safety comes from `O_APPEND` + a hard per-line size
-  cap so a partial final line can only ever be a single malformed
-  record the reader skips.
-* **Line size cap.** ``MAX_DRAIN_LINE`` bytes. On overflow we truncate
-  the ``data`` payload and set ``"truncated": true`` so the reader can
-  surface "data elided" rather than silently dropping.
-* **Fresh-install safe.** ``DrainStore(...)`` creates the parent dir
-  eagerly so the first emit doesn't race the filesystem.
+* **On the spine.** ``emit`` appends one envelope via
+  :class:`~lore_core.spine.SpineWriter` (POSIX-atomic ``O_APPEND``);
+  ``read`` filters the spine to ``source="drain"`` and this session's id.
+* **Never raises, but visible.** A failed write is swallowed by the spine
+  writer *and* leaves the ``spine-failed.marker`` — a dropped drain event
+  is no longer invisible.
+* **Fresh-install safe.** ``DrainStore(...)`` creates ``.lore/drain/``
+  eagerly (for the cursor files) so the first read doesn't race the fs.
 
 Session-id resolution is its own function (:func:`resolve_session_id`)
 because the "who is this session?" question has four distinct sources
@@ -24,7 +25,6 @@ with a deterministic priority order.
 """
 from __future__ import annotations
 
-import json
 import os
 import time
 from dataclasses import dataclass
@@ -32,7 +32,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-MAX_DRAIN_LINE = 4096  # bytes per record, including trailing newline
+from lore_core.spine import SpineWriter, read_spine
+
 SYSTEM_SESSION = "_system"
 
 
@@ -62,14 +63,12 @@ class DrainStore:
     def __init__(self, lore_root: Path, session_id: str) -> None:
         self._lore_root = lore_root
         self._session_id = session_id
+        # `.lore/drain/` now holds only the news cursor files; drain *events*
+        # live on the shared spine. Created eagerly so a cursor read/write
+        # never races the filesystem on a fresh install.
         self._dir = lore_root / ".lore" / "drain"
         self._dir.mkdir(parents=True, exist_ok=True)
-        self._path = self._dir / f"{session_id}.jsonl"
         self._cursor_path = self._dir / f"{session_id}.cursor"
-
-    @property
-    def path(self) -> Path:
-        return self._path
 
     @property
     def session_id(self) -> str:
@@ -80,16 +79,22 @@ class DrainStore:
         event: str,
         *,
         wiki: str | None = None,
+        trace_id: str | None = None,
         **data: Any,
     ) -> None:
-        """Append one event record to the drain.
+        """Emit one drain event onto the spine (``source="drain"``).
 
         Raises ValueError on an unknown ``event`` name, or when a
-        non-``transcript-synced`` event is targeted at the system
-        drain (``SYSTEM_SESSION``). The system stream is shared
-        across all sessions, so per-note events written there would
-        haunt every future SessionStart — only ``transcript-synced``
-        belongs in ``_system``.
+        non-``transcript-synced`` event is targeted at the system drain
+        (``SYSTEM_SESSION``) — the shared stream, where per-note events would
+        haunt every future SessionStart. The spine write itself never raises:
+        a failure is swallowed *and* marked (``spine-failed.marker``), so a
+        dropped drain event is no longer invisible.
+
+        ``trace_id`` correlates a note event with the flush that produced it
+        (#188); ``None`` for events outside a traced flush. Callers must keep
+        ``data`` small — a drain record shares the spine's PIPE_BUF atomicity
+        budget (only bounded metadata is ever passed today).
         """
         if event not in EVENT_VOCAB:
             raise ValueError(f"unknown drain event: {event!r}")
@@ -97,38 +102,17 @@ class DrainStore:
             raise ValueError(
                 f"system drain accepts only 'transcript-synced'; got {event!r}"
             )
-
-        record: dict[str, Any] = {
-            "ts": datetime.now(UTC).isoformat(),
-            "event": event,
-            "wiki": wiki,
-            "session_id": self._session_id,
-            "data": data,
-        }
-        line = (json.dumps(record) + "\n").encode("utf-8")
-        if len(line) > MAX_DRAIN_LINE:
-            # Retry with truncated payload.
-            record["data"] = {"truncated_from_keys": sorted(data.keys())}
-            record["truncated"] = True
-            line = (json.dumps(record) + "\n").encode("utf-8")
-            # If even the shell is too big (pathological), drop data entirely.
-            if len(line) > MAX_DRAIN_LINE:
-                record["data"] = {}
-                line = (json.dumps(record) + "\n").encode("utf-8")
-
-        # O_APPEND on a local POSIX fs delivers atomic per-write semantics
-        # for writes <= PIPE_BUF (4096 on Linux). Our cap is 4096 bytes
-        # INCLUDING the newline, so a single write() is safe. The `with`
-        # block close-flushes before return.
-        try:
-            fd = os.open(str(self._path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
-            try:
-                os.write(fd, line)
-            finally:
-                os.close(fd)
-        except OSError:
-            # Drain is telemetry; never block real work.
-            pass
+        # ponytail: no per-record size cap here; drain producers only ever pass
+        # bounded metadata (wiki, wikilink, note path, transcript id). Add a
+        # truncate-in-adapter guard if a large-payload producer ever appears.
+        SpineWriter(self._lore_root).emit(
+            source="drain",
+            event=event,
+            trace_id=trace_id,
+            session_id=self._session_id,
+            wiki=wiki,
+            data=dict(data),
+        )
 
     def read(
         self,
@@ -136,48 +120,32 @@ class DrainStore:
         since: datetime | None = None,
         limit: int = 50,
     ) -> list[DrainEvent]:
-        """Return up to ``limit`` events, optionally filtered by ``since``.
+        """Return up to ``limit`` of this session's drain events from the spine.
 
-        Malformed lines are silently skipped (see the atomicity note in
-        the module docstring). Returns chronological order, oldest first.
+        Filtered to ``source="drain"`` and this store's ``session_id``,
+        optionally since ``since``. Chronological (oldest first); malformed
+        spine lines are skipped by the reader.
         """
-        if not self._path.exists():
-            return []
         out: list[DrainEvent] = []
-        try:
-            with self._path.open("r", encoding="utf-8", errors="replace") as fp:
-                for raw in fp:
-                    line = raw.strip()
-                    if not line:
-                        continue
-                    try:
-                        obj = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    if not isinstance(obj, dict):
-                        continue
-                    ts_raw = obj.get("ts")
-                    if not isinstance(ts_raw, str):
-                        continue
-                    try:
-                        ts = datetime.fromisoformat(ts_raw)
-                    except ValueError:
-                        continue
-                    if since is not None and ts < since:
-                        continue
-                    out.append(
-                        DrainEvent(
-                            ts=ts,
-                            event=str(obj.get("event", "")),
-                            wiki=obj.get("wiki"),
-                            session_id=str(obj.get("session_id", "")),
-                            data=obj.get("data") or {},
-                            truncated=bool(obj.get("truncated", False)),
-                        )
-                    )
-        except OSError:
-            return []
-        # Tail ``limit`` entries.
+        for rec in read_spine(self._lore_root, source="drain"):
+            if rec.get("session_id") != self._session_id:
+                continue
+            ts = _parse_ts(rec.get("ts"))
+            if ts is None:
+                continue
+            if since is not None and ts < since:
+                continue
+            data = rec.get("data") or {}
+            out.append(
+                DrainEvent(
+                    ts=ts,
+                    event=str(rec.get("event", "")),
+                    wiki=rec.get("wiki"),
+                    session_id=str(rec.get("session_id", "")),
+                    data=data,
+                    truncated=bool(data.get("truncated", False)),
+                )
+            )
         if limit > 0:
             out = out[-limit:]
         return out
@@ -222,6 +190,16 @@ class DrainStore:
         anchor = now if now is not None else datetime.now(UTC)
         self.write_cursor(anchor)
         return anchor
+
+
+def _parse_ts(raw: Any) -> datetime | None:
+    """Parse a spine ``ts`` (ISO-8601, possibly ``Z``-suffixed)."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def resolve_session_id(

--- a/lib/lore_core/linkage.py
+++ b/lib/lore_core/linkage.py
@@ -48,6 +48,9 @@ class Linkage:
     prs: list[int] = field(default_factory=list)
     epics: list[int] = field(default_factory=list)
     author: str = ""
+    # Correlation id of the flush that produced the note (#188); the note
+    # carries the id of the run that wrote it. None outside a traced flush.
+    trace_id: str | None = None
 
 
 def classify_refs(text: str) -> tuple[set[int], set[int], set[int]]:

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -249,6 +249,7 @@ def _apply_linkage(fm: dict[str, Any], linkage: Linkage | None) -> None:
         "prs": list(linkage.prs),
         "epics": list(linkage.epics),
         "author": linkage.author,
+        "trace_id": linkage.trace_id,
     }
 
 

--- a/lib/lore_core/run_log.py
+++ b/lib/lore_core/run_log.py
@@ -118,6 +118,7 @@ class RunLogger:
         trace_llm: bool = False,
         ledger_snapshot_hash: str | None = None,
         run_id: str | None = None,
+        trace_id: str | None = None,
         on_record: RecordCallback | None = None,
     ):
         self._lore_root = lore_root
@@ -130,6 +131,9 @@ class RunLogger:
         self._trace_llm = trace_llm
         self._ledger_snapshot_hash = ledger_snapshot_hash
         self.run_id = run_id or generate_run_id()
+        # One correlation id for the whole flush; stamped on every emit so a
+        # run's events join the drain event and the published note (#188).
+        self.trace_id = trace_id
         self._counts = {
             "notes_new": 0,
             "notes_merged": 0,
@@ -202,7 +206,7 @@ class RunLogger:
             event=record_type,
             level=self._level(record_type),
             run_id=self.run_id,
-            trace_id=None,  # #188 stamps this
+            trace_id=self.trace_id,
             wiki=fields.get("wiki"),
             scope=fields.get("scope") if isinstance(fields.get("scope"), str) else None,
             data=self._spine_data(record_type, fields),

--- a/lib/lore_core/spine.py
+++ b/lib/lore_core/spine.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import json
 import os
+import secrets
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -109,6 +110,17 @@ _ERROR_CODE_VALUES: frozenset[str] = frozenset(c.value for c in ErrorCode)
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def new_trace_id() -> str:
+    """Mint a correlation id for one flush.
+
+    Threaded hook decision point -> detached-flush spawn (env var) -> curator
+    run events -> drain event -> published note, so a whole flush is
+    correlatable and concurrent flushes stay separable. Opaque and short;
+    readers only ever compare it for equality.
+    """
+    return secrets.token_hex(8)
 
 
 class SpineWriter:

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -45,7 +45,7 @@ module consumes a request and drives the composer + gate + note.
 from __future__ import annotations
 
 import contextlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -57,7 +57,7 @@ from lore_core.flush_store import FlushState, FlushStore
 from lore_core.lockfile import LockContendedError, curator_lock
 from lore_core.publish_gate import GateResult, PublishGate
 from lore_core.session_writer import FiledNote
-from lore_core.spine import ErrorCode, SpineWriter
+from lore_core.spine import ErrorCode, SpineWriter, new_trace_id
 from lore_core.types import TranscriptHandle, Turn
 
 from lore_curator._auto_commit import maybe_auto_commit
@@ -516,6 +516,11 @@ def _apply_outcome(
     sidecar = buffer.read_sidecar() or Sidecar(transcript_id=buffer.stem)
     facts = facts_from_replay(rb)
     linkage = linkage_from_replay(rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=sidecar.handle)
+    # The logger carries this flush's trace_id (minted at spawn, delivered via
+    # env). Stamp it onto the note's linkage and the flush record so run
+    # events, the drain event and the note all share one id (#188).
+    trace_id = logger.trace_id if logger is not None else None
+    linkage = replace(linkage, trace_id=trace_id)
     out = FlushOutcome(
         buffer_stem=buffer.stem,
         state_before=state_before,
@@ -540,7 +545,7 @@ def _apply_outcome(
     # dead-lettered transition below. The record is the source of truth for
     # "what is in-flight right now"; every transition also emits a spine event.
     store = FlushStore(lore_root)
-    flush_rec = store.begin(buffer.stem, wiki=sidecar.wiki)
+    flush_rec = store.begin(buffer.stem, wiki=sidecar.wiki, trace_id=trace_id)
     if FlushState(flush_rec.state) is FlushState.QUEUED:
         flush_rec = store.transition(flush_rec, FlushState.RUNNING)
 
@@ -824,6 +829,7 @@ def _post_flush(
         DrainStore(lore_root, sid).emit(
             "note-filed" if close else "note-appended",
             wiki=sidecar.wiki,
+            trace_id=logger.trace_id if logger is not None else None,
             wikilink=outcome.wikilink,
             path=str(outcome.note_path),
             transcript_id=sidecar.transcript_id,
@@ -1052,13 +1058,17 @@ def _emit_spawn_failed(buffer_path: Path, lore_root: Path, exc: Exception) -> No
     )
 
 
-def spawn_detached_flush(buffer_path: Path, *, lore_root: Path) -> bool:
+def spawn_detached_flush(
+    buffer_path: Path, *, lore_root: Path, trace_id: str | None = None
+) -> str | None:
     """Fire-and-forget ``lore curator flush <buffer-path> --config-from-buffer``.
 
-    Returns True on successful Popen, False on OSError. Never blocks the
-    caller. A per-buffer spawn-lock under ``<stem>.spawn.lock`` prevents a
-    double-spawn when a reaper races cap-trip; a held lock skips rather
-    than queueing.
+    Mints a ``trace_id`` (unless the caller supplies one) and delivers it to
+    the detached curator via ``LORE_TRACE_ID`` — the one place the id crosses
+    the process boundary. Returns the trace_id on a successful Popen, or
+    ``None`` on a skipped/failed spawn. Never blocks the caller. A per-buffer
+    spawn-lock under ``<stem>.spawn.lock`` prevents a double-spawn when a
+    reaper races cap-trip; a held lock skips rather than queueing.
     """
     import os
     import subprocess
@@ -1070,7 +1080,8 @@ def spawn_detached_flush(buffer_path: Path, *, lore_root: Path) -> bool:
     try:
         with flocked(spawn_lock, blocking=False) as held:
             if not held:
-                return False
+                return None
+            trace_id = trace_id or new_trace_id()
             cmd = [
                 sys.executable,
                 "-m",
@@ -1083,6 +1094,7 @@ def spawn_detached_flush(buffer_path: Path, *, lore_root: Path) -> bool:
             env = os.environ.copy()
             env["LORE_ROOT"] = str(lore_root)
             env["LORE_CURATOR_MODE"] = "1"
+            env["LORE_TRACE_ID"] = trace_id
             try:
                 subprocess.Popen(
                     cmd,
@@ -1093,10 +1105,10 @@ def spawn_detached_flush(buffer_path: Path, *, lore_root: Path) -> bool:
                     stdin=subprocess.DEVNULL,
                     env=env,
                 )
-                return True
+                return trace_id
             except (OSError, subprocess.SubprocessError) as exc:
                 _emit_spawn_failed(buffer_path, lore_root, exc)
-                return False
+                return None
     except OSError as exc:
         _emit_spawn_failed(buffer_path, lore_root, exc)
-        return False
+        return None

--- a/lib/lore_curator/session_curator.py
+++ b/lib/lore_curator/session_curator.py
@@ -659,7 +659,7 @@ def _process_chunk(
         # heartbeat keeps folding into the same buffer and the same note.
         from lore_curator.synthesis import spawn_detached_flush
 
-        spawned = spawn_detached_flush(
+        flush_trace_id = spawn_detached_flush(
             outcome.buffer.sidecar_path, lore_root=lore_root,
         )
         if logger is not None:
@@ -668,7 +668,8 @@ def _process_chunk(
                 trigger="cap-trip",
                 transcript_id=entry.transcript_id,
                 buffer_stem=outcome.buffer.stem,
-                spawned=spawned,
+                spawned=bool(flush_trace_id),
+                trace_id=flush_trace_id,
             )
 
     if note_result is not None:

--- a/tests/test_drain.py
+++ b/tests/test_drain.py
@@ -1,7 +1,6 @@
 """Tests for lore_core.drain — per-session event store + session-id resolver."""
 from __future__ import annotations
 
-import json
 import os
 import time
 from datetime import UTC, datetime, timedelta
@@ -11,12 +10,12 @@ import pytest
 
 from lore_core.drain import (
     EVENT_VOCAB,
-    MAX_DRAIN_LINE,
     SYSTEM_SESSION,
     DrainEvent,
     DrainStore,
     resolve_session_id,
 )
+from lore_core.spine import read_spine
 
 
 # ---------------------------------------------------------------------------
@@ -30,41 +29,28 @@ def test_drain_store_creates_parent_dir_on_init(tmp_path):
     assert (tmp_path / ".lore" / "drain").exists()
     # emit should work even before any other drain activity
     store.emit("note-filed", wiki="w", path="/x")
-    assert store.path.exists()
+    assert len(store.read()) == 1
 
 
-def test_drain_store_emit_writes_valid_json_line(tmp_path):
+def test_drain_store_emit_lands_on_spine_with_source_drain(tmp_path):
     store = DrainStore(tmp_path, "s1")
-    store.emit("note-filed", wiki="ccat", wikilink="[[2026-04-22-foo]]")
-    lines = store.path.read_text().splitlines()
-    assert len(lines) == 1
-    rec = json.loads(lines[0])
+    store.emit("note-filed", wiki="ccat", trace_id="tr-1", wikilink="[[2026-04-22-foo]]")
+    recs = read_spine(tmp_path, source="drain")
+    assert len(recs) == 1
+    rec = recs[0]
+    assert rec["source"] == "drain"
     assert rec["event"] == "note-filed"
     assert rec["wiki"] == "ccat"
     assert rec["session_id"] == "s1"
+    assert rec["trace_id"] == "tr-1"
     assert rec["data"]["wikilink"] == "[[2026-04-22-foo]]"
-    assert "ts" in rec
+    assert rec["ts"]
 
 
 def test_drain_store_rejects_unknown_event(tmp_path):
     store = DrainStore(tmp_path, "s1")
     with pytest.raises(ValueError, match="unknown drain event"):
         store.emit("something-bogus", wiki="w")
-
-
-def test_drain_store_caps_line_at_max_size_with_truncation_marker(tmp_path):
-    """Oversize data payload → truncated marker, line stays within MAX_DRAIN_LINE."""
-    store = DrainStore(tmp_path, "s1")
-    huge = "X" * 10_000  # well over the cap
-    store.emit("note-filed", wiki="w", huge_blob=huge)
-
-    raw = store.path.read_bytes()
-    assert len(raw) <= MAX_DRAIN_LINE, f"line exceeded cap: {len(raw)} bytes"
-    rec = json.loads(raw.decode())
-    assert rec["truncated"] is True
-    # huge_blob must be gone; we still know it existed via truncated_from_keys
-    assert "huge_blob" not in rec["data"]
-    assert "huge_blob" in rec["data"]["truncated_from_keys"]
 
 
 def test_drain_store_emit_survives_unwritable_dir(tmp_path, monkeypatch):
@@ -118,8 +104,9 @@ def test_drain_read_limit_tails(tmp_path):
 def test_drain_read_skips_malformed_lines(tmp_path):
     store = DrainStore(tmp_path, "s1")
     store.emit("note-filed", wiki="w", n=1)
-    # Manually tack on a garbage line + a second good one
-    with store.path.open("a") as fp:
+    # Tack a garbage line onto the spine, then a second good event.
+    spine = tmp_path / ".lore" / "spine.jsonl"
+    with spine.open("a") as fp:
         fp.write("NOT JSON\n")
     store.emit("note-filed", wiki="w", n=2)
     got = store.read()
@@ -151,11 +138,14 @@ def test_drain_session_isolation(tmp_path):
     assert b_events[0].data["marker"] == "B"
 
 
-def test_drain_system_session_path(tmp_path):
-    """The _system session lands at a predictable filename."""
+def test_drain_system_session_reads_back_from_spine(tmp_path):
+    """The _system stream stays separable on the shared spine by session_id."""
     store = DrainStore(tmp_path, SYSTEM_SESSION)
     store.emit("transcript-synced", wiki="w", transcript_id="t1")
-    assert (tmp_path / ".lore" / "drain" / "_system.jsonl").exists()
+    events = store.read()
+    assert len(events) == 1
+    assert events[0].session_id == SYSTEM_SESSION
+    assert events[0].event == "transcript-synced"
 
 
 def test_drain_system_session_rejects_non_transcript_synced(tmp_path):

--- a/tests/test_flush_silent_paths.py
+++ b/tests/test_flush_silent_paths.py
@@ -163,7 +163,7 @@ def test_spawn_failure_emits_event(tmp_path, monkeypatch):
 
     monkeypatch.setattr("subprocess.Popen", boom)
     ok = spawn_detached_flush(buf.sidecar_path, lore_root=lore_root)
-    assert ok is False
+    assert ok is None
     errs = [
         e for e in _curator_events(lore_root) if e.get("error_code") == ErrorCode.SPAWN_FAILED.value
     ]

--- a/tests/test_heartbeat_session_drain.py
+++ b/tests/test_heartbeat_session_drain.py
@@ -27,15 +27,26 @@ def _write_legacy_system_row(lore_root: Path, *, event: str, wiki: str,
     written before the guard. The reader path must continue to handle
     them gracefully — those tests need to plant exactly that shape.
     """
-    path = lore_root / ".lore" / "drain" / "_system.jsonl"
+    # Post-#188 the drain lives on the spine; plant a raw source="drain"
+    # envelope (bypassing DrainStore.emit()'s _system guard) so the reader
+    # still surfaces a legacy system-stream drain event.
+    spine = lore_root / ".lore" / "spine.jsonl"
+    spine.parent.mkdir(parents=True, exist_ok=True)
     record = {
-        "ts": (ts or datetime.now(UTC)).isoformat(),
+        "ts": (ts or datetime.now(UTC)).isoformat().replace("+00:00", "Z"),
+        "v": 1,
+        "source": "drain",
         "event": event,
-        "wiki": wiki,
+        "level": "info",
+        "trace_id": None,
         "session_id": SYSTEM_SESSION,
+        "run_id": None,
+        "wiki": wiki,
+        "scope": None,
+        "error_code": None,
         "data": {"wikilink": wikilink},
     }
-    with path.open("a") as fp:
+    with spine.open("a") as fp:
         fp.write(json.dumps(record) + "\n")
 
 

--- a/tests/test_hooks_cross_scope.py
+++ b/tests/test_hooks_cross_scope.py
@@ -18,33 +18,49 @@ def _emit_event(lore_root: Path, event: str, wiki: str) -> None:
     if event == "transcript-synced":
         store.emit("transcript-synced", wiki=wiki, transcript_id="t")
         return
-    drain_dir = lore_root / ".lore" / "drain"
-    drain_dir.mkdir(parents=True, exist_ok=True)
+    # Post-#188 drain rows live on the spine; write a raw source="drain"
+    # envelope (bypassing the _system emit guard) so the reader sees it.
+    spine = lore_root / ".lore" / "spine.jsonl"
+    spine.parent.mkdir(parents=True, exist_ok=True)
     record = {
-        "ts": datetime.now(UTC).isoformat(),
+        "ts": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "v": 1,
+        "source": "drain",
         "event": event,
+        "level": "info",
+        "trace_id": None,
         "wiki": wiki,
         "session_id": SYSTEM_SESSION,
+        "run_id": None,
+        "scope": None,
+        "error_code": None,
         "data": {},
     }
-    path = drain_dir / f"{SYSTEM_SESSION}.jsonl"
-    with open(path, "a") as f:
+    with open(spine, "a") as f:
         f.write(json.dumps(record) + "\n")
 
 
 def _emit_old_event(lore_root: Path, event: str, wiki: str, ts: datetime) -> None:
     """Write a drain event with a specific timestamp (bypassing DrainStore.emit)."""
-    drain_dir = lore_root / ".lore" / "drain"
-    drain_dir.mkdir(parents=True, exist_ok=True)
+    # Post-#188 drain rows live on the spine; write a raw source="drain"
+    # envelope (bypassing the _system emit guard) so the reader sees it.
+    spine = lore_root / ".lore" / "spine.jsonl"
+    spine.parent.mkdir(parents=True, exist_ok=True)
     record = {
-        "ts": ts.isoformat(),
+        "ts": ts.isoformat().replace("+00:00", "Z"),
+        "v": 1,
+        "source": "drain",
         "event": event,
+        "level": "info",
+        "trace_id": None,
         "wiki": wiki,
         "session_id": SYSTEM_SESSION,
+        "run_id": None,
+        "scope": None,
+        "error_code": None,
         "data": {},
     }
-    path = drain_dir / f"{SYSTEM_SESSION}.jsonl"
-    with open(path, "a") as f:
+    with open(spine, "a") as f:
         f.write(json.dumps(record) + "\n")
 
 

--- a/tests/test_hooks_drain_banner.py
+++ b/tests/test_hooks_drain_banner.py
@@ -39,19 +39,29 @@ def _write_legacy_system_row(lore_root: Path, *, event: str, wiki: str,
     guard. The reader path keeps surfacing them so users notice
     pollution and can prune it.
     """
-    path = lore_root / ".lore" / "drain" / "_system.jsonl"
-    path.parent.mkdir(parents=True, exist_ok=True)
+    # Post-#188 the drain lives on the spine; plant a raw source="drain"
+    # envelope directly (bypassing DrainStore.emit()'s _system guard) to
+    # simulate a system-stream drain event the banner must still surface.
+    spine = lore_root / ".lore" / "spine.jsonl"
+    spine.parent.mkdir(parents=True, exist_ok=True)
     data = dict(extra)
     if wikilink is not None:
         data["wikilink"] = wikilink
     record = {
-        "ts": datetime.now(UTC).isoformat(),
+        "ts": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "v": 1,
+        "source": "drain",
         "event": event,
-        "wiki": wiki,
+        "level": "info",
+        "trace_id": None,
         "session_id": SYSTEM_SESSION,
+        "run_id": None,
+        "wiki": wiki,
+        "scope": None,
+        "error_code": None,
         "data": data,
     }
-    with path.open("a") as fp:
+    with spine.open("a") as fp:
         fp.write(json.dumps(record) + "\n")
 
 

--- a/tests/test_hooks_heartbeat.py
+++ b/tests/test_hooks_heartbeat.py
@@ -33,17 +33,25 @@ def _emit(lore_root: Path, event: str, wiki: str = "private", **data) -> None:
     if event == "transcript-synced":
         store.emit("transcript-synced", wiki=wiki, **data)
         return
-    drain_dir = lore_root / ".lore" / "drain"
-    drain_dir.mkdir(parents=True, exist_ok=True)
+    # Post-#188 drain rows live on the spine; write a raw source="drain"
+    # envelope (bypassing the _system emit guard) so the reader sees it.
+    spine = lore_root / ".lore" / "spine.jsonl"
+    spine.parent.mkdir(parents=True, exist_ok=True)
     record = {
-        "ts": datetime.now(UTC).isoformat(),
+        "ts": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "v": 1,
+        "source": "drain",
         "event": event,
+        "level": "info",
+        "trace_id": None,
         "wiki": wiki,
         "session_id": SYSTEM_SESSION,
+        "run_id": None,
+        "scope": None,
+        "error_code": None,
         "data": dict(data),
     }
-    path = drain_dir / f"{SYSTEM_SESSION}.jsonl"
-    with open(path, "a") as f:
+    with open(spine, "a") as f:
         f.write(json.dumps(record) + "\n")
 
 

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -146,6 +146,7 @@ def test_create_writes_linkage_block(tmp_path):
         "prs": [],
         "epics": [162],
         "author": "Christof Buchbender",
+        "trace_id": None,
     }
 
 

--- a/tests/test_session_note.py
+++ b/tests/test_session_note.py
@@ -125,6 +125,7 @@ def test_first_heartbeat_records_linkage_frontmatter(tmp_path):
         "prs": [],
         "epics": [],
         "author": "",
+        "trace_id": None,
     }
 
 

--- a/tests/test_trace_id.py
+++ b/tests/test_trace_id.py
@@ -1,0 +1,273 @@
+"""trace_id propagation end-to-end + drain producer on the spine (#188).
+
+One flush mints a trace_id at the spawn boundary, delivers it to the
+detached curator via an env var, and stamps it on every event the flush
+emits — curator run events, flush-state events, the drain event, and the
+published note's linkage frontmatter — so a whole flush is correlatable,
+and two concurrent flushes stay separable by trace_id.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+from lore_core import note_document as nd
+from lore_core.run_log import RunLogger
+from lore_core.spine import read_spine
+from lore_core.types import Turn
+from lore_core.wiki_config import WikiConfig
+from lore_curator.buffer_append import append_chunk
+from lore_curator.buffer_store import Buffer
+from lore_curator.chapter_flush import spawn_detached_flush, synth_and_close
+
+# ---------------------------------------------------------------------------
+# Fakes (mirrors test_chapter_flush's harness — every LLM call is stubbed)
+# ---------------------------------------------------------------------------
+
+
+class _Adapter:
+    integration = "fake"
+
+    def __init__(self, turns: list[Turn]) -> None:
+        self._turns = turns
+
+    def transcript_path_for_id(self, transcript_id: str, cwd: Path) -> Path:
+        return cwd / f"{transcript_id}.jsonl"
+
+    def read_slice(self, handle, from_index: int = 0):
+        yield from (t for t in self._turns if t.index >= from_index)
+
+
+def _lookup(adapter: _Adapter):
+    def _l(integration: str):
+        return adapter
+
+    return _l
+
+
+class _Block:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.type = "tool_use"
+        self.input = payload
+
+
+class _Resp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.content = [_Block(payload)]
+        self.model = "m"
+
+
+class _Messages:
+    def __init__(self, payloads: list[dict | None]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> _Resp:
+        self.calls.append(kwargs)
+        payload = self._payloads.pop(0) if self._payloads else {}
+        return _Resp(payload)
+
+
+class _Client:
+    def __init__(self, payloads: list[dict | None]) -> None:
+        self.messages = _Messages(payloads)
+
+
+def _chapter_payload(lead: str, body: str, anchor: int) -> dict[str, Any]:
+    return {"blocks": [{"lead": lead, "body": body, "anchor": anchor}]}
+
+
+@pytest.fixture(autouse=True)
+def _patch_collectors(monkeypatch):
+    monkeypatch.setattr("lore_curator.session_activity.collect_commits_by_sha", lambda *a, **k: [])
+    monkeypatch.setattr("lore_core.git.git_repo_root", lambda cwd: None)
+    monkeypatch.setattr("lore_core.git.current_repo", lambda cwd: "")
+
+
+def _turns(lo: int, hi: int) -> list[Turn]:
+    return [
+        Turn(index=i, timestamp=None, role="user" if i % 2 == 0 else "assistant", text=f"line {i}")
+        for i in range(lo, hi + 1)
+    ]
+
+
+def _lore_root(tmp_path: Path) -> Path:
+    (tmp_path / ".lore" / "buffers").mkdir(parents=True)
+    (tmp_path / "wiki" / "private" / "sessions").mkdir(parents=True)
+    return tmp_path
+
+
+def _append(lore_root: Path, turns: list[Turn], *, tid: str = "abc") -> Buffer:
+    outcome = append_chunk(
+        lore_root=lore_root,
+        chunk_turns=turns,
+        local_date="2026-05-01",
+        transcript_id=tid,
+        integration="fake",
+        wiki="private",
+        scope="proj:x",
+        cwd=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        cfg=WikiConfig(),
+    )
+    return outcome.buffer
+
+
+def _flush(lore_root: Path, buf: Buffer, turns: list[Turn], trace_id: str):
+    """Run a full close flush under a RunLogger carrying ``trace_id``."""
+    wiki_root = lore_root / "wiki" / "private"
+    client = _Client([_chapter_payload("Traced the flush", "prose.", turns[len(turns) // 2].index)])
+    with RunLogger(lore_root, trigger="flush", trace_id=trace_id) as logger:
+        return synth_and_close(
+            buf.sidecar_path,
+            lore_root=lore_root,
+            wiki_root=wiki_root,
+            llm_client=client,
+            model="m",
+            adapter_lookup=_lookup(_Adapter(turns)),
+            auto_commit=False,
+            logger=logger,
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC1 — mint at the spawn boundary + deliver via env var
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_mints_trace_id_and_delivers_via_env(tmp_path, monkeypatch):
+    buffer_path = tmp_path / "abc.state.json"
+    buffer_path.write_text("{}")
+    captured: dict[str, Any] = {}
+
+    class _FakePopen:
+        def __init__(self, *a, **kw):
+            captured["env"] = kw.get("env")
+
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+
+    trace_id = spawn_detached_flush(buffer_path, lore_root=tmp_path)
+    assert isinstance(trace_id, str) and trace_id
+    assert captured["env"]["LORE_TRACE_ID"] == trace_id
+
+
+def test_spawn_honours_explicit_trace_id(tmp_path, monkeypatch):
+    buffer_path = tmp_path / "def.state.json"
+    buffer_path.write_text("{}")
+    captured: dict[str, Any] = {}
+
+    class _FakePopen:
+        def __init__(self, *a, **kw):
+            captured["env"] = kw.get("env")
+
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+
+    trace_id = spawn_detached_flush(buffer_path, lore_root=tmp_path, trace_id="fixed-123")
+    assert trace_id == "fixed-123"
+    assert captured["env"]["LORE_TRACE_ID"] == "fixed-123"
+
+
+# ---------------------------------------------------------------------------
+# AC2 — tracer bullet: one flush, one trace_id on every record + the note
+# ---------------------------------------------------------------------------
+
+
+def test_one_flush_stamps_one_trace_id_across_run_drain_and_note(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    turns = _turns(0, 9)
+    buf = _append(lore_root, turns)
+    trace = "trace-tracer-bullet"
+
+    outcome = _flush(lore_root, buf, turns, trace)
+    assert outcome.status == "composed"
+
+    recs = read_spine(lore_root)
+    sources = {r["source"] for r in recs}
+    events = {r["event"] for r in recs}
+    assert "curator" in sources  # run + flush-state events
+    assert "drain" in sources  # note-filed drain event
+    assert "run-start" in events
+    assert {"note-filed", "note-appended"} & events
+
+    # Every record this flush emitted carries the SAME trace_id.
+    assert recs, "no spine records emitted"
+    for r in recs:
+        assert r["trace_id"] == trace, (
+            f"{r['source']}/{r['event']} lost trace_id: {r['trace_id']!r}"
+        )
+
+    # The published note carries the id that produced it.
+    view = nd.read_note(outcome.note_path)
+    assert view.frontmatter["linkage"]["trace_id"] == trace
+
+
+# ---------------------------------------------------------------------------
+# AC3 — drain producer emits through the spine (source="drain")
+# ---------------------------------------------------------------------------
+
+
+def test_drain_event_is_a_spine_record_not_a_legacy_file(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    turns = _turns(0, 9)
+    buf = _append(lore_root, turns)
+    _flush(lore_root, buf, turns, "trace-drain")
+
+    drain_recs = read_spine(lore_root, source="drain")
+    assert drain_recs, "drain event never reached the spine"
+    assert all(r["source"] == "drain" for r in drain_recs)
+    # The legacy per-session drain jsonl writer is gone.
+    assert not list((lore_root / ".lore" / "drain").glob("*.jsonl"))
+
+
+# ---------------------------------------------------------------------------
+# AC4 — a failed drain write degrades without raising and leaves a marker
+# ---------------------------------------------------------------------------
+
+
+def test_drain_write_failure_degrades_with_marker(tmp_path):
+    from lore_core.drain import DrainStore
+
+    lore_dir = tmp_path / ".lore"
+    lore_dir.mkdir(parents=True)
+    # Make the spine path a directory so O_WRONLY opens fail loudly.
+    (lore_dir / "spine.jsonl").mkdir()
+
+    DrainStore(tmp_path, "s1").emit("note-filed", wiki="w", path="/x")  # must not raise
+    assert (lore_dir / "spine-failed.marker").exists()
+
+
+# ---------------------------------------------------------------------------
+# AC5 — two interleaved flushes stay separable by trace_id
+# ---------------------------------------------------------------------------
+
+
+def test_two_flushes_are_separable_by_trace_id(tmp_path):
+    lore_root = _lore_root(tmp_path)
+    t1, t2 = _turns(0, 9), _turns(0, 9)
+    buf1 = _append(lore_root, t1, tid="sess-one")
+    buf2 = _append(lore_root, t2, tid="sess-two")
+
+    _flush(lore_root, buf1, t1, "trace-ONE")
+    _flush(lore_root, buf2, t2, "trace-TWO")
+
+    recs = read_spine(lore_root)
+    # No record leaks a null trace_id — both flushes fully stamped.
+    assert all(r["trace_id"] in {"trace-ONE", "trace-TWO"} for r in recs)
+
+    # run_ids partition cleanly: each run_id belongs to exactly one trace.
+    run_to_traces: dict[str, set[str]] = defaultdict(set)
+    for r in recs:
+        if r["run_id"] is not None:
+            run_to_traces[r["run_id"]].add(r["trace_id"])
+    assert run_to_traces, "no run_id-bearing records"
+    assert all(len(traces) == 1 for traces in run_to_traces.values())
+
+    # Each trace has its own drain note event.
+    drain_by_trace = defaultdict(list)
+    for r in read_spine(lore_root, source="drain"):
+        drain_by_trace[r["trace_id"]].append(r)
+    assert set(drain_by_trace) == {"trace-ONE", "trace-TWO"}


### PR DESCRIPTION
Closes #188.

## What

Threads one `trace_id` through a whole flush and migrates the drain producer onto the unified event spine.

**trace_id, hook fire → note.** `spawn_detached_flush` mints a `trace_id` at the process boundary and delivers it to the detached curator via the `LORE_TRACE_ID` env var. The child `lore curator flush` reads it into its `RunLogger`, which now carries the id and stamps it on every emit. From there it flows to the flush-state machine (`FlushStore.begin(trace_id=...)`), the drain event, and the published note's `linkage` frontmatter — so a whole flush is correlatable, and two concurrent flushes stay separable by `trace_id`.

**drain onto the spine.** `DrainStore` now emits through `SpineWriter` (`source="drain"`) and reads back via `read_spine`; the legacy per-session `.lore/drain/<sid>.jsonl` writer is deleted and `lore news` reads the spine (through `DrainStore.read`). The `.lore/drain/` dir now holds only the news cursor files. A failed drain write degrades without raising **and** leaves the `spine-failed.marker` — a swallowed write is no longer invisible.

`run_log.py` already carried a `trace_id=None  # #188 stamps this` placeholder (from #189); this fills it in. Same for `flush_store.FlushRecord.trace_id`.

## Acceptance criteria → tests (`tests/test_trace_id.py`)

1. Minted at the spawn boundary, delivered via env var → `test_spawn_mints_trace_id_and_delivers_via_env`, `test_spawn_honours_explicit_trace_id`
2. Every run + drain event of one flush shares the id, incl. the note's linkage frontmatter → `test_one_flush_stamps_one_trace_id_across_run_drain_and_note` (the tracer bullet)
3. Drain emits through the spine (`source="drain"`), legacy writer gone → `test_drain_event_is_a_spine_record_not_a_legacy_file`
4. Drain write failure degrades without raising + leaves the marker → `test_drain_write_failure_degrades_with_marker`
5. Two interleaved flushes separable by `trace_id` → `test_two_flushes_are_separable_by_trace_id`

## Red → green

Tracer bullet written first; all six failed red on the missing surface, then passed once threaded:

```
# RED (before implementation)
RunLogger.__init__() got an unexpected keyword argument 'trace_id'
spawn_detached_flush() got an unexpected keyword argument 'trace_id'
assert False   # spine-failed.marker not created (drain still wrote a legacy .jsonl)
6 failed in 0.48s

# GREEN
6 passed in 0.48s
```

Full suite: **2790 passed**, 16 skipped, **11 failed** — all 11 are the pre-existing ANSI-color CliRunner failures on `epic/183` (in `test_cli_scopes`, `test_core_llm_wiring`, `test_drain_prune`, `test_install_dispatcher`, `test_log_cmd`, `test_proc_cmd` — none touched by this PR). Zero new failures.

## Decisions

- **RunLogger is the in-child carrier.** The child reads `LORE_TRACE_ID` once into the `RunLogger`; `flush_chapter` reads `logger.trace_id` to stamp the flush record, linkage, and drain event. One read, one source, minimal threading — no new param on the flush call chain.
- **`DrainStore` kept as a thin spine adapter.** Only the writer changed; producers (`session_curator`, `chapter_flush`, `transcript_sync`) and `lore news` keep their call shapes, so the migration is a small diff. The `_system` guard and cursor logic are unchanged.
- **`spawn_detached_flush` now returns `str | None`** (trace_id / skipped-or-failed) instead of `bool`; truthiness is preserved for existing callers (`reaper`, `session_curator`), and `session_curator` now stamps the spawned flush's id on its `flush-spawned` breadcrumb.
- **No per-record size cap on drain** (was `MAX_DRAIN_LINE` truncation). Drain producers only ever pass bounded metadata; a `ponytail:` note marks the truncate-in-adapter upgrade path if a large-payload producer ever appears.
- **Legacy `_system.jsonl` rows are no longer surfaced** post-migration (they become `lore drain prune`/#190's cleanup target). Banner/heartbeat/cross-scope tests that planted raw legacy rows were repointed to plant raw spine envelopes, preserving their rendering coverage.

## Boundaries

Did not touch `run_retention.py`, `drain_cmd.py`, `_crash_log.py`, or spine rotation (sibling #190). `note_document.py` gained `trace_id` on the existing deterministic `linkage` block (PRD 0004 / #175), extending it rather than adding a parallel block.
