### PR TITLE
Merge grill-me/grill-with-docs into grilling's doc-context mode (#265)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
     {
       "name": "lore-workflow",
       "source": "./lore-workflow",
-      "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams (13 skills: orient, grilling, to-epic, orchestrate-epic, tdd, debug, document-epic, \u2026). Depends on lore."
+      "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams (11 skills: orient, grilling, to-epic, orchestrate-epic, tdd, debug, document-epic, \u2026). Depends on lore."
     }
   ]
 }

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -264,7 +264,7 @@ above:
 Terms used in the workflow layer and orchestration:
 
 - **Workflow** — a skill-bundled planning chain: `seed-epic → orient →
-  grill-with-docs → to-epic → orchestrate-epic → document-epic`. Each step
+  grilling → to-epic → orchestrate-epic → document-epic`. Each step
   is a callable skill, with checkpoints between shaping (human-controlled)
   and autonomous build. See `docs/conventions.md` for the stage vocabulary,
   artifact homes, and tier assignments.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dependency only runs one way — nothing in `lore` core imports or requires
 The chain it bundles:
 
 ```
-seed-epic → orient → grill-with-docs → to-epic → orchestrate-epic → document-epic
+seed-epic → orient → grilling → to-epic → orchestrate-epic → document-epic
 ```
 
 with `implement-issue` as a lighter-weight track for one well-understood

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -24,14 +24,14 @@ the next; the human is the checkpoint between *shaping* and *autonomous
 build*.
 
 ```
-seed-epic → orient → grill-with-docs → to-epic → orchestrate-epic → document-epic
+seed-epic → orient → grilling → to-epic → orchestrate-epic → document-epic
 ```
 
 | Step | What it does |
 |------|--------------|
 | `seed-epic` | End-of-session capture: distils hard-won context into a GitHub **epic seed** issue a cold session can `orient` on. A discussion seed, not a spec. |
 | `orient` | First step of any work. The session does its own homework with read-only subagents, then reflects its understanding back for confirmation. Explores; does not implement or fix scope. |
-| `grill-with-docs` | A relentless, one-question-at-a-time interview that stress-tests a plan against the project's domain model and documented decisions, sharpening terminology and updating `CONTEXT.md`/ADRs inline. Composes `grilling` + `domain-modeling`. |
+| `grilling` | A relentless, one-question-at-a-time interview that stress-tests a plan. Default mode ("grill me") checks whether `domain-modeling` is needed at the end; "grill with docs" mode runs it alongside the interview from the start, sharpening terminology and updating `CONTEXT.md`/ADRs inline. |
 | `to-epic` | The human checkpoint. Turns a shaped plan into an **epic tracker** issue (linking a PRD under `docs/prd/`) plus one sub-issue per feature, emitting the canonical roadmap DAG `orchestrate-epic` consumes. |
 | `orchestrate-epic` | Fully autonomous: fans out one test-first teammate per feature, crosschecks every pull request, integrates onto an `epic/<n>` branch in dependency order, and lands one final pull request to the detected target branch. |
 | `document-epic` | Runs as `orchestrate-epic`'s **final automatic stage** (see below), not a manual step. Updates the Diátaxis docs to match the landed epic. |
@@ -45,8 +45,8 @@ fast path for one well-understood issue, keeping the same discipline (strict
 TDD, ADR check, Diátaxis docs pass) at single-issue weight.
 
 **Bundled skills:** `ccat-workflow-init`, `seed-epic`, `orient`, `grilling`,
-`domain-modeling`, `grill-with-docs`, `grill-me`, `to-epic`,
-`orchestrate-epic`, `document-epic`, `tdd`, `debug`, `implement-issue` — all
+`domain-modeling`, `to-epic`, `orchestrate-epic`, `document-epic`, `tdd`,
+`debug`, `implement-issue` — all
 shipped as `lore-workflow:<name>` skills. `ccat-workflow-init` is a one-time
 onboarding scaffold, not part of the per-epic chain above; see
 [Onboard a repo](how-to/onboard-a-repo.md).

--- a/docs/how-to/run-an-epic.md
+++ b/docs/how-to/run-an-epic.md
@@ -19,9 +19,9 @@ small, clear change, use the [fast path](use-the-fast-path.md) instead.
 
 1. **Shape it.** In a session pointed at the idea (or the seed issue), run
    `/lore-workflow:orient` to reflect the work back and confirm it, then
-   `/lore-workflow:grill-with-docs` to stress-test the plan and record
-   decisions inline. Do not skip this: an epic built on an unshaped plan
-   wastes the autonomous build.
+   `/lore-workflow:grilling` — say "grill with docs" — to stress-test the plan
+   and record decisions inline. Do not skip this: an epic built on an
+   unshaped plan wastes the autonomous build.
 2. **Cross the checkpoint.** Run `/lore-workflow:to-epic`. It writes the PRD
    to `docs/prd/` via `lore workflow create-prd`, opens the epic tracker
    issue and one sub-issue per feature, and emits the roadmap dependency

--- a/lore-workflow/README.md
+++ b/lore-workflow/README.md
@@ -20,9 +20,7 @@ delegation conventions shared across skills live in
 |-------|----------------|
 | `ccat-workflow-init` | Onboard a repo — a thin pointer at `lore attach --scaffold-workflow`. |
 | `orient` | First step of a task — homework, then reflect understanding back before planning. |
-| `grilling` | Interview the user relentlessly to stress-test a plan or design. |
-| `grill-me` | Run a `/lore-workflow:grilling` session. |
-| `grill-with-docs` | Run a `/lore-workflow:grilling` session that also drives `domain-modeling`. |
+| `grilling` | Interview the user relentlessly to stress-test a plan or design — "grill with docs" mode also drives `domain-modeling`. |
 | `domain-modeling` | Build and sharpen a project's domain model (CONTEXT.md, ADRs). |
 | `to-epic` | Turn a plan/PRD into a PRD file plus an epic tracker issue with a roadmap DAG. |
 | `orchestrate-epic` | Supervise parallel TDD implementation of an epic — plan, dispatch, crosscheck, land. |

--- a/lore-workflow/skills/grill-me/SKILL.md
+++ b/lore-workflow/skills/grill-me/SKILL.md
@@ -1,7 +1,0 @@
----
-name: lore-workflow:grill-me
-description: A relentless interview to sharpen a plan or design.
-disable-model-invocation: true
----
-
-Run a `/lore-workflow:grilling` session.

--- a/lore-workflow/skills/grill-with-docs/SKILL.md
+++ b/lore-workflow/skills/grill-with-docs/SKILL.md
@@ -1,7 +1,0 @@
----
-name: lore-workflow:grill-with-docs
-description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
-disable-model-invocation: true
----
-
-Run a `/lore-workflow:grilling` session, using the `/lore-workflow:domain-modeling` skill.

--- a/lore-workflow/skills/grilling/SKILL.md
+++ b/lore-workflow/skills/grilling/SKILL.md
@@ -21,6 +21,6 @@ How much /lore-workflow:domain-modeling runs alongside the interview is a mode, 
 - **Plain ("grill me"), default.** Once all questions are solved to satisfaction, check if /lore-workflow:domain-modeling is needed and, if so, align with the user before updating the domain model.
 - **With docs ("grill with docs").** Run /lore-workflow:domain-modeling alongside the interview from the start — record ADRs and glossary terms as each decision lands, not only at the end.
 
-Else: if all questions and any domain model updates are satisfactory, say so and invoke /lore-workflow:to-epic.
+Once all questions and any domain-model updates are satisfactory, say so and invoke /lore-workflow:to-epic.
 
 If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/lore-workflow/skills/grilling/SKILL.md
+++ b/lore-workflow/skills/grilling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lore-workflow:grilling
-description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, says "grill me" or "grill with docs", or uses any other 'grill' trigger phrase.
 ---
 
 **Tier note:** this step runs in the main session at frontier-tier — it is not delegated to a
@@ -14,6 +14,13 @@ If opts to grill slow:
 
 Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
 
-Else: if all questions solved to satisfaction, check if /lore-workflow:domain-modeling is needed and if need be align with the user before updating the domain model then if all questions and domain modle updates are satisfactory say so and invoke /lore-workflow:to-epic. 
+## Doc-context mode
+
+How much /lore-workflow:domain-modeling runs alongside the interview is a mode, picked by how the user asked to be grilled:
+
+- **Plain ("grill me"), default.** Once all questions are solved to satisfaction, check if /lore-workflow:domain-modeling is needed and, if so, align with the user before updating the domain model.
+- **With docs ("grill with docs").** Run /lore-workflow:domain-modeling alongside the interview from the start — record ADRs and glossary terms as each decision lands, not only at the end.
+
+Else: if all questions and any domain model updates are satisfactory, say so and invoke /lore-workflow:to-epic.
 
 If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/lore-workflow/skills/implement-issue/SKILL.md
+++ b/lore-workflow/skills/implement-issue/SKILL.md
@@ -7,7 +7,7 @@ description: Fast path for one well-understood GitHub issue — read the issue a
 
 A fast path for a single, well-understood GitHub issue. It is a **second track
 beside the epic chain, not a new chain phase**: the chain
-(`seed-epic → orient → grill-with-docs → to-epic → orchestrate-epic → document-epic`)
+(`seed-epic → orient → grilling → to-epic → orchestrate-epic → document-epic`)
 is the right weight for a shaped body of work, but far too heavy for one small,
 clear change. Bypassing the workflow for that change is the other trap — it drops
 exactly the discipline the workflow exists to keep (test-first development, the
@@ -24,7 +24,7 @@ human stays present, so **merging stays with the user**.
 Reach for this when the user hands you a single GitHub issue they wrote and the
 change is small and clear enough that spinning up the full epic chain would be
 pure overhead. If the work is really several features, or the shape is still
-unsettled, it belongs on the chain (`orient` → `grill-with-docs` → `to-epic`),
+unsettled, it belongs on the chain (`orient` → `grilling` → `to-epic`),
 not here.
 
 ## Flow

--- a/lore-workflow/skills/orient/SKILL.md
+++ b/lore-workflow/skills/orient/SKILL.md
@@ -63,9 +63,9 @@ Ask whether this matches. If the user corrects or adds input, re-orient with a *
 re-explore — only the facets that moved, not a full re-run. Repeat until they confirm.
 
 ### 5. Handoff
-On confirmation, carry the shared understanding into the grilling step — default
-`/lore-workflow:grill-with-docs` (it aligns terminology against CONTEXT.md/ADRs, which the downstream
-`/lore-workflow:to-epic` slices depend on). Use `/lore-workflow:grill-me` instead when there is no domain model to align
+On confirmation, carry the shared understanding into the grilling step — default to
+`/lore-workflow:grilling` in its "grill with docs" mode (it aligns terminology against CONTEXT.md/ADRs, which the downstream
+`/lore-workflow:to-epic` slices depend on). Say "grill me" for plain `/lore-workflow:grilling` instead when there is no domain model to align
 against.
 
-Chain: `/lore-workflow:orient` → `/lore-workflow:grill-with-docs` → `/lore-workflow:to-epic` → `/lore-workflow:orchestrate-epic`.
+Chain: `/lore-workflow:orient` → `/lore-workflow:grilling` → `/lore-workflow:to-epic` → `/lore-workflow:orchestrate-epic`.

--- a/lore-workflow/skills/seed-epic/SKILL.md
+++ b/lore-workflow/skills/seed-epic/SKILL.md
@@ -12,7 +12,7 @@ description: At the end of a long session — often after /lore-workflow:orchest
 Capture this session's context into an **epic seed** — a tracker issue a fresh session can
 orient on cold. The seed is a **discussion seed, not a spec**: it carries the intent and the
 expensive-to-rebuild context, then the new session forms the epic via
-`/lore-workflow:orient → /lore-workflow:grill-with-docs → /lore-workflow:to-epic → /lore-workflow:orchestrate-epic`. Do NOT pre-slice or pre-decide
+`/lore-workflow:orient → /lore-workflow:grilling → /lore-workflow:to-epic → /lore-workflow:orchestrate-epic`. Do NOT pre-slice or pre-decide
 scope — that is orient/grill/lore-workflow:to-epic's job.
 
 **Tier note:** this step runs in the main session at frontier-tier — it is not delegated to a

--- a/tests/test_workflow_docs_drift.py
+++ b/tests/test_workflow_docs_drift.py
@@ -18,7 +18,7 @@ DOCS_FILES = sorted((REPO_ROOT / "docs").rglob("*.md")) + [REPO_ROOT / "README.m
 
 SKILL_REF_RE = re.compile(r"lore-workflow:([a-z][a-z-]*)")
 CHAIN_RE = re.compile(
-    r"seed-epic\s*→\s*orient\s*→\s*grill-with-docs\s*→\s*to-epic\s*→\s*orchestrate-epic\s*→\s*document-epic"
+    r"seed-epic\s*→\s*orient\s*→\s*grilling\s*→\s*to-epic\s*→\s*orchestrate-epic\s*→\s*document-epic"
 )
 
 

--- a/tests/test_workflow_plugin_structural.py
+++ b/tests/test_workflow_plugin_structural.py
@@ -38,8 +38,6 @@ EXPECTED_SKILL_NAMES = {
     "document-epic",
     "domain-modeling",
     "grilling",
-    "grill-me",
-    "grill-with-docs",
     "implement-issue",
     "orchestrate-epic",
     "orient",
@@ -50,8 +48,6 @@ EXPECTED_SKILL_NAMES = {
 
 GRILLING_SKILL_FILES = {
     "grilling": ("SKILL.md",),
-    "grill-me": ("SKILL.md",),
-    "grill-with-docs": ("SKILL.md",),
     "domain-modeling": ("SKILL.md", "CONTEXT-FORMAT.md", "ADR-FORMAT.md"),
 }
 
@@ -209,11 +205,14 @@ def test_grilling_subsystem_cohesion() -> None:
         for filename in files:
             path = SKILLS_ROOT / skill / filename
             assert path.exists(), f"missing required file: {path.relative_to(REPO_ROOT)}"
-    gwd_text = (SKILLS_ROOT / "grill-with-docs" / "SKILL.md").read_text()
-    for referenced in ("grilling", "domain-modeling"):
-        assert referenced in gwd_text, f"grill-with-docs must reference '{referenced}'"
-    grill_me_text = (SKILLS_ROOT / "grill-me" / "SKILL.md").read_text()
-    assert "grilling" in grill_me_text, "grill-me must reference 'grilling'"
+    grilling_text = (SKILLS_ROOT / "grilling" / "SKILL.md").read_text()
+    frontmatter = _parse_frontmatter(grilling_text)
+    description = frontmatter["description"].lower()
+    for phrase in ("grill me", "grill with docs", "grill"):
+        assert phrase in description, f"grilling description must carry trigger phrase '{phrase}'"
+    assert "domain-modeling" in grilling_text, (
+        "grilling must reference 'domain-modeling' for its doc-context mode"
+    )
 
 
 def test_no_hardcoded_model_names() -> None:


### PR DESCRIPTION
Closes #265 (part of epic #257).

## What changed
The three grill skills (`grilling`, `grill-me`, `grill-with-docs`) only ever differed in how eagerly `domain-modeling` ran. `grill-me` was a bare wrapper, `grill-with-docs` a wrapper that always drove `domain-modeling`. Merged both into `grilling` as an explicit **doc-context mode** in the skill body:

- **Plain ("grill me"), default** — same as the old `grilling`: check whether `domain-modeling` is needed once all questions are resolved.
- **With docs ("grill with docs")** — run `domain-modeling` alongside the interview from the start, recording ADRs/glossary as decisions land.

`grill-me/SKILL.md` and `grill-with-docs/SKILL.md` are deleted; `lore-workflow:grilling` is the sole surviving skill and keeps its name. The merged description carries all three predecessors' trigger phrases verbatim ("grill me", "grill with docs", generic `'grill'` phrases) so existing user habits keep working as plain triggers rather than slash commands.

Updated every in-scope reference to the removed names: `lore-workflow/README.md` skill table, root `README.md` and `docs/conventions.md` chain diagrams + skill list, `docs/how-to/run-an-epic.md`, and the `seed-epic` / `implement-issue` / `orient` skills that named `grill-with-docs`/`grill-me` explicitly in their chain text. `lore-workflow/TIER-DELEGATION.md` needed no change (it only ever named `grilling`).

Left untouched: root `CONTEXT.md`'s one stale chain mention — it's outside `docs/`, isn't a skill file, isn't covered by any test, and doc alignment beyond the removed-name references is explicitly a separate slice's job per the epic's task split.

## TDD evidence

Extended the two existing structural tests that already asserted invariants over the grill skill trio:
- `tests/test_workflow_plugin_structural.py`: `EXPECTED_SKILL_NAMES` / `GRILLING_SKILL_FILES` now expect one `grilling` skill (not three dirs); `test_grilling_subsystem_cohesion` now asserts the merged skill's frontmatter `description` carries all three trigger phrases and the body references `domain-modeling`.
- `tests/test_workflow_docs_drift.py`: `CHAIN_RE` now expects the canonical chain to name `grilling` instead of `grill-with-docs`.

**Red** (before the merge, 3 failures):
```
FAILED tests/test_workflow_plugin_structural.py::test_every_expected_skill_ships
  AssertionError: skill set mismatch — unexpected: {'grill-with-docs', 'grill-me'}
FAILED tests/test_workflow_plugin_structural.py::test_grilling_subsystem_cohesion
  AssertionError: grilling description must carry trigger phrase 'grill me'
FAILED tests/test_workflow_docs_drift.py::test_docs_conventions_chain_matches_readme_chain
  AssertionError: docs/conventions.md is missing the canonical chain diagram
3 failed, 51 passed
```

**Green** (after the merge):
```
48 passed
```

Full suite: `2858 passed, 6 failed, 16 skipped` — the 6 failures are in `test_cli_scopes.py`, `test_core_llm_wiring.py`, `test_install_dispatcher.py`, `test_log_cmd.py`, `test_proc_cmd.py`, none of which this PR touches; confirmed pre-existing on the `epic/257` baseline (unrelated ANSI/rich-rendering assertions).

`ruff check` clean on both edited test files.

## Merged skill's frontmatter (verbatim)
```yaml
name: lore-workflow:grilling
description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, says "grill me" or "grill with docs", or uses any other 'grill' trigger phrase.
```