### PR TITLE
feat: `lore trace` — correlated drill-down of one flush

### DIFF
--- a/lib/lore_cli/__main__.py
+++ b/lib/lore_cli/__main__.py
@@ -92,6 +92,7 @@ def _build_app() -> typer.Typer:
         session_cmd,
         status_cmd,
         tier_cmd,
+        trace_cmd,
         transcripts_cmd,
         wiki_cmd,
         workflow_cmd,
@@ -149,6 +150,7 @@ def _build_app() -> typer.Typer:
     app.add_typer(registry_cmd.app, name="registry", rich_help_panel=_ADV)
     app.add_typer(runs_cmd.app, name="runs", rich_help_panel=_ADV)
     app.add_typer(scopes_cmd.app, name="scopes", rich_help_panel=_ADV)
+    app.add_typer(trace_cmd.app, name="trace", rich_help_panel=_ADV)
     app.add_typer(transcripts_cmd.app, name="transcripts", rich_help_panel=_ADV)
     app.add_typer(workflow_cmd.app, name="workflow", rich_help_panel=_ADV)
 

--- a/lib/lore_cli/trace_cmd.py
+++ b/lib/lore_cli/trace_cmd.py
@@ -1,0 +1,183 @@
+"""`lore trace` — correlated drill-down of one flush.
+
+Reads the event spine + flush record only (see ``lore_core.trace``); never
+writes. Consolidates the debugging role of `lore log` / `lore runs` /
+`lore proc` into one story keyed by trace_id.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+
+import typer
+from lore_core.trace import (
+    FlushTrace,
+    TraceNotFound,
+    TraceStep,
+    dead_flushes,
+    flush_by_trace_id,
+    resolve_selector,
+)
+from rich.console import Console
+from rich.tree import Tree
+
+from lore_cli._argv_compat import argv_main
+
+console = Console()
+
+app = typer.Typer(
+    add_completion=False,
+    help=__doc__,
+    no_args_is_help=False,
+    rich_markup_mode="rich",
+    # Allow options after the positional selector, e.g. `lore trace <id> --plain`
+    # as well as `lore trace --plain <id>` (see lore_cli/drill_cmd.py).
+    context_settings={"allow_interspersed_args": True},
+)
+
+
+def _parse_ts(raw: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def _duration_label(steps: list[TraceStep], i: int) -> str:
+    """Gap to the *next* step — the trace has no other notion of "how long"."""
+    if i + 1 >= len(steps):
+        return ""
+    a, b = _parse_ts(steps[i].ts), _parse_ts(steps[i + 1].ts)
+    if a is None or b is None:
+        return ""
+    delta = (b - a).total_seconds()
+    return f"+{delta:.1f}s" if delta >= 0 else ""
+
+
+def _step_label(step: TraceStep) -> str:
+    bits = [f"{step.source}/{step.event}"]
+    if step.event in ("llm-prompt", "llm-response"):
+        model = step.data.get("model")
+        tokens = step.data.get("token_count")
+        if model:
+            bits.append(f"model={model}")
+        if tokens is not None:
+            bits.append(f"tokens={tokens}")
+    elif step.event in ("note-filed", "note-appended", "session-note"):
+        path = step.data.get("path") or step.data.get("wikilink")
+        if path:
+            bits.append(f"-> {path}")
+    if step.error_code:
+        # Parens, not brackets — a literal `[...]` collides with Rich's
+        # markup-tag syntax when this label is wrapped in a `[red]...[/red]`.
+        bits.append(f"({step.error_code})")
+    return " ".join(bits)
+
+
+def _step_line(steps: list[TraceStep], i: int) -> str:
+    step = steps[i]
+    line = _step_label(step)
+    dur = _duration_label(steps, i)
+    return f"{line}  {dur}" if dur else line
+
+
+def _render_tree(trace: FlushTrace) -> Tree:
+    tree = Tree(f"trace {trace.trace_id} — [bold]{trace.status}[/bold]")
+    for i, step in enumerate(trace.steps):
+        line = _step_line(trace.steps, i)
+        if step.level == "error":
+            line = f"[red]{line}[/red]"
+        elif step.level == "warn":
+            line = f"[yellow]{line}[/yellow]"
+        tree.add(line)
+    return tree
+
+
+def _render_plain(trace: FlushTrace) -> str:
+    lines = [f"trace {trace.trace_id} -- {trace.status}"]
+    for i, step in enumerate(trace.steps):
+        marker = "!" if step.level == "error" else ("~" if step.level == "warn" else " ")
+        lines.append(f"  {marker} {_step_line(trace.steps, i)}")
+    if not trace.steps:
+        lines.append("  (no spine events for this trace_id)")
+    return "\n".join(lines)
+
+
+def _print_dead(*, records, json_out: bool) -> None:
+    if json_out:
+        for rec in records:
+            sys.stdout.write(json.dumps(rec.to_dict()) + "\n")
+        return
+    if not records:
+        console.print("[dim]No dead-lettered flushes.[/dim]")
+        return
+    # ponytail: dead-letter listing is a flat table, not a per-flush tree —
+    # --plain has nothing extra to strip, so one aligned rendering serves
+    # both the default and --plain paths.
+    for rec in records:
+        line = (
+            f"{rec.trace_id or rec.flush_id}  {rec.wiki or '-'}  "
+            f"{rec.reason or '-'}  {rec.updated_at}"
+        )
+        console.print(f"[red]{line}[/red]", highlight=False)
+
+
+@app.callback(invoke_without_command=True)
+def trace(
+    # Argument default is None (not `...`) so this callback-only Typer app
+    # collapses to a single command instead of a click Group requiring a
+    # subcommand after the argument — same workaround as drill_cmd/search_cmd.
+    selector: str = typer.Argument(
+        None, help="trace-id | session-id | last | dead | note path or [[wikilink]]"
+    ),
+    plain: bool = typer.Option(False, "--plain", help="Aligned text, no tree glyphs/color."),
+    json_out: bool = typer.Option(False, "--json", help="Raw spine event list (JSONL)."),
+) -> None:
+    """Chronological drill-down of one flush, correlated by trace_id."""
+    from lore_core.config import get_lore_root
+
+    if not selector:
+        console.print("[red]error:[/red] selector is required")
+        raise typer.Exit(code=2)
+
+    try:
+        lore_root = get_lore_root()
+    except Exception as exc:
+        console.print("[red]LORE_ROOT not set.[/red]")
+        raise typer.Exit(1) from exc
+
+    try:
+        resolved = resolve_selector(lore_root, selector)
+    except TraceNotFound as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1) from e
+
+    if resolved == "dead":
+        _print_dead(records=dead_flushes(lore_root), json_out=json_out)
+        return
+
+    traces = [flush_by_trace_id(lore_root, tid) for tid in resolved]
+
+    if json_out:
+        for t in traces:
+            for step in t.steps:
+                sys.stdout.write(json.dumps(step.raw) + "\n")
+        return
+
+    for t in traces:
+        if plain:
+            # No markup, no auto-highlight — plain text is meant to be
+            # exactly what it says: e.g. literal `(compose-failed)`, no
+            # ANSI codes injected around numbers inside trace_ids/models.
+            console.print(_render_plain(t), markup=False, highlight=False)
+        else:
+            console.print(_render_tree(t))
+
+
+main = argv_main(app)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/lore_core/trace.py
+++ b/lib/lore_core/trace.py
@@ -1,0 +1,178 @@
+"""Business logic for `lore trace` — correlated drill-down of one flush.
+
+Reconstructs a flush's story purely by reading two existing stores — the
+event spine (:mod:`lore_core.spine`, #185/#188) and the flush lifecycle
+record (:mod:`lore_core.flush_store`, #189) — never writes. A flush's
+steps are simply every spine record sharing its ``trace_id``, ordered by
+timestamp; there is no new storage or correlation mechanism here, only a
+selector that maps the five ways a user names a flush onto that
+``trace_id``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lore_core.flush_store import FlushRecord, FlushState, FlushStore
+from lore_core.note_document import read_note
+from lore_core.spine import read_spine
+
+
+class TraceNotFound(ValueError):
+    """No flush, session, or note matches the given selector."""
+
+
+@dataclass(frozen=True)
+class TraceStep:
+    """One spine record belonging to a flush, in the shape the renderer needs."""
+
+    ts: str
+    source: str
+    event: str
+    level: str
+    error_code: str | None
+    data: dict[str, Any]
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class FlushTrace:
+    trace_id: str
+    record: FlushRecord | None
+    steps: list[TraceStep]
+
+    @property
+    def status(self) -> str:
+        """Current state-machine status — 'unknown' when no record exists
+
+        (a flush whose spine events outlived its record, or a synthetic
+        trace_id with only stray events).
+        """
+        return self.record.state if self.record is not None else "unknown"
+
+
+def flush_by_trace_id(lore_root: Path, trace_id: str) -> FlushTrace:
+    """Every spine record for ``trace_id``, chronological, plus its flush record.
+
+    A dead-lettered or otherwise partial flush simply has fewer steps —
+    there is nothing to truncate, the tree ends wherever the last emitted
+    event does.
+    """
+    steps = [
+        TraceStep(
+            ts=r.get("ts", ""),
+            source=r.get("source", "?"),
+            event=r.get("event", "?"),
+            level=r.get("level", "info"),
+            error_code=r.get("error_code"),
+            data=r.get("data") or {},
+            raw=r,
+        )
+        for r in read_spine(lore_root)
+        if r.get("trace_id") == trace_id
+    ]
+    steps.sort(key=lambda s: s.ts)
+    record = next((rec for rec in FlushStore(lore_root).list() if rec.trace_id == trace_id), None)
+    return FlushTrace(trace_id=trace_id, record=record, steps=steps)
+
+
+def trace_ids_for_session(lore_root: Path, session_id: str) -> list[str]:
+    """Distinct trace_ids touched by ``session_id``, most-recently-active first."""
+    latest_ts: dict[str, str] = {}
+    for r in read_spine(lore_root):
+        if r.get("session_id") != session_id:
+            continue
+        tid = r.get("trace_id")
+        if not tid:
+            continue
+        ts = r.get("ts", "")
+        if ts > latest_ts.get(tid, ""):
+            latest_ts[tid] = ts
+    return sorted(latest_ts, key=lambda t: latest_ts[t], reverse=True)
+
+
+def last_trace_id(lore_root: Path) -> str | None:
+    """The most-recently-updated flush's trace_id, or None if no flush has one."""
+    for rec in FlushStore(lore_root).list():  # already newest-updated-first
+        if rec.trace_id:
+            return rec.trace_id
+    return None
+
+
+def dead_flushes(lore_root: Path) -> list[FlushRecord]:
+    """Dead-lettered flush records, newest-updated first."""
+    return FlushStore(lore_root).list(state=FlushState.DEAD_LETTERED)
+
+
+def _resolve_note_path(lore_root: Path, note_ref: str) -> Path | None:
+    """Resolve a note path or ``[[wikilink]]`` to a file. None if nothing matches."""
+    ref = note_ref.strip()
+    if ref.startswith("[[") and ref.endswith("]]"):
+        ref = ref[2:-2].split("|", 1)[0].strip()
+
+    def _try(name: str) -> Path | None:
+        for candidate in (Path(name), lore_root / name, Path.cwd() / name):
+            if candidate.is_file():
+                return candidate
+        return None
+
+    found = _try(ref)
+    if found is not None:
+        return found
+    if not ref.endswith(".md"):
+        found = _try(f"{ref}.md")
+        if found is not None:
+            return found
+        ref = f"{ref}.md"
+    # Bare slug: search every wiki (wikilink resolution is per-wiki, but a
+    # reverse CLI lookup has no wiki context yet — search all of them).
+    wiki_dir = lore_root / "wiki"
+    if wiki_dir.is_dir():
+        matches = sorted(wiki_dir.glob(f"*/**/{ref}"))
+        if matches:
+            return matches[0]
+    return None
+
+
+def trace_id_for_note(lore_root: Path, note_ref: str) -> str | None:
+    """Reverse lookup: a note's ``linkage.trace_id`` frontmatter field."""
+    path = _resolve_note_path(lore_root, note_ref)
+    if path is None:
+        return None
+    linkage = read_note(path).frontmatter.get("linkage") or {}
+    tid = linkage.get("trace_id")
+    return tid if isinstance(tid, str) else None
+
+
+def resolve_selector(lore_root: Path, selector: str) -> str | list[str]:
+    """Map a `lore trace` argument onto trace_id(s).
+
+    Returns the literal ``"dead"`` for the dead-letter listing (a
+    different output shape from a flush tree — a list, not one story);
+    otherwise a list of one or more trace_ids, newest first.
+    """
+    if selector == "dead":
+        return "dead"
+    if selector == "last":
+        tid = last_trace_id(lore_root)
+        if tid is None:
+            raise TraceNotFound("no flush records yet")
+        return [tid]
+
+    note_tid = trace_id_for_note(lore_root, selector)
+    if note_tid is not None:
+        return [note_tid]
+
+    known_trace_ids = {rec.trace_id for rec in FlushStore(lore_root).list() if rec.trace_id}
+    if selector in known_trace_ids or any(
+        r.get("trace_id") == selector for r in read_spine(lore_root)
+    ):
+        return [selector]
+
+    session_tids = trace_ids_for_session(lore_root, selector)
+    if session_tids:
+        return session_tids
+
+    raise TraceNotFound(f"no flush, session, or note matches {selector!r}")

--- a/tests/test_trace_cmd.py
+++ b/tests/test_trace_cmd.py
@@ -1,0 +1,337 @@
+"""`lore trace` (#192) — correlated drill-down of one flush.
+
+Golden-output tests for --plain / --json pin the rendering; the fixtures
+write spine records and flush records directly (the pattern used by
+test_status_cmd.py / test_log_cmd.py) rather than driving the full
+pipeline, since the reader is the thing under test here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from lore_cli.trace_cmd import app
+from lore_core.flush_store import ErrorCode, FlushState, FlushStore
+from lore_core.spine import SpineWriter
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _lore_root(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / ".lore").mkdir(parents=True)
+    return root
+
+
+def _emit(lore_root: Path, *, source: str, event: str, **kw) -> None:
+    SpineWriter(lore_root).emit(source=source, event=event, **kw)
+
+
+def _invoke(lore_root: Path, *args: str, monkeypatch) -> object:
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    return runner.invoke(app, list(args), catch_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# AC1 — all five selectors
+# ---------------------------------------------------------------------------
+
+
+def test_exact_trace_id_selector(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    trace_id = "trace-exact-1"
+    _emit(lore_root, source="curator", event="run-start", trace_id=trace_id, run_id="r1")
+    _emit(lore_root, source="curator", event="run-end", trace_id=trace_id, run_id="r1")
+
+    result = _invoke(lore_root, trace_id, "--plain", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    assert f"trace {trace_id}" in result.output
+    assert "curator/run-start" in result.output
+    assert "curator/run-end" in result.output
+
+
+def test_session_id_selector_returns_all_flushes_of_session(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    sid = "sess-shared"
+    _emit(
+        lore_root,
+        source="drain",
+        event="note-filed",
+        trace_id="trace-A",
+        session_id=sid,
+        wiki="private",
+        data={"path": "wiki/private/sessions/a.md"},
+    )
+    _emit(
+        lore_root,
+        source="drain",
+        event="note-appended",
+        trace_id="trace-B",
+        session_id=sid,
+        wiki="private",
+        data={"path": "wiki/private/sessions/b.md"},
+    )
+    # A third, unrelated flush from a different session must not appear.
+    _emit(
+        lore_root,
+        source="drain",
+        event="note-filed",
+        trace_id="trace-C",
+        session_id="sess-other",
+        wiki="private",
+    )
+
+    result = _invoke(lore_root, sid, "--plain", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    assert "trace-A" in result.output
+    assert "trace-B" in result.output
+    assert "trace-C" not in result.output
+
+
+def test_last_selector_picks_most_recently_updated_flush(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    store = FlushStore(lore_root)
+    older = store.begin("older-buffer", wiki="private", trace_id="trace-older")
+    store.transition(older, FlushState.RUNNING)
+    store.transition(older, FlushState.PUBLISHED)
+    newer = store.begin("newer-buffer", wiki="private", trace_id="trace-newer")
+    store.transition(newer, FlushState.RUNNING)
+
+    result = _invoke(lore_root, "last", "--plain", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    assert "trace-newer" in result.output
+    assert "trace-older" not in result.output
+
+
+def test_dead_selector_lists_dead_lettered_newest_first(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    store = FlushStore(lore_root)
+
+    first = store.begin("buf-1", wiki="private", trace_id="trace-dead-1")
+    store.transition(first, FlushState.RUNNING)
+    store.transition(first, FlushState.DEAD_LETTERED, reason=ErrorCode.COMPOSE_FAILED)
+
+    second = store.begin("buf-2", wiki="private", trace_id="trace-dead-2")
+    store.transition(second, FlushState.RUNNING)
+    store.transition(second, FlushState.DEAD_LETTERED, reason=ErrorCode.SPAWN_FAILED)
+
+    # A published flush must not show up in the dead list.
+    ok = store.begin("buf-3", wiki="private", trace_id="trace-ok")
+    store.transition(ok, FlushState.RUNNING)
+    store.transition(ok, FlushState.PUBLISHED)
+
+    result = _invoke(lore_root, "dead", "--plain", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    first_pos = result.output.index("trace-dead-2")
+    second_pos = result.output.index("trace-dead-1")
+    assert first_pos < second_pos, "newest dead-letter must render first"
+    assert "trace-ok" not in result.output
+
+
+def test_note_selector_resolves_via_frontmatter_linkage(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    trace_id = "trace-from-note"
+    _emit(lore_root, source="curator", event="run-start", trace_id=trace_id, run_id="r1")
+
+    note_dir = lore_root / "wiki" / "private" / "sessions"
+    note_dir.mkdir(parents=True)
+    note_path = note_dir / "2026-05-01-example.md"
+    note_path.write_text(
+        "---\n"
+        "schema_version: 1\n"
+        "type: session\n"
+        "linkage:\n"
+        f"  trace_id: {trace_id}\n"
+        "---\n"
+        "Disclaimer.\n"
+    )
+
+    by_path = _invoke(lore_root, str(note_path), "--plain", monkeypatch=monkeypatch)
+    assert by_path.exit_code == 0
+    assert trace_id in by_path.output
+
+    by_wikilink = _invoke(lore_root, "[[2026-05-01-example]]", "--plain", monkeypatch=monkeypatch)
+    assert by_wikilink.exit_code == 0
+    assert trace_id in by_wikilink.output
+
+
+def test_unknown_selector_errors_without_crashing(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    result = _invoke(lore_root, "no-such-thing", monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# AC2 — header is the current flush status; steps carry model/tokens, note path
+# ---------------------------------------------------------------------------
+
+
+def test_header_shows_current_flush_status(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    store = FlushStore(lore_root)
+    rec = store.begin("buf-status", wiki="private", trace_id="trace-status")
+    store.transition(rec, FlushState.RUNNING)
+
+    result = _invoke(lore_root, "trace-status", "--plain", monkeypatch=monkeypatch)
+    assert "-- running" in result.output
+
+
+def test_llm_step_shows_model_and_tokens(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    trace_id = "trace-llm"
+    _emit(
+        lore_root,
+        source="curator",
+        event="llm-response",
+        trace_id=trace_id,
+        run_id="r1",
+        data={"model": "claude-opus-4-8", "token_count": 512},
+    )
+
+    result = _invoke(lore_root, trace_id, "--plain", monkeypatch=monkeypatch)
+    assert "model=claude-opus-4-8" in result.output
+    assert "tokens=512" in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC3 — golden --plain / --json
+# ---------------------------------------------------------------------------
+
+
+def test_golden_plain_output(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    trace_id = "trace-golden"
+    _emit(lore_root, source="hook", event="capture", trace_id=trace_id, data={})
+    _emit(
+        lore_root,
+        source="curator",
+        event="run-start",
+        trace_id=trace_id,
+        run_id="r1",
+        data={},
+    )
+    _emit(
+        lore_root,
+        source="drain",
+        event="note-filed",
+        trace_id=trace_id,
+        session_id="s1",
+        data={"path": "wiki/private/sessions/x.md"},
+    )
+    # SpineWriter always stamps ``ts`` itself — overwrite the file directly
+    # so the fixture controls timestamps (needed for a deterministic golden).
+    _rewrite_timestamps(
+        lore_root,
+        {
+            0: "2026-05-01T10:00:00Z",
+            1: "2026-05-01T10:00:01Z",
+            2: "2026-05-01T10:00:03Z",
+        },
+    )
+
+    result = _invoke(lore_root, trace_id, "--plain", monkeypatch=monkeypatch)
+    expected = (
+        "trace trace-golden -- unknown\n"
+        "    hook/capture  +1.0s\n"
+        "    curator/run-start  +2.0s\n"
+        "    drain/note-filed -> wiki/private/sessions/x.md"
+    )
+    assert result.output.strip() == expected
+
+
+def _rewrite_timestamps(lore_root: Path, ts_by_line: dict) -> None:
+    spine = lore_root / ".lore" / "spine.jsonl"
+    lines = spine.read_text().splitlines()
+    out = []
+    for i, line in enumerate(lines):
+        rec = json.loads(line)
+        if i in ts_by_line:
+            rec["ts"] = ts_by_line[i]
+        out.append(json.dumps(rec))
+    spine.write_text("\n".join(out) + "\n")
+
+
+def test_golden_json_output(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    trace_id = "trace-json"
+    _emit(lore_root, source="curator", event="run-start", trace_id=trace_id, run_id="r1")
+    _emit(lore_root, source="curator", event="run-end", trace_id=trace_id, run_id="r1")
+
+    result = _invoke(lore_root, trace_id, "--json", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    lines = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert [rec["event"] for rec in lines] == ["run-start", "run-end"]
+    assert all(rec["trace_id"] == trace_id for rec in lines)
+
+
+# ---------------------------------------------------------------------------
+# AC4 — partial/failed trace truncates, never errors
+# ---------------------------------------------------------------------------
+
+
+def test_dead_lettered_flush_truncates_at_failure(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    store = FlushStore(lore_root)
+    trace_id = "trace-truncated"
+    rec = store.begin("buf-fail", wiki="private", trace_id=trace_id)
+    store.transition(rec, FlushState.RUNNING)
+    _emit(lore_root, source="curator", event="buffer-opened", trace_id=trace_id, run_id="r1")
+    store.transition(rec, FlushState.DEAD_LETTERED, reason=ErrorCode.COMPOSE_FAILED)
+
+    result = _invoke(lore_root, trace_id, "--plain", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    assert "-- dead-lettered" in result.output
+    # Last line rendered is the dead-letter transition itself — nothing
+    # is synthesized past the last real event.
+    last_line = [ln for ln in result.output.splitlines() if ln.strip()][-1]
+    assert "flush-dead-lettered" in last_line
+    assert "(compose-failed)" in last_line
+
+
+def test_trace_with_no_events_does_not_crash(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    store = FlushStore(lore_root)
+    store.begin("buf-empty", wiki="private", trace_id="trace-empty")
+
+    result = _invoke(lore_root, "trace-empty", "--plain", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# AC5 — read-only
+# ---------------------------------------------------------------------------
+
+
+def _snapshot(lore_root: Path) -> dict[str, str]:
+    out = {}
+    for p in sorted(lore_root.rglob("*")):
+        if p.is_file():
+            out[str(p.relative_to(lore_root))] = hashlib.sha256(p.read_bytes()).hexdigest()
+    return out
+
+
+def test_trace_never_writes_to_lore_root(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    store = FlushStore(lore_root)
+    rec = store.begin("buf-ro", wiki="private", trace_id="trace-readonly")
+    store.transition(rec, FlushState.RUNNING)
+    _emit(lore_root, source="curator", event="run-start", trace_id="trace-readonly", run_id="r1")
+    note_dir = lore_root / "wiki" / "private" / "sessions"
+    note_dir.mkdir(parents=True)
+    (note_dir / "n.md").write_text("---\nlinkage:\n  trace_id: trace-readonly\n---\nbody\n")
+
+    before = _snapshot(lore_root)
+    for args in (
+        ["trace-readonly"],
+        ["trace-readonly", "--plain"],
+        ["trace-readonly", "--json"],
+        ["last"],
+        ["dead"],
+        [str(note_dir / "n.md")],
+    ):
+        _invoke(lore_root, *args, monkeypatch=monkeypatch)
+    after = _snapshot(lore_root)
+    assert before == after, "lore trace must never write to lore_root"


### PR DESCRIPTION
## Summary

- Adds `lore trace <selector>` — the correlated debugging surface from PRD 0005 Pillar B. Reads only two existing stores: the event spine (`lore_core.spine.read_spine`, #185/#188) and the flush lifecycle record (`lore_core.flush_store.FlushStore`, #189). Never writes.
- Five selectors resolve to trace_id(s) in `lore_core.trace.resolve_selector`: exact `trace_id`, `session_id` (all flushes of a session), `last` (most-recently-updated flush), `dead` (dead-lettered flushes, newest first — a list, not a tree), and a note path or `[[wikilink]]` (reverse lookup via `linkage.trace_id` frontmatter).
- Renders a chronological story of one flush's spine records with the flush's current state-machine status as the header, per-step durations (gap to the next event), and LLM call / note-append annotations. `--plain` (aligned text, no markup/highlight) and `--json` (raw spine records) are golden-tested. A dead-lettered/partial flush simply has fewer steps — the render ends at the last real event, never errors.
- New business logic lives in `lib/lore_core/trace.py` (selector resolution + `FlushTrace`/`TraceStep` assembly) per the CLI contract's layering rule; `lib/lore_cli/trace_cmd.py` is argument parsing + Rich rendering only. Registered in `__main__.py` via one `add_typer` line (2-line diff total).
- Does not touch `log_cmd.py` / `runs_cmd.py` / `proc_cmd.py` (deprecation is #195) or the janitor/retention/status modules.

## Red → green

Wrote `tests/test_trace_cmd.py` first (13 tests: one per selector, header/status, LLM-step annotation, golden `--plain`/`--json`, dead-lettered truncation, empty-trace no-crash, and a read-only assertion that snapshots the vault before/after six different invocations). Initial run failed on argument parsing — `typer.Argument(..., required)` collapses a callback-only Typer app into a Click `Group` that then demands a subcommand after the positional. Fixed the same way `drill_cmd.py`/`search_cmd.py` already do: default the argument to `None` (validate presence in the body) plus `context_settings={"allow_interspersed_args": True}` so `lore trace <id> --plain` and `lore trace --plain <id>` both parse. Then hit Rich's default `highlight=True` auto-colorizing digits inside trace_ids/models (breaking `--plain` determinism) and its markup parser treating a literal `[compose-failed]` as a style tag — fixed with `markup=False, highlight=False` on the plain-text print path and switching the error-code annotation to parens.

```
$ PYTHONPATH=lib .venv/bin/python -m pytest tests/test_trace_cmd.py -q
11 failed, 2 passed   # first run: Usage/MissingParameter errors from the Group-collapse issue
...
5 failed, 8 passed    # after the argument-parsing fix: Rich markup/highlight artifacts in --plain
...
13 passed             # after markup=False/highlight=False + paren error-code format
```

Full suite: `2819 passed, 16 skipped` plus the same 10 pre-existing ANSI-color CliRunner failures already present on `epic/183` (none in files this PR touches — confirmed via `git status` showing only `trace_cmd.py`, `trace.py`, `test_trace_cmd.py`, and a 2-line additive `__main__.py` diff).

`ruff check` + `ruff format --check` clean on all touched files.

Closes #192

## Test plan

- [x] `pytest tests/test_trace_cmd.py -q` — 13/13 passing
- [x] `pytest tests/test_cli_contract.py tests/test_layering.py tests/test_trace_id.py -q` — 51/51 passing (layering + trace_id propagation unaffected)
- [x] `pytest tests/ -q` — 2819 passed, 16 skipped, 10 pre-existing failures (unrelated files, present on `epic/183` before this PR)
- [x] `ruff check` / `ruff format --check` clean on touched files