### PR TITLE
fix: stamp trace_id on flush-spawn-failed spine events (#255)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore",
   "description": "LLM-optimized knowledge graph for AI-coding teams \u2014 session notes, auto-extracted knowledge, pluggable briefings, magic context injection at session start.",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.61.1] - 2026-07-12
+
+Epic #183 polish (#255).
+
+### Fixed
+
+- **`flush-spawn-failed` events now carry a `trace_id`** — the trace-id is
+  minted before the spawn lock is taken, so both spawn-failure paths (the
+  detached subprocess failing to start and the spawn-lock flock erroring)
+  emit a traceable event that `lore trace` can correlate with the rest of
+  the flush's story. Previously these events landed on the spine with
+  `trace_id: null`.
+- Stale `_system.jsonl` wording in a `hooks.py` docstring updated to name
+  the shared `_system` spine stream; the now-fixed known-gap passages were
+  removed from the troubleshooting and observability docs.
+
 ## [0.61.0] - 2026-07-11
 
 Epic #183 — onboarding, connection config & observability revamp (PRD 0005).

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -104,13 +104,12 @@ a detached flush needs to run.
 trace_id, sorted by timestamp — there is no separate correlation index,
 the trace *is* the filtered spine.
 
-**Known gap:** the Popen-boundary failure path in `spawn_detached_flush`
-(the subprocess literally fails to start) calls `_emit_spawn_failed`
-without a trace_id, even though one has usually already been minted in
-that scope by the time the `Popen` call fails. That one event surfaces
-under `source="curator"`, `event="flush-spawn-failed"` with
-`trace_id: null` — visible on the spine, just not attachable to the rest
-of that flush's story via `lore trace`.
+Spawn failures are traceable too: `spawn_detached_flush` mints its
+trace_id before taking the spawn lock, so both failure paths — the
+subprocess failing to start at the OS level and the spawn-lock flock
+itself erroring — emit `source="curator"`, `event="flush-spawn-failed"`
+with that trace_id attached, making the event reachable via
+`lore trace` like every other step of the flush's story.
 
 ---
 

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -80,13 +80,6 @@ states.
   and print ahead of the `if json_out` branch. Script against `lore
   doctor --json` (without `--fix`), or pass `--fix --yes` and parse only
   the trailing JSON line.
-- **A Popen-boundary spawn failure can lack a trace_id.** If the detached
-  curator subprocess fails to start at the OS level, the
-  `flush-spawn-failed` event is still written to the spine (so `lore
-  status`/`lore doctor` see it), but it isn't attachable to the rest of
-  that flush's story via `lore trace` — look for `event:
-  flush-spawn-failed` directly in `lore trace <session-id>`'s output
-  instead of expecting it under a specific trace_id.
 
 ## Deprecated commands still work, but check the pointer
 

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -2240,8 +2240,9 @@ def _render_drain_lines(lore_root: Path, cwd: Path) -> list[str]:
     cursor (``{sid}.cursor``) prevents repeat SessionStarts within
     one Claude run from re-rendering session events. The system
     cursor (``_system.cursor``) is the single authoritative
-    "shown through" mark for the shared system stream — without it,
-    a stale row in ``_system.jsonl`` would haunt every fresh session.
+    "shown through" mark for the shared system stream — without it, a
+    stale row on the shared ``_system`` spine stream would haunt every
+    fresh session.
     Cold-start initialises ``_system.cursor`` to ``now`` so the first
     read on a new install never reaches back through history.
     """

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -338,7 +338,6 @@ def flush_chapter(
             skipped_reason="already-closed",
         )
 
-
     # ---- Snapshot under the flock: note path, note-so-far, slice bounds -
     with buffer.with_lock():
         sidecar = buffer.read_sidecar()
@@ -639,9 +638,7 @@ def _apply_outcome(
                     wiki_root=wiki_root,
                 )
             out.status = "failed"
-            store.transition(
-                flush_rec, FlushState.DEAD_LETTERED, reason=ErrorCode.COMPOSE_FAILED
-            )
+            store.transition(flush_rec, FlushState.DEAD_LETTERED, reason=ErrorCode.COMPOSE_FAILED)
         else:
             # Bounded retry with backoff replaces the old silent-defer /
             # give-up-at-2x-cap heuristic. record_failure() re-queues with a
@@ -864,9 +861,9 @@ class SweepReport:
     swept: int = 0
     alive_skipped: int = 0
     uncertain_skipped: int = 0
-    stale_closed: int = 0   # dead + too old → closed with a marker, no LLM call
-    deferred: int = 0       # recent dead buffers left for the next sweep (budget hit)
-    discarded: int = 0      # trivial / all-empty sessions whose stub was removed
+    stale_closed: int = 0  # dead + too old → closed with a marker, no LLM call
+    deferred: int = 0  # recent dead buffers left for the next sweep (budget hit)
+    discarded: int = 0  # trivial / all-empty sessions whose stub was removed
     contended: bool = False
     swept_stems: list[str] = field(default_factory=list)
 
@@ -1047,12 +1044,13 @@ def _resolve_model(wiki_root: Path) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def _emit_spawn_failed(buffer_path: Path, lore_root: Path, exc: Exception) -> None:
+def _emit_spawn_failed(buffer_path: Path, lore_root: Path, exc: Exception, trace_id: str) -> None:
     """A detached-flush spawn that fails is no longer swallowed silently."""
     SpineWriter(lore_root).emit(
         source="curator",
         event="flush-spawn-failed",
         level="error",
+        trace_id=trace_id,
         error_code=ErrorCode.SPAWN_FAILED,
         data={"buffer": buffer_path.name, "error": str(exc)},
     )
@@ -1077,11 +1075,12 @@ def spawn_detached_flush(
     from lore_core.lockfile import flocked
 
     spawn_lock = buffer_path.with_suffix(".spawn.lock")
+    # Minted before the lock so even a flock failure emits a traceable event.
+    trace_id = trace_id or new_trace_id()
     try:
         with flocked(spawn_lock, blocking=False) as held:
             if not held:
                 return None
-            trace_id = trace_id or new_trace_id()
             cmd = [
                 sys.executable,
                 "-m",
@@ -1107,8 +1106,8 @@ def spawn_detached_flush(
                 )
                 return trace_id
             except (OSError, subprocess.SubprocessError) as exc:
-                _emit_spawn_failed(buffer_path, lore_root, exc)
+                _emit_spawn_failed(buffer_path, lore_root, exc, trace_id)
                 return None
     except OSError as exc:
-        _emit_spawn_failed(buffer_path, lore_root, exc)
+        _emit_spawn_failed(buffer_path, lore_root, exc, trace_id)
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lore"
-version = "0.61.0"
+version = "0.61.1"
 description = "LLM-optimized knowledge graph for AI-coding teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_flush_silent_paths.py
+++ b/tests/test_flush_silent_paths.py
@@ -168,6 +168,24 @@ def test_spawn_failure_emits_event(tmp_path, monkeypatch):
         e for e in _curator_events(lore_root) if e.get("error_code") == ErrorCode.SPAWN_FAILED.value
     ]
     assert errs, "a spawn failure must emit a spine event"
+    assert errs[-1]["trace_id"], "spawn-failed event must carry the minted trace_id"
+
+
+def test_spawn_lock_failure_emits_event_with_trace_id(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    buf = _append(lore_root, _turns(0, 2))
+
+    def boom(*a, **k):
+        raise OSError("flock denied")
+
+    monkeypatch.setattr("lore_core.lockfile.flocked", boom)
+    ok = spawn_detached_flush(buf.sidecar_path, lore_root=lore_root)
+    assert ok is None
+    errs = [
+        e for e in _curator_events(lore_root) if e.get("error_code") == ErrorCode.SPAWN_FAILED.value
+    ]
+    assert errs, "a spawn-lock failure must emit a spine event"
+    assert errs[-1]["trace_id"], "lock-failure event must carry a trace_id too"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #255.

## What

- **`flush-spawn-failed` events now carry a `trace_id`.** `spawn_detached_flush` mints the trace-id *before* taking the spawn flock and threads it into `_emit_spawn_failed`, so both failure paths — the detached subprocess failing to start (Popen boundary) and the spawn-lock flock itself erroring — emit an event `lore trace` can correlate with the rest of the flush's story. Previously these landed on the spine with `trace_id: null`.
- **Stale `_system.jsonl` docstring in `hooks.py` reworded** to name the shared `_system` spine stream (the file went away with #188; the cursor logic it documents was already correct).
- **Docs updated in the same PR:** the "known gap" passages describing the now-fixed trace-id hole are removed from `docs/how-to/troubleshooting.md` and replaced in `docs/architecture/observability.md` with the new behavior.
- **Release bump to 0.61.1** rides along, per the repo rule that every merge to `main` shipping curator/hook code ends with a version bump.

## Tests

- Extended `test_spawn_failure_emits_event` to assert the emitted event carries the minted trace-id (was red before the fix).
- New `test_spawn_lock_failure_emits_event_with_trace_id` covering the outer flock-OSError path.
- Full suite: green except 6 pre-existing environment-dependent failures that fail identically on clean `main` (ANSI/rich output assertions in `test_cli_scopes`, `test_log_cmd`, `test_proc_cmd`, `test_core_llm_wiring`, `test_install_dispatcher`); ruff backlog in `hooks.py` unchanged (tracked as #196).

Review pass (mid tier, 3 finder angles + verify) surfaced no correctness findings; the version-bump convention finding is addressed by the release commit.