### PR TITLE
feat: unified retention janitor with tiered, visible policy (#190)

### DIFF
--- a/lib/lore_cli/_crash_log.py
+++ b/lib/lore_cli/_crash_log.py
@@ -108,3 +108,58 @@ def recent_crashes(within_days: int = 7) -> list[Path]:
         return []
     out.sort(key=lambda t: t[0], reverse=True)
     return [p for _, p in out]
+
+
+def purge_old_crashes(within_days: int, *, lore_root: Path | None = None) -> tuple[int, int]:
+    """Delete crash logs older than ``within_days``. Returns (deleted, failed).
+
+    Crash logs live under the global ``$LORE_CACHE``, not a specific
+    ``lore_root`` — so a caller without a resolved root still gets the
+    deletion (pure best-effort, matching :func:`write_crash`'s degrade
+    contract) but no spine visibility, since there's nowhere to log it.
+    With ``lore_root``, every deletion/failure is a ``source="janitor"``
+    spine event (issue #190) — crash logs no longer accumulate silently.
+    """
+    cdir = _crash_dir()
+    if not cdir.exists():
+        return 0, 0
+    cutoff = datetime.now(UTC).timestamp() - within_days * 86400
+    writer = None
+    if lore_root is not None:
+        from lore_core.spine import SpineWriter
+
+        writer = SpineWriter(lore_root)
+
+    deleted = 0
+    failed = 0
+    try:
+        candidates = [p for p in cdir.iterdir() if p.is_file() and p.name.endswith(".log")]
+    except OSError:
+        return 0, 0
+    for p in candidates:
+        try:
+            mtime = p.stat().st_mtime
+            size = p.stat().st_size
+        except OSError:
+            continue
+        if mtime >= cutoff:
+            continue
+        try:
+            p.unlink()
+            deleted += 1
+            if writer is not None:
+                writer.emit(
+                    source="janitor",
+                    event="retention-delete",
+                    data={"family": "crash-log", "path": p.name, "bytes": size},
+                )
+        except OSError as exc:
+            failed += 1
+            if writer is not None:
+                writer.emit(
+                    source="janitor",
+                    event="retention-delete-failed",
+                    level="warn",
+                    data={"family": "crash-log", "path": p.name, "error": str(exc)},
+                )
+    return deleted, failed

--- a/lib/lore_cli/_janitor_entry.py
+++ b/lib/lore_cli/_janitor_entry.py
@@ -1,0 +1,36 @@
+"""Opportunistic entry point for the retention janitor (issue #190).
+
+``lore_core.janitor.run_janitor`` covers everything scoped to one
+``lore_root/.lore/`` (spine tiers, run-archival, flush store); this
+composer adds the two families that live outside that layering — crash
+logs under the global ``$LORE_CACHE`` (``lore_cli._crash_log``) and drain
+orphan pruning (``lore_cli.drain_cmd``, owned by the CLI layer) — and is
+what hook fire / curator run end actually call.
+
+Best-effort like every other opportunistic hook-path call
+(``_gc_sessions_cache`` is the existing precedent): never raises, so a
+janitor bug can't take down a hook or a curator run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def run_opportunistic_janitor(lore_root: Path) -> None:
+    try:
+        from lore_core.janitor import run_janitor
+        from lore_core.root_config import load_root_config
+
+        cfg = load_root_config(lore_root)
+        run_janitor(lore_root, cfg.observability)
+
+        from lore_cli._crash_log import purge_old_crashes
+
+        purge_old_crashes(cfg.observability.retention.crash_log_days, lore_root=lore_root)
+
+        from lore_cli.drain_cmd import prune_orphans
+
+        prune_orphans(lore_root)
+    except Exception:
+        pass

--- a/lib/lore_cli/curator_cmd.py
+++ b/lib/lore_cli/curator_cmd.py
@@ -281,6 +281,15 @@ def flush_command(
             logger=logger,
         )
 
+    # Opportunistic retention sweep (#190) at curator-run end — flock-guarded,
+    # daemon-free; a contended lock just skips this cycle.
+    try:
+        from lore_cli._janitor_entry import run_opportunistic_janitor
+
+        run_opportunistic_janitor(lore_root)
+    except Exception:  # noqa: BLE001 - janitor must never crash a flush run
+        pass
+
     console.print(
         f"[bold]flush[/bold] {outcome.buffer_stem} — "
         f"phase1={'ok' if outcome.phase1_completed else 'skipped'}, "

--- a/lib/lore_cli/drain_cmd.py
+++ b/lib/lore_cli/drain_cmd.py
@@ -5,6 +5,8 @@ Today the only subcommand is ``prune``, which drops orphan rows from
 append-only by design; ``prune`` is the explicit escape hatch for
 cleanup. The producer-side guard in ``DrainStore.emit()`` (Change C)
 prevents new pollution; ``prune`` excises legacy rows that predate it.
+The retention janitor (#190) folds this into its opportunistic sweep too
+— :func:`prune_orphans` is the shared core both callers use.
 
 Scope is intentionally narrow:
 
@@ -24,14 +26,16 @@ from __future__ import annotations
 import json
 import os
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import typer
+from lore_core.drain import SYSTEM_SESSION
+from lore_core.spine import SpineWriter
 from rich.console import Console
 from rich.markup import escape
 
 from lore_cli._argv_compat import argv_main
-from lore_core.drain import SYSTEM_SESSION
 
 console = Console()
 err_console = Console(stderr=True)
@@ -79,18 +83,35 @@ def _is_orphan_row(obj: dict) -> bool:
     return not Path(path).exists()
 
 
-@app.command("prune", help="Drop orphan rows from `_system.jsonl`.")
-def cmd_prune(
-    dry_run: bool = typer.Option(
-        False, "--dry-run", help="Report what would be dropped without rewriting.",
-    ),
-) -> None:
-    """Walk `_system.jsonl`; drop note-style rows whose `data.path` is gone."""
-    lore_root = _lore_root_or_die()
+@dataclass
+class PruneResult:
+    """Outcome of one :func:`prune_orphans` pass."""
+
+    file_existed: bool = False
+    dropped: list[dict] = field(default_factory=list)
+    applied: bool = False  # True iff the file was actually rewritten
+    failed: bool = False
+    error: str | None = None
+
+    @property
+    def dropped_count(self) -> int:
+        return len(self.dropped)
+
+
+def prune_orphans(lore_root: Path, *, dry_run: bool = False) -> PruneResult:
+    """Drop `_system.jsonl` rows whose referenced note is gone.
+
+    Shared core for ``lore drain prune`` and the retention janitor's
+    opportunistic sweep (#190) — folding orphan pruning into the janitor's
+    policy means it no longer requires a manual invocation to happen.
+    A non-dry-run pass that actually drops rows emits ONE aggregate
+    ``source="janitor"`` spine event (not one per row — the drain itself
+    already narrated each note's own event); a write failure emits a warn
+    event instead of the caller silently losing it.
+    """
     target = lore_root / ".lore" / "drain" / f"{SYSTEM_SESSION}.jsonl"
     if not target.exists():
-        console.print("[dim]nothing to prune (no _system.jsonl)[/dim]")
-        return
+        return PruneResult(file_existed=False)
 
     survivors: list[str] = []
     dropped: list[dict] = []
@@ -110,22 +131,9 @@ def cmd_prune(
                 continue
             survivors.append(line)
 
-    if not dropped:
-        console.print("[dim]nothing to prune[/dim]")
-        return
-
-    if dry_run:
-        console.print(
-            f"[yellow]would prune {len(dropped)} orphan row"
-            f"{'s' if len(dropped) != 1 else ''}[/yellow]"
-        )
-        for obj in dropped:
-            wikilink = (obj.get("data") or {}).get("wikilink", "?")
-            path = (obj.get("data") or {}).get("path", "?")
-            console.print(
-                f"  · {escape(str(wikilink))} [dim](path: {escape(str(path))})[/dim]"
-            )
-        return
+    result = PruneResult(file_existed=True, dropped=dropped)
+    if not dropped or dry_run:
+        return result
 
     # Atomic rewrite: write the survivors, fsync, replace.
     tmp = target.with_suffix(".jsonl.tmp")
@@ -137,16 +145,66 @@ def cmd_prune(
             os.fsync(out.fileno())
         os.replace(tmp, target)
     except OSError as exc:
-        err_console.print(f"[red]prune failed: {exc}[/red]")
         try:
             tmp.unlink()
         except OSError:
             pass
+        result.failed = True
+        result.error = str(exc)
+        SpineWriter(lore_root).emit(
+            source="janitor",
+            event="retention-delete-failed",
+            level="warn",
+            data={"family": "drain-orphans", "error": str(exc)},
+        )
+        return result
+
+    result.applied = True
+    SpineWriter(lore_root).emit(
+        source="janitor",
+        event="retention-delete",
+        data={"family": "drain-orphans", "dropped": len(dropped)},
+    )
+    return result
+
+
+@app.command("prune", help="Drop orphan rows from `_system.jsonl`.")
+def cmd_prune(
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Report what would be dropped without rewriting.",
+    ),
+) -> None:
+    """Walk `_system.jsonl`; drop note-style rows whose `data.path` is gone."""
+    lore_root = _lore_root_or_die()
+    result = prune_orphans(lore_root, dry_run=dry_run)
+
+    if not result.file_existed:
+        console.print("[dim]nothing to prune (no _system.jsonl)[/dim]")
+        return
+    if not result.dropped:
+        console.print("[dim]nothing to prune[/dim]")
+        return
+
+    if dry_run:
+        console.print(
+            f"[yellow]would prune {result.dropped_count} orphan row"
+            f"{'s' if result.dropped_count != 1 else ''}[/yellow]"
+        )
+        for obj in result.dropped:
+            wikilink = (obj.get("data") or {}).get("wikilink", "?")
+            path = (obj.get("data") or {}).get("path", "?")
+            console.print(
+                f"  · {escape(str(wikilink))} [dim](path: {escape(str(path))})[/dim]"
+            )
+        return
+
+    if result.failed:
+        err_console.print(f"[red]prune failed: {result.error}[/red]")
         raise typer.Exit(1)
 
-    noun = "row" if len(dropped) == 1 else "rows"
-    console.print(f"[green]pruned {len(dropped)} orphan {noun}[/green]")
-    for obj in dropped:
+    noun = "row" if result.dropped_count == 1 else "rows"
+    console.print(f"[green]pruned {result.dropped_count} orphan {noun}[/green]")
+    for obj in result.dropped:
         wikilink = (obj.get("data") or {}).get("wikilink", "?")
         console.print(f"  · {escape(str(wikilink))}")
 

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -1272,6 +1272,16 @@ def cmd_session_start(
         except Exception:  # noqa: BLE001 — pull must never crash SessionStart
             auto_pull_warning = None
 
+    # Opportunistic retention sweep (#190) — flock-guarded, daemon-free; a
+    # contended lock just skips this cycle, the next SessionStart retries.
+    if scope is not None and lore_root is not None and not probe:
+        try:
+            from lore_cli._janitor_entry import run_opportunistic_janitor
+
+            run_opportunistic_janitor(lore_root)
+        except Exception:  # noqa: BLE001 - janitor must never crash SessionStart
+            pass
+
     # Buffer-and-flush handover-poll: when a sibling session ended
     # mid-flush, wait briefly for ``state=closed`` so the resulting
     # wikilink lands in this SessionStart's context rather than only in

--- a/lib/lore_core/flush_store.py
+++ b/lib/lore_core/flush_store.py
@@ -140,6 +140,14 @@ class FlushRecord:
         return cls(**known)
 
 
+@dataclass
+class PurgeResult:
+    """Outcome of one :meth:`FlushStore.purge` pass."""
+
+    deleted: int = 0
+    failed: int = 0
+
+
 def is_retry_due(rec: FlushRecord, *, now: datetime | None = None) -> bool:
     """True when a queued record's backoff has elapsed (retry may proceed)."""
     if FlushState(rec.state) is not FlushState.QUEUED:
@@ -273,6 +281,75 @@ class FlushStore:
         level = "error" if to is FlushState.DEAD_LETTERED else "info"
         self._emit(rec, level=level)
         return rec
+
+    # -- retention (issue #190) ---------------------------------------------
+    def purge(self, *, terminal_max_age_days: float, dead_letter_hard_cap: int) -> PurgeResult:
+        """Delete resolved records past their window; cap unresolved ones.
+
+        PUBLISHED/WITHHELD are resolved — deleted once older than
+        ``terminal_max_age_days`` (by ``updated_at``). DEAD_LETTERED is
+        exempt from the age window (a human still needs to act on it) but
+        capped by count: beyond ``dead_letter_hard_cap`` the oldest are
+        dropped so a permanently-stuck pipeline can't grow the store
+        forever. QUEUED/RUNNING (in-flight) are never touched here — that's
+        the flush pipeline's job, not retention's.
+        """
+        result = PurgeResult()
+        writer = SpineWriter(self._lore_root)
+        now = _now()
+
+        terminal_ok = (FlushState.PUBLISHED, FlushState.WITHHELD)
+        for rec in self.list():
+            state = FlushState(rec.state)
+            if state not in terminal_ok:
+                continue
+            updated = _parse_iso(rec.updated_at)
+            age_days = (now - updated).total_seconds() / 86400 if updated else 0
+            if age_days > terminal_max_age_days:
+                self._purge_one(rec, writer=writer, result=result)
+
+        dead = sorted(self.list(state=FlushState.DEAD_LETTERED), key=lambda r: r.updated_at)
+        overflow = len(dead) - dead_letter_hard_cap
+        for rec in dead[: max(overflow, 0)]:
+            self._purge_one(rec, writer=writer, result=result)
+
+        return result
+
+    def _purge_one(self, rec: FlushRecord, *, writer: SpineWriter, result: PurgeResult) -> None:
+        path = self._path(rec.flush_id)
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = 0
+        with flocked(self._lock_path(rec.flush_id)):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                result.failed += 1
+                writer.emit(
+                    source="janitor",
+                    event="retention-delete-failed",
+                    level="warn",
+                    trace_id=rec.trace_id,
+                    wiki=rec.wiki or None,
+                    data={"family": "flush-record", "flush_id": rec.flush_id, "error": str(exc)},
+                )
+                return
+        result.deleted += 1
+        writer.emit(
+            source="janitor",
+            event="retention-delete",
+            trace_id=rec.trace_id,
+            wiki=rec.wiki or None,
+            data={
+                "family": "flush-record",
+                "flush_id": rec.flush_id,
+                "bytes": size,
+                "state": rec.state,
+            },
+        )
 
     def record_failure(self, rec: FlushRecord, *, error_code: ErrorCode) -> FlushRecord:
         """Register a failed run: schedule a backed-off retry, or dead-letter.

--- a/lib/lore_core/janitor.py
+++ b/lib/lore_core/janitor.py
@@ -1,0 +1,200 @@
+"""Unified retention janitor (issue #190).
+
+One flock-guarded sweep enforces tiered retention across the event spine
+and the flush record store, replacing the old inconsistent per-family
+behavior (10 MB hook rotation, count+MB run caps with swallowed delete
+errors, append-forever drain, soft-hidden crash logs). Runs
+opportunistically from hook fire / curator run end (see
+``lore_cli._janitor_entry``) — no daemon.
+
+Tiers, per spine file:
+
+* **hot** — the live ``spine.jsonl``: detailed events, short window
+  (default 7 days). An age or (currently-configured) size overage
+  triggers a downgrade: rotate hot -> cold (reuses
+  :meth:`SpineWriter.janitor_rotate_if_due`, itself sharing the rotation
+  flock with the size-triggered rotation ``emit()`` does inline).
+* **cold** — the rotated ``spine.jsonl.1``: the retained window before
+  deletion (default 30 days) with an independent size cap. No tier below
+  cold — an overage deletes the file outright.
+
+.. note::
+    This is file-level tiering, not per-record compaction: a "downgrade"
+    moves the whole file, it doesn't strip fields to shrink individual
+    records. Compacting cold-tier records into denser summaries is a
+    plausible future slice; nothing here depends on it.
+
+Legacy run-archival files and crash logs are separate families with their
+own age/count windows (see :mod:`lore_core.run_retention` and
+``lore_cli._crash_log``); this module composes run-archival + the flush
+store's dead-letter/terminal purge under ONE lock since both live under
+``lore_root/.lore/``. Crash-log purge and drain-orphan pruning are
+independently safe under light concurrency (atomic replace / tolerant of
+FileNotFoundError) so they're composed alongside this, not inside the same
+critical section — see ``lore_cli._janitor_entry.run_opportunistic_janitor``.
+
+Every deletion and tier-downgrade emits a ``source="janitor"`` spine event;
+a delete failure emits a warn-level event instead of failing silently.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lore_core.flush_store import FlushStore
+from lore_core.lockfile import flocked
+from lore_core.root_config import ObservabilityConfig
+from lore_core.run_retention import enforce_retention
+from lore_core.spine import SpineWriter
+
+
+@dataclass
+class JanitorReport:
+    """Outcome of one :func:`run_janitor` pass."""
+
+    ran: bool = True  # False iff the lock was contended
+    hot_bytes: int = 0
+    cold_bytes: int = 0
+    deleted: int = 0
+    downgraded: bool = False
+    failed: int = 0
+
+
+@contextmanager
+def janitor_lock(lore_root: Path):
+    """Non-blocking sibling-flock guarding one janitor pass at a time.
+
+    Yields ``True`` iff acquired. A contended lock means another sweep is
+    already running — the caller skips this cycle; the next opportunistic
+    trigger retries. No stale-lock recovery needed: flock releases on
+    process exit (see ``lore_core.lockfile.flocked``).
+    """
+    with flocked(lore_root / ".lore" / "janitor.lock", blocking=False) as held:
+        yield held
+
+
+def run_janitor(lore_root: Path, cfg: ObservabilityConfig) -> JanitorReport:
+    """Enforce tiered retention across the spine + flush store. Never raises.
+
+    Self-contained critical section: acquires :func:`janitor_lock`, sweeps
+    the hot/cold spine tiers, the legacy run-archival family, and the
+    flush store's terminal/dead-letter purge, then persists the queryable
+    usage snapshot (see :func:`read_janitor_status`).
+    """
+    with janitor_lock(lore_root) as held:
+        if not held:
+            return JanitorReport(ran=False)
+
+        report = JanitorReport()
+        writer = SpineWriter(lore_root)
+        lore_dir = lore_root / ".lore"
+        hot = lore_dir / "spine.jsonl"
+        cold = lore_dir / "spine.jsonl.1"
+
+        # Hot -> cold: age or the currently-configured size cap.
+        if SpineWriter(lore_root).janitor_rotate_if_due(
+            max_age_days=cfg.retention.hot_days,
+            max_size_mb=cfg.hook_events.max_size_mb,
+        ):
+            report.downgraded = True
+
+        # Cold tier: age or size cap deletes it outright — no tier below.
+        if cold.exists():
+            _maybe_delete_cold(cold, cfg, writer=writer, report=report)
+
+        # Legacy run-archival files (pre-migration; RunLogger no longer
+        # writes here — see run_log.py). Already emits its own events.
+        enforce_retention(
+            lore_root,
+            keep=cfg.runs.keep,
+            max_total_mb=cfg.runs.max_total_mb,
+            keep_trace=cfg.runs.keep_trace,
+        )
+
+        # Flush store: terminal records age out, dead letters survive
+        # unless over the hard cap. Already emits its own events.
+        purge_result = FlushStore(lore_root).purge(
+            terminal_max_age_days=cfg.retention.cold_days,
+            dead_letter_hard_cap=cfg.retention.dead_letter_hard_cap,
+        )
+        report.deleted += purge_result.deleted
+        report.failed += purge_result.failed
+
+        report.hot_bytes = _size_or_zero(hot)
+        report.cold_bytes = _size_or_zero(cold)
+        _write_status(lore_root, report)
+        return report
+
+
+def _maybe_delete_cold(
+    cold: Path, cfg: ObservabilityConfig, *, writer: SpineWriter, report: JanitorReport
+) -> None:
+    try:
+        size = cold.stat().st_size
+        age_days = (time.time() - cold.stat().st_mtime) / 86400
+    except OSError:
+        return
+    over_age = age_days > cfg.retention.cold_days
+    over_size = size > cfg.retention.cold_max_mb * 1024 * 1024
+    if not (over_age or over_size):
+        return
+    try:
+        cold.unlink()
+        report.deleted += 1
+        writer.emit(
+            source="janitor",
+            event="retention-delete",
+            data={"family": "spine-cold", "path": cold.name, "bytes": size},
+        )
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        report.failed += 1
+        writer.emit(
+            source="janitor",
+            event="retention-delete-failed",
+            level="warn",
+            data={"family": "spine-cold", "path": cold.name, "error": str(exc)},
+        )
+
+
+def _size_or_zero(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _write_status(lore_root: Path, report: JanitorReport) -> None:
+    status_path = lore_root / ".lore" / "janitor-status.json"
+    payload = {
+        "last_run_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "hot_bytes": report.hot_bytes,
+        "cold_bytes": report.cold_bytes,
+        "deleted": report.deleted,
+        "failed": report.failed,
+    }
+    try:
+        status_path.parent.mkdir(parents=True, exist_ok=True)
+        status_path.write_text(json.dumps(payload))
+    except OSError:
+        pass
+
+
+def read_janitor_status(lore_root: Path) -> dict | None:
+    """Pure read of the last janitor pass's usage snapshot.
+
+    Returns None when the janitor has never run or the status file is
+    missing/corrupt — callers (``lore status``, #193) treat that as "no
+    data yet", not an error.
+    """
+    status_path = lore_root / ".lore" / "janitor-status.json"
+    try:
+        return json.loads(status_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None

--- a/lib/lore_core/root_config.py
+++ b/lib/lore_core/root_config.py
@@ -41,9 +41,35 @@ class ProcConfig:
 
 
 @dataclass
+class RetentionConfig:
+    """Tiered janitor policy for the event spine + adjacent log families
+    (issue #190).
+
+    Hot tier = the live ``spine.jsonl`` (detailed events); size cap is
+    ``hook_events.max_size_mb`` (single source of truth, not duplicated
+    here). Cold tier = the rotated ``spine.jsonl.1`` — a hot->cold
+    downgrade (age- or size-triggered) moves data there; ``cold_days`` /
+    ``cold_max_mb`` bound how long it survives before outright deletion
+    (there is no tier below cold).
+
+    ``crash_log_days`` bounds ``$LORE_CACHE/crashes/``. ``dead_letter_hard_cap``
+    is the escape valve for flush dead letters: unresolved dead letters are
+    exempt from normal age-based retention (a human needs to see them) but
+    a permanently-stuck pipeline still can't grow the store forever.
+    """
+
+    hot_days: int = 7
+    cold_days: int = 30
+    cold_max_mb: int = 20
+    crash_log_days: int = 30
+    dead_letter_hard_cap: int = 50
+
+
+@dataclass
 class ObservabilityConfig:
     hook_events: HookEventsConfig = field(default_factory=HookEventsConfig)
     runs: RunsConfig = field(default_factory=RunsConfig)
+    retention: RetentionConfig = field(default_factory=RetentionConfig)
     proc: ProcConfig = field(default_factory=ProcConfig)
 
 

--- a/lib/lore_core/run_retention.py
+++ b/lib/lore_core/run_retention.py
@@ -1,23 +1,47 @@
-"""Lazy retention cleanup for run logs.
+"""Legacy run-archival retention — one family the unified janitor (#190)
+enforces (see lore_core.janitor).
 
-Invoked at the end of each Curator run (from RunLogger.__exit__).
-Best-effort — never raises; skips files that fail to unlink.
+RunLogger no longer writes ``.lore/runs/*.jsonl`` (curator runs live on the
+event spine, see run_log.py), so this only cleans up pre-migration archives
+that may still be on disk. Deletions and delete failures are logged onto
+the spine (source="janitor") instead of the old silent-swallow — see
+:func:`_safe_unlink`. Still best-effort: never raises.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+from lore_core.spine import SpineWriter
 
-def _safe_unlink(path: Path) -> bool:
-    """Return True iff path was deleted (or already gone)."""
+
+def _safe_unlink(path: Path, *, writer: SpineWriter, family: str) -> bool:
+    """Delete ``path``, logging the outcome onto the spine. Return True iff
+    deleted (or already gone). Never raises — a failure emits a warn event
+    instead of being swallowed silently.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = 0
     try:
         path.unlink()
+        writer.emit(
+            source="janitor",
+            event="retention-delete",
+            data={"family": family, "path": path.name, "bytes": size},
+        )
         return True
     except FileNotFoundError:
         return True
-    except OSError:
+    except OSError as exc:
         # Windows: open files raise PermissionError. POSIX: perms.
+        writer.emit(
+            source="janitor",
+            event="retention-delete-failed",
+            level="warn",
+            data={"family": family, "path": path.name, "error": str(exc)},
+        )
         return False
 
 
@@ -33,6 +57,8 @@ def enforce_retention(
     if not runs.exists():
         return
 
+    writer = SpineWriter(lore_root)
+
     try:
         from lore_core.run_reader import list_archival_runs
         archival = list_archival_runs(lore_root)
@@ -40,14 +66,17 @@ def enforce_retention(
     except OSError:
         return
 
+    def _unlink(path: Path) -> bool:
+        return _safe_unlink(path, writer=writer, family="run-archival")
+
     # 1) Count cap on archival (delete oldest first).
     while len(archival) > keep:
         victim = archival[0]
-        if _safe_unlink(victim):
+        if _unlink(victim):
             archival.pop(0)
             trace_sibling = runs / (victim.stem + ".trace.jsonl")
             if trace_sibling.exists():
-                _safe_unlink(trace_sibling)
+                _unlink(trace_sibling)
                 if trace_sibling in trace:
                     trace.remove(trace_sibling)
         else:
@@ -67,11 +96,11 @@ def enforce_retention(
 
     while archival and _total() > max_bytes:
         victim = archival[0]
-        if _safe_unlink(victim):
+        if _unlink(victim):
             archival.pop(0)
             trace_sibling = runs / (victim.stem + ".trace.jsonl")
             if trace_sibling.exists():
-                _safe_unlink(trace_sibling)
+                _unlink(trace_sibling)
                 if trace_sibling in trace:
                     trace.remove(trace_sibling)
         else:
@@ -83,14 +112,14 @@ def enforce_retention(
     for t in trace:
         stem = t.name[: -len(".trace.jsonl")]
         if stem not in archival_stems:
-            _safe_unlink(t)
+            _unlink(t)
         else:
             trace_live.append(t)
 
     # 4) Trace cap.
     while len(trace_live) > keep_trace:
         victim = trace_live[0]
-        if _safe_unlink(victim):
+        if _unlink(victim):
             trace_live.pop(0)
         else:
             break

--- a/lib/lore_core/spine.py
+++ b/lib/lore_core/spine.py
@@ -123,6 +123,30 @@ def new_trace_id() -> str:
     return secrets.token_hex(8)
 
 
+def _oldest_record_age_days(path: Path) -> float | None:
+    """Age in days of the first record's ``ts``, or None if unreadable.
+
+    Only the first line is read — cheap enough for the janitor's
+    opportunistic per-hook check even on a multi-MB spine file.
+    """
+    try:
+        with path.open("r") as f:
+            first = f.readline()
+    except OSError:
+        return None
+    first = first.strip()
+    if not first:
+        return None
+    try:
+        rec = json.loads(first)
+        ts = datetime.fromisoformat(str(rec["ts"]).replace("Z", "+00:00"))
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - ts).total_seconds() / 86400
+
+
 class SpineWriter:
     """Single-record appender for the event spine. Never raises.
 
@@ -187,21 +211,57 @@ class SpineWriter:
             return
         if size < self._max_size:
             return
-        # Non-blocking flock — loser skips rotation this cycle.
+        self._rotate_locked(due=lambda: self._over_size(self._max_size))
+
+    def janitor_rotate_if_due(self, *, max_age_days: float, max_size_mb: float) -> bool:
+        """Force a hot->cold downgrade if age or the CURRENT config's size
+        cap is exceeded. Returns True iff a rotation happened.
+
+        Used by the retention janitor (#190), distinct from the size-only
+        trigger baked into ``emit()`` at construction time: re-checking
+        against live config here means a user who tightens
+        ``observability.hook_events.max_size_mb`` gets it enforced on the
+        next opportunistic pass, and a low-traffic spine that never trips
+        the size cap still ages out of the hot tier.
+        """
+        max_bytes = max_size_mb * 1024 * 1024
+
+        def _due() -> bool:
+            if self._over_size(max_bytes):
+                return True
+            oldest = _oldest_record_age_days(self._path)
+            return oldest is not None and oldest > max_age_days
+
+        if not self._path.exists() or not _due():
+            return False
+        return self._rotate_locked(due=_due)
+
+    def _over_size(self, max_bytes: float) -> bool:
+        try:
+            return self._path.stat().st_size >= max_bytes
+        except OSError:
+            return False
+
+    def _rotate_locked(self, *, due) -> bool:
+        """Rename hot -> cold under the rotation flock. Returns True iff
+        this call performed the rotation.
+
+        ``due`` is re-evaluated *after* the lock is held — a TOCTOU guard:
+        the caller's outer check can go stale between "size looked over
+        cap" and "lock acquired" if another writer rotated (and a fresh,
+        small file was recreated) in between. A contended/lost race also
+        yields False — the loser skips, matching ``emit()``'s semantics.
+        """
         from lore_core.lockfile import flocked
 
         try:
             with flocked(self._rotate_lock, blocking=False) as held:
-                if not held:
-                    return
-                try:
-                    if self._path.stat().st_size < self._max_size:
-                        return
-                except OSError:
-                    return
+                if not held or not self._path.exists() or not due():
+                    return False
                 os.replace(self._path, self._rotated)
+                return True
         except OSError:
-            pass
+            return False
 
     def _touch_marker(self) -> None:
         try:

--- a/tests/test_crash_log.py
+++ b/tests/test_crash_log.py
@@ -40,9 +40,7 @@ def _disable_dev_filter(monkeypatch):
     But these tests are exactly the ones that exercise the write
     path, so they need to opt out.
     """
-    monkeypatch.setattr(
-        "lore_cli._crash_log._is_dev_invocation", lambda: False
-    )
+    monkeypatch.setattr("lore_cli._crash_log._is_dev_invocation", lambda: False)
 
 
 def test_write_crash_persists_traceback(tmp_path, monkeypatch):
@@ -74,9 +72,7 @@ def test_write_crash_skipped_when_pytest_in_argv(tmp_path, monkeypatch):
     """
     # Override the autouse fixture for THIS test only — we want the
     # dev-invocation filter active here.
-    monkeypatch.setattr(
-        "lore_cli._crash_log._is_dev_invocation", lambda: True
-    )
+    monkeypatch.setattr("lore_cli._crash_log._is_dev_invocation", lambda: True)
     monkeypatch.setenv("LORE_CACHE", str(tmp_path))
     from lore_cli._crash_log import write_crash
 
@@ -123,6 +119,7 @@ def test_recent_crashes_returns_newest_first(tmp_path, monkeypatch):
     # Force ordering by mtime even on coarse-resolution filesystems.
     import os
     import time
+
     os.utime(p1, (time.time() - 60, time.time() - 60))
 
     recent = recent_crashes(within_days=7)
@@ -137,9 +134,117 @@ def test_recent_crashes_empty_when_dir_missing(tmp_path, monkeypatch):
     assert recent_crashes() == []
 
 
-def test_shield_writes_crash_log_and_includes_path_in_banner(
-    tmp_path, monkeypatch, capsys
-):
+# ---------------------------------------------------------------------------
+# #190 — explicit retention: crash logs no longer accumulate forever.
+# ---------------------------------------------------------------------------
+
+
+def test_purge_old_crashes_deletes_past_window(tmp_path, monkeypatch):
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path))
+    from lore_cli._crash_log import purge_old_crashes, write_crash
+
+    try:
+        raise RuntimeError("old")
+    except RuntimeError as exc:
+        old_path = write_crash("SessionStart", exc)
+    import os
+    import time
+
+    os.utime(old_path, (time.time() - 40 * 86400, time.time() - 40 * 86400))
+
+    deleted, failed = purge_old_crashes(30, lore_root=tmp_path)
+    assert deleted == 1
+    assert failed == 0
+    assert not old_path.exists()
+
+
+def test_purge_old_crashes_keeps_recent(tmp_path, monkeypatch):
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path))
+    from lore_cli._crash_log import purge_old_crashes, write_crash
+
+    try:
+        raise RuntimeError("recent")
+    except RuntimeError as exc:
+        recent_path = write_crash("SessionStart", exc)
+
+    deleted, failed = purge_old_crashes(30, lore_root=tmp_path)
+    assert deleted == 0
+    assert recent_path.exists()
+
+
+def test_purge_old_crashes_emits_janitor_spine_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path))
+    from lore_cli._crash_log import purge_old_crashes, write_crash
+    from lore_core.spine import read_spine, validate_envelope
+
+    try:
+        raise RuntimeError("old")
+    except RuntimeError as exc:
+        old_path = write_crash("SessionStart", exc)
+    import os
+    import time
+
+    os.utime(old_path, (time.time() - 40 * 86400, time.time() - 40 * 86400))
+
+    purge_old_crashes(30, lore_root=tmp_path)
+    events = [r for r in read_spine(tmp_path, source="janitor") if r["event"] == "retention-delete"]
+    assert events
+    assert events[0]["data"]["family"] == "crash-log"
+    validate_envelope(events[0])
+
+
+def test_purge_old_crashes_failure_emits_warn_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path))
+    from lore_cli._crash_log import purge_old_crashes, write_crash
+    from lore_core.spine import read_spine
+
+    try:
+        raise RuntimeError("old")
+    except RuntimeError as exc:
+        old_path = write_crash("SessionStart", exc)
+    import os
+    import time
+
+    os.utime(old_path, (time.time() - 40 * 86400, time.time() - 40 * 86400))
+
+    real_unlink = Path.unlink
+
+    def bad_unlink(self, *args, **kwargs):
+        raise PermissionError("locked")
+
+    monkeypatch.setattr(Path, "unlink", bad_unlink)
+    deleted, failed = purge_old_crashes(30, lore_root=tmp_path)
+    monkeypatch.setattr(Path, "unlink", real_unlink)
+
+    assert failed == 1
+    failures = [
+        r for r in read_spine(tmp_path, source="janitor") if r["event"] == "retention-delete-failed"
+    ]
+    assert failures
+    assert failures[0]["level"] == "warn"
+    assert failures[0]["data"]["family"] == "crash-log"
+
+
+def test_purge_old_crashes_without_lore_root_still_deletes(tmp_path, monkeypatch):
+    """No lore_root -> best-effort deletion, no spine emission (nowhere to write it)."""
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path))
+    from lore_cli._crash_log import purge_old_crashes, write_crash
+
+    try:
+        raise RuntimeError("old")
+    except RuntimeError as exc:
+        old_path = write_crash("SessionStart", exc)
+    import os
+    import time
+
+    os.utime(old_path, (time.time() - 40 * 86400, time.time() - 40 * 86400))
+
+    deleted, failed = purge_old_crashes(30)
+    assert deleted == 1
+    assert not old_path.exists()
+
+
+def test_shield_writes_crash_log_and_includes_path_in_banner(tmp_path, monkeypatch, capsys):
     """End-to-end: shield catches an unexpected exception, writes a
     crash file, and the file path appears in the user-facing banner."""
     monkeypatch.setenv("LORE_CACHE", str(tmp_path))
@@ -201,9 +306,7 @@ def test_main_backstop_catches_pre_dispatch_exception(tmp_path, monkeypatch, cap
     assert "simulated typer dispatch failure" in files[0].read_text()
 
 
-def test_main_backstop_human_caller_writes_log_but_no_envelope(
-    tmp_path, monkeypatch, capsys
-):
+def test_main_backstop_human_caller_writes_log_but_no_envelope(tmp_path, monkeypatch, capsys):
     """For non-hook callers (e.g. a developer running `lore search foo`
     that crashes), main() should write the log + a terse stderr line
     instead of a JSON envelope."""
@@ -243,6 +346,7 @@ def test_doctor_check_recent_crashes_advisory(tmp_path, monkeypatch):
 
     # Drop a crash log in place; check should now report it.
     from lore_cli._crash_log import write_crash
+
     try:
         raise RuntimeError("bang")
     except RuntimeError as exc:

--- a/tests/test_drain_cmd.py
+++ b/tests/test_drain_cmd.py
@@ -1,0 +1,105 @@
+"""Tests for the reusable orphan-pruning core behind `lore drain prune`.
+
+`prune_orphans` is the extracted logic `cmd_prune` (the CLI command) and
+the retention janitor (#190) both call — the janitor folds orphan pruning
+into its opportunistic sweep instead of leaving it as a manual-only
+escape hatch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lore_cli.drain_cmd import prune_orphans
+from lore_core.spine import read_spine, validate_envelope
+
+
+def _write_system_jsonl(lore_root: Path, rows: list[dict]) -> Path:
+    target = lore_root / ".lore" / "drain" / "_system.jsonl"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return target
+
+
+def test_prune_orphans_drops_rows_with_missing_path(tmp_path: Path):
+    gone = tmp_path / "gone.md"  # never created
+    kept = tmp_path / "kept.md"
+    kept.write_text("x")
+    target = _write_system_jsonl(
+        tmp_path,
+        [
+            {"event": "note-filed", "data": {"path": str(gone), "wikilink": "[[gone]]"}},
+            {"event": "note-filed", "data": {"path": str(kept), "wikilink": "[[kept]]"}},
+            {"event": "transcript-synced", "data": {}},  # no path, always kept
+        ],
+    )
+    result = prune_orphans(tmp_path)
+    assert result.dropped_count == 1
+    lines = [json.loads(x) for x in target.read_text().splitlines() if x.strip()]
+    assert len(lines) == 2
+    assert {r["event"] for r in lines} == {"note-filed", "transcript-synced"}
+
+
+def test_prune_orphans_dry_run_does_not_modify_file(tmp_path: Path):
+    gone = tmp_path / "gone.md"
+    target = _write_system_jsonl(tmp_path, [{"event": "note-filed", "data": {"path": str(gone)}}])
+    before = target.read_text()
+    result = prune_orphans(tmp_path, dry_run=True)
+    assert result.dropped_count == 1
+    assert target.read_text() == before
+
+
+def test_prune_orphans_missing_file_is_noop(tmp_path: Path):
+    result = prune_orphans(tmp_path)
+    assert result.dropped_count == 0
+
+
+def test_prune_orphans_no_orphans_is_noop(tmp_path: Path):
+    kept = tmp_path / "kept.md"
+    kept.write_text("x")
+    _write_system_jsonl(tmp_path, [{"event": "note-filed", "data": {"path": str(kept)}}])
+    result = prune_orphans(tmp_path)
+    assert result.dropped_count == 0
+
+
+def test_prune_orphans_emits_janitor_spine_event(tmp_path: Path):
+    gone = tmp_path / "gone.md"
+    _write_system_jsonl(tmp_path, [{"event": "note-filed", "data": {"path": str(gone)}}])
+    prune_orphans(tmp_path)
+    events = [r for r in read_spine(tmp_path, source="janitor") if r["event"] == "retention-delete"]
+    assert events
+    assert events[0]["data"]["family"] == "drain-orphans"
+    assert events[0]["data"]["dropped"] == 1
+    validate_envelope(events[0])
+
+
+def test_prune_orphans_dry_run_emits_no_spine_event(tmp_path: Path):
+    gone = tmp_path / "gone.md"
+    _write_system_jsonl(tmp_path, [{"event": "note-filed", "data": {"path": str(gone)}}])
+    prune_orphans(tmp_path, dry_run=True)
+    assert read_spine(tmp_path, source="janitor") == []
+
+
+def test_prune_orphans_write_failure_emits_warn_event(tmp_path: Path, monkeypatch):
+    gone = tmp_path / "gone.md"
+    _write_system_jsonl(tmp_path, [{"event": "note-filed", "data": {"path": str(gone)}}])
+
+    import os
+
+    real_replace = os.replace
+
+    def bad_replace(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "replace", bad_replace)
+    result = prune_orphans(tmp_path)
+    monkeypatch.setattr(os, "replace", real_replace)
+
+    assert result.failed is True
+    failures = [
+        r for r in read_spine(tmp_path, source="janitor") if r["event"] == "retention-delete-failed"
+    ]
+    assert failures
+    assert failures[0]["level"] == "warn"
+    assert failures[0]["data"]["family"] == "drain-orphans"

--- a/tests/test_flush_store.py
+++ b/tests/test_flush_store.py
@@ -230,6 +230,132 @@ def test_begin_reopens_after_terminal(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# #190 — retention purge: terminal records age out, dead letters survive
+# unless over the hard cap.
+# ---------------------------------------------------------------------------
+
+
+def _age(lore_root: Path, rec: FlushRecord, days: float) -> None:
+    """Backdate a persisted record's updated_at for purge-window tests."""
+    path = lore_root / ".lore" / "flushes" / f"{rec.flush_id}.json"
+    raw = json.loads(path.read_text())
+    raw["updated_at"] = (
+        (datetime.now(UTC) - timedelta(days=days)).isoformat().replace("+00:00", "Z")
+    )
+    path.write_text(json.dumps(raw))
+
+
+def test_purge_deletes_old_terminal_records(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("old__20260101")
+    store.transition(rec, FlushState.RUNNING)
+    rec = store.transition(rec, FlushState.PUBLISHED)
+    _age(tmp_path, rec, days=40)
+
+    result = store.purge(terminal_max_age_days=30, dead_letter_hard_cap=50)
+    assert store.get(rec.flush_id) is None
+    assert result.deleted == 1
+
+
+def test_purge_keeps_recent_terminal_records(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("recent__20260101")
+    store.transition(rec, FlushState.RUNNING)
+    store.transition(rec, FlushState.WITHHELD)
+
+    result = store.purge(terminal_max_age_days=30, dead_letter_hard_cap=50)
+    assert store.get(rec.flush_id) is not None
+    assert result.deleted == 0
+
+
+def test_purge_never_touches_in_flight_records(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    queued = store.begin("queued__20260101")
+    _age(tmp_path, queued, days=999)
+    running = store.begin("running__20260101")
+    store.transition(running, FlushState.RUNNING)
+    _age(tmp_path, running, days=999)
+
+    store.purge(terminal_max_age_days=1, dead_letter_hard_cap=1)
+    assert store.get(queued.flush_id) is not None
+    assert store.get(running.flush_id) is not None
+
+
+def test_purge_dead_letters_survive_normal_age_window(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("dead__20260101")
+    for _ in range(MAX_ATTEMPTS):
+        store.transition(rec, FlushState.RUNNING)
+        rec = store.record_failure(rec, error_code=ErrorCode.COMPOSE_FAILED)
+    _age(tmp_path, rec, days=999)  # ancient, but unresolved — must survive
+
+    result = store.purge(terminal_max_age_days=1, dead_letter_hard_cap=50)
+    assert store.get(rec.flush_id) is not None
+    assert result.deleted == 0
+
+
+def test_purge_dead_letters_capped_beyond_hard_cap(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    dead_letters = []
+    for i in range(5):
+        rec = store.begin(f"dead{i}__20260101")
+        for _ in range(MAX_ATTEMPTS):
+            store.transition(rec, FlushState.RUNNING)
+            rec = store.record_failure(rec, error_code=ErrorCode.COMPOSE_FAILED)
+        _age(tmp_path, rec, days=i)  # dead0 newest .. dead4 oldest
+        dead_letters.append(rec)
+
+    result = store.purge(terminal_max_age_days=9999, dead_letter_hard_cap=3)
+    remaining = store.list(state=FlushState.DEAD_LETTERED)
+    assert len(remaining) == 3
+    assert result.deleted == 2
+    # Oldest (largest artificial age) purged first.
+    remaining_ids = {r.flush_id for r in remaining}
+    assert dead_letters[4].flush_id not in remaining_ids
+    assert dead_letters[3].flush_id not in remaining_ids
+    assert dead_letters[0].flush_id in remaining_ids
+
+
+def test_purge_deletion_emits_janitor_spine_event(tmp_path: Path):
+    store = FlushStore(tmp_path)
+    rec = store.begin("old__20260101")
+    store.transition(rec, FlushState.RUNNING)
+    rec = store.transition(rec, FlushState.PUBLISHED)
+    _age(tmp_path, rec, days=40)
+
+    store.purge(terminal_max_age_days=30, dead_letter_hard_cap=50)
+    events = [r for r in read_spine(tmp_path, source="janitor") if r["event"] == "retention-delete"]
+    assert events
+    assert events[0]["data"]["family"] == "flush-record"
+    validate_envelope(events[0])
+
+
+def test_purge_failure_emits_warn_spine_event(tmp_path: Path, monkeypatch):
+    store = FlushStore(tmp_path)
+    rec = store.begin("old__20260101")
+    store.transition(rec, FlushState.RUNNING)
+    rec = store.transition(rec, FlushState.PUBLISHED)
+    _age(tmp_path, rec, days=40)
+
+    real_unlink = Path.unlink
+
+    def bad_unlink(self, *args, **kwargs):
+        raise PermissionError("locked")
+
+    monkeypatch.setattr(Path, "unlink", bad_unlink)
+    result = store.purge(terminal_max_age_days=30, dead_letter_hard_cap=50)
+    monkeypatch.setattr(Path, "unlink", real_unlink)
+
+    assert result.failed == 1
+    failures = [
+        r for r in read_spine(tmp_path, source="janitor") if r["event"] == "retention-delete-failed"
+    ]
+    assert failures
+    assert failures[0]["level"] == "warn"
+    assert failures[0]["data"]["family"] == "flush-record"
+
+
 def test_is_retry_due(tmp_path: Path):
     now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     future = (now + timedelta(seconds=120)).isoformat().replace("+00:00", "Z")

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -1,0 +1,168 @@
+"""Unified retention janitor tests (issue #190).
+
+Covers the parts that don't already have a home in test_run_retention.py
+(run-archival), test_flush_store.py (dead-letter purge) or test_spine.py
+(hot->cold rotation): lock contention, cold-tier deletion, orchestration
+of all families in one pass, and the queryable usage status.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from lore_core.janitor import janitor_lock, read_janitor_status, run_janitor
+from lore_core.lockfile import flocked
+from lore_core.root_config import ObservabilityConfig
+from lore_core.spine import SpineWriter, read_spine, validate_envelope
+
+
+def _cfg(**retention_overrides) -> ObservabilityConfig:
+    cfg = ObservabilityConfig()
+    for k, v in retention_overrides.items():
+        setattr(cfg.retention, k, v)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Lock-guarded, cheap, daemon-free
+# ---------------------------------------------------------------------------
+
+
+def test_contended_lock_skips_run_without_side_effects(tmp_path: Path):
+    with flocked(tmp_path / ".lore" / "janitor.lock"):
+        report = run_janitor(tmp_path, _cfg())
+    assert report.ran is False
+
+
+def test_uncontended_run_acquires_and_releases(tmp_path: Path):
+    run_janitor(tmp_path, _cfg())
+    # Lock released after the pass — a second call can also acquire it.
+    with janitor_lock(tmp_path) as held:
+        assert held is True
+
+
+# ---------------------------------------------------------------------------
+# Cold tier: age or size cap deletes the rotated file outright.
+# ---------------------------------------------------------------------------
+
+
+def test_cold_tier_deleted_when_past_age_window(tmp_path: Path):
+    cold = tmp_path / ".lore" / "spine.jsonl.1"
+    cold.parent.mkdir(parents=True, exist_ok=True)
+    cold.write_text("x\n")
+    old = time.time() - 40 * 86400
+    os_utime = __import__("os").utime
+    os_utime(cold, (old, old))
+
+    report = run_janitor(tmp_path, _cfg(cold_days=30))
+    assert not cold.exists()
+    assert report.deleted >= 1
+
+
+def test_cold_tier_deleted_when_over_size_cap(tmp_path: Path):
+    cold = tmp_path / ".lore" / "spine.jsonl.1"
+    cold.parent.mkdir(parents=True, exist_ok=True)
+    cold.write_text("x" * 2_100_000 + "\n")
+
+    report = run_janitor(tmp_path, _cfg(cold_max_mb=1))
+    assert not cold.exists()
+    assert report.deleted >= 1
+
+
+def test_cold_tier_survives_within_window(tmp_path: Path):
+    cold = tmp_path / ".lore" / "spine.jsonl.1"
+    cold.parent.mkdir(parents=True, exist_ok=True)
+    cold.write_text("x\n")
+
+    run_janitor(tmp_path, _cfg(cold_days=30, cold_max_mb=20))
+    assert cold.exists()
+
+
+def test_cold_tier_deletion_emits_janitor_spine_event(tmp_path: Path):
+    cold = tmp_path / ".lore" / "spine.jsonl.1"
+    cold.parent.mkdir(parents=True, exist_ok=True)
+    cold.write_text("x\n")
+
+    run_janitor(tmp_path, _cfg(cold_max_mb=0))
+    events = read_spine(tmp_path, source="janitor")
+    deletes = [e for e in events if e["event"] == "retention-delete"]
+    assert any(e["data"]["family"] == "spine-cold" for e in deletes)
+    for e in events:
+        validate_envelope(e)
+
+
+def test_cold_tier_delete_failure_emits_warn_event(tmp_path: Path, monkeypatch):
+    cold = tmp_path / ".lore" / "spine.jsonl.1"
+    cold.parent.mkdir(parents=True, exist_ok=True)
+    cold.write_text("x\n")
+
+    real_unlink = Path.unlink
+
+    def bad_unlink(self, *args, **kwargs):
+        raise PermissionError("locked")
+
+    monkeypatch.setattr(Path, "unlink", bad_unlink)
+    run_janitor(tmp_path, _cfg(cold_max_mb=0))
+    monkeypatch.setattr(Path, "unlink", real_unlink)
+
+    events = read_spine(tmp_path, source="janitor")
+    failures = [e for e in events if e["event"] == "retention-delete-failed"]
+    assert failures
+    assert failures[0]["level"] == "warn"
+    assert failures[0]["data"]["family"] == "spine-cold"
+
+
+# ---------------------------------------------------------------------------
+# Hot tier: age-triggered downgrade, using the configured (not hardcoded)
+# hook_events.max_size_mb.
+# ---------------------------------------------------------------------------
+
+
+def test_hot_tier_downgrades_by_age(tmp_path: Path):
+    hot = tmp_path / ".lore" / "spine.jsonl"
+    hot.parent.mkdir(parents=True, exist_ok=True)
+    old_rec = {
+        "ts": "2020-01-01T00:00:00Z",
+        "v": 1,
+        "source": "hook",
+        "event": "e",
+        "level": "info",
+        "trace_id": None,
+        "session_id": None,
+        "run_id": None,
+        "wiki": None,
+        "scope": None,
+        "error_code": None,
+        "data": {},
+    }
+    hot.write_text(json.dumps(old_rec) + "\n")
+
+    run_janitor(tmp_path, _cfg(hot_days=7))
+    assert (tmp_path / ".lore" / "spine.jsonl.1").exists()
+
+
+# ---------------------------------------------------------------------------
+# Queryable usage — consumed by `lore status` (#193).
+# ---------------------------------------------------------------------------
+
+
+def test_status_queryable_after_run(tmp_path: Path):
+    SpineWriter(tmp_path).emit(source="hook", event="e")
+    run_janitor(tmp_path, _cfg())
+    status = read_janitor_status(tmp_path)
+    assert status is not None
+    assert status["hot_bytes"] > 0
+    assert "last_run_at" in status
+
+
+def test_status_none_when_never_run(tmp_path: Path):
+    assert read_janitor_status(tmp_path) is None
+
+
+def test_status_tolerant_of_corrupt_file(tmp_path: Path):
+    status_path = tmp_path / ".lore" / "janitor-status.json"
+    status_path.parent.mkdir(parents=True, exist_ok=True)
+    status_path.write_text("{not json")
+    assert read_janitor_status(tmp_path) is None

--- a/tests/test_janitor_entry.py
+++ b/tests/test_janitor_entry.py
@@ -1,0 +1,66 @@
+"""Tests for the CLI-layer janitor composer (issue #190).
+
+``lore_core.janitor`` doesn't know about crash logs (they live under the
+global ``$LORE_CACHE``, not a specific ``lore_root``) or drain orphan
+pruning (owned by ``lore_cli.drain_cmd``) — this composer wires the core
+sweep together with those two lore_cli-only families for the opportunistic
+entry points (hook fire, curator run end).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lore_cli._janitor_entry import run_opportunistic_janitor
+from lore_core.spine import SpineWriter
+
+
+def test_composer_runs_core_sweep_and_crash_purge(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+    monkeypatch.setattr("lore_cli._crash_log._is_dev_invocation", lambda: False)
+    SpineWriter(tmp_path).emit(source="hook", event="e")
+
+    from lore_cli._crash_log import write_crash
+
+    try:
+        raise RuntimeError("old")
+    except RuntimeError as exc:
+        old_crash = write_crash("SessionStart", exc)
+    import os
+    import time
+
+    os.utime(old_crash, (time.time() - 999 * 86400, time.time() - 999 * 86400))
+
+    run_opportunistic_janitor(tmp_path)
+
+    assert not old_crash.exists()
+    from lore_core.janitor import read_janitor_status
+
+    assert read_janitor_status(tmp_path) is not None
+
+
+def test_composer_prunes_drain_orphans(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+    target = tmp_path / ".lore" / "drain" / "_system.jsonl"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    gone = tmp_path / "gone.md"
+    target.write_text(json.dumps({"event": "note-filed", "data": {"path": str(gone)}}) + "\n")
+
+    run_opportunistic_janitor(tmp_path)
+
+    lines = [x for x in target.read_text().splitlines() if x.strip()]
+    assert lines == []
+
+
+def test_composer_never_raises(tmp_path: Path, monkeypatch):
+    """Best-effort like every other opportunistic hook-path call."""
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    import lore_core.janitor as janitor_mod
+
+    monkeypatch.setattr(janitor_mod, "run_janitor", boom)
+    run_opportunistic_janitor(tmp_path)  # must not raise

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -15,6 +15,24 @@ def test_defaults_when_file_absent(tmp_path: Path):
     assert cfg.observability.runs.keep_trace == 30
 
 
+def test_retention_defaults_when_file_absent(tmp_path: Path):
+    cfg = load_root_config(tmp_path)
+    assert cfg.observability.retention.hot_days == 7
+    assert cfg.observability.retention.cold_days == 30
+    assert cfg.observability.retention.cold_max_mb == 20
+    assert cfg.observability.retention.crash_log_days == 30
+    assert cfg.observability.retention.dead_letter_hard_cap == 50
+
+
+def test_retention_partial_override(tmp_path: Path):
+    lore_dir = tmp_path / ".lore"
+    lore_dir.mkdir()
+    (lore_dir / "config.yml").write_text("observability:\n  retention:\n    hot_days: 3\n")
+    cfg = load_root_config(tmp_path)
+    assert cfg.observability.retention.hot_days == 3  # overridden
+    assert cfg.observability.retention.cold_days == 30  # default preserved
+
+
 def test_partial_override(tmp_path: Path):
     lore_dir = tmp_path / ".lore"
     lore_dir.mkdir()

--- a/tests/test_run_retention.py
+++ b/tests/test_run_retention.py
@@ -1,8 +1,7 @@
-import json
-import os
 from pathlib import Path
 
 from lore_core.run_retention import enforce_retention
+from lore_core.spine import read_spine, validate_envelope
 
 
 def _mk_run(dir_: Path, name: str, size: int = 500) -> Path:
@@ -60,9 +59,51 @@ def test_retention_is_best_effort_no_raise(tmp_path, monkeypatch):
     for i in range(205):
         _mk_run(runs, f"2026-04-{i:02d}T10-00-00-xxxxxx")
     real_unlink = Path.unlink
+
     def bad_unlink(self, *args, **kwargs):
         raise PermissionError("locked")
+
     monkeypatch.setattr(Path, "unlink", bad_unlink)
     # Should not raise even if every unlink fails.
     enforce_retention(tmp_path, keep=200, max_total_mb=9999, keep_trace=30)
     monkeypatch.setattr(Path, "unlink", real_unlink)
+
+
+# ---------------------------------------------------------------------------
+# #190 — deletions are logged, delete failures are warnings, never silence.
+# ---------------------------------------------------------------------------
+
+
+def test_deletion_emits_janitor_spine_event(tmp_path):
+    runs = tmp_path / ".lore" / "runs"
+    runs.mkdir(parents=True)
+    for i in range(205):
+        _mk_run(runs, f"2026-04-{i:02d}T10-00-00-xxxxxx")
+    enforce_retention(tmp_path, keep=200, max_total_mb=9999, keep_trace=30)
+    events = read_spine(tmp_path, source="janitor")
+    deletes = [e for e in events if e["event"] == "retention-delete"]
+    assert len(deletes) == 5  # 205 - keep=200
+    for e in deletes:
+        validate_envelope(e)
+        assert e["level"] == "info"
+        assert e["data"]["family"] == "run-archival"
+
+
+def test_delete_failure_emits_warn_spine_event(tmp_path, monkeypatch):
+    runs = tmp_path / ".lore" / "runs"
+    runs.mkdir(parents=True)
+    for i in range(205):
+        _mk_run(runs, f"2026-04-{i:02d}T10-00-00-xxxxxx")
+
+    def bad_unlink(self, *args, **kwargs):
+        raise PermissionError("locked")
+
+    monkeypatch.setattr(Path, "unlink", bad_unlink)
+    enforce_retention(tmp_path, keep=200, max_total_mb=9999, keep_trace=30)
+    events = read_spine(tmp_path, source="janitor")
+    failures = [e for e in events if e["event"] == "retention-delete-failed"]
+    assert failures, "a delete failure must emit a warn-level spine event, not silence"
+    for e in failures:
+        validate_envelope(e)
+        assert e["level"] == "warn"
+        assert e["data"]["family"] == "run-archival"

--- a/tests/test_spine.py
+++ b/tests/test_spine.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import threading
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -28,6 +29,10 @@ from lore_core.spine import (
 
 def _read(path: Path) -> list[dict]:
     return [json.loads(x) for x in path.read_text().splitlines() if x.strip()]
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +197,52 @@ def test_rotation_crosses_threshold(tmp_path: Path) -> None:
     assert rotated.exists()
     assert path.exists()
     assert path.stat().st_size < 2000
+
+
+# ---------------------------------------------------------------------------
+# #190 — janitor-triggered rotation: age or the currently-configured size
+# cap, independent of the fixed cap a writer was constructed with.
+# ---------------------------------------------------------------------------
+
+
+def test_janitor_rotate_if_due_by_age(tmp_path: Path) -> None:
+    writer = SpineWriter(tmp_path)
+    path = tmp_path / ".lore" / "spine.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    old_rec = {**_template(), "ts": "2020-01-01T00:00:00Z"}
+    path.write_text(json.dumps(old_rec) + "\n")
+    rotated = writer.janitor_rotate_if_due(max_age_days=7, max_size_mb=10)
+    assert rotated is True
+    assert (tmp_path / ".lore" / "spine.jsonl.1").exists()
+    # Rotation is a rename; the hot path only reappears on the next emit().
+    assert not path.exists()
+
+
+def test_janitor_rotate_if_due_by_configured_size(tmp_path: Path) -> None:
+    writer = SpineWriter(tmp_path, max_size_mb=10)  # writer's own fixed cap
+    path = tmp_path / ".lore" / "spine.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x" * 2000 + "\n")
+    # Janitor re-checks against a tighter, currently-configured cap.
+    rotated = writer.janitor_rotate_if_due(max_age_days=365, max_size_mb=0.001)
+    assert rotated is True
+    assert (tmp_path / ".lore" / "spine.jsonl.1").exists()
+
+
+def test_janitor_rotate_if_due_noop_within_window(tmp_path: Path) -> None:
+    writer = SpineWriter(tmp_path)
+    path = tmp_path / ".lore" / "spine.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fresh_rec = {**_template(), "ts": _now_iso()}
+    path.write_text(json.dumps(fresh_rec) + "\n")
+    rotated = writer.janitor_rotate_if_due(max_age_days=7, max_size_mb=10)
+    assert rotated is False
+    assert not (tmp_path / ".lore" / "spine.jsonl.1").exists()
+
+
+def test_janitor_rotate_if_due_missing_file_is_noop(tmp_path: Path) -> None:
+    writer = SpineWriter(tmp_path)
+    assert writer.janitor_rotate_if_due(max_age_days=7, max_size_mb=10) is False
 
 
 def test_rotation_race_no_data_loss(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #190

## Summary

Replaces today's inconsistent per-family retention — 10 MB hook rotation, count+MB run caps with silently-swallowed delete errors, append-forever drain, soft-hidden crash logs — with one flock-guarded janitor over the whole event spine and its adjacent log families.

- **`lore_core.janitor`** — the orchestrator. One non-blocking sibling flock (`.lore/janitor.lock`) guards a single pass that enforces:
  - **hot tier** (`spine.jsonl`): age-triggered downgrade (default 7 days) via a new `SpineWriter.janitor_rotate_if_due`, which also re-checks the *currently configured* size cap rather than the fixed value a writer was constructed with.
  - **cold tier** (`spine.jsonl.1`): age (default 30 days) or size cap deletes it outright — there's no tier below cold.
  - **legacy run-archival** (`.lore/runs/`): delegates to the generalized `run_retention.enforce_retention`.
  - **flush store**: delegates to the new `FlushStore.purge` — terminal (published/withheld) records age out; dead-lettered records are exempt from the age window (unresolved, needs a human) but capped by count so a permanently-stuck pipeline can't grow the store forever.
  - Persists a queryable usage snapshot (`read_janitor_status`: bytes per tier + last-run timestamp) for `lore status` (#193) to consume.
- **`lore_cli._janitor_entry`** — composes the core sweep with the two families that live outside `lore_root/.lore/` layering: crash-log purge (global `$LORE_CACHE`) and drain orphan pruning (CLI-owned). Never raises — same best-effort contract as the existing `_gc_sessions_cache` precedent.
- Wired opportunistically into **SessionStart** (`hooks.py`) and **curator flush-run end** (`curator_cmd.py`), matching the issue's "hook fire / curator run end" entry points. Both are non-blocking flock, no daemon, and skip cleanly when contended.
- Every deletion/downgrade emits a `source="janitor"` spine event; every delete failure emits a `level="warn"` spine event instead of the old silent swallow.
- `observability.retention.*` (`hot_days`, `cold_days`, `cold_max_mb`, `crash_log_days`, `dead_letter_hard_cap`) is settable via `lore config` — reuses the existing `hook_events.max_size_mb` for the hot-tier size cap rather than duplicating it.

## Design notes

- File-level tiering, not per-record compaction: a "downgrade" moves the whole file. Denser per-record summaries are a plausible future slice; nothing here depends on it.
- `drain_cmd.py`'s orphan-pruning logic was extracted into a reusable `prune_orphans()` so both the CLI command and the janitor call the same core — `drain.py` itself (owned by #188) was untouched.
- `SpineWriter._rotate_locked` now takes a `due` predicate re-evaluated *after* the lock is acquired, preserving the original TOCTOU guard for both the size-triggered rotation in `emit()` and the janitor's age/size-triggered rotation.

## Red → green evidence

Every AC had a failing test before implementation. Representative examples:

```
tests/test_janitor.py::test_cold_tier_deleted_when_past_age_window — AttributeError: module 'lore_core.janitor' not found → green after janitor.py
tests/test_spine.py::test_janitor_rotate_if_due_by_age — AttributeError: 'SpineWriter' object has no attribute 'janitor_rotate_if_due' → green after spine.py
tests/test_run_retention.py::test_delete_failure_emits_warn_spine_event — AssertionError: a delete failure must emit a warn-level spine event, not silence → green after run_retention.py
tests/test_flush_store.py::test_purge_dead_letters_capped_beyond_hard_cap — AttributeError: 'FlushStore' object has no attribute 'purge' → green after flush_store.py
tests/test_crash_log.py::test_purge_old_crashes_deletes_past_window — ImportError: cannot import name 'purge_old_crashes' → green after _crash_log.py
tests/test_drain_cmd.py::test_prune_orphans_emits_janitor_spine_event — ImportError: cannot import name 'prune_orphans' → green after drain_cmd.py
```

## Test plan

- [x] New tests for every AC: tier boundaries (hot age/size, cold age/size), logged deletions, delete-failure warnings, dead-letter survival + hard cap, lock contention, queryable status.
- [x] Full suite: `2826 passed, 16 skipped, 11 subtests passed` — the 11 failures present on `epic/183` before this change (ANSI-color CliRunner assertions in unrelated files: `test_cli_scopes.py`, `test_core_llm_wiring.py`, `test_drain_prune.py`, `test_install_dispatcher.py`, `test_log_cmd.py`, `test_proc_cmd.py`) are unchanged — zero new failures.
- [x] `ruff check` clean on every new file; zero new violations on touched files (verified against a clean HEAD worktree, line-by-line).
- [x] `ruff format --check` clean on every new file; the 3 touched files still flagged (`curator_cmd.py`, `drain_cmd.py`, `run_retention.py`) were already "would reformat" before this change.
- [x] Manual smoke test: `lore drain prune --dry-run` / `lore drain prune` CLI output unchanged after the `prune_orphans()` extraction.