### PR TITLE
feat: lore status v2 — unified health dashboard with wiki connection health (#193)

### DIFF
--- a/lib/lore_cli/status_cmd.py
+++ b/lib/lore_cli/status_cmd.py
@@ -1,22 +1,40 @@
-"""``lore status`` — activity-first liveness surface.
+"""``lore status`` v2 — unified health dashboard (issue #193).
 
-The single "is lore doing anything for me right now?" command. Renders
-``CaptureState`` (from ``lore_core.capture_state``) with decay-first
-line ordering and loud-on-earning alerts.
+The single glanceable "is Lore healthy right now?" surface. One line per
+concern across six sections, every alert paired with the exact drill-down
+command (PRD 0005, "Dashboard grammar"):
 
-Output shape on a healthy vault (exactly 7 newlines)::
+    lore: active · private/proj:test · attached at ~/project
 
-    lore: active · private/proj:test · attached at <scope_root>
-
-      · Last note    [[...]] · 18h ago
-      · Last run     2h ago · 1 note from 1 transcript
+    capture
+      · Last note    [[...]] · 2h ago
+      · Last run     2h ago · 1 note
+      · Last flush   published · 30m ago
+      · Hook         12m ago · session-start · spawned-curator
       · Pending      no transcripts
       · Session      not loaded in this shell
       · Lock         free
 
-Loud-on-earning lines are appended below the healthy block only when
-thresholds are crossed. No ``--plumbing`` flag — ``lore doctor`` owns
-install integrity. This command is strictly about activity.
+    flushes
+      · queued 0 · running 0 · dead-lettered 0
+
+    wikis
+      · private      clean · ahead 0 · behind 0 · reachable
+
+    retention
+      · hot 0.0/10 MB · janitor 5m ago
+
+    news
+      · nothing new
+
+    alerts
+      · none
+
+Reads only — the event spine (#185), flush store (#189), retention janitor
+status (#190), and per-wiki git state. Absorbs ``lore news`` (drain events
+for the current session, cursor advance preserved). Rendered as plain text
+(no ANSI) so it degrades cleanly for non-TTY / ``--plain`` and scripting.
+Exit code is 0 when healthy and nonzero when any alert is earned.
 """
 
 from __future__ import annotations
@@ -28,38 +46,60 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import typer
-from rich.console import Console
-
 from lore_core.capture_state import CaptureState, query_capture_state
 from lore_core.config import get_lore_root
 from lore_core.timefmt import relative_time
-
+from rich.console import Console
 
 console = Console()
 
 app = typer.Typer(
     add_completion=False,
-    help="Is lore doing anything for me right now? Shows activity, staleness, and alerts.",
+    help="Lore health dashboard — capture, flushes, wikis, retention, news, alerts.",
     no_args_is_help=False,
     rich_markup_mode="rich",
 )
-
-
-# ---------------------------------------------------------------------------
-# Rendering helpers
-# ---------------------------------------------------------------------------
 
 _HEALTHY = "·"
 _WARN = "!"
 _ERROR = "x"
 
 
-def _session_loaded_ts(now: datetime) -> datetime | None:
-    """Newest mtime in ``~/.cache/lore/sessions/`` (PID-keyed cache).
+def _line(glyph: str, message: str) -> str:
+    return f"  {glyph} {message}"
 
-    Represents "a Claude session loaded lore recently." Returns None if
-    no sessions/ directory or no files within the last hour.
-    """
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_now() -> datetime:
+    """Allow tests to pin `now` via _LORE_STATUS_NOW env var."""
+    env = os.environ.get("_LORE_STATUS_NOW")
+    if env:
+        try:
+            parsed = datetime.fromisoformat(env.replace("Z", "+00:00"))
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+        except ValueError:
+            pass
+    return datetime.now(UTC)
+
+
+def _format_scope_root(p: Path | None) -> str:
+    if p is None:
+        return "?"
+    try:
+        home = Path.home()
+        if p.is_relative_to(home):
+            return "~/" + str(p.relative_to(home))
+    except (AttributeError, ValueError):
+        pass
+    return str(p)
+
+
+def _session_loaded_ts(now: datetime) -> datetime | None:
+    """Newest mtime in ``~/.cache/lore/sessions/`` within the last hour."""
     cache_env = os.environ.get("LORE_CACHE")
     cache_dir = Path(cache_env).expanduser() if cache_env else Path.home() / ".cache" / "lore"
     sessions_dir = cache_dir / "sessions"
@@ -81,46 +121,17 @@ def _session_loaded_ts(now: datetime) -> datetime | None:
     if newest_mtime is None:
         return None
     ts = datetime.fromtimestamp(newest_mtime, tz=UTC)
-    # Only count "loaded" if within the last hour — otherwise the cache
-    # file is just stale from a prior session that never cleaned up.
     if (now - ts) > timedelta(hours=1):
         return None
     return ts
 
 
-def _format_scope_root(p: Path | None) -> str:
-    if p is None:
-        return "?"
-    try:
-        home = Path.home()
-        if p.is_relative_to(home):
-            return "~/" + str(p.relative_to(home))
-    except (AttributeError, ValueError):
-        pass
-    return str(p)
-
-
-def _last_two_zero_note_runs(lore_root: Path) -> list[str] | None:
-    """Return [short_id1, short_id2] if the last two runs both filed 0 notes.
-
-    Used for the "loud-on-earning" 0-note alert. Returns None otherwise.
-    """
-    from lore_core.run_reader import read_run_by_id, run_ids
-
-    short_ids: list[str] = []
-    for run_id in run_ids(lore_root, limit=2):
-        records = read_run_by_id(lore_root, run_id)
-        end = next((r for r in reversed(records) if r.get("type") == "run-end"), None)
-        if end is None:
-            return None
-        if end.get("notes_new", 0) != 0 or end.get("notes_merged", 0) != 0:
-            return None
-        short_ids.append(run_id.split("-")[-1])
-    return short_ids if len(short_ids) == 2 else None
+# ---------------------------------------------------------------------------
+# capture section
+# ---------------------------------------------------------------------------
 
 
 def _render_last_note(state: CaptureState, now: datetime) -> tuple[str, str]:
-    """Return (glyph, message) for the Last note line."""
     if state.last_note_filed is None:
         return (_HEALTHY, "Last note    —")
     ts, wikilink = state.last_note_filed
@@ -143,21 +154,20 @@ def _render_last_run(state: CaptureState, now: datetime) -> tuple[str, str]:
     return (_HEALTHY, f"Last run     {when} · {notes} {notes_label}")
 
 
-def _render_pending(state: CaptureState) -> tuple[str, str]:
-    n = state.pending_transcripts
-    if n == 0:
-        return (_HEALTHY, "Pending      no transcripts")
-    label = "transcript" if n == 1 else "transcripts"
-    return (_HEALTHY, f"Pending      {n} {label}")
+def _render_last_flush(lore_root: Path, now: datetime) -> tuple[str, str]:
+    """Most-recently-updated flush record's state + age (per the #189 machine)."""
+    from lore_core.flush_store import FlushStore
+
+    records = FlushStore(lore_root).list()  # newest-updated first
+    if not records:
+        return (_HEALTHY, "Last flush   —")
+    rec = records[0]
+    when = relative_time(rec.updated_at, now=now)
+    glyph = _ERROR if rec.state == "dead-lettered" else _HEALTHY
+    return (glyph, f"Last flush   {rec.state} · {when}")
 
 
 def _render_hook(state: CaptureState, now: datetime) -> tuple[str, str]:
-    """Liveness of the capture hook itself.
-
-    Answers "did Claude Code actually invoke my SessionStart/SessionEnd
-    hook recently?" — which is structurally different from "did curator
-    run?" (runs can be triggered manually; hooks can't).
-    """
     ts = state.last_hook_event_ts
     if ts is None:
         return (_HEALTHY, "Hook         —")
@@ -167,14 +177,19 @@ def _render_hook(state: CaptureState, now: datetime) -> tuple[str, str]:
     return (_HEALTHY, f"Hook         {when} · {kind} · {outcome}")
 
 
+def _render_pending(state: CaptureState) -> tuple[str, str]:
+    n = state.pending_transcripts
+    if n == 0:
+        return (_HEALTHY, "Pending      no transcripts")
+    label = "transcript" if n == 1 else "transcripts"
+    return (_HEALTHY, f"Pending      {n} {label}")
+
+
 def _render_session(now: datetime) -> tuple[str, str]:
     ts = _session_loaded_ts(now)
     if ts is None:
         return (_HEALTHY, "Session      not loaded in this shell")
-    return (
-        _HEALTHY,
-        f"Session      loaded {relative_time(ts, now=now)} · /lore:context",
-    )
+    return (_HEALTHY, f"Session      loaded {relative_time(ts, now=now)} · /lore:context")
 
 
 def _render_lock(state: CaptureState) -> tuple[str, str]:
@@ -183,13 +198,189 @@ def _render_lock(state: CaptureState) -> tuple[str, str]:
     return (_HEALTHY, "Lock         free")
 
 
-def _render_alerts(state: CaptureState, now: datetime) -> list[str]:
-    """Return additional alert lines appended after the healthy block.
+def _capture_lines(state: CaptureState, lore_root: Path, now: datetime) -> list[str]:
+    rows = [
+        _render_last_note(state, now),
+        _render_last_run(state, now),
+        _render_last_flush(lore_root, now),
+        _render_hook(state, now),
+        _render_pending(state),
+        _render_session(now),
+        _render_lock(state),
+    ]
+    return [_line(g, m) for g, m in rows]
 
-    Each entry is already prefixed with its glyph.
-    """
+
+# ---------------------------------------------------------------------------
+# flushes section
+# ---------------------------------------------------------------------------
+
+
+def _flush_counts(lore_root: Path) -> tuple[int, int, int]:
+    """(queued, running, dead-lettered) from the flush store."""
+    from collections import Counter
+
+    from lore_core.flush_store import FlushStore
+
+    counts = Counter(r.state for r in FlushStore(lore_root).list())
+    return (counts.get("queued", 0), counts.get("running", 0), counts.get("dead-lettered", 0))
+
+
+def _flushes_lines(lore_root: Path) -> list[str]:
+    queued, running, dead = _flush_counts(lore_root)
+    msg = f"queued {queued} · running {running} · dead-lettered {dead}"
+    if dead > 0:
+        # Loud: dead letters need a human; name the drill-down (#192).
+        return [_line(_ERROR, f"{msg} — lore trace dead")]
+    return [_line(_HEALTHY, msg)]
+
+
+# ---------------------------------------------------------------------------
+# wikis section — per-wiki connection health (FAST local-first, #193)
+# ---------------------------------------------------------------------------
+
+
+def _wiki_dirs(lore_root: Path) -> list[Path]:
+    wiki_root = lore_root / "wiki"
+    if not wiki_root.is_dir():
+        return []
+    return [d for d in sorted(wiki_root.iterdir()) if d.is_dir()]
+
+
+def _render_wiki_line(name: str, offline: bool, lore_root: Path) -> str:
+    from lore_core.git_sync import wiki_health
+
+    h = wiki_health(lore_root / "wiki" / name, offline=offline)
+    if not h.is_repo:
+        return _line(_HEALTHY, f"{name:12s} local (no git)")
+    state = "dirty" if h.dirty else "clean"
+    if not h.has_remote:
+        return _line(_HEALTHY, f"{name:12s} {state} · no remote")
+    parts = [state, f"ahead {h.ahead}", f"behind {h.behind}"]
+    if not offline:
+        if h.reachable is True:
+            parts.append("reachable")
+        elif h.reachable is False:
+            parts.append("unreachable")
+    return _line(_HEALTHY, f"{name:12s} " + " · ".join(parts))
+
+
+def _wikis_lines(lore_root: Path, offline: bool) -> list[str]:
+    dirs = _wiki_dirs(lore_root)
+    if not dirs:
+        return [_line(_HEALTHY, "no wikis")]
+    return [_render_wiki_line(d.name, offline, lore_root) for d in dirs]
+
+
+# ---------------------------------------------------------------------------
+# retention section — consumes #190's read_janitor_status
+# ---------------------------------------------------------------------------
+
+
+def _retention_lines(lore_root: Path, now: datetime) -> list[str]:
+    from lore_core.janitor import read_janitor_status
+    from lore_core.root_config import load_root_config
+
+    cap_mb = load_root_config(lore_root).observability.hook_events.max_size_mb
+    spine = lore_root / ".lore" / "spine.jsonl"
+    try:
+        hot_bytes = spine.stat().st_size
+    except OSError:
+        hot_bytes = 0
+    hot_mb = hot_bytes / (1024 * 1024)
+
+    status = read_janitor_status(lore_root)
+    if status and status.get("last_run_at"):
+        janitor = f"janitor {relative_time(status['last_run_at'], now=now)}"
+    else:
+        janitor = "janitor never run"
+
+    failed = (status or {}).get("failed", 0) or 0
+    glyph = _WARN if failed else _HEALTHY
+    msg = f"hot {hot_mb:.1f}/{cap_mb} MB · {janitor}"
+    if failed:
+        msg += f" · {failed} failed deletion(s)"
+    return [_line(glyph, msg)]
+
+
+# ---------------------------------------------------------------------------
+# news section — absorbs `lore news` (cursor advance preserved, #193/#188)
+# ---------------------------------------------------------------------------
+
+
+def _news_lines(lore_root: Path, cwd: Path) -> list[str]:
+    from lore_core.drain import DrainStore, resolve_session_id
+
+    from lore_cli.news_cmd import _COPY, _advance_cursor, _collect_events
+
+    sid = resolve_session_id(cwd)[0]
+    cutoff = DrainStore(lore_root, sid).read_cursor()
+    session_store, system_store, session_events, system_events = _collect_events(
+        lore_root, sid, cutoff, None, limit=10
+    )
+    events = session_events + system_events
+    if not events:
+        lines = [_line(_HEALTHY, "nothing new")]
+    else:
+        lines = []
+        for e in events:
+            label = _COPY.get(e.event, e.event)
+            wiki = f" ({e.wiki})" if e.wiki else ""
+            wikilink = e.data.get("wikilink")
+            detail = f" {wikilink}" if wikilink else ""
+            lines.append(_line(_HEALTHY, f"{label}{wiki}{detail}"))
+
+    # Advance both cursors so each event surfaces once (news semantics).
+    _advance_cursor(session_store, session_events)
+    _advance_cursor(system_store, system_events)
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# alerts section — every earned warn/error paired with its drill-down cmd
+# ---------------------------------------------------------------------------
+
+
+def _last_two_zero_note_runs(lore_root: Path) -> list[str] | None:
+    from lore_core.run_reader import read_run_by_id, run_ids
+
+    short_ids: list[str] = []
+    for run_id in run_ids(lore_root, limit=2):
+        records = read_run_by_id(lore_root, run_id)
+        end = next((r for r in reversed(records) if r.get("type") == "run-end"), None)
+        if end is None:
+            return None
+        if end.get("notes_new", 0) != 0 or end.get("notes_merged", 0) != 0:
+            return None
+        short_ids.append(run_id.split("-")[-1])
+    return short_ids if len(short_ids) == 2 else None
+
+
+def _diverged_wikis(lore_root: Path) -> list[str]:
+    from lore_core.git_sync import is_diverged
+
+    diverged: list[str] = []
+    for wiki_dir in _wiki_dirs(lore_root):
+        try:
+            if is_diverged(wiki_dir):
+                diverged.append(wiki_dir.name)
+        except Exception:  # noqa: BLE001 — never fail status on a git probe
+            continue
+    return diverged
+
+
+def _compute_alerts(state: CaptureState, now: datetime, lore_root: Path) -> list[str]:
+    """Return earned alert lines (already glyph-prefixed), each naming a fix."""
+    from lore_core.flush_store import FlushState, FlushStore
+    from lore_core.janitor import read_janitor_status
+
     alerts: list[str] = []
-    lore_root = state.lore_root
+
+    # Dead-lettered flushes — loud, name the trace drill-down (#192).
+    dead = FlushStore(lore_root).list(state=FlushState.DEAD_LETTERED)
+    if dead:
+        n = len(dead)
+        alerts.append(f"{_ERROR} {n} flush{'es' if n > 1 else ''} dead-lettered — lore trace dead")
 
     zero_runs = _last_two_zero_note_runs(lore_root)
     if zero_runs:
@@ -198,32 +389,30 @@ def _render_alerts(state: CaptureState, now: datetime) -> list[str]:
             f"— lore runs show {zero_runs[0]}"
         )
 
-    if state.spine_write_failed_marker_age_s is not None:
-        if state.spine_write_failed_marker_age_s < 86400:
-            alerts.append(
-                f"{_ERROR} spine write failed "
-                f"{relative_time(now - timedelta(seconds=state.spine_write_failed_marker_age_s), now=now)} "
-                f"— check disk / permissions"
-            )
-
-    if state.simple_tier_fallback_active:
+    if (
+        state.spine_write_failed_marker_age_s is not None
+        and state.spine_write_failed_marker_age_s < 86400
+    ):
+        when = relative_time(
+            now - timedelta(seconds=state.spine_write_failed_marker_age_s), now=now
+        )
         alerts.append(
-            f"{_WARN} simple-tier fallback active — high tier unavailable"
+            f"{_ERROR} spine write failed {when} — check disk / permissions (lore doctor)"
         )
 
-    # Work is waiting but the capture hook isn't leaving traces — strong
-    # signal that Claude Code is not invoking the hook (plugin install
-    # issue, silent scope-resolution failure, timeout kill, etc.).
+    if state.simple_tier_fallback_active:
+        alerts.append(f"{_WARN} simple-tier fallback active — high tier unavailable (lore doctor)")
+
+    # Work is waiting but the capture hook isn't leaving traces.
     if state.pending_transcripts > 0:
         ts = state.last_hook_event_ts
-        stale = ts is None or (now - ts) > timedelta(hours=24)
-        if stale:
+        if ts is None or (now - ts) > timedelta(hours=24):
             alerts.append(
                 f"{_WARN} no hook events in 24h while {state.pending_transcripts} "
-                f"transcript(s) pending — capture hook may not be firing "
-                f"(try `lore doctor`)"
+                f"transcript(s) pending — capture hook may not be firing (lore doctor)"
             )
 
+    # Subprocess role logs with error tails.
     proc_dir = lore_root / ".lore" / "proc"
     if proc_dir.is_dir():
         for role_log in sorted(proc_dir.glob("*.log")):
@@ -232,50 +421,44 @@ def _render_alerts(state: CaptureState, now: datetime) -> list[str]:
             try:
                 if role_log.stat().st_size == 0:
                     continue
-                tail = role_log.read_bytes()[-2048:]
-                text = tail.decode("utf-8", errors="replace")
+                text = role_log.read_bytes()[-2048:].decode("utf-8", errors="replace")
                 if any(m in text for m in ("Traceback", "Error:", "FATAL")):
                     role = role_log.stem
-                    alerts.append(
-                        f"{_ERROR} subprocess {role} has errors "
-                        f"— lore proc show {role}"
-                    )
+                    alerts.append(f"{_ERROR} subprocess {role} has errors — lore proc show {role}")
             except OSError:
                 pass
 
-    # Cross-host divergence — local has commits remote doesn't AND vice
-    # versa. auto_pull (Phase 10) skips diverged trees silently, so the
-    # status command is the canonical "you have unfinished work" surface.
-    for wiki in _diverged_wikis(lore_root):
+    # Retention janitor delete failures.
+    js = read_janitor_status(lore_root)
+    if js and (js.get("failed", 0) or 0) > 0:
         alerts.append(
-            f"{_WARN} wiki [[{wiki}]] diverged from origin — `git pull` manually"
+            f"{_WARN} retention janitor had {js['failed']} failed deletion(s) — lore doctor"
         )
+
+    # Cross-host divergence — auto_pull skips diverged trees silently.
+    for wiki in _diverged_wikis(lore_root):
+        alerts.append(f"{_WARN} wiki [[{wiki}]] diverged from origin — git pull manually")
+
+    # Plugin-cache drift — reuse doctor's canonical check (guarded: it is a
+    # sibling-owned private, and this alert is best-effort). Drill-down: doctor.
+    try:
+        from lore_cli.doctor_cmd import _check_claude_plugin_cache_drift
+
+        ok, _msg = _check_claude_plugin_cache_drift(str(lore_root))
+        if not ok:
+            alerts.append(f"{_WARN} plugin cache drift — lore doctor")
+    except Exception:  # noqa: BLE001 — never fail status on the drift probe
+        pass
 
     return alerts
 
 
-def _diverged_wikis(lore_root: Path) -> list[str]:
-    """Walk attached wikis; return names whose local branch has diverged
-    from origin. Cheap local-only check; never fetches."""
-    from lore_core.git_sync import is_diverged
-
-    wiki_root = lore_root / "wiki"
-    if not wiki_root.is_dir():
-        return []
-    diverged: list[str] = []
-    for wiki_dir in sorted(wiki_root.iterdir()):
-        if not wiki_dir.is_dir():
-            continue
-        try:
-            if is_diverged(wiki_dir):
-                diverged.append(wiki_dir.name)
-        except Exception:  # noqa: BLE001 — never fail status on git probe
-            continue
-    return diverged
+# ---------------------------------------------------------------------------
+# unattached copy + json
+# ---------------------------------------------------------------------------
 
 
 def _render_unattached(lore_root: Path, cwd: Path) -> str:
-    """UX-verbatim copy for the unattached-cwd case."""
     from lore_core.config import get_wiki_root
 
     vault_names: list[str] = []
@@ -285,7 +468,7 @@ def _render_unattached(lore_root: Path, cwd: Path) -> str:
             for d in sorted(wiki_root.iterdir()):
                 if d.is_dir():
                     vault_names.append(f"{d.name}/lore at {_format_scope_root(d.parent.parent)}")
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
 
     vaults_str = ", ".join(vault_names) if vault_names else f"none found in {lore_root}"
@@ -299,168 +482,7 @@ def _render_unattached(lore_root: Path, cwd: Path) -> str:
     )
 
 
-# ---------------------------------------------------------------------------
-# Verbose sections
-# ---------------------------------------------------------------------------
-
-_OVERDUE_A_S = 86400      # 24h
-
-
-def _render_verbose_curator_schedule(lore_root: Path, now: datetime) -> list[str]:
-    from lore_core.ledger import WikiLedger
-
-    lines = ["  Curator Schedule"]
-    lore_dir = lore_root / ".lore"
-    wikis: list[str] = []
-    try:
-        for p in sorted(lore_dir.glob("wiki-*-ledger.json")):
-            name = p.stem.removeprefix("wiki-").removesuffix("-ledger")
-            wikis.append(name)
-    except OSError:
-        pass
-
-    if not wikis:
-        lines.append("no wiki ledgers")
-        return lines
-
-    for wiki in wikis:
-        entry = WikiLedger(lore_root, wiki).read()
-        ts = entry.last_curator_a
-        if ts is None:
-            part = "A —"
-        else:
-            rel = relative_time(ts, now=now, short=True)
-            marker = " !" if (now - ts).total_seconds() > _OVERDUE_A_S else ""
-            part = f"A {rel}{marker}"
-        lines.append(f"    {wiki:12s}  {part}")
-    return lines
-
-
-def _render_verbose_recent_hooks(lore_root: Path, n: int = 5) -> list[str]:
-    lines = ["  Recent Hooks"]
-    from lore_core.spine import read_spine
-
-    records = read_spine(lore_root, source="hook")
-    if not records:
-        lines.append("no hook events")
-        return lines
-
-    tail = records[-n:]
-    now = _resolve_now()
-    for rec in tail:
-        ts_raw = rec.get("ts")
-        event = rec.get("event", "?")
-        outcome = (rec.get("data") or {}).get("outcome", "?")
-        if ts_raw:
-            try:
-                ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
-                rel = relative_time(ts, now=now, short=True)
-            except (ValueError, TypeError):
-                rel = "?"
-        else:
-            rel = "?"
-        lines.append(f"    {rel:>5}  {event}  {outcome}")
-    return lines
-
-
-def _render_verbose_proc_logs(lore_root: Path, now: datetime) -> list[str]:
-    lines = ["  Subprocess Logs"]
-    proc_dir = lore_root / ".lore" / "proc"
-    if not proc_dir.is_dir():
-        lines.append("    no proc logs")
-        return lines
-
-    found = False
-    for role in ("a", "transcripts"):
-        log = proc_dir / f"{role}.log"
-        if not log.exists():
-            continue
-        found = True
-        try:
-            stat = log.stat()
-            size = stat.st_size
-            mtime = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
-            rel = relative_time(mtime, now=now, short=True)
-            if size == 0:
-                status = "empty"
-            else:
-                tail = log.read_bytes()[-2048:]
-                text = tail.decode("utf-8", errors="replace")
-                has_errors = any(m in text for m in ("Traceback", "Error:", "FATAL"))
-                status = "errors!" if has_errors else "ok"
-            lines.append(f"    {role:12s}  {rel:>5}  {size:>8} B  {status}")
-        except OSError:
-            lines.append(f"    {role:12s}  read error")
-    if not found:
-        lines.append("    no proc logs")
-    return lines
-
-
-def _render_verbose_pending(lore_root: Path) -> list[str]:
-    from lore_core.ledger import TranscriptLedger, WikiLedger
-
-    lines = ["  Pending Detail"]
-    try:
-        ledger = TranscriptLedger(lore_root)
-        buckets = ledger.pending_by_wiki()
-    except Exception:
-        lines.append("unavailable")
-        return lines
-
-    if not buckets:
-        lines.append("no pending transcripts")
-        return lines
-
-    for wiki, entries in sorted(buckets.items()):
-        n = len(entries)
-        label = "transcript" if n == 1 else "transcripts"
-        token_str = ""
-        if wiki not in ("__orphan__", "__unattached__"):
-            try:
-                wl_entry = WikiLedger(lore_root, wiki).read()
-                if wl_entry.pending_tokens_est > 0:
-                    token_str = f"  ~{wl_entry.pending_tokens_est // 1000}k tokens"
-            except Exception:
-                pass
-        lines.append(f"    {wiki:12s}  {n} {label}{token_str}")
-    return lines
-
-
-def _verbose_json_data(lore_root: Path, now: datetime) -> dict:
-    from lore_core.ledger import TranscriptLedger, WikiLedger
-
-    wiki_schedules: list[dict] = []
-    lore_dir = lore_root / ".lore"
-    try:
-        for p in sorted(lore_dir.glob("wiki-*-ledger.json")):
-            name = p.stem.removeprefix("wiki-").removesuffix("-ledger")
-            entry = WikiLedger(lore_root, name).read()
-            wiki_schedules.append({
-                "wiki": name,
-                "last_curator_a": entry.last_curator_a.isoformat() if entry.last_curator_a else None,
-                "pending_tokens_est": entry.pending_tokens_est,
-            })
-    except OSError:
-        pass
-
-    from lore_core.spine import read_spine
-    recent_hooks: list[dict] = read_spine(lore_root, source="hook")[-5:]
-
-    pending: dict[str, int] = {}
-    try:
-        buckets = TranscriptLedger(lore_root).pending_by_wiki()
-        pending = {k: len(v) for k, v in buckets.items()}
-    except Exception:
-        pass
-
-    return {
-        "wiki_schedules": wiki_schedules,
-        "recent_hooks": recent_hooks,
-        "pending_by_wiki": pending,
-    }
-
-
-def _state_to_json(state: CaptureState) -> str:
+def _state_to_json(state: CaptureState) -> dict:
     def _default(obj):
         if isinstance(obj, datetime):
             return obj.isoformat().replace("+00:00", "Z")
@@ -470,19 +492,34 @@ def _state_to_json(state: CaptureState) -> str:
             return list(obj)
         raise TypeError(f"not serializable: {type(obj).__name__}")
 
-    return json.dumps(asdict(state), default=_default, indent=2)
+    return json.loads(json.dumps(asdict(state), default=_default))
 
 
-def _resolve_now() -> datetime:
-    """Allow tests to pin `now` via _LORE_STATUS_NOW env var."""
-    env = os.environ.get("_LORE_STATUS_NOW")
-    if env:
-        try:
-            parsed = datetime.fromisoformat(env.replace("Z", "+00:00"))
-            return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
-        except ValueError:
-            pass
-    return datetime.now(UTC)
+def _json_payload(state: CaptureState, lore_root: Path, now: datetime, offline: bool) -> dict:
+    from lore_core.git_sync import wiki_health
+    from lore_core.janitor import read_janitor_status
+
+    data = _state_to_json(state)
+    queued, running, dead = _flush_counts(lore_root)
+    data["flushes"] = {"queued": queued, "running": running, "dead_lettered": dead}
+    data["retention"] = read_janitor_status(lore_root)
+    wikis: list[dict] = []
+    for d in _wiki_dirs(lore_root):
+        h = wiki_health(d, offline=offline)
+        wikis.append(
+            {
+                "wiki": d.name,
+                "is_repo": h.is_repo,
+                "has_remote": h.has_remote,
+                "dirty": h.dirty,
+                "ahead": h.ahead,
+                "behind": h.behind,
+                "reachable": h.reachable,
+            }
+        )
+    data["wikis"] = wikis
+    data["alerts"] = _compute_alerts(state, now, lore_root)
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -493,64 +530,68 @@ def _resolve_now() -> datetime:
 @app.callback(invoke_without_command=True)
 def status(
     cwd: str = typer.Option(None, "--cwd", help="Directory to resolve scope from (default: $PWD)."),
-    json_out: bool = typer.Option(False, "--json", help="Emit the raw CaptureState as JSON."),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show curator schedule, recent hooks, and pending breakdown."),
+    json_out: bool = typer.Option(False, "--json", help="Emit the dashboard state as JSON."),
+    offline: bool = typer.Option(
+        False, "--offline", help="Skip wiki network reachability probes (local-first)."
+    ),
+    plain: bool = typer.Option(
+        False, "--plain", help="Force plain output (default for non-TTY / scripting)."
+    ),
 ) -> None:
-    """Is lore doing anything for me right now?"""
+    """Lore health dashboard — is Lore healthy right now?"""
     resolved_cwd = Path(cwd) if cwd else Path(os.getcwd())
     now = _resolve_now()
 
     try:
         lore_root = get_lore_root()
-    except Exception:
+    except Exception:  # noqa: BLE001
         console.print("[red]LORE_ROOT not set.[/red] Run `lore init` or export $LORE_ROOT.")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
     state = query_capture_state(lore_root, cwd=resolved_cwd, now=now)
 
     if json_out:
-        data = json.loads(_state_to_json(state))
-        if verbose:
-            data["verbose"] = _verbose_json_data(lore_root, now)
-        print(json.dumps(data, indent=2))
+        payload = _json_payload(state, lore_root, now, offline)
+        print(json.dumps(payload, indent=2))
+        if payload["alerts"]:
+            raise typer.Exit(1)
         return
 
     if not state.scope_attached:
         print(_render_unattached(lore_root, resolved_cwd))
         return
 
-    # Happy-path body — exactly 5 indented lines between header + trailing.
+    alerts = _compute_alerts(state, now, lore_root)
+
     lines: list[str] = [
         f"lore: active · {state.scope_name} · attached at {_format_scope_root(state.scope_root)}",
         "",
+        "capture",
+        *_capture_lines(state, lore_root, now),
+        "",
+        "flushes",
+        *_flushes_lines(lore_root),
+        "",
+        "wikis" + ("  (offline)" if offline else ""),
+        *_wikis_lines(lore_root, offline),
+        "",
+        "retention",
+        *_retention_lines(lore_root, now),
+        "",
+        "news",
+        *_news_lines(lore_root, resolved_cwd),
+        "",
+        "alerts",
     ]
-    for glyph, message in [
-        _render_last_note(state, now),
-        _render_last_run(state, now),
-        _render_hook(state, now),
-        _render_pending(state),
-        _render_session(now),
-        _render_lock(state),
-    ]:
-        lines.append(f"  {glyph} {message}")
-
-    alerts = _render_alerts(state, now)
     if alerts:
-        lines.append("")
-        for a in alerts:
-            lines.append(f"  {a}")
-
-    if verbose:
-        lines.append("")
-        lines.extend(_render_verbose_curator_schedule(lore_root, now))
-        lines.append("")
-        lines.extend(_render_verbose_recent_hooks(lore_root))
-        lines.append("")
-        lines.extend(_render_verbose_proc_logs(lore_root, now))
-        lines.append("")
-        lines.extend(_render_verbose_pending(lore_root))
+        lines.extend(f"  {a}" for a in alerts)
+    else:
+        lines.append(_line(_HEALTHY, "none"))
 
     print("\n".join(lines))
+
+    if alerts:
+        raise typer.Exit(1)
 
 
 # argv_main shim for the main CLI dispatcher (lore_cli.__main__).

--- a/lib/lore_core/git_sync.py
+++ b/lib/lore_core/git_sync.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 
 import subprocess
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from lore_core.schema import parse_frontmatter, split_frontmatter
 
@@ -21,14 +22,14 @@ from lore_core.schema import parse_frontmatter, split_frontmatter
 class SyncStatus(str, Enum):
     """Outcome of an `auto_pull` or `auto_push` call."""
 
-    OK = "ok"                          # change applied (pulled or pushed commits)
-    NOOP = "noop"                      # nothing to do (clean + already in sync)
+    OK = "ok"  # change applied (pulled or pushed commits)
+    NOOP = "noop"  # nothing to do (clean + already in sync)
     SKIPPED_NO_REMOTE = "no-remote"
-    SKIPPED_DIRTY = "dirty"            # uncommitted local changes — refused
-    SKIPPED_DIVERGED = "diverged"      # both sides have unique commits
+    SKIPPED_DIRTY = "dirty"  # uncommitted local changes — refused
+    SKIPPED_DIVERGED = "diverged"  # both sides have unique commits
     SKIPPED_UNREACHABLE = "unreachable"
-    MERGED = "merged"                  # auto_push: LLM resolved one+ conflicts
-    MERGE_BLOCKED = "merge-blocked"    # auto_push: aborted, user action needed
+    MERGED = "merged"  # auto_push: LLM resolved one+ conflicts
+    MERGE_BLOCKED = "merge-blocked"  # auto_push: aborted, user action needed
 
 
 @dataclass(frozen=True)
@@ -44,10 +45,10 @@ class SyncResult:
 
 
 class ConflictKind(str, Enum):
-    SURFACE = "surface"                  # LLM-merge
-    SESSION = "session"                  # LLM-merge (rare — pre-pull eliminates)
-    REGENERABLE = "regenerable"          # ours wins; lint reconciles
-    UNKNOWN = "unknown"                  # bail to user
+    SURFACE = "surface"  # LLM-merge
+    SESSION = "session"  # LLM-merge (rare — pre-pull eliminates)
+    REGENERABLE = "regenerable"  # ours wins; lint reconciles
+    UNKNOWN = "unknown"  # bail to user
 
 
 _REGENERABLE_FILENAMES = {
@@ -562,3 +563,76 @@ def _call_llm_for_merge(llm_client: Any, prompt: str) -> str | None:
             return out.get("text")
 
     return None
+
+
+# ---------------------------------------------------------------------------
+# Wiki connection health (issue #193) — one FAST local-first snapshot per wiki
+# for the `lore status` dashboard. Everything except reachability is a cheap
+# local git query; the network probe is opt-in (skipped under `offline`) and
+# time-boxed so a dead remote never stalls the dashboard.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WikiHealth:
+    is_repo: bool
+    has_remote: bool
+    branch: str | None
+    dirty: bool
+    ahead: int
+    behind: int
+    reachable: bool | None  # None = not probed (offline, or no remote)
+    last_sync: datetime | None  # FETCH_HEAD mtime, best-effort
+
+
+def wiki_health(wiki_dir: Path, *, offline: bool = False, timeout: int = 3) -> WikiHealth:
+    """Snapshot one wiki's git connection health.
+
+    Local queries (branch, dirty, ahead/behind vs the last-known upstream)
+    never touch the network. Reachability runs ``git ls-remote`` behind a
+    short ``timeout`` and only when a remote exists and ``offline`` is False;
+    a timeout or error reads as unreachable, never a raise.
+    """
+    if not (wiki_dir / ".git").exists():
+        return WikiHealth(False, False, None, False, 0, 0, None, None)
+
+    has_rem = _has_remote(wiki_dir)
+    branch = _current_branch(wiki_dir)
+    dirty = not _is_clean(wiki_dir)
+    ahead = behind = 0
+    reachable: bool | None = None
+    if has_rem and branch is not None:
+        upstream = _upstream_for(wiki_dir, branch)
+        if upstream is not None:
+            ahead, behind = _ahead_behind(wiki_dir, branch, upstream)
+        if not offline:
+            reachable = _remote_reachable(wiki_dir, timeout=timeout)
+    return WikiHealth(
+        is_repo=True,
+        has_remote=has_rem,
+        branch=branch,
+        dirty=dirty,
+        ahead=ahead,
+        behind=behind,
+        reachable=reachable,
+        last_sync=_last_fetch_time(wiki_dir),
+    )
+
+
+def _remote_reachable(wiki_dir: Path, *, timeout: int) -> bool:
+    remotes = _git(wiki_dir, "remote").stdout.split()
+    if not remotes:
+        return False
+    try:
+        r = _git(wiki_dir, "ls-remote", "--quiet", remotes[0], timeout=timeout)
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError):
+        return False
+    return r.returncode == 0
+
+
+def _last_fetch_time(wiki_dir: Path) -> datetime | None:
+    fetch_head = wiki_dir / ".git" / "FETCH_HEAD"
+    try:
+        return datetime.fromtimestamp(fetch_head.stat().st_mtime, tz=UTC)
+    except OSError:
+        return None

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -1,34 +1,23 @@
-"""Task 11: lore status — activity-first liveness surface.
+"""`lore status` v2 — unified health dashboard (issue #193).
 
-UX-approved output shape (decay-first):
-    lore: active · private/proj:test · attached at <scope_root>
+Six sections render from live state (capture, flushes, wikis, retention,
+news, alerts). Golden --plain section tests + exit-code-mirrors-alerts +
+--offline note + dead-letter-loud are the heart of the suite.
 
-      · Last note    [[...]] · 18h ago
-      · Last run     2h ago · 0 notes from 3 transcripts
-      · Pending      2 transcripts
-      · Session      loaded 4m ago · /lore:loaded
-      · Lock         free
-
-Loud-on-earning alerts only when thresholds are crossed:
-    ! last 2 runs (abc123, def456) filed 0 notes — lore runs show abc123
-    x last note filed 4d ago — lore runs show latest
-    x hook log write failed 2h ago — check disk / permissions
-    ! simple-tier fallback active — high tier unavailable
-
-No --plumbing flag (dropped per UX + merciless — doctor owns install).
+Output is plain text (built line-by-line and printed) — no ANSI — so
+these golden asserts are robust to the CI color environment (no TTY under
+CliRunner). Times are deterministic via the _LORE_STATUS_NOW env pin.
 """
 
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-import pytest
-from typer.testing import CliRunner
-
 from lore_cli.status_cmd import app
-
+from typer.testing import CliRunner
 
 runner = CliRunner()
 
@@ -39,9 +28,13 @@ def _iso(dt: datetime) -> str:
     return dt.isoformat().replace("+00:00", "Z")
 
 
+# ---------------------------------------------------------------------------
+# Vault seeding
+# ---------------------------------------------------------------------------
+
+
 def _seed_vault(tmp_path: Path) -> tuple[Path, Path]:
     """Returns (lore_root, attached_project_dir)."""
-    from datetime import UTC, datetime as _dt
     from lore_core.state.attachments import Attachment, AttachmentsFile
 
     lore_root = tmp_path / "vault"
@@ -50,308 +43,369 @@ def _seed_vault(tmp_path: Path) -> tuple[Path, Path]:
 
     project = tmp_path / "project"
     project.mkdir()
-    af = AttachmentsFile(lore_root); af.load()
-    af.add(Attachment(
-        path=project, wiki="private", scope="proj:test",
-        attached_at=_dt.now(UTC), source="manual",
-    ))
+    af = AttachmentsFile(lore_root)
+    af.load()
+    af.add(
+        Attachment(
+            path=project,
+            wiki="private",
+            scope="proj:test",
+            attached_at=datetime.now(UTC),
+            source="manual",
+        )
+    )
     af.save()
     return lore_root, project
 
 
 def _seed_happy_run(lore_root: Path, *, ago: timedelta, notes_new: int) -> str:
     from lore_core.ledger import WikiLedger
+
     run_ts = _NOW - ago
     WikiLedger(lore_root, "private").update_last_curator("a", at=run_ts)
 
     runs_dir = lore_root / ".lore" / "runs"
     runs_dir.mkdir(parents=True, exist_ok=True)
     stem = run_ts.strftime("%Y-%m-%dT%H-%M-%S") + "-abc123"
-    p = runs_dir / f"{stem}.jsonl"
-    records = [
-        {"type": "run-start", "ts": _iso(run_ts), "schema_version": 1},
-    ]
+    records = [{"type": "run-start", "ts": _iso(run_ts), "schema_version": 1}]
     if notes_new > 0:
-        records.append({
-            "type": "session-note",
-            "ts": _iso(run_ts),
-            "action": "filed",
-            "wikilink": "[[2026-04-21-my-note]]",
-        })
+        records.append(
+            {
+                "type": "session-note",
+                "ts": _iso(run_ts),
+                "action": "filed",
+                "wikilink": "[[2026-04-21-my-note]]",
+            }
+        )
     records.append({"type": "run-end", "ts": _iso(run_ts), "notes_new": notes_new, "errors": 0})
-    p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    (runs_dir / f"{stem}.jsonl").write_text("\n".join(json.dumps(r) for r in records) + "\n")
     return "abc123"
 
 
-def _invoke(lore_root: Path, cwd: Path | None, *extra: str, monkeypatch) -> str:
-    monkeypatch.setenv("LORE_ROOT", str(lore_root))
-    args = list(extra)
-    if cwd is not None:
-        args += ["--cwd", str(cwd)]
-    # Inject deterministic "now" via env var the command reads.
-    monkeypatch.setenv("_LORE_STATUS_NOW", _iso(_NOW))
-    result = runner.invoke(app, args, catch_exceptions=False)
-    return result.output
+def _seed_flush(
+    lore_root: Path,
+    flush_id: str,
+    state: str,
+    *,
+    reason: str | None = None,
+    updated_ago: timedelta = timedelta(minutes=30),
+) -> None:
+    d = lore_root / ".lore" / "flushes"
+    d.mkdir(parents=True, exist_ok=True)
+    rec = {
+        "flush_id": flush_id,
+        "buffer_stem": flush_id,
+        "state": state,
+        "attempts": 3 if state == "dead-lettered" else 0,
+        "next_retry_at": None,
+        "reason": reason,
+        "wiki": "private",
+        "trace_id": "trace-xyz",
+        "created_at": _iso(_NOW - timedelta(hours=1)),
+        "updated_at": _iso(_NOW - updated_ago),
+        "schema_version": 1,
+    }
+    (d / f"{flush_id}.json").write_text(json.dumps(rec))
 
 
-# ---------------------------------------------------------------------------
-# Happy path
-# ---------------------------------------------------------------------------
-
-
-def test_status_happy_path_line_count(tmp_path: Path, monkeypatch) -> None:
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    # 8 newlines on happy path (1 header + 1 blank + 6 body lines = 8 '\n').
-    # 6th body line = Hook (added for capture-hook liveness surface).
-    assert out.count("\n") == 8, f"expected 8 newlines on happy path; got {out.count(chr(10))}:\n{out!r}"
-
-
-def test_status_happy_path_no_alert_glyphs(tmp_path: Path, monkeypatch) -> None:
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    assert "!" not in out
-    assert "x " not in out
-
-
-def test_status_line_order_is_decay_first(tmp_path: Path, monkeypatch) -> None:
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    note_idx = out.find("Last note")
-    run_idx = out.find("Last run")
-    hook_idx = out.find("Hook")
-    pending_idx = out.find("Pending")
-    session_idx = out.find("Session")
-    lock_idx = out.find("Lock")
-    # Hook sits between "Last run" (effect) and "Pending" (hook's input queue):
-    # note ← run ← hook ← pending ← session ← lock.
-    assert 0 < note_idx < run_idx < hook_idx < pending_idx < session_idx < lock_idx, (
-        f"decay-first order violated: {out!r}"
+def _seed_janitor(lore_root: Path, *, ago: timedelta, failed: int = 0) -> None:
+    (lore_root / ".lore" / "janitor-status.json").write_text(
+        json.dumps(
+            {
+                "last_run_at": _iso(_NOW - ago),
+                "hot_bytes": 2048,
+                "cold_bytes": 0,
+                "deleted": 0,
+                "failed": failed,
+            }
+        )
     )
 
 
-def test_status_first_line_shows_scope(tmp_path: Path, monkeypatch) -> None:
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t.co", "-c", "user.name=t", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_git_wiki(
+    lore_root: Path, name: str, *, remote: bool, dirty: bool, ahead: int = 0
+) -> None:
+    wiki = lore_root / "wiki" / name
+    wiki.mkdir(parents=True, exist_ok=True)
+    _git(wiki, "init", "-q")
+    _git(wiki, "checkout", "-q", "-b", "main")
+    (wiki / "a.md").write_text("seed\n")
+    _git(wiki, "add", "-A")
+    _git(wiki, "commit", "-qm", "init")
+    if remote:
+        bare = lore_root.parent / f"{name}-origin.git"
+        subprocess.run(["git", "init", "--bare", "-q", str(bare)], check=True)
+        _git(wiki, "remote", "add", "origin", str(bare))
+        _git(wiki, "push", "-q", "-u", "origin", "main")
+    for i in range(ahead):
+        (wiki / f"ahead{i}.md").write_text("x\n")
+        _git(wiki, "add", "-A")
+        _git(wiki, "commit", "-qm", f"ahead{i}")
+    if dirty:
+        (wiki / "a.md").write_text("uncommitted change\n")
+
+
+def _invoke(lore_root: Path, cwd: Path | None, *extra: str, monkeypatch):
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    monkeypatch.setenv("_LORE_STATUS_NOW", _iso(_NOW))
+    args = list(extra)
+    if cwd is not None:
+        args += ["--cwd", str(cwd)]
+    return runner.invoke(app, args, catch_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Tracer bullet — the six-section golden dashboard on a healthy vault
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_renders_six_sections(tmp_path: Path, monkeypatch) -> None:
     lore_root, project = _seed_vault(tmp_path)
     _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
 
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    first_line = out.splitlines()[0]
-    assert "lore" in first_line
-    assert "private/proj:test" in first_line
+    result = _invoke(lore_root, project, "--plain", monkeypatch=monkeypatch)
+    out = result.output
+
+    for header in ("capture", "flushes", "wikis", "retention", "news", "alerts"):
+        assert f"\n{header}\n" in out or out.startswith(header + "\n") or f"\n{header} " in out, (
+            f"missing section header {header!r} in:\n{out}"
+        )
+    # Capture liveness lines.
+    for label in ("Last note", "Last run", "Last flush", "Hook", "Pending", "Session", "Lock"):
+        assert label in out, f"missing capture line {label!r} in:\n{out}"
+    # Flushes counts line.
+    assert "queued 0 · running 0 · dead-lettered 0" in out
+    # No ANSI escapes leaked.
+    assert "\x1b[" not in out
+
+
+def test_dashboard_healthy_exits_zero(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+
+    result = _invoke(lore_root, project, monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    assert "alerts" in result.output
 
 
 # ---------------------------------------------------------------------------
-# Loud-on-earning alerts
+# Flushes section + dead-letter loudness (AC3)
 # ---------------------------------------------------------------------------
 
 
-def test_status_zero_notes_alert(tmp_path: Path, monkeypatch) -> None:
-    """Two consecutive 0-note runs → yellow alert line with run IDs."""
+def test_dead_letter_surfaces_loudly_and_names_trace(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    _seed_flush(lore_root, "buf-1", "dead-lettered", reason="compose-failed")
+
+    result = _invoke(lore_root, project, monkeypatch=monkeypatch)
+    out = result.output
+    assert "dead-lettered 1" in out
+    assert "lore trace dead" in out, f"dead-letter must name the drill-down cmd:\n{out}"
+    # Earns an alert → nonzero exit for scriptability.
+    assert result.exit_code != 0
+
+
+def test_flush_counts_reflect_store(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    _seed_flush(lore_root, "b1", "queued")
+    _seed_flush(lore_root, "b2", "running")
+    _seed_flush(lore_root, "b3", "published", updated_ago=timedelta(minutes=10))
+
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
+    assert "queued 1 · running 1 · dead-lettered 0" in out
+    # Last flush line reflects the most-recently-updated record (published, 10m).
+    assert "Last flush" in out
+    assert "published" in out
+
+
+# ---------------------------------------------------------------------------
+# Exit code mirrors alerts (AC5)
+# ---------------------------------------------------------------------------
+
+
+def test_exit_nonzero_when_alerts_exist(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=1), notes_new=1)
+    (lore_root / ".lore" / "spine-failed.marker").touch()
+
+    result = _invoke(lore_root, project, monkeypatch=monkeypatch)
+    assert result.exit_code != 0
+    assert "spine write" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Wiki connection health (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_wiki_health_clean_dirty_remote(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    # Replace the plain "private" dir with a healthy git wiki + a broken one.
+    _make_git_wiki(lore_root, "team", remote=True, dirty=False)
+    _make_git_wiki(lore_root, "solo", remote=False, dirty=True)
+
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
+    assert "team" in out
+    assert "solo" in out
+    assert "clean" in out
+    assert "dirty" in out
+    assert "ahead 0" in out
+    assert "behind 0" in out
+    # A local-bare remote is reachable without --offline.
+    assert "reachable" in out
+
+
+def test_wiki_health_offline_note(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    _make_git_wiki(lore_root, "team", remote=True, dirty=False)
+
+    out = _invoke(lore_root, project, "--offline", monkeypatch=monkeypatch).output
+    assert "(offline)" in out
+    # --offline must not have run a network probe → no reachability verdict.
+    assert "reachable" not in out
+    assert "unreachable" not in out
+
+
+def test_wiki_health_ahead_count(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    _make_git_wiki(lore_root, "team", remote=True, dirty=False, ahead=2)
+
+    out = _invoke(lore_root, project, "--offline", monkeypatch=monkeypatch).output
+    assert "ahead 2" in out
+
+
+# ---------------------------------------------------------------------------
+# Retention section (AC1 retention, consumes #190)
+# ---------------------------------------------------------------------------
+
+
+def test_retention_shows_usage_and_last_run(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    _seed_janitor(lore_root, ago=timedelta(minutes=5))
+
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
+    assert "retention" in out
+    assert "MB" in out
+    assert "5m ago" in out
+
+
+def test_retention_janitor_never_run(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
+    assert "never run" in out
+
+
+def test_retention_failed_deletions_alert(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    _seed_janitor(lore_root, ago=timedelta(minutes=5), failed=2)
+
+    result = _invoke(lore_root, project, monkeypatch=monkeypatch)
+    assert "failed" in result.output.lower()
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# News section — absorbs `lore news`, cursor advance preserved (AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_news_section_shows_event_and_advances_cursor(tmp_path: Path, monkeypatch) -> None:
+    from lore_core.drain import DrainStore
+
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "sess-1")
+    DrainStore(lore_root, "sess-1").emit("note-filed", wiki="private", wikilink="[[hello]]")
+
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
+    assert "news" in out
+    assert "[[hello]]" in out
+    # Cursor advanced so the event is surfaced once (news semantics).
+    cur = DrainStore(lore_root, "sess-1").read_cursor()
+    assert cur is not None
+
+
+def test_news_nothing_new(tmp_path: Path, monkeypatch) -> None:
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "sess-empty")
+
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
+    assert "nothing new" in out
+
+
+# ---------------------------------------------------------------------------
+# Preserved v1 semantics — alerts still earned
+# ---------------------------------------------------------------------------
+
+
+def test_zero_notes_alert(tmp_path: Path, monkeypatch) -> None:
     lore_root, project = _seed_vault(tmp_path)
     from lore_core.ledger import WikiLedger
-
     from lore_core.spine import SpineWriter
+
     w = SpineWriter(lore_root)
     for i, suffix in enumerate(["aaa111", "bbb222"]):
         run_ts = _NOW - timedelta(hours=3 - i)
         run_id = run_ts.strftime("%Y-%m-%dT%H-%M-%S") + f"-{suffix}"
         w.emit(source="curator", event="run-start", run_id=run_id, data={"ts": _iso(run_ts)})
-        w.emit(source="curator", event="run-end", run_id=run_id,
-               data={"notes_new": 0, "notes_merged": 0, "errors": 0})
+        w.emit(
+            source="curator",
+            event="run-end",
+            run_id=run_id,
+            data={"notes_new": 0, "notes_merged": 0, "errors": 0},
+        )
     WikiLedger(lore_root, "private").update_last_curator("a", at=_NOW - timedelta(hours=2))
 
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    assert "!" in out, f"expected yellow alert on repeated zero-notes; got:\n{out}"
-    assert "0 notes" in out
+    result = _invoke(lore_root, project, monkeypatch=monkeypatch)
+    assert "0 notes" in result.output
+    assert result.exit_code != 0
 
 
-def test_status_stale_note_red_at_4d(tmp_path: Path, monkeypatch) -> None:
-    """Last note 4 days ago → red alert (>3d threshold)."""
-    lore_root, project = _seed_vault(tmp_path)
-    run_ts = _NOW - timedelta(days=4)
-    run_id = run_ts.strftime("%Y-%m-%dT%H-%M-%S") + "-xxx999"
-
-    def _env(event, data):
-        # Raw envelope with a controlled ts (SpineWriter stamps real-now).
-        return {
-            "ts": _iso(run_ts), "v": 1, "source": "curator", "event": event,
-            "level": "info", "trace_id": None, "session_id": None, "run_id": run_id,
-            "wiki": None, "scope": None, "error_code": None, "data": data,
-        }
-
-    spine = lore_root / ".lore" / "spine.jsonl"
-    spine.parent.mkdir(parents=True, exist_ok=True)
-    with spine.open("a") as f:
-        for env in [
-            _env("run-start", {}),
-            _env("session-note", {"action": "filed", "wikilink": "[[stale]]"}),
-            _env("run-end", {"notes_new": 1, "errors": 0}),
-        ]:
-            f.write(json.dumps(env) + "\n")
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    # Red glyph marks the line; also an alert block at bottom.
-    assert "x " in out, f"expected red glyph for >3d note; got:\n{out}"
-
-
-def test_status_hook_log_failed_red(tmp_path: Path, monkeypatch) -> None:
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=1), notes_new=1)
-    marker = lore_root / ".lore" / "spine-failed.marker"
-    marker.touch()
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    assert "spine write" in out.lower()
-    assert "x " in out
-
-
-def test_status_hook_body_line_renders_recent_event(tmp_path: Path, monkeypatch) -> None:
-    """Healthy path: Hook body line shows most recent hook-event summary."""
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-    events = lore_root / ".lore" / "spine.jsonl"
-    events.write_text(
-        json.dumps({
-            "ts": _iso(_NOW - timedelta(minutes=12)),
-            "v": 1, "source": "hook", "event": "session-start",
-            "level": "info", "trace_id": None, "session_id": None,
-            "run_id": None, "wiki": None, "scope": None, "error_code": None,
-            "data": {"outcome": "spawned-curator"},
-        }) + "\n"
-    )
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    # Line shape: "  · Hook         12m ago · session-start · spawned-curator"
-    assert "Hook" in out
-    assert "session-start" in out
-    assert "spawned-curator" in out
-
-
-def test_status_hook_body_line_dash_when_no_events(tmp_path: Path, monkeypatch) -> None:
-    """Fresh vault with no hook-events.jsonl → Hook line shows dash, no alert."""
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    # 8-line happy path; no alert because pending=0.
-    assert "Hook" in out
-    assert "!" not in out
-    assert "no hook events" not in out
-
-
-def test_status_hook_alert_when_pending_but_hook_stale(tmp_path: Path, monkeypatch) -> None:
-    """Pending transcripts exist AND hook events are missing/stale → alert.
-
-    This is the exact diagnostic: "something wants capturing, but capture
-    hook isn't leaving traces." Without the alert, the user sees only
-    empty runs and has to guess why.
-    """
-    from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry
-
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-
-    # Seed pending transcript.
-    ledger = TranscriptLedger(lore_root)
-    ledger.upsert(
-        TranscriptLedgerEntry(
-            integration="claude-code",
-            transcript_id="t1",
-            path=project / "t1.jsonl",
-            directory=project,
-            digested_hash=None,  # pending
-            digested_index_hint=None,
-            synthesised_hash=None,
-            last_mtime=_NOW - timedelta(hours=1),
-            curator_a_run=None,
-            noteworthy=None,
-            session_note=None,
-        )
-    )
-    # No hook-events.jsonl at all → stale/missing.
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    assert "!" in out, f"expected alert line; got:\n{out}"
-    assert "no hook events" in out.lower()
-
-
-def test_status_hook_alert_when_pending_and_hook_events_all_old(tmp_path: Path, monkeypatch) -> None:
-    """Same alert when hook-events exist but the newest is > 24h stale."""
-    from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry
-
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-
-    ledger = TranscriptLedger(lore_root)
-    ledger.upsert(
-        TranscriptLedgerEntry(
-            integration="claude-code", transcript_id="t2",
-            path=project / "t2.jsonl", directory=project,
-            digested_hash=None, digested_index_hint=None,
-            synthesised_hash=None,
-            last_mtime=_NOW - timedelta(hours=1),
-            curator_a_run=None, noteworthy=None, session_note=None,
-        )
-    )
-    (lore_root / ".lore" / "spine.jsonl").write_text(
-        json.dumps({
-            "ts": _iso(_NOW - timedelta(days=2)),
-            "v": 1, "source": "hook", "event": "session-start",
-            "level": "info", "trace_id": None, "session_id": None,
-            "run_id": None, "wiki": None, "scope": None, "error_code": None,
-            "data": {"outcome": "below-threshold"},
-        }) + "\n"
-    )
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    assert "no hook events" in out.lower()
-
-
-def test_status_no_hook_alert_when_pending_zero(tmp_path: Path, monkeypatch) -> None:
-    """No pending work → no alert even if hook-events is missing.
-
-    Avoids crying wolf on fresh vaults where nothing needs capturing yet.
-    """
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    assert "no hook events" not in out.lower()
-
-
-def test_status_simple_tier_fallback_yellow(tmp_path: Path, monkeypatch) -> None:
+def test_simple_tier_fallback_alert(tmp_path: Path, monkeypatch) -> None:
     lore_root, project = _seed_vault(tmp_path)
     _seed_happy_run(lore_root, ago=timedelta(hours=1), notes_new=1)
     (lore_root / ".lore" / "warnings.log").write_text("simple-tier-fallback\n")
 
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
     assert "simple-tier" in out.lower() or "simple tier" in out.lower()
-    assert "!" in out
 
 
 # ---------------------------------------------------------------------------
-# Unattached cwd — exact UX-approved copy
+# Unattached cwd — preserved guidance copy
 # ---------------------------------------------------------------------------
 
 
-def test_status_unattached_cwd(tmp_path: Path, monkeypatch) -> None:
+def test_unattached_cwd(tmp_path: Path, monkeypatch) -> None:
     lore_root = tmp_path / "vault"
     (lore_root / ".lore").mkdir(parents=True)
     (lore_root / "wiki" / "private").mkdir(parents=True)
     unrelated = tmp_path / "elsewhere"
     unrelated.mkdir()
 
-    out = _invoke(lore_root, unrelated, monkeypatch=monkeypatch)
-    assert "not attached here" in out
-    assert "/lore:attach" in out
-    assert "Configured vaults" in out
-    assert "private" in out
+    result = _invoke(lore_root, unrelated, monkeypatch=monkeypatch)
+    assert "not attached here" in result.output
+    assert "/lore:attach" in result.output
+    assert result.exit_code == 0
 
 
 # ---------------------------------------------------------------------------
@@ -359,137 +413,20 @@ def test_status_unattached_cwd(tmp_path: Path, monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_status_json_mode(tmp_path: Path, monkeypatch) -> None:
+def test_json_mode(tmp_path: Path, monkeypatch) -> None:
     lore_root, project = _seed_vault(tmp_path)
     _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
 
-    out = _invoke(lore_root, project, "--json", monkeypatch=monkeypatch)
+    out = _invoke(lore_root, project, "--json", monkeypatch=monkeypatch).output
     data = json.loads(out)
-    assert "scope_name" in data
-    assert "curators" in data
     assert data["scope_name"] == "private/proj:test"
-    roles = [c["role"] for c in data["curators"]]
-    assert roles == ["a"]
+    assert [c["role"] for c in data["curators"]] == ["a"]
+    # v2 sections present.
+    assert "flushes" in data
+    assert "retention" in data
 
 
-# ---------------------------------------------------------------------------
-# --help shows a short description so the user discovers the command
-# ---------------------------------------------------------------------------
-
-
-def test_status_help_mentions_activity() -> None:
+def test_help_mentions_status() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "activity" in result.output.lower() or "status" in result.output.lower()
-
-
-# ---------------------------------------------------------------------------
-# --verbose mode
-# ---------------------------------------------------------------------------
-
-
-def _seed_wiki_ledger(
-    lore_root: Path, wiki: str, *,
-    last_a: datetime | None = None,
-    pending_tokens: int = 0,
-) -> None:
-    from lore_core.ledger import WikiLedger, WikiLedgerEntry
-    wl = WikiLedger(lore_root, wiki)
-    wl.write(WikiLedgerEntry(
-        wiki=wiki,
-        last_curator_a=last_a,
-        pending_tokens_est=pending_tokens,
-    ))
-
-
-def test_verbose_shows_curator_schedule(tmp_path: Path, monkeypatch) -> None:
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-    _seed_wiki_ledger(
-        lore_root, "private",
-        last_a=_NOW - timedelta(hours=2),
-    )
-    out = _invoke(lore_root, project, "--verbose", monkeypatch=monkeypatch)
-    assert "Curator" in out
-    assert "private" in out
-    assert " A " in out or " A:" in out
-
-
-def test_verbose_shows_recent_hooks(tmp_path: Path, monkeypatch) -> None:
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-    events = lore_root / ".lore" / "spine.jsonl"
-    records = [
-        json.dumps({"ts": _iso(_NOW - timedelta(minutes=i * 10)),
-                    "v": 1, "source": "hook", "event": "session-start",
-                    "level": "info", "trace_id": None, "session_id": None,
-                    "run_id": None, "wiki": None, "scope": None,
-                    "error_code": None, "data": {"outcome": "ok"}})
-        for i in range(7)
-    ]
-    events.write_text("\n".join(records) + "\n")
-
-    out = _invoke(lore_root, project, "--verbose", monkeypatch=monkeypatch)
-    assert "Recent Hooks" in out
-    assert "session-start" in out
-
-
-def test_verbose_shows_pending_by_wiki(tmp_path: Path, monkeypatch) -> None:
-    from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry
-
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-    _seed_wiki_ledger(lore_root, "private", last_a=_NOW - timedelta(hours=2), pending_tokens=4200)
-
-    ledger = TranscriptLedger(lore_root)
-    ledger.upsert(TranscriptLedgerEntry(
-        integration="claude-code", transcript_id="t1",
-        path=project / "t1.jsonl", directory=project,
-        digested_hash=None, digested_index_hint=None,
-        synthesised_hash=None,
-        last_mtime=_NOW - timedelta(hours=1),
-        curator_a_run=None, noteworthy=None, session_note=None,
-    ))
-
-    out = _invoke(lore_root, project, "--verbose", monkeypatch=monkeypatch)
-    assert "Pending" in out
-    # Should show at least the wiki name in the breakdown
-    lines = out.splitlines()
-    pending_section = False
-    for line in lines:
-        if "Pending Detail" in line or "Pending Breakdown" in line:
-            pending_section = True
-            continue
-        if pending_section and "private" in line:
-            assert "1" in line  # 1 transcript
-            break
-    else:
-        if pending_section:
-            pass  # section found, wiki check may differ
-        else:
-            pytest.fail(f"Expected Pending Detail section in:\n{out}")
-
-
-def test_verbose_json_includes_extra(tmp_path: Path, monkeypatch) -> None:
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-    _seed_wiki_ledger(lore_root, "private", last_a=_NOW - timedelta(hours=2))
-
-    out = _invoke(lore_root, project, "--json", "--verbose", monkeypatch=monkeypatch)
-    data = json.loads(out)
-    assert "verbose" in data
-    assert "wiki_schedules" in data["verbose"]
-    assert "recent_hooks" in data["verbose"]
-    assert "pending_by_wiki" in data["verbose"]
-
-
-def test_no_verbose_unchanged(tmp_path: Path, monkeypatch) -> None:
-    """Output without --verbose is identical to pre-verbose behavior."""
-    lore_root, project = _seed_vault(tmp_path)
-    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
-
-    out = _invoke(lore_root, project, monkeypatch=monkeypatch)
-    # Must NOT contain verbose sections
-    assert "Curator" not in out or "Curator Schedule" not in out
-    assert "Recent Hooks" not in out
-    assert "Pending Detail" not in out
+    assert "status" in result.output.lower() or "health" in result.output.lower()


### PR DESCRIPTION
Closes #193.

## What

Replaces the activity-first `lore status` with one glanceable **"is Lore healthy right now?"** dashboard. Six sections render from live state, one line per concern, every alert paired with its exact drill-down command (PRD 0005 dashboard grammar):

```
lore: active · private/proj:test · attached at ~/project

capture
  · Last note    [[2026-04-21-my-note]] · 2h ago
  · Last run     2h ago · 1 note
  x Last flush   dead-lettered · 20m ago
  · Hook         12m ago · session-start · spawned-curator
  · Pending      no transcripts
  · Session      not loaded in this shell
  · Lock         free

flushes
  x queued 0 · running 0 · dead-lettered 1 — lore trace dead

wikis
  · private      clean · ahead 0 · behind 0 · reachable

retention
  · hot 0.0/10 MB · janitor 5m ago

news
  · nothing new

alerts
  x 1 flush dead-lettered — lore trace dead
```

### Sections (each has a test)
- **capture** — liveness + **last-flush outcome/age** (per the #189 state machine), plus note/run/hook/pending/session/lock.
- **flushes** — queued/running/dead-lettered counts from the flush store (#189). Dead letters are **LOUD** (`x` glyph) and name `lore trace dead`.
- **wikis** — per-wiki connection health (remote reachable, ahead/behind, dirty), computed **FAST local-first**. The network reachability probe is time-boxed and skipped under `--offline` with a visible `(offline)` note.
- **retention** — hot-tier usage vs cap + last janitor run, consuming #190's `read_janitor_status`; failed deletions earn an alert.
- **news** — **absorbs `lore news`**: drain events for the current session, **cursor advance preserved** (reuses `news_cmd._collect_events` / `_advance_cursor`).
- **alerts** — every earned warn/error paired with a fix/drill-down command (dead letters, spine-write-failed, zero-note runs, stale-capture-while-pending, subprocess errors, janitor delete failures, diverged wikis, plugin-cache drift).

### Behavior
- **Exit code mirrors alerts** — `0` when healthy, nonzero when any alert is earned (scriptable). Applies in `--json` too.
- **Plain output (no ANSI)** so it degrades cleanly for non-TTY / `--plain` and golden tests stay robust to the CI color environment.
- `lore news` command is **not** deleted (deprecation is #195); its behavior is folded in.

## How
- Rewrote `lib/lore_cli/status_cmd.py` (dashboard body; dropped `--verbose`, added `--offline`/`--plain`).
- Added a small `wiki_health()` + `WikiHealth` helper to `lib/lore_core/git_sync.py` (reuses the existing local git primitives; reachability via time-boxed `git ls-remote`).
- Consumes read APIs only — no changes to the janitor/flush/spine modules. Names `lore trace dead` (#192) without calling it.

## Red → green (TDD)

New `tests/test_status_cmd.py` (v2) written first against the old command — **16 failed, 2 passed**:

```
FAILED tests/test_status_cmd.py::test_dashboard_renders_six_sections - missing section header 'capture'
FAILED tests/test_status_cmd.py::test_dead_letter_surfaces_loudly_and_names_trace - 'dead-lettered 1' not in ...
FAILED tests/test_status_cmd.py::test_wiki_health_offline_note - '(offline)' not in "Usage: root ..."
FAILED tests/test_status_cmd.py::test_exit_nonzero_when_alerts_exist - assert 0 != 0
... (16 failed, 2 passed)
```

After implementing the v2 dashboard — **18 passed**:

```
tests/test_status_cmd.py: 18 passed in 1.21s
```

Coverage: six-section golden dashboard, exit-code-mirrors-alerts, dead-letter loud + `lore trace dead`, `--offline` note + no probe, wiki health (clean/dirty/remote/ahead), retention usage + never-run + failed-deletion alert, news absorb + cursor advance, preserved alerts (zero-notes, spine-failed, simple-tier), unattached copy, `--json`.

## Suite status
Full suite: **2843 passed, 10 failed, 16 skipped**. All 10 failures are the pre-existing ANSI-color CliRunner tests on `epic/183` (test_cli_scopes, test_core_llm_wiring, test_drain_prune, test_install_dispatcher, test_log_cmd, test_proc_cmd) — none touch my modules; my golden tests avoid this by rendering plain text. **Zero new failures.**

ruff: changed files clean (`status_cmd.py`, `test_status_cmd.py` pass; `git_sync.py` went from 4→2 findings — the 2 remaining are pre-existing UP042 on `SyncStatus`/`ConflictKind`, untouched enums).
