### PR TITLE
MCP surface trim: remove five no-caller tools, honest exposed-tools header

### DIFF
--- a/lib/lore_mcp/__init__.py
+++ b/lib/lore_mcp/__init__.py
@@ -1,6 +1,5 @@
 """lore_mcp — MCP server exposing vault retrieval to any MCP client.
 
-Wraps `lore_search` and the linter's `_catalog.json` / `_index.txt`
-outputs behind the MCP tool surface:
-lore_search, lore_read, lore_index, lore_catalog, lore_resume, lore_wikilinks.
+See `lore_mcp/server.py` for the exposed tool list — kept there only,
+so it doesn't rot into a second stale copy.
 """

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -6,21 +6,19 @@ Windsurf, Zed, etc.) can register this and query the vault.
 Exposed tools:
     lore_search             — hybrid ranked search, top-k paths
     lore_read               — read one note by wiki/path
-    lore_index              — return a wiki's _index.txt
-    lore_catalog            — return a wiki's _catalog.json
     lore_resume             — unified context gather (recent/wiki/keyword/scope)
-    lore_wikilinks          — in/out wikilinks for a note
     lore_drill              — composite multi-stage retrieval (search→read→
                               expand→read_expanded) in one envelope with a
                               structured trace
-    lore_briefing_gather    — read-only briefing gather (new sessions since last
-                              briefing + sink config + ledger); skill writes
-                              prose, then shells out to publish + mark
     lore_inbox_classify     — read-only inbox walk (file list with type +
                               routing hint); skill composes notes, then shells
                               out to `lore inbox archive`
+    lore_journal_write      — append a freeform entry to the AI or human journal
+    lore_pending_verdicts   — enumerate wiki-wide pending freshness verdicts
+    lore_verdict            — record a freshness verdict (confirm/stale/clear-stale)
     lore_repo_docs_list     — list a connected repo's ADRs or PRDs (pull-only)
     lore_repo_docs_fetch    — fetch one ADR or PRD's content (pull-only)
+    lore_tier_resolve       — resolve a semantic model tier to a concrete model
     lore_codemap            — bounded code-map query (symbols/directory/top-N)
     lore_context_pack       — bounded pointer pack (sessions/ADR/PRD/epic state)
                               joined from linkage frontmatter, given cwd/branch/issue
@@ -447,42 +445,6 @@ def _extract_section(text: str, query: str) -> tuple[str | None, list[str]]:
     return "\n".join(lines[start:end]), all_heading_strs
 
 
-def handle_index(wiki: str | None = None) -> dict[str, Any]:
-    wiki_path = _resolve_wiki(wiki)
-    if wiki_path is None:
-        return _mcp_error(
-            "wiki_not_found",
-            f"wiki not found: {wiki}",
-            next_="run `lore status` to list configured wikis",
-        )
-    index = wiki_path / "_index.txt"
-    if not index.exists():
-        return _mcp_error(
-            "catalog_missing",
-            "no _index.txt",
-            next_="run `lore lint` to regenerate the index",
-        )
-    return {"wiki": wiki_path.name, "content": index.read_text(errors="replace")}
-
-
-def handle_catalog(wiki: str | None = None) -> dict[str, Any]:
-    wiki_path = _resolve_wiki(wiki)
-    if wiki_path is None:
-        return _mcp_error(
-            "wiki_not_found",
-            f"wiki not found: {wiki}",
-            next_="run `lore status` to list configured wikis",
-        )
-    cat = wiki_path / "_catalog.json"
-    if not cat.exists():
-        return _mcp_error(
-            "catalog_missing",
-            "no _catalog.json",
-            next_="run `lore lint` to regenerate the catalog",
-        )
-    return json.loads(cat.read_text())
-
-
 def handle_resume(
     wiki: str | None = None,
     days: int = 3,
@@ -502,23 +464,6 @@ def handle_resume(
         keyword=keyword,
         days=days,
         k=k,
-    )
-
-
-def handle_briefing_gather(
-    wiki: str,
-    since: str | None = None,
-    include_body_sections: bool = True,
-    epic: int | None = None,
-) -> dict[str, Any]:
-    """Read-only briefing gather. Delegates to lore_core.briefing.gather()."""
-    from lore_core.briefing import gather
-
-    return gather(
-        wiki=wiki,
-        since=since,
-        include_body_sections=include_body_sections,
-        epic=epic,
     )
 
 
@@ -554,25 +499,6 @@ def handle_journal_write(
     except ValueError as e:
         return _mcp_error("invalid_entry", str(e))
     return {"schema": "lore.journal.write/1", "data": result}
-
-
-def handle_journal_read(
-    kind: str = "ai",
-    limit: int = 10,
-) -> dict[str, Any]:
-    """Read recent entries from the AI or human journal (newest-first)."""
-    from lore_core import journal
-
-    if kind not in journal.VALID_KINDS:
-        return _mcp_error(
-            "invalid_kind",
-            f"journal kind must be one of {journal.VALID_KINDS!r}, got {kind!r}",
-        )
-    entries = journal.read(kind, limit=limit)  # type: ignore[arg-type]
-    return {
-        "schema": "lore.journal.read/1",
-        "data": {"kind": kind, "entries": entries},
-    }
 
 
 def handle_drill(
@@ -631,9 +557,8 @@ def handle_drill(
     # Stage 2: read top hits
     # Drill is the user-invoked deep-dive surface (PRD #92 retrieval
     # contract): pass ``include_human=True`` so the full note — including
-    # the human-only region — is returned. ``handle_search`` /
-    # ``handle_briefing_gather`` are the auto-load surfaces where
-    # redaction is enforced.
+    # the human-only region — is returned. ``handle_search`` is the
+    # auto-load surface where redaction is enforced instead.
     t0 = _time.monotonic()
     top_paths = [h["path"] for h in hits]
     read_failed_top: list[str] = []
@@ -931,45 +856,6 @@ def handle_pending_verdicts(wiki: str | None = None) -> dict[str, Any]:
     }
 
 
-def handle_wikilinks(note: str, wiki: str | None = None) -> dict[str, Any]:
-    wiki_path = _resolve_wiki(wiki)
-    if wiki_path is None:
-        return _mcp_error(
-            "wiki_not_found",
-            f"wiki not found: {wiki}",
-            next_="run `lore status` to list configured wikis",
-        )
-    cat_path = wiki_path / "_catalog.json"
-    if not cat_path.exists():
-        return _mcp_error(
-            "catalog_missing",
-            "no _catalog.json",
-            next_="run `lore lint` to regenerate the catalog",
-        )
-    catalog = json.loads(cat_path.read_text())
-    for entries in catalog.get("sections", {}).values():
-        for entry in entries:
-            if entry["name"] == note or entry["path"] == note:
-                return {
-                    "wiki": wiki_path.name,
-                    "note": entry["name"],
-                    "links_out": entry.get("links_out", []),
-                    "links_in": entry.get("links_in", []),
-                }
-    # Fall back to live parse
-    candidates = list(wiki_path.rglob(f"{note}.md"))
-    if candidates:
-        text = candidates[0].read_text(errors="replace")
-        return {
-            "wiki": wiki_path.name,
-            "note": note,
-            "links_out": extract_wikilinks(text),
-            "links_in": [],
-            "note_missing_from_catalog": True,
-        }
-    return _mcp_error("note_not_found", f"note not found: {note}")
-
-
 def _resolve_repo_root(repo_path: str | None) -> Path | None:
     """Resolve the connected repo's root for the repo-docs pull tools.
 
@@ -1174,22 +1060,6 @@ def _tool_schema() -> list[dict]:
             },
         },
         {
-            "name": "lore_index",
-            "description": "Return the wiki's _index.txt (LLM-scannable knowledge map; markdown body with wikilinks).",
-            "inputSchema": {
-                "type": "object",
-                "properties": {"wiki": {"type": "string"}},
-            },
-        },
-        {
-            "name": "lore_catalog",
-            "description": "Return the wiki's _catalog.json (full machine-readable metadata + link graph).",
-            "inputSchema": {
-                "type": "object",
-                "properties": {"wiki": {"type": "string"}},
-            },
-        },
-        {
             "name": "lore_resume",
             "description": (
                 "Load working context from the vault. Modes (priority "
@@ -1224,18 +1094,6 @@ def _tool_schema() -> list[dict]:
                         "description": "Top-k results for keyword search",
                     },
                 },
-            },
-        },
-        {
-            "name": "lore_wikilinks",
-            "description": "Return incoming and outgoing [[wikilinks]] for a note (graph traversal).",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "note": {"type": "string"},
-                    "wiki": {"type": "string"},
-                },
-                "required": ["note"],
             },
         },
         {
@@ -1281,39 +1139,6 @@ def _tool_schema() -> list[dict]:
             },
         },
         {
-            "name": "lore_briefing_gather",
-            "description": (
-                "Read-only briefing gather: returns the new session "
-                "notes (since the last briefing) plus the wiki's sink "
-                "config and ledger state. Caller composes the briefing "
-                "prose, then shells out to `lore briefing publish` and "
-                "`lore briefing mark`. No LLM call inside the tool."
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "wiki": {"type": "string"},
-                    "since": {
-                        "type": "string",
-                        "description": "ISO date floor (YYYY-MM-DD)",
-                    },
-                    "include_body_sections": {
-                        "type": "boolean",
-                        "default": True,
-                        "description": "Extract H2 sections per session",
-                    },
-                    "epic": {
-                        "type": "integer",
-                        "description": (
-                            "Filter to sessions whose `linkage.epics` "
-                            "names this epic number."
-                        ),
-                    },
-                },
-                "required": ["wiki"],
-            },
-        },
-        {
             "name": "lore_inbox_classify",
             "description": (
                 "Read-only inbox walk: returns every file in the root "
@@ -1353,25 +1178,6 @@ def _tool_schema() -> list[dict]:
                     },
                 },
                 "required": ["kind", "text"],
-            },
-        },
-        {
-            "name": "lore_journal_read",
-            "description": (
-                "Read recent entries from the AI or human journal "
-                "(newest-first). Use sparingly — the journal is for "
-                "*writing*, not for self-referential reading."
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "kind": {
-                        "type": "string",
-                        "enum": ["ai", "human"],
-                        "default": "ai",
-                    },
-                    "limit": {"type": "integer", "default": 10},
-                },
             },
         },
         {
@@ -1616,24 +1422,14 @@ def _dispatch(tool_name: str, args: dict) -> Any:
             return handle_search(**args)
         case "lore_read":
             return handle_read(**args)
-        case "lore_index":
-            return handle_index(**args)
-        case "lore_catalog":
-            return handle_catalog(**args)
         case "lore_resume":
             return handle_resume(**args)
-        case "lore_wikilinks":
-            return handle_wikilinks(**args)
         case "lore_drill":
             return handle_drill(**args)
-        case "lore_briefing_gather":
-            return handle_briefing_gather(**args)
         case "lore_inbox_classify":
             return handle_inbox_classify(**args)
         case "lore_journal_write":
             return handle_journal_write(**args)
-        case "lore_journal_read":
-            return handle_journal_read(**args)
         case "lore_verdict":
             return handle_verdict(**args)
         case "lore_pending_verdicts":

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -737,14 +737,6 @@ def test_gather_epic_filter_no_match_returns_empty(linkage_briefing_vault):
     assert result["new_sessions"] == []
 
 
-def test_mcp_handle_briefing_gather_forwards_epic(linkage_briefing_vault):
-    from lore_mcp.server import handle_briefing_gather
-
-    result = handle_briefing_gather(wiki="ccat", epic=162)
-    assert len(result["new_sessions"]) == 1
-    assert result["new_sessions"][0]["slug"] == "fix-a"
-
-
 def test_render_briefing_links_to_source_note():
     """Digest bullets carry a wikilink back to the source session note."""
     result = {

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -167,7 +167,7 @@ def test_session_start_directive_on_when_enabled(vault):
 
 
 def test_mcp_journal_write_round_trip(vault):
-    from lore_mcp.server import handle_journal_read, handle_journal_write
+    from lore_mcp.server import handle_journal_write
 
     out = handle_journal_write(
         kind="ai", text="hello from MCP", author="opus"
@@ -175,9 +175,9 @@ def test_mcp_journal_write_round_trip(vault):
     assert out["schema"] == "lore.journal.write/1"
     assert "error" not in out
 
-    read_out = handle_journal_read(kind="ai", limit=5)
-    assert read_out["schema"] == "lore.journal.read/1"
-    entries = read_out["data"]["entries"]
+    # lore_journal_read has no MCP exposure — verify the write landed
+    # through the core module directly (still the read path in use).
+    entries = journal.read("ai", limit=5)
     assert len(entries) == 1
     assert entries[0]["body"] == "hello from MCP"
     assert entries[0]["author"] == "opus"

--- a/tests/test_mcp_error_envelope.py
+++ b/tests/test_mcp_error_envelope.py
@@ -15,13 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from lore_mcp.server import (
-    _mcp_error,
-    handle_catalog,
-    handle_index,
-    handle_read,
-    handle_wikilinks,
-)
+from lore_mcp.server import _mcp_error, handle_read
 
 
 # ---- helper itself ----
@@ -71,22 +65,6 @@ def _assert_envelope(result: dict, code: str, *, want_next: bool = False) -> Non
     assert isinstance(err["message"], str) and err["message"], "message empty"
     if want_next:
         assert err.get("next"), f"expected 'next' hint for code={code!r}"
-
-
-def test_handle_index_missing_catalog_envelope(empty_vault: Path) -> None:
-    result = handle_index(wiki="private")
-    _assert_envelope(result, "catalog_missing", want_next=True)
-    assert "lore lint" in result["error"]["next"]
-
-
-def test_handle_catalog_missing_envelope(empty_vault: Path) -> None:
-    result = handle_catalog(wiki="private")
-    _assert_envelope(result, "catalog_missing", want_next=True)
-
-
-def test_handle_wikilinks_missing_catalog_envelope(empty_vault: Path) -> None:
-    result = handle_wikilinks(note="anything", wiki="private")
-    _assert_envelope(result, "catalog_missing", want_next=True)
 
 
 def test_handle_read_unknown_wiki_envelope(empty_vault: Path) -> None:

--- a/tests/test_mcp_surface_trim.py
+++ b/tests/test_mcp_surface_trim.py
@@ -1,0 +1,49 @@
+"""MCP surface trim — five no-caller tools removed from exposure.
+
+`lore_index`, `lore_catalog`, `lore_wikilinks`, `lore_journal_read`, and
+`lore_briefing_gather` have no caller (no skill, template, integration-rules
+file, or hook instructs a model to call them). The underlying core they
+wrapped stays reachable through other paths: `lore_core/wikilinks.py` backs
+`lore_drill`'s expand stage, `lore briefing gather` is a CLI command, and
+`lore_core.journal` is still written via `lore_journal_write`.
+"""
+from __future__ import annotations
+
+from lore_mcp.server import _dispatch, _tool_schema
+
+REMOVED_TOOLS = {
+    "lore_index",
+    "lore_catalog",
+    "lore_wikilinks",
+    "lore_journal_read",
+    "lore_briefing_gather",
+}
+
+
+def test_tool_schema_has_exactly_thirteen_tools() -> None:
+    names = [t["name"] for t in _tool_schema()]
+    assert len(names) == 13, names
+
+
+def test_tool_schema_excludes_removed_tools() -> None:
+    names = {t["name"] for t in _tool_schema()}
+    assert names.isdisjoint(REMOVED_TOOLS), names & REMOVED_TOOLS
+
+
+def test_dispatch_rejects_removed_tool_names() -> None:
+    for name in REMOVED_TOOLS:
+        result = _dispatch(name, {})
+        assert result["error"]["code"] == "unknown_tool", (name, result)
+
+
+def test_removed_handlers_no_longer_defined() -> None:
+    import lore_mcp.server as server
+
+    for handler in (
+        "handle_index",
+        "handle_catalog",
+        "handle_wikilinks",
+        "handle_journal_read",
+        "handle_briefing_gather",
+    ):
+        assert not hasattr(server, handler), handler

--- a/tests/test_mcp_surface_trim.py
+++ b/tests/test_mcp_surface_trim.py
@@ -7,6 +7,7 @@ wrapped stays reachable through other paths: `lore_core/wikilinks.py` backs
 `lore_drill`'s expand stage, `lore briefing gather` is a CLI command, and
 `lore_core.journal` is still written via `lore_journal_write`.
 """
+
 from __future__ import annotations
 
 from lore_mcp.server import _dispatch, _tool_schema


### PR DESCRIPTION
## Summary
Closes #260, resolves #210 (stale exposed-tools header).

Removes the five MCP tools with no caller anywhere (verified: no skill, template, session_templates, integration-rules file, or hook instructs a model to call them): `lore_index`, `lore_catalog`, `lore_wikilinks`, `lore_journal_read`, `lore_briefing_gather`. The server's `tools/list` goes from 18 to 13 exposed tools.

- Removed the five tool schema entries from `_tool_schema()` and their `case` statements in `_dispatch()`.
- Deleted the five now-dead handler functions (`handle_index`, `handle_catalog`, `handle_wikilinks`, `handle_journal_read`, `handle_briefing_gather`) — each had no caller left outside the MCP dispatch and direct unit tests.
- Rewrote the "Exposed tools" header comment in `lib/lore_mcp/server.py` to list exactly the 13 remaining tools.
- Underlying core modules with other callers are untouched: `lore_core/wikilinks.py` still backs `lore_drill`'s expand stage (confirmed via its own callers in `lore_curator/`, `lore_core/lint.py`, `lore_core/migrate.py`), `lore briefing gather` remains a CLI-only path (`lore_cli/briefing_cmd.py` calls `lore_core.briefing.gather()` directly, never through the deleted MCP wrapper), and journal writes stay gated behind `journal.enabled` via `lore_journal_write` (kept).
- Updated the three test files that unit-tested the deleted wrappers directly: `test_mcp_error_envelope.py` (dropped the `handle_index`/`handle_catalog`/`handle_wikilinks` envelope tests), `test_journal.py` (round-trip test now verifies the write via `lore_core.journal.read()` instead of the deleted `handle_journal_read`), `test_briefing.py` (dropped the MCP-wrapper test; `gather()`'s epic-filter behavior is still covered directly by `test_gather_filters_by_epic`).

## Final exposed tool list (13)
`lore_search`, `lore_read`, `lore_resume`, `lore_drill`, `lore_inbox_classify`, `lore_journal_write`, `lore_pending_verdicts`, `lore_verdict`, `lore_repo_docs_list`, `lore_tier_resolve`, `lore_codemap`, `lore_repo_docs_fetch`, `lore_context_pack`

## Red → green evidence
New test `tests/test_mcp_surface_trim.py`, run against the pre-cut code (18 tools):
```
FAILED tests/test_mcp_surface_trim.py::test_tool_schema_has_exactly_thirteen_tools - AssertionError: ['lore_search', 'lore_read', 'lore_index', 'lore_catalog', ...
FAILED tests/test_mcp_surface_trim.py::test_tool_schema_excludes_removed_tools - AssertionError: {'lore_briefing_gather', 'lore_catalog', 'lore_index', ...
FAILED tests/test_mcp_surface_trim.py::test_dispatch_rejects_removed_tool_names - KeyError: 'error'
FAILED tests/test_mcp_surface_trim.py::test_removed_handlers_no_longer_defined - AssertionError: handle_index
4 failed in 0.48s
```
After the cut, all 4 pass:
```
....                                                                     [100%]
4 passed in 0.23s
```

## Test plan
- [x] Full suite: `2864 passed, 16 skipped` (6 pre-existing failures in unrelated modules — `test_cli_scopes.py`, `test_core_llm_wiring.py`, `test_install_dispatcher.py`, `test_log_cmd.py`, `test_proc_cmd.py` — confirmed identical on `epic/257` baseline with this branch's changes stashed out; unrelated to this PR, look like ANSI/rich-output environment flakiness)
- [x] `ruff check` on every touched file — no new findings introduced (baseline-vs-branch diffed to confirm; pre-existing findings in `server.py`/`test_journal.py`/`test_mcp_error_envelope.py` predate this change and total finding count actually dropped from 12 to 9 across touched files)
- [x] `lore_drill` expand stage and `lore briefing gather` CLI unaffected (their tests pass unchanged)