### PR TITLE
Hotspot decomposition: run_lint, _apply_outcome, install/_helpers relocation, hygiene wrappers (#264)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ Adding a new host (Codex, Gemini, OpenCode, …) is one Python file.
    functions:
 
    ```python
+   from lore_core import managed_files
    from lore_core.install import _helpers
    from lore_core.install.base import Action, InstallContext, LegacyArtifact
 
@@ -90,17 +91,24 @@ Adding a new host (Codex, Gemini, OpenCode, …) is one Python file.
 3. **Add a `_binary_for()` mapping** in `lib/lore_cli/install_cmd.py`
    so `--host all` can detect the host's CLI on PATH.
 
-4. **Use the existing primitives in `_helpers.py`** rather than rolling
-   your own:
+4. **Use the existing primitives** rather than rolling your own.
+   Writing into files the user owns lives in `lore_core.managed_files`:
    - `json_merge_atomic(path, mutator, validate=…)` for JSON config
      files (handles flock + symlink realpath + retry-after-validate)
    - `write_managed_markdown(path, body)` / `remove_managed_block(path)`
      for rules / system-prompt files (preserves user content outside
      the managed markers)
+   - `copy_dir_atomic(src, dst)` / `remove_managed_dir(path)` for plugin
+     trees — both refuse to touch a tree without Lore's sentinel
+
+   Install-specific pieces live in `lore_core.install._helpers`:
    - `lore_mcp_entry(SCHEMA_VERSION)` for the canonical MCP server
      block — distinguishes Lore-managed from user-authored entries
      via `_lore_schema_version`
    - `check_lore_on_path()` if your host needs `lore` reachable
+
+   Finding the on-disk Lore source tree (skills, plugin manifest) is
+   `lore_core.source_root.resolve_lore_source_root()`.
 
 5. **Tests** in `tests/test_install_<host>.py` — follow the
    `test_install_cursor.py` shape: monkeypatch `sys.platform` for

--- a/lib/lore_cli/doctor_cmd.py
+++ b/lib/lore_cli/doctor_cmd.py
@@ -118,7 +118,7 @@ def _check_lore_version_drift(cwd: str) -> Check:
     line to silently show the *binary's* old version even after a
     successful plugin update.
     """
-    from lore_core.install._helpers import check_lore_version_match
+    from lore_core.source_root import check_lore_version_match
 
     # Find the source repo root by walking up from this file looking
     # for a pyproject.toml. Returns None gracefully if running from a
@@ -772,7 +772,8 @@ def _check_cursor_plugin_dir(cwd: str) -> Check:
         return True, "skipped: ~/.cursor not present"
 
     from importlib.metadata import PackageNotFoundError, version
-    from lore_core.install._helpers import PLUGIN_SENTINEL, cursor_plugin_dir
+    from lore_core.install._helpers import cursor_plugin_dir
+    from lore_core.managed_files import PLUGIN_SENTINEL
 
     plugin_dir = cursor_plugin_dir()
     if not plugin_dir.exists():

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -40,7 +40,7 @@ def _lore_version() -> str:
     fall back to the installed package metadata, which is the only source
     there.
     """
-    from lore_core.install._helpers import (
+    from lore_core.source_root import (
         read_claude_manifest,
         resolve_lore_source_root,
     )

--- a/lib/lore_core/install/_helpers.py
+++ b/lib/lore_core/install/_helpers.py
@@ -1,32 +1,35 @@
-"""Shared helpers for the per-integration install modules.
+"""Install-specific helpers for the per-integration install modules.
 
-Three groups of utilities:
+What lives here is what only an *installer* needs:
 
   Path resolution         per-platform config paths for each integration
-  File primitives         atomic JSON merge with flock + retry,
-                          markdown-with-managed-markers writer,
-                          content-hash for change detection
+  Self-install            installer cascade + binary-presence checks
+  Cursor packaging        translate the Claude plugin manifest into
+                          Cursor's manifest + hooks schema
+  Legacy detection        find install.sh-era state still on disk
   Action execution        switch on Action.kind to preview / apply / undo
 
-Everything here is stdlib-only except for `lore_core.io.atomic_write_text`.
-No imports from `lore_cli` (the CLI dispatcher imports from us, not
-the other way).
+The general-purpose file primitives these executors are built on (atomic
+JSON merge, managed markdown blocks, sentinel-gated trees) live in
+`lore_core.managed_files`; source-tree resolution lives in
+`lore_core.source_root`. Both are used outside install and are imported,
+not re-exported, here.
+
+No imports from `lore_cli` (the CLI dispatcher imports from us, not the
+other way).
 """
 
 from __future__ import annotations
 
-import contextlib
-import hashlib
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from lore_core import managed_files
 from lore_core.install.base import (
     KIND_CHECK,
     KIND_DELETE,
@@ -39,22 +42,11 @@ from lore_core.install.base import (
     LegacyArtifact,
 )
 from lore_core.io import atomic_write_text
+from lore_core.source_root import check_lore_version_match
 
 # ---------------------------------------------------------------------------
 # Per-platform path resolution
 # ---------------------------------------------------------------------------
-
-# `_lore_schema_version` field marker — distinguishes Lore-managed
-# blocks from user-authored ones inside shared JSON config files.
-SCHEMA_VERSION_KEY = "_lore_schema_version"
-
-# Standard Lore-managed-rules-file marker pair. Anything between these
-# two markers is replaced on upgrade and removed on uninstall; anything
-# outside the pair is preserved.
-MANAGED_BLOCK_START = (
-    "<!-- lore-managed-start; uninstall via lore uninstall -->"
-)
-MANAGED_BLOCK_END = "<!-- lore-managed-end -->"
 
 
 def claude_config_dir() -> Path:
@@ -121,157 +113,6 @@ def cursor_plugin_dir() -> Path:
     return Path.home() / ".cursor" / "plugins" / "local" / "lore"
 
 
-# Sentinel file written at the root of a lore-managed plugin tree.
-# uninstall refuses to remove a directory tree that lacks this marker
-# (defends against blowing away unrelated user content if a path
-# collision happens).
-PLUGIN_SENTINEL = ".lore-managed"
-
-
-# ---------------------------------------------------------------------------
-# File primitives
-# ---------------------------------------------------------------------------
-
-
-def content_hash(text: str) -> str:
-    """Stable SHA-256 of UTF-8 bytes, hex digest. Used for change detection."""
-    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
-
-
-@contextlib.contextmanager
-def _flocked(path: Path) -> Iterator[None]:
-    """fcntl.flock context manager on a sibling lock file.
-
-    We lock a sibling ``.lock`` file so the lock survives ``os.replace``
-    (which ``atomic_write_text`` does) — locking the target path itself
-    would lose the lock when the file is replaced.
-
-    Thin wrapper over ``lore_core.lockfile.flocked``; kept for the
-    sibling-path convention specific to ``json_merge_atomic``.
-    """
-    from lore_core.lockfile import flocked
-
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    with flocked(lock_path, blocking=True):
-        yield
-
-
-def json_merge_atomic(
-    path: Path,
-    mutator: callable,  # type: ignore[type-arg]
-    validate: callable | None = None,  # type: ignore[type-arg]
-) -> dict[str, Any]:
-    """Read-modify-write a JSON file under flock, with optional validation.
-
-    `mutator(data: dict) -> dict` returns the new data. If `validate`
-    is given, it runs on the freshly-read-back file after write; if
-    it returns False, retry the merge once. If still failing, raises
-    ConcurrentEditError.
-
-    Resolves symlinks before mutating (so chezmoi/Stow users don't
-    have their symlinks replaced with regular files by os.replace).
-    Refuses to load malformed JSON — the caller sees a clean error.
-    """
-    real_path = Path(os.path.realpath(path))
-    real_path.parent.mkdir(parents=True, exist_ok=True)
-
-    def _do_one_pass() -> dict[str, Any]:
-        data: dict[str, Any]
-        if real_path.exists():
-            try:
-                data = json.loads(real_path.read_text())
-            except json.JSONDecodeError as e:
-                raise MalformedConfigError(
-                    f"{real_path} is not valid JSON: {e}"
-                ) from e
-            if not isinstance(data, dict):
-                raise MalformedConfigError(
-                    f"{real_path} root must be a JSON object, got "
-                    f"{type(data).__name__}"
-                )
-        else:
-            data = {}
-        new_data = mutator(data)
-        atomic_write_text(real_path, json.dumps(new_data, indent=2) + "\n")
-        return new_data
-
-    with _flocked(real_path):
-        result = _do_one_pass()
-        if validate is None:
-            return result
-        if validate(result):
-            return result
-        # Validate-after-write failed — retry once
-        result = _do_one_pass()
-        if validate(result):
-            return result
-        raise ConcurrentEditError(
-            f"{real_path} keys missing after write; concurrent edit detected. "
-            "Quit Claude Code (or other writer) and retry."
-        )
-
-
-class MalformedConfigError(RuntimeError):
-    pass
-
-
-class ConcurrentEditError(RuntimeError):
-    pass
-
-
-def write_managed_markdown(path: Path, body: str) -> None:
-    """Write a markdown file wrapped in lore-managed-start/end markers.
-
-    Atomic. Creates parent dirs. Resolves symlinks before writing.
-    """
-    real_path = Path(os.path.realpath(path)) if path.exists() else path
-    real_path.parent.mkdir(parents=True, exist_ok=True)
-    full = (
-        f"{MANAGED_BLOCK_START}\n{body.rstrip()}\n{MANAGED_BLOCK_END}\n"
-    )
-    atomic_write_text(real_path, full)
-
-
-_MANAGED_BLOCK_RE = re.compile(
-    re.escape(MANAGED_BLOCK_START)
-    + r"\n(.*?)\n"
-    + re.escape(MANAGED_BLOCK_END)
-    + r"\n?",
-    re.DOTALL,
-)
-
-
-def remove_managed_block(path: Path) -> bool:
-    """Remove the lore-managed range from a markdown file.
-
-    Preserves any user content outside the managed markers. Returns
-    True if a block was removed, False if the file had no managed
-    block (no-op). If no content remains outside the block, the file
-    is removed entirely.
-    """
-    real_path = Path(os.path.realpath(path)) if path.exists() else path
-    if not real_path.exists():
-        return False
-    text = real_path.read_text()
-    new_text, n = _MANAGED_BLOCK_RE.subn("", text, count=1)
-    if n == 0:
-        return False
-    new_text = new_text.strip()
-    if not new_text:
-        real_path.unlink()
-    else:
-        atomic_write_text(real_path, new_text + "\n")
-    return True
-
-
-def managed_block_content(path: Path) -> str | None:
-    """Return the text inside lore-managed markers, or None if absent."""
-    if not path.exists():
-        return None
-    m = _MANAGED_BLOCK_RE.search(path.read_text())
-    return m.group(1) if m else None
-
-
 # ---------------------------------------------------------------------------
 # Self-install + binary-presence checks
 # ---------------------------------------------------------------------------
@@ -284,13 +125,21 @@ INSTALLERS = ("pipx", "uv", "pip")  # cascade order
 # the GitHub repo.
 LORE_GIT_URL = "git+https://github.com/buchbend/lore.git"
 
+# Per-installer argv prefix. The editable flag and the source argument are
+# appended by `install_self_via`; all three installers spell them the same.
+_INSTALL_ARGV = {
+    "pipx": ["pipx", "install", "--force"],
+    "uv": ["uv", "tool", "install", "--force"],
+    "pip": ["pip", "install", "--user", "--force-reinstall"],
+}
+
 
 def install_self_via(target: Path | None = None) -> tuple[str, list[str]]:
     """Pick the first available installer and return its argv.
 
     `target` is the editable source path for dev installs (or None to
     install from the GitHub repo via git+ URL — PyPI publish is blocked
-    on the `lore` name being squatted). Mirrors install.sh:49–62.
+    on the `lore` name being squatted).
 
     Returns `(installer_name, argv)`. Caller invokes via subprocess.
     Raises RuntimeError if none are available.
@@ -298,21 +147,10 @@ def install_self_via(target: Path | None = None) -> tuple[str, list[str]]:
     src = str(target) if target else LORE_GIT_URL
     for installer in INSTALLERS:
         if shutil.which(installer):
-            if installer == "pipx":
-                argv = ["pipx", "install", "--force"]
-                if target:
-                    argv += ["--editable"]
-                argv.append(src)
-            elif installer == "uv":
-                argv = ["uv", "tool", "install", "--force"]
-                if target:
-                    argv += ["--editable"]
-                argv.append(src)
-            else:  # pip
-                argv = ["pip", "install", "--user", "--force-reinstall"]
-                if target:
-                    argv += ["--editable"]
-                argv.append(src)
+            argv = list(_INSTALL_ARGV[installer])
+            if target:
+                argv.append("--editable")
+            argv.append(src)
             return installer, argv
     raise RuntimeError(
         "No Python installer found (tried pipx, uv, pip). "
@@ -328,66 +166,6 @@ def check_lore_on_path() -> tuple[bool, str]:
         "lore not on PATH. Run: pipx ensurepath; then reopen your shell "
         "and re-run lore install. (If pipx isn't installed, the "
         "claude integration self-install bootstrap will offer to add it.)"
-    )
-
-
-def check_lore_version_match(
-    lore_repo: "Path | str | None" = None,
-) -> tuple[bool, str]:
-    """Compare the installed Python package version against the on-disk source.
-
-    Closes the install-side counterpart to ``tests/test_version_sync.py``:
-    that pytest guard catches drift between ``pyproject.toml``,
-    ``plugin.json``, and ``CHANGELOG.md`` *in the source tree*; this check
-    catches drift between the installed pipx/pip/uv binary and that
-    source tree on the user's machine.
-
-    The hook footgun: ``claude plugin update lore@lore`` refreshes the
-    Claude Code plugin (skills/hooks/MCP wiring) but does not reinstall
-    the Python ``lore`` CLI. SessionStart's status line reads via
-    ``importlib.metadata.version(\"lore\")`` — i.e. the installed binary
-    — so a stale binary silently shows the old version forever.
-
-    Returns (ok, message). The message includes a copy-pasteable fix
-    command tailored to the install method (editable vs. non-editable).
-    Returns (True, "...skipped...") when no on-disk source is available
-    to compare against (e.g. user installed from PyPI without a clone).
-    """
-    from importlib.metadata import PackageNotFoundError, version
-
-    try:
-        installed = version("lore")
-    except PackageNotFoundError:
-        return False, (
-            "lore Python package not installed in this environment. "
-            "Run: pipx install --force --editable <path-to-lore-repo>"
-        )
-
-    repo_path = Path(lore_repo).expanduser() if lore_repo else None
-    if repo_path is None or not (repo_path / "pyproject.toml").is_file():
-        return True, f"lore CLI version {installed} (no source tree to compare against)"
-
-    pyproject = repo_path / "pyproject.toml"
-    try:
-        import tomllib
-
-        on_disk = tomllib.loads(pyproject.read_text())["project"]["version"]
-    except (OSError, KeyError, tomllib.TOMLDecodeError) as exc:
-        return True, (
-            f"lore CLI version {installed} "
-            f"(could not read on-disk pyproject.toml: {exc})"
-        )
-
-    if installed == on_disk:
-        return True, f"lore CLI version {installed} (matches source)"
-
-    # The installed and on-disk versions disagree. Pick the right fix
-    # command based on whether the install looks editable or not.
-    fix_cmd = f"pipx install --force --editable {repo_path}"
-    return False, (
-        f"lore CLI version drift: installed {installed}, source at {repo_path} "
-        f"is {on_disk}. The Claude Code plugin will silently use the older "
-        f"installed binary for `lore hook session-start` etc. Run: {fix_cmd}"
     )
 
 
@@ -412,55 +190,8 @@ def lore_mcp_entry(schema_version: str) -> dict[str, Any]:
     return {
         "command": shutil.which("lore") or "lore",
         "args": ["mcp"],
-        SCHEMA_VERSION_KEY: schema_version,
+        managed_files.SCHEMA_VERSION_KEY: schema_version,
     }
-
-
-def resolve_lore_source_root(lore_repo: Path | None = None) -> Path | None:
-    """Locate the lore source-of-truth root containing skills/ + .claude-plugin/.
-
-    Resolution order:
-      1. ``lore_repo`` (passed by ``lore install --lore-repo`` for dev installs)
-      2. Walk up from this file looking for a directory containing both
-         ``skills/`` and ``.claude-plugin/plugin.json`` (editable pip install)
-      3. ``~/.claude/plugins/cache/lore/lore/<version>/`` (Claude Code
-         marketplace install — newest version dir wins)
-
-    Returns ``None`` if nothing resolves; callers decide whether that's
-    fatal or a warning.
-    """
-    if lore_repo:
-        candidate = Path(lore_repo).expanduser().resolve()
-        if (candidate / "skills").is_dir() and (
-            candidate / ".claude-plugin" / "plugin.json"
-        ).is_file():
-            return candidate
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "skills").is_dir() and (
-            parent / ".claude-plugin" / "plugin.json"
-        ).is_file():
-            return parent
-    cache_root = Path.home() / ".claude" / "plugins" / "cache" / "lore" / "lore"
-    if cache_root.is_dir():
-        version_dirs = sorted(
-            (d for d in cache_root.iterdir() if d.is_dir()),
-            key=lambda d: d.name,
-            reverse=True,
-        )
-        for version_dir in version_dirs:
-            if (version_dir / "skills").is_dir() and (
-                version_dir / ".claude-plugin" / "plugin.json"
-            ).is_file():
-                return version_dir
-    return None
-
-
-def read_claude_manifest(source_root: Path) -> dict[str, Any]:
-    """Read ``.claude-plugin/plugin.json`` from a resolved source root."""
-    return json.loads(
-        (source_root / ".claude-plugin" / "plugin.json").read_text()
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -515,16 +246,36 @@ def generate_cursor_plugin_manifest(
     return out
 
 
+def _flatten_hook_group(group: Any) -> list[dict[str, Any]]:
+    """Flatten one Claude hook group into Cursor's per-entry hook list.
+
+    Claude nests hooks under a group that carries the matcher; Cursor has
+    no group level, so the group matcher is propagated onto each entry.
+    """
+    if not isinstance(group, dict):
+        return []
+    group_matcher = group.get("matcher")
+    flat: list[dict[str, Any]] = []
+    for hook in group.get("hooks") or []:
+        if not isinstance(hook, dict):
+            continue
+        cmd = hook.get("command")
+        if not cmd:
+            continue
+        entry: dict[str, Any] = {
+            "type": hook.get("type", "command"),
+            "command": _resolve_lore_in_command(cmd),
+        }
+        if group_matcher:
+            entry["matcher"] = group_matcher
+        flat.append(entry)
+    return flat
+
+
 def generate_cursor_hooks_json(
     claude_manifest: dict[str, Any],
 ) -> dict[str, Any]:
     """Generate a Cursor ``hooks.json`` from the Claude manifest's hooks block.
-
-    Claude's shape: each event maps to an array of "hook groups", each
-    group has an inner ``hooks`` list and an optional group-level
-    ``matcher``. Cursor's shape: each event maps directly to a flat
-    list of hook entries (with per-entry ``matcher``). We flatten by
-    propagating the group matcher onto each inner hook.
 
     Hook commands of the form ``lore <subcmd>`` are rewritten with the
     absolute ``lore`` path (same reason as MCP entries — GUI subprocess
@@ -542,77 +293,10 @@ def generate_cursor_hooks_json(
             continue
         flat: list[dict[str, Any]] = []
         for group in groups or []:
-            if not isinstance(group, dict):
-                continue
-            group_matcher = group.get("matcher")
-            for hook in group.get("hooks") or []:
-                if not isinstance(hook, dict):
-                    continue
-                cmd = hook.get("command")
-                if not cmd:
-                    continue
-                entry: dict[str, Any] = {
-                    "type": hook.get("type", "command"),
-                    "command": _resolve_lore_in_command(cmd),
-                }
-                if group_matcher:
-                    entry["matcher"] = group_matcher
-                flat.append(entry)
+            flat.extend(_flatten_hook_group(group))
         if flat:
             out_hooks[cursor_event] = flat
     return {"version": 1, "hooks": out_hooks}
-
-
-# ---------------------------------------------------------------------------
-# Directory-tree copy with managed sentinel — used for skills/rules bundling
-# ---------------------------------------------------------------------------
-
-
-def copy_dir_atomic(src: Path, dst: Path) -> None:
-    """Copy a directory tree from src to dst, idempotent on re-run.
-
-    Uses ``shutil.copytree(dirs_exist_ok=True)`` semantics: re-running
-    install overwrites, files removed from src disappear from dst on
-    next install only if we wipe-and-recopy, so we wipe first to keep
-    dst exactly mirroring src. The wipe is gated on the
-    ``PLUGIN_SENTINEL`` file at dst's parent (not dst itself — the
-    parent is the plugin root that owns the whole tree).
-
-    Resolves symlinks in src so the dst is always a real tree.
-    """
-    src_real = Path(os.path.realpath(src))
-    if not src_real.is_dir():
-        raise FileNotFoundError(f"copy source not found or not a dir: {src}")
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    if dst.exists():
-        # Refuse to wipe dst if the plugin root has no sentinel — that
-        # means we don't own this tree.
-        plugin_root = dst.parent
-        if not (plugin_root / PLUGIN_SENTINEL).exists():
-            raise PermissionError(
-                f"refusing to overwrite {dst}: plugin root {plugin_root} "
-                f"has no {PLUGIN_SENTINEL} sentinel (not lore-managed)"
-            )
-        shutil.rmtree(dst)
-    shutil.copytree(src_real, dst, symlinks=False)
-
-
-def remove_managed_dir(path: Path) -> None:
-    """Remove a lore-managed directory tree, gated on the sentinel.
-
-    Only removes ``path`` if a ``PLUGIN_SENTINEL`` file exists at
-    ``path`` itself (the plugin root). Any other path raises so we
-    never wipe user content by accident.
-    """
-    real = Path(os.path.realpath(path)) if path.exists() else path
-    if not real.exists():
-        return
-    if not (real / PLUGIN_SENTINEL).exists():
-        raise PermissionError(
-            f"refusing to remove {real}: no {PLUGIN_SENTINEL} sentinel "
-            f"(not lore-managed)"
-        )
-    shutil.rmtree(real)
 
 
 # ---------------------------------------------------------------------------
@@ -626,104 +310,104 @@ _LEGACY_PERMISSION_RULES = {
 }
 
 
+def _legacy_symlinks(
+    directory: Path,
+    *,
+    name_prefix: str,
+    kind: str,
+    lore_repo: Path | None,
+) -> list[LegacyArtifact]:
+    """Lore-owned symlinks install.sh dropped into a ~/.claude subdirectory.
+
+    `lore_repo` narrows the match to links pointing into that repo; with
+    no repo given, any target under a `/lore/` path counts.
+    """
+    if not directory.is_dir():
+        return []
+    found: list[LegacyArtifact] = []
+    for entry in sorted(directory.iterdir()):
+        if not entry.name.startswith(name_prefix) or not entry.is_symlink():
+            continue
+        target = os.readlink(entry)
+        if lore_repo is not None and str(lore_repo) not in target:
+            continue
+        if "/lore/" not in target and lore_repo is None:
+            continue
+        found.append(LegacyArtifact(kind=kind, path=str(entry), detail=target))
+    return found
+
+
+def _legacy_settings_artifacts(settings_path: Path) -> list[LegacyArtifact]:
+    """Hook entries, permission rules and env vars install.sh wrote into settings.json."""
+    if not settings_path.exists():
+        return []
+    try:
+        cfg = json.loads(settings_path.read_text())
+    except json.JSONDecodeError:
+        cfg = {}
+
+    found: list[LegacyArtifact] = []
+    for event, group_list in (cfg.get("hooks") or {}).items():
+        for grp in group_list:
+            for h in grp.get("hooks") or []:
+                cmd = h.get("command", "")
+                if isinstance(cmd, str) and cmd.startswith(
+                    _LEGACY_HOOK_COMMAND_PREFIX
+                ):
+                    found.append(
+                        LegacyArtifact(
+                            kind="hook_entry",
+                            path=str(settings_path),
+                            detail=f"{event}: {cmd}",
+                        )
+                    )
+
+    allow = (cfg.get("permissions") or {}).get("allow") or []
+    for rule in allow:
+        if rule in _LEGACY_PERMISSION_RULES:
+            found.append(
+                LegacyArtifact(
+                    kind="permission_rule",
+                    path=str(settings_path),
+                    detail=rule,
+                )
+            )
+
+    if "LORE_ROOT" in (cfg.get("env") or {}):
+        found.append(
+            LegacyArtifact(
+                kind="env_entry",
+                path=str(settings_path),
+                detail=f"LORE_ROOT={cfg['env']['LORE_ROOT']}",
+            )
+        )
+    return found
+
+
 def detect_install_sh_artifacts(
     lore_repo: Path | None = None,
 ) -> list[LegacyArtifact]:
     """Scan ~/.claude for install.sh-era state.
 
-    Returns artifacts in a stable order. `lore_repo` filters skill /
-    agent symlinks to those pointing into that repo (or any "lore"
-    repo if None — symlink target contains `/lore/`).
+    Returns artifacts in a stable order: skill symlinks, then agent
+    symlinks, then settings.json mutations.
     """
-    artifacts: list[LegacyArtifact] = []
-    home = Path.home()
-
-    # 1. Skill symlinks
-    skills_dir = home / ".claude" / "skills"
-    if skills_dir.is_dir():
-        for entry in sorted(skills_dir.iterdir()):
-            if not entry.name.startswith("lore:"):
-                continue
-            if not entry.is_symlink():
-                continue
-            target = os.readlink(entry)
-            if lore_repo is not None and str(lore_repo) not in target:
-                continue
-            if "/lore/" not in target and lore_repo is None:
-                continue
-            artifacts.append(
-                LegacyArtifact(
-                    kind="skill_symlink",
-                    path=str(entry),
-                    detail=target,
-                )
-            )
-
-    # 2. Agent symlinks
-    agents_dir = home / ".claude" / "agents"
-    if agents_dir.is_dir():
-        for entry in sorted(agents_dir.iterdir()):
-            if not entry.name.startswith("lore-"):
-                continue
-            if not entry.is_symlink():
-                continue
-            target = os.readlink(entry)
-            if lore_repo is not None and str(lore_repo) not in target:
-                continue
-            if "/lore/" not in target and lore_repo is None:
-                continue
-            artifacts.append(
-                LegacyArtifact(
-                    kind="agent_symlink",
-                    path=str(entry),
-                    detail=target,
-                )
-            )
-
-    # 3. settings.json mutations
-    settings_path = home / ".claude" / "settings.json"
-    if settings_path.exists():
-        try:
-            cfg = json.loads(settings_path.read_text())
-        except json.JSONDecodeError:
-            cfg = {}
-        # Hook entries
-        for event, group_list in (cfg.get("hooks") or {}).items():
-            for grp in group_list:
-                for h in grp.get("hooks") or []:
-                    cmd = h.get("command", "")
-                    if isinstance(cmd, str) and cmd.startswith(
-                        _LEGACY_HOOK_COMMAND_PREFIX
-                    ):
-                        artifacts.append(
-                            LegacyArtifact(
-                                kind="hook_entry",
-                                path=str(settings_path),
-                                detail=f"{event}: {cmd}",
-                            )
-                        )
-        # Permission rules
-        allow = (cfg.get("permissions") or {}).get("allow") or []
-        for rule in allow:
-            if rule in _LEGACY_PERMISSION_RULES:
-                artifacts.append(
-                    LegacyArtifact(
-                        kind="permission_rule",
-                        path=str(settings_path),
-                        detail=rule,
-                    )
-                )
-        # LORE_ROOT env entry
-        if "LORE_ROOT" in (cfg.get("env") or {}):
-            artifacts.append(
-                LegacyArtifact(
-                    kind="env_entry",
-                    path=str(settings_path),
-                    detail=f"LORE_ROOT={cfg['env']['LORE_ROOT']}",
-                )
-            )
-
-    return artifacts
+    claude = Path.home() / ".claude"
+    return [
+        *_legacy_symlinks(
+            claude / "skills",
+            name_prefix="lore:",
+            kind="skill_symlink",
+            lore_repo=lore_repo,
+        ),
+        *_legacy_symlinks(
+            claude / "agents",
+            name_prefix="lore-",
+            kind="agent_symlink",
+            lore_repo=lore_repo,
+        ),
+        *_legacy_settings_artifacts(claude / "settings.json"),
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -774,157 +458,220 @@ def preview_action(action: Action) -> str:
     raise ValueError(f"unknown action kind: {action.kind}")
 
 
+def _real_path(path: Path) -> Path:
+    """Resolve symlinks for an existing path, else leave it alone.
+
+    Writes follow the symlink so dotfile managers (chezmoi, Stow) keep
+    their links instead of having them replaced by a regular file.
+    """
+    return Path(os.path.realpath(path)) if path.exists() else path
+
+
+def _set_key(key_path: list, value: Any) -> callable:  # type: ignore[type-arg]
+    """Mutator that writes `value` at the nested `key_path`, creating parents."""
+
+    def _mutator(data: dict) -> dict:
+        cur = data
+        for key in key_path[:-1]:
+            cur = cur.setdefault(key, {})
+        cur[key_path[-1]] = value
+        return data
+
+    return _mutator
+
+
+def _del_key(key_path: list) -> callable:  # type: ignore[type-arg]
+    """Mutator that removes the nested `key_path`; a no-op when it is absent."""
+
+    def _mutator(data: dict) -> dict:
+        cur = data
+        for key in key_path[:-1]:
+            if not isinstance(cur, dict) or key not in cur:
+                return data
+            cur = cur[key]
+        if isinstance(cur, dict) and key_path[-1] in cur:
+            del cur[key_path[-1]]
+        return data
+
+    return _mutator
+
+
+def _has_key(key_path: list) -> callable:  # type: ignore[type-arg]
+    """Validator asserting the nested `key_path` survived the write."""
+
+    def _validator(data: dict) -> bool:
+        cur = data
+        for key in key_path:
+            if not isinstance(cur, dict) or key not in cur:
+                return False
+            cur = cur[key]
+        return True
+
+    return _validator
+
+
+def _exec_new(action: Action, schema_version: str) -> ApplyResult:
+    path = Path(action.payload["path"]).expanduser()
+    copy_from = action.payload.get("copy_from")
+    if copy_from:
+        managed_files.copy_dir_atomic(Path(copy_from).expanduser(), path)
+        return ApplyResult(ok=True)
+    real = _real_path(path)
+    real.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(real, action.payload["content"])
+    return ApplyResult(ok=True)
+
+
+def _exec_merge(action: Action, schema_version: str) -> ApplyResult:
+    path = Path(action.payload["path"]).expanduser()
+    key_path = list(action.payload["key_path"])
+    managed_files.json_merge_atomic(
+        path,
+        _set_key(key_path, action.payload["value"]),
+        validate=_has_key(key_path),
+    )
+    return ApplyResult(ok=True)
+
+
+def _exec_replace(action: Action, schema_version: str) -> ApplyResult:
+    # Replace behaves exactly like merge on disk; the two kinds differ only
+    # in how the dispatcher prompts the user before getting here.
+    return execute_action(
+        Action(
+            kind=KIND_MERGE,
+            description=action.description,
+            target=action.target,
+            summary=action.summary,
+            payload={
+                "path": action.payload["path"],
+                "key_path": action.payload["key_path"],
+                "value": action.payload["new_value"],
+                "schema_version": schema_version,
+            },
+        ),
+        schema_version=schema_version,
+    )
+
+
+def _exec_run(action: Action, schema_version: str) -> ApplyResult:
+    argv = action.payload["argv"]
+    fallback = action.payload.get("fallback_message")
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=action.payload.get("timeout", 60),
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        msg = f"{e} — {fallback}" if fallback else f"{e}"
+        return ApplyResult(ok=False, error=msg)
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip()[:300]
+        msg = f"exit {result.returncode}: {err}"
+        if fallback:
+            msg = f"{msg} — {fallback}"
+        return ApplyResult(ok=False, error=msg)
+    return ApplyResult(ok=True, diff=result.stdout.strip()[:500] or None)
+
+
+def _exec_check(action: Action, schema_version: str) -> ApplyResult:
+    check = action.payload["check"]
+    if check == "lore_on_path":
+        ok, msg = check_lore_on_path()
+        return ApplyResult(ok=ok, error=None if ok else msg)
+    if check == "lore_version_match":
+        ok, msg = check_lore_version_match(action.payload.get("lore_repo"))
+        # Surface the message even when ok so the user sees the version
+        # they're running.
+        return ApplyResult(ok=ok, error=None if ok else msg, diff=msg if ok else None)
+    if check == "binary_on_path":
+        bin_name = action.payload["args"]["binary"]
+        if shutil.which(bin_name):
+            return ApplyResult(ok=True)
+        return ApplyResult(
+            ok=False,
+            error=action.payload.get("fail_message", f"{bin_name} not on PATH"),
+        )
+    if check == "always_advisory":
+        # Surfaces the fail_message as informational; paired with
+        # on_failure="continue" at the call site.
+        return ApplyResult(
+            ok=False, error=action.payload.get("fail_message", "advisory")
+        )
+    return ApplyResult(ok=False, error=f"unknown check: {check}")
+
+
+def _exec_delete(action: Action, schema_version: str) -> ApplyResult:
+    real = _real_path(Path(action.payload["path"]).expanduser())
+    kp = action.payload.get("key_path")
+    if kp:
+        if real.exists():
+            managed_files.json_merge_atomic(real, _del_key(list(kp)))
+        return ApplyResult(ok=True)
+    if action.payload.get("recursive"):
+        # Only lore-managed plugin trees (sentinel present) may be removed.
+        managed_files.remove_managed_dir(real)
+        return ApplyResult(ok=True)
+    if real.exists():
+        # Managed block first, else the whole file.
+        if managed_files.managed_block_content(real) is not None:
+            managed_files.remove_managed_block(real)
+        else:
+            real.unlink()
+    return ApplyResult(ok=True)
+
+
+_EXECUTORS = {
+    KIND_NEW: _exec_new,
+    KIND_MERGE: _exec_merge,
+    KIND_REPLACE: _exec_replace,
+    KIND_RUN: _exec_run,
+    KIND_CHECK: _exec_check,
+    KIND_DELETE: _exec_delete,
+}
+
+
 def execute_action(action: Action, *, schema_version: str = "1") -> ApplyResult:
     """Apply an Action; idempotent for kinds that should be."""
+    executor = _EXECUTORS.get(action.kind)
+    if executor is None:
+        return ApplyResult(ok=False, error=f"unknown action kind: {action.kind}")
     try:
-        if action.kind == KIND_NEW:
-            path = Path(action.payload["path"]).expanduser()
-            copy_from = action.payload.get("copy_from")
-            if copy_from:
-                src = Path(copy_from).expanduser()
-                copy_dir_atomic(src, path)
-                return ApplyResult(ok=True)
-            content = action.payload["content"]
-            real = Path(os.path.realpath(path)) if path.exists() else path
-            real.parent.mkdir(parents=True, exist_ok=True)
-            atomic_write_text(real, content)
-            return ApplyResult(ok=True)
-        if action.kind == KIND_MERGE:
-            path = Path(action.payload["path"]).expanduser()
-            key_path = list(action.payload["key_path"])
-            value = action.payload["value"]
-
-            def _mutator(data: dict) -> dict:
-                cur = data
-                for key in key_path[:-1]:
-                    cur = cur.setdefault(key, {})
-                cur[key_path[-1]] = value
-                return data
-
-            def _validator(data: dict) -> bool:
-                cur = data
-                for key in key_path:
-                    if not isinstance(cur, dict) or key not in cur:
-                        return False
-                    cur = cur[key]
-                return True
-
-            json_merge_atomic(path, _mutator, validate=_validator)
-            return ApplyResult(ok=True)
-        if action.kind == KIND_REPLACE:
-            # For now treat replace identically to merge; the prompt
-            # difference happens at the dispatcher level.
-            return execute_action(
-                Action(
-                    kind=KIND_MERGE,
-                    description=action.description,
-                    target=action.target,
-                    summary=action.summary,
-                    payload={
-                        "path": action.payload["path"],
-                        "key_path": action.payload["key_path"],
-                        "value": action.payload["new_value"],
-                        "schema_version": schema_version,
-                    },
-                ),
-                schema_version=schema_version,
-            )
-        if action.kind == KIND_RUN:
-            argv = action.payload["argv"]
-            timeout = action.payload.get("timeout", 60)
-            try:
-                result = subprocess.run(
-                    argv,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                    check=False,
-                )
-            except (OSError, subprocess.TimeoutExpired) as e:
-                fallback = action.payload.get("fallback_message")
-                msg = f"{e}"
-                if fallback:
-                    msg = f"{e} — {fallback}"
-                return ApplyResult(ok=False, error=msg)
-            if result.returncode != 0:
-                fallback = action.payload.get("fallback_message")
-                err = (result.stderr or result.stdout or "").strip()[:300]
-                msg = f"exit {result.returncode}: {err}"
-                if fallback:
-                    msg = f"{msg} — {fallback}"
-                return ApplyResult(ok=False, error=msg)
-            return ApplyResult(ok=True, diff=result.stdout.strip()[:500] or None)
-        if action.kind == KIND_CHECK:
-            check = action.payload["check"]
-            if check == "lore_on_path":
-                ok, msg = check_lore_on_path()
-                return ApplyResult(ok=ok, error=None if ok else msg)
-            if check == "lore_version_match":
-                lore_repo = action.payload.get("lore_repo")
-                ok, msg = check_lore_version_match(lore_repo)
-                # Surface the message even when ok so the user sees
-                # the version they're running.
-                return ApplyResult(
-                    ok=ok,
-                    error=None if ok else msg,
-                    diff=msg if ok else None,
-                )
-            if check == "binary_on_path":
-                bin_name = action.payload["args"]["binary"]
-                if shutil.which(bin_name):
-                    return ApplyResult(ok=True)
-                return ApplyResult(
-                    ok=False,
-                    error=action.payload.get(
-                        "fail_message", f"{bin_name} not on PATH"
-                    ),
-                )
-            if check == "always_advisory":
-                # Always-advisory check — surfaces the fail_message as
-                # informational (paired with on_failure="continue").
-                return ApplyResult(
-                    ok=False,
-                    error=action.payload.get("fail_message", "advisory"),
-                )
-            return ApplyResult(ok=False, error=f"unknown check: {check}")
-        if action.kind == KIND_DELETE:
-            path = Path(action.payload["path"]).expanduser()
-            real = Path(os.path.realpath(path)) if path.exists() else path
-            kp = action.payload.get("key_path")
-            if kp:
-                # JSON key removal
-                if not real.exists():
-                    return ApplyResult(ok=True)  # nothing to remove
-
-                def _mutator(data: dict) -> dict:
-                    cur = data
-                    for key in kp[:-1]:
-                        if not isinstance(cur, dict) or key not in cur:
-                            return data
-                        cur = cur[key]
-                    if isinstance(cur, dict) and kp[-1] in cur:
-                        del cur[kp[-1]]
-                    return data
-
-                json_merge_atomic(real, _mutator)
-                return ApplyResult(ok=True)
-            if action.payload.get("recursive"):
-                # Recursive directory removal — only allowed on
-                # lore-managed plugin trees marked with PLUGIN_SENTINEL.
-                remove_managed_dir(real)
-                return ApplyResult(ok=True)
-            # File removal — managed block first, else whole file
-            if real.exists():
-                if managed_block_content(real) is not None:
-                    remove_managed_block(real)
-                else:
-                    real.unlink()
-            return ApplyResult(ok=True)
-    except (MalformedConfigError, ConcurrentEditError) as e:
+        return executor(action, schema_version)
+    except (managed_files.MalformedConfigError, managed_files.ConcurrentEditError) as e:
         return ApplyResult(ok=False, error=str(e))
     except Exception as e:  # noqa: BLE001
         return ApplyResult(ok=False, error=f"{type(e).__name__}: {e}")
-    return ApplyResult(ok=False, error=f"unknown action kind: {action.kind}")
+
+
+def _undo_new(action: Action) -> ApplyResult:
+    real = _real_path(Path(action.payload["path"]).expanduser())
+    if action.payload.get("copy_from"):
+        # Tree-copy undo: remove the dst tree if it's still lore-managed
+        # (parent sentinel present). Only the dst dir goes, not the
+        # plugin root.
+        if real.is_dir() and (real.parent / managed_files.PLUGIN_SENTINEL).exists():
+            shutil.rmtree(real)
+        return ApplyResult(ok=True)
+    if real.exists():
+        # Managed markers mean the file is shared with the user: strip
+        # only our block. Otherwise the file is ours and goes entirely.
+        if managed_files.managed_block_content(real) is not None:
+            managed_files.remove_managed_block(real)
+        else:
+            real.unlink()
+    return ApplyResult(ok=True)
+
+
+def _undo_merge(action: Action) -> ApplyResult:
+    real = _real_path(Path(action.payload["path"]).expanduser())
+    if real.exists():
+        managed_files.json_merge_atomic(
+            real, _del_key(list(action.payload["key_path"]))
+        )
+    return ApplyResult(ok=True)
 
 
 def undo_action(action: Action) -> ApplyResult:
@@ -934,51 +681,17 @@ def undo_action(action: Action) -> ApplyResult:
     byte-equivalent file state. User-edited entries are warn-and-
     remove unless `--no-clobber-edits` was passed (handled by
     dispatcher; this function always removes).
+
+    Undoing a run/check is a no-op: the integration's own undo handles the
+    side effect (e.g. `claude plugin uninstall` is its own action, not a
+    reverse of `claude plugin install`).
     """
     try:
         if action.kind == KIND_NEW:
-            path = Path(action.payload["path"]).expanduser()
-            real = Path(os.path.realpath(path)) if path.exists() else path
-            if action.payload.get("copy_from"):
-                # Tree-copy undo: remove the dst tree if it's still
-                # lore-managed (parent sentinel present). We only
-                # remove the dst dir itself, not the plugin root.
-                if real.exists() and real.is_dir():
-                    plugin_root = real.parent
-                    if (plugin_root / PLUGIN_SENTINEL).exists():
-                        shutil.rmtree(real)
-                return ApplyResult(ok=True)
-            if real.exists():
-                # Check whether the file uses managed markers; if yes
-                # remove just that block, else delete the whole file.
-                if managed_block_content(real) is not None:
-                    remove_managed_block(real)
-                else:
-                    real.unlink()
-            return ApplyResult(ok=True)
+            return _undo_new(action)
         if action.kind in (KIND_MERGE, KIND_REPLACE):
-            path = Path(action.payload["path"]).expanduser()
-            key_path = list(action.payload["key_path"])
-
-            def _mutator(data: dict) -> dict:
-                cur = data
-                for key in key_path[:-1]:
-                    if not isinstance(cur, dict) or key not in cur:
-                        return data
-                    cur = cur[key]
-                if isinstance(cur, dict) and key_path[-1] in cur:
-                    del cur[key_path[-1]]
-                return data
-
-            real = Path(os.path.realpath(path)) if path.exists() else path
-            if real.exists():
-                json_merge_atomic(real, _mutator)
-            return ApplyResult(ok=True)
+            return _undo_merge(action)
         if action.kind in (KIND_RUN, KIND_CHECK):
-            # Undoing a run/check is a no-op (the integration's own undo
-            # handles the side effect — e.g. `claude plugin uninstall`
-            # is its own action, not a reverse of `claude plugin
-            # install`).
             return ApplyResult(ok=True)
     except Exception as e:  # noqa: BLE001
         return ApplyResult(ok=False, error=f"{type(e).__name__}: {e}")

--- a/lib/lore_core/install/cursor.py
+++ b/lib/lore_core/install/cursor.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from lore_core import managed_files
 from lore_core.install import _helpers
 from lore_core.install.base import (
     KIND_CHECK,
@@ -31,6 +32,7 @@ from lore_core.install.base import (
     InstallContext,
     LegacyArtifact,
 )
+from lore_core.source_root import read_claude_manifest, resolve_lore_source_root
 
 SCHEMA_VERSION = "1"
 
@@ -63,7 +65,7 @@ def plan(ctx: InstallContext) -> list[Action]:
     rules_dir = _helpers.cursor_rules_dir()
     mcp_path = config_dir / "mcp.json"
     rules_path = rules_dir / "lore.md"
-    source_root = _helpers.resolve_lore_source_root(ctx.lore_repo)
+    source_root = resolve_lore_source_root(ctx.lore_repo)
     plugin_will_install = source_root is not None
 
     # 1. Global mcp.json — only when plugin packaging won't run (legacy
@@ -104,7 +106,7 @@ def plan(ctx: InstallContext) -> list[Action]:
                 },
             )
         )
-    elif existing.get(_helpers.SCHEMA_VERSION_KEY) is None:
+    elif existing.get(managed_files.SCHEMA_VERSION_KEY) is None:
         # Absent schema version — legacy or user-authored. Migrate
         # in place silently (kind=merge, no extra prompt).
         actions.append(
@@ -121,7 +123,7 @@ def plan(ctx: InstallContext) -> list[Action]:
                 },
             )
         )
-    elif existing.get(_helpers.SCHEMA_VERSION_KEY) != SCHEMA_VERSION:
+    elif existing.get(managed_files.SCHEMA_VERSION_KEY) != SCHEMA_VERSION:
         # Present-but-old schema — true bump, needs explicit prompt.
         actions.append(
             Action(
@@ -130,7 +132,7 @@ def plan(ctx: InstallContext) -> list[Action]:
                 target=str(mcp_path),
                 summary=(
                     f"replace mcpServers.lore "
-                    f"({existing.get(_helpers.SCHEMA_VERSION_KEY)} "
+                    f"({existing.get(managed_files.SCHEMA_VERSION_KEY)} "
                     f"→ {SCHEMA_VERSION})"
                 ),
                 payload={
@@ -140,7 +142,7 @@ def plan(ctx: InstallContext) -> list[Action]:
                     "new_value": new_value,
                     "reason": (
                         f"_lore_schema_version "
-                        f"{existing.get(_helpers.SCHEMA_VERSION_KEY)} "
+                        f"{existing.get(managed_files.SCHEMA_VERSION_KEY)} "
                         f"→ {SCHEMA_VERSION}"
                     ),
                 },
@@ -194,7 +196,7 @@ def plan(ctx: InstallContext) -> list[Action]:
     #    dispatcher will refuse to clobber without --force.
     body = _read_directive_body()
     full_content = (
-        f"{_helpers.MANAGED_BLOCK_START}\n{body}\n{_helpers.MANAGED_BLOCK_END}\n"
+        f"{managed_files.MANAGED_BLOCK_START}\n{body}\n{managed_files.MANAGED_BLOCK_END}\n"
     )
     if not rules_path.exists():
         actions.append(
@@ -211,7 +213,7 @@ def plan(ctx: InstallContext) -> list[Action]:
             )
         )
     else:
-        existing_managed = _helpers.managed_block_content(rules_path)
+        existing_managed = managed_files.managed_block_content(rules_path)
         if existing_managed is None:
             # File exists with no managed markers — user-authored
             actions.append(
@@ -230,7 +232,7 @@ def plan(ctx: InstallContext) -> list[Action]:
                     },
                 )
             )
-        elif _helpers.content_hash(existing_managed) != _helpers.content_hash(body):
+        elif managed_files.content_hash(existing_managed) != managed_files.content_hash(body):
             # Markers present, content drifted from the canonical
             # template — replace the managed block (preserving any
             # user content outside the markers).
@@ -277,7 +279,7 @@ def _plan_plugin_packaging(ctx: InstallContext) -> list[Action]:
     """
     actions: list[Action] = []
     plugin_dir = _helpers.cursor_plugin_dir()
-    source_root = _helpers.resolve_lore_source_root(ctx.lore_repo)
+    source_root = resolve_lore_source_root(ctx.lore_repo)
     if source_root is None:
         actions.append(
             Action(
@@ -303,14 +305,14 @@ def _plan_plugin_packaging(ctx: InstallContext) -> list[Action]:
         )
         return actions
 
-    claude_manifest = _helpers.read_claude_manifest(source_root)
+    claude_manifest = read_claude_manifest(source_root)
     cursor_manifest = _helpers.generate_cursor_plugin_manifest(claude_manifest)
     cursor_hooks = _helpers.generate_cursor_hooks_json(claude_manifest)
     plugin_mcp = {
         "mcpServers": {"lore": _helpers.lore_mcp_entry(SCHEMA_VERSION)}
     }
 
-    sentinel_path = plugin_dir / _helpers.PLUGIN_SENTINEL
+    sentinel_path = plugin_dir / managed_files.PLUGIN_SENTINEL
     manifest_path = plugin_dir / ".cursor-plugin" / "plugin.json"
     skills_dst = plugin_dir / "skills"
     rules_dst = plugin_dir / "rules"
@@ -324,7 +326,7 @@ def _plan_plugin_packaging(ctx: InstallContext) -> list[Action]:
             kind=KIND_NEW,
             description="Mark plugin dir as lore-managed",
             target=str(sentinel_path),
-            summary=f"sentinel {_helpers.PLUGIN_SENTINEL} (provenance for uninstall)",
+            summary=f"sentinel {managed_files.PLUGIN_SENTINEL} (provenance for uninstall)",
             payload={
                 "path": str(sentinel_path),
                 "content": (
@@ -454,7 +456,7 @@ def _is_lore_managed_entry(existing: dict) -> bool:
         return False
     if cmd != "lore" and Path(cmd).name != "lore":
         return False
-    allowed = {"command", "args", _helpers.SCHEMA_VERSION_KEY}
+    allowed = {"command", "args", managed_files.SCHEMA_VERSION_KEY}
     return set(existing.keys()) <= allowed
 
 
@@ -485,7 +487,7 @@ def uninstall_plan(ctx: InstallContext) -> list[Action]:
                 },
             )
         )
-    if rules_path.exists() and _helpers.managed_block_content(rules_path) is not None:
+    if rules_path.exists() and managed_files.managed_block_content(rules_path) is not None:
         actions.append(
             Action(
                 kind=KIND_DELETE,
@@ -500,14 +502,14 @@ def uninstall_plan(ctx: InstallContext) -> list[Action]:
         )
 
     plugin_dir = _helpers.cursor_plugin_dir()
-    sentinel = plugin_dir / _helpers.PLUGIN_SENTINEL
+    sentinel = plugin_dir / managed_files.PLUGIN_SENTINEL
     if plugin_dir.exists() and sentinel.exists():
         actions.append(
             Action(
                 kind=KIND_DELETE,
                 description="Remove Lore Cursor plugin directory",
                 target=str(plugin_dir),
-                summary=f"rmtree (gated on {_helpers.PLUGIN_SENTINEL} sentinel)",
+                summary=f"rmtree (gated on {managed_files.PLUGIN_SENTINEL} sentinel)",
                 payload={
                     "path": str(plugin_dir),
                     "recursive": True,

--- a/lib/lore_core/lint.py
+++ b/lib/lore_core/lint.py
@@ -419,57 +419,78 @@ def check_hierarchy(
     return issues
 
 
-def check_agent_guidance_sync(wiki_path: Path, wiki_name: str) -> list[Issue]:
-    """Phase 7: surface drift between project orientation and the
-    attached repo's AGENTS.md / CLAUDE.md.
+def _repo_by_project_slug(wiki_name: str) -> dict[str, Path]:
+    """Map each project slug in this wiki to the repo path attached to it.
 
-    For each project orientation note carrying a ``## Agent guidance``
-    H2 section, locate the attached repo path via ``attachments.json``
-    and compare normalised content. Drift → ``WARNING`` issue.
-
-    Best-effort: missing attachments file, missing repos, malformed
-    notes, etc. all skip silently rather than fail the lint. The check
-    targets the user-visible action ("here's a drift, run sync") not
-    consistency enforcement.
+    Empty when nothing is attached, or when the attachment machinery isn't
+    importable — a drift check is advisory and never fails the lint.
     """
-    issues: list[Issue] = []
-
     try:
         from lore_core.config import resolve_lore_root
-        from lore_core.projects.agent_sync import compute_sync_status
         from lore_core.state.attachments import AttachmentsFile
     except ImportError:
-        return issues
+        return {}
 
     lore_root = resolve_lore_root()
     if lore_root is None or not lore_root.exists():
-        return issues
+        return {}
     af = AttachmentsFile(lore_root)
     af.load()
 
-    # Map: project slug → attached repo path (last scope segment).
-    repo_by_slug: dict[str, Path] = {}
+    repos: dict[str, Path] = {}
     for a in af.all():
-        if a.wiki != wiki_name:
-            continue
-        if not a.scope:
+        if a.wiki != wiki_name or not a.scope:
             continue
         slug = a.scope.rsplit(":", 1)[-1]
         if slug:
-            repo_by_slug[slug] = a.path
+            repos[slug] = a.path
+    return repos
 
-    projects_dir_path = wiki_path / "projects"
-    if not projects_dir_path.is_dir():
-        return issues
 
-    for project_dir in sorted(projects_dir_path.iterdir()):
+def _orientation_notes(projects_dir: Path) -> list[tuple[Path, str]]:
+    """Every project orientation note in a wiki, as (path, slug) pairs.
+
+    Covers both layouts: the current ``projects/<slug>/<slug>.md`` folder
+    and the legacy flat ``projects/<slug>.md``.
+    """
+    found: list[tuple[Path, str]] = []
+    for project_dir in sorted(projects_dir.iterdir()):
         if not project_dir.is_dir():
-            # Legacy flat ``projects/<slug>.md`` — covered below.
             continue
         slug = project_dir.name
         orientation = project_dir / f"{slug}.md"
-        if not orientation.is_file():
-            continue
+        if orientation.is_file():
+            found.append((orientation, slug))
+    for legacy in sorted(projects_dir.glob("*.md")):
+        if not legacy.name.startswith("_"):
+            found.append((legacy, legacy.stem))
+    return found
+
+
+def check_agent_guidance_sync(wiki_path: Path, wiki_name: str) -> list[Issue]:
+    """Surface drift between a project's orientation note and its repo.
+
+    For each project orientation note carrying a ``## Agent guidance``
+    H2 section, locate the attached repo via ``attachments.json`` and
+    compare normalised content against its AGENTS.md / CLAUDE.md.
+
+    Best-effort: a missing attachments file, missing repo, or malformed
+    note skips silently rather than failing the lint. The check targets
+    the user-visible action ("here's a drift, run sync"), not consistency
+    enforcement.
+    """
+    try:
+        from lore_core.projects.agent_sync import compute_sync_status
+    except ImportError:
+        return []
+
+    projects_dir = wiki_path / "projects"
+    if not projects_dir.is_dir():
+        return []
+
+    repo_by_slug = _repo_by_project_slug(wiki_name)
+    issues: list[Issue] = []
+    for orientation, slug in _orientation_notes(projects_dir):
         repo_root = repo_by_slug.get(slug)
         if repo_root is None or not repo_root.exists():
             continue
@@ -477,52 +498,22 @@ def check_agent_guidance_sync(wiki_path: Path, wiki_name: str) -> list[Issue]:
             status = compute_sync_status(orientation, repo_root)
         except Exception:  # noqa: BLE001 - never fail lint on sync drift
             continue
-        if status.orientation_has_section and not status.in_sync:
-            issues.append(
-                Issue(
-                    severity="WARNING",
-                    wiki=wiki_name,
-                    file=str(orientation.relative_to(wiki_path)),
-                    check="agent_guidance_drift",
-                    message=(
-                        f"`## Agent guidance` in orientation differs from "
-                        f"repo's AGENTS.md/CLAUDE.md. Run "
-                        f"`lore project sync {slug} --to-repo` "
-                        f"or `--from-repo` to reconcile."
-                    ),
-                )
+        if not (status.orientation_has_section and not status.in_sync):
+            continue
+        issues.append(
+            Issue(
+                severity="WARNING",
+                wiki=wiki_name,
+                file=str(orientation.relative_to(wiki_path)),
+                check="agent_guidance_drift",
+                message=(
+                    f"`## Agent guidance` in orientation differs from "
+                    f"repo's AGENTS.md/CLAUDE.md. Run "
+                    f"`lore project sync {slug} --to-repo` "
+                    f"or `--from-repo` to reconcile."
+                ),
             )
-
-    # Legacy flat ``projects/<slug>.md`` — same check, no project subfolder.
-    for legacy in sorted(projects_dir_path.glob("*.md")):
-        if legacy.parent != projects_dir_path:
-            continue
-        if legacy.name.startswith("_"):
-            continue
-        slug = legacy.stem
-        repo_root = repo_by_slug.get(slug)
-        if repo_root is None or not repo_root.exists():
-            continue
-        try:
-            status = compute_sync_status(legacy, repo_root)
-        except Exception:  # noqa: BLE001
-            continue
-        if status.orientation_has_section and not status.in_sync:
-            issues.append(
-                Issue(
-                    severity="WARNING",
-                    wiki=wiki_name,
-                    file=str(legacy.relative_to(wiki_path)),
-                    check="agent_guidance_drift",
-                    message=(
-                        f"`## Agent guidance` in orientation differs from "
-                        f"repo's AGENTS.md/CLAUDE.md. Run "
-                        f"`lore project sync {slug} --to-repo` "
-                        f"or `--from-repo` to reconcile."
-                    ),
-                )
-            )
-
+        )
     return issues
 
 
@@ -854,6 +845,197 @@ def generate_type_collection_txt(
 # ---------------------------------------------------------------------------
 
 
+def _parse_note(fpath: Path, wiki_path: Path, wiki_name: str) -> NoteInfo:
+    """Read one note file into its catalog record."""
+    text = fpath.read_text(errors="replace")
+    fm = parse_frontmatter(text)
+
+    parts = fpath.relative_to(wiki_path).parts
+    parent_folder: str | None = None
+    if len(parts) >= 3 and parts[0] in KNOWLEDGE_DIRS:
+        parent_folder = parts[1]
+
+    note = NoteInfo(
+        path=str(fpath.relative_to(wiki_path)),
+        filename=fpath.stem,
+        wiki=wiki_name,
+        note_type=fm.get("type"),
+        status=fm.get("status"),
+        lifecycle=compute_lifecycle(fm),
+        superseded_by=fm.get("superseded_by"),
+        description=fm.get("description"),
+        tags=fm.get("tags", []) or [],
+        created=str(fm["created"]) if fm.get("created") else None,
+        last_reviewed=str(fm["last_reviewed"]) if fm.get("last_reviewed") else None,
+        lines=count_lines(text),
+        links_out=extract_wikilinks(text),
+        parent_folder=parent_folder,
+    )
+    # A folder's index note is the one named after the folder (or prefixed
+    # with it), e.g. concepts/lore/lore.md or concepts/lore/lore-mcp.md.
+    if parent_folder and (
+        fpath.stem == parent_folder or fpath.stem.startswith(parent_folder + "-")
+    ):
+        note.is_index = True
+    return note
+
+
+def _scan_notes(
+    wikis: list[Path],
+) -> tuple[dict[str, NoteInfo], dict[str, list[NoteInfo]]]:
+    """Parse every note in every wiki, keyed by slug and grouped by wiki.
+
+    Always scans *all* wikis even when the lint is scoped to one, because
+    wikilink targets resolve across the whole vault.
+    """
+    all_notes: dict[str, NoteInfo] = {}
+    notes_by_wiki: dict[str, list[NoteInfo]] = defaultdict(list)
+    for wiki_path in wikis:
+        wiki_name = wiki_path.name
+        for fpath in discover_notes(wiki_path):
+            note = _parse_note(fpath, wiki_path, wiki_name)
+            all_notes[fpath.stem] = note
+            notes_by_wiki[wiki_name].append(note)
+    return all_notes, notes_by_wiki
+
+
+def _build_link_graph(
+    all_notes: dict[str, NoteInfo],
+    notes_by_wiki: dict[str, list[NoteInfo]],
+) -> None:
+    """Fill in backlinks and index children from the parsed link lists."""
+    for name, note in all_notes.items():
+        for link in note.links_out:
+            if link in all_notes:
+                all_notes[link].links_in.append(name)
+
+    for note in all_notes.values():
+        if not (note.is_index and note.parent_folder):
+            continue
+        # parent_folder is just the basename; require sibling notes to
+        # share the index's full directory prefix so that, e.g.,
+        # ``concepts/lore/`` and ``decisions/lore/`` don't bleed
+        # children into each other's indexes.
+        note_dir = note.path.rsplit("/", 1)[0] + "/" if "/" in note.path else ""
+        note.children = [
+            n.filename
+            for n in notes_by_wiki[note.wiki]
+            if n.parent_folder == note.parent_folder
+            and n.filename != note.filename
+            and n.path.startswith(note_dir)
+        ]
+
+
+def _collect_issues(
+    wikis: list[Path],
+    all_notes: dict[str, NoteInfo],
+    notes_by_wiki: dict[str, list[NoteInfo]],
+) -> list[Issue]:
+    """Run every check over the scoped wikis; also records issues on each note."""
+    all_issues: list[Issue] = []
+    for wiki_path in wikis:
+        wiki_name = wiki_path.name
+        for note in notes_by_wiki[wiki_name]:
+            fm = parse_frontmatter((wiki_path / note.path).read_text(errors="replace"))
+            note_issues = [
+                *check_frontmatter(note, fm, wiki_name),
+                *check_staleness(note, fm, wiki_name),
+                *check_description(note, fm, wiki_name),
+            ]
+            all_issues.extend(note_issues)
+            note.issues = [f"{i.check}: {i.message}" for i in note_issues]
+        all_issues.extend(check_hierarchy(notes_by_wiki, wiki_name, wiki_path))
+        all_issues.extend(check_agent_guidance_sync(wiki_path, wiki_name))
+
+    all_issues.extend(check_wikilinks(all_notes, {w.name for w in wikis}))
+    return all_issues
+
+
+def _orphan_paths(wiki_path: Path) -> list[str]:
+    """Wiki-relative paths of notes holding orphan links.
+
+    Cached into the catalog so the read-time freshness check is an O(1)
+    membership test instead of a whole-wiki walk on every retrieval.
+    """
+    try:
+        from lore_core.wikilinks import find_orphan_links
+
+        return sorted(
+            {str(p.relative_to(wiki_path)) for p, _slug, _off in find_orphan_links(wiki_path)}
+        )
+    except Exception:
+        # An orphan-scan failure must not break lint.
+        return []
+
+
+def _drop_legacy_artifacts(wiki_path: Path) -> None:
+    """Remove generated files older lore versions wrote, so vaults self-heal.
+
+    ``_index.md`` (a god-object in Obsidian's graph) and ``llms.txt`` (a
+    markdown-in-txt mirror) are superseded by ``_index.txt``; ``threads.md``
+    by ``_threads.txt``; ``sessions/_recent.md`` by its ``.txt`` sibling.
+    The ``.md`` collections used to be wikilink-graph nodes — the ``.txt``
+    versions are not.
+    """
+    for legacy in ("_index.md", "llms.txt", "threads.md", "sessions/_recent.md"):
+        stale = wiki_path / legacy
+        if stale.exists():
+            stale.unlink()
+
+
+def _regenerate_wiki(
+    wiki_path: Path, notes: list[NoteInfo], all_issues: list[Issue]
+) -> None:
+    """Rewrite one wiki's catalog, index and collection files."""
+    wiki_name = wiki_path.name
+
+    catalog = build_catalog(wiki_name, notes, all_issues)
+    catalog["orphan_set"] = _orphan_paths(wiki_path)
+    atomic_write_text(
+        wiki_path / "_catalog.json", json.dumps(catalog, indent=2, default=str)
+    )
+
+    atomic_write_text(wiki_path / "_index.txt", generate_index_txt(wiki_name, notes))
+    _drop_legacy_artifacts(wiki_path)
+
+    # sessions/_recent.txt — last 20 session notes as wikilinks
+    recent_txt = generate_recent_txt(wiki_path)
+    if recent_txt is not None:
+        atomic_write_text(wiki_path / "sessions" / "_recent.txt", recent_txt)
+
+    # _concepts.txt, _decisions.txt — flat per-type collections at wiki root.
+    # The ``.txt`` extension excludes them from the wikilink graph (which
+    # globs ``.md`` only), so they don't become god-nodes.
+    for note_type, title, filename in (
+        ("concept", "Concepts", "_concepts.txt"),
+        ("decision", "Decisions", "_decisions.txt"),
+    ):
+        body = generate_type_collection_txt(
+            wiki_name, notes, note_type=note_type, title=title
+        )
+        if body is not None:
+            atomic_write_text(wiki_path / filename, body)
+
+
+def _build_report(
+    wikis: list[Path], all_notes: dict[str, NoteInfo], all_issues: list[Issue]
+) -> dict:
+    """Assemble the machine-readable lint report."""
+    return {
+        "generated": datetime.now().isoformat(timespec="seconds"),
+        "schema_version": 1,
+        "wikis_scanned": [w.name for w in wikis],
+        "total_notes": len(all_notes),
+        "total_issues": len(all_issues),
+        "by_severity": {
+            "errors": sum(1 for i in all_issues if i.severity == "ERROR"),
+            "warnings": sum(1 for i in all_issues if i.severity == "WARNING"),
+            "infos": sum(1 for i in all_issues if i.severity == "INFO"),
+        },
+        "issues": [asdict(i) for i in all_issues],
+    }
+
+
 def run_lint(
     wiki_filter: str | None = None,
     check_only: bool = False,
@@ -869,173 +1051,15 @@ def run_lint(
             next_=f"create a wiki under {get_wiki_root()} or run `lore init`",
         )
 
-    all_wikis = discover_wikis(None)
-    all_notes: dict[str, NoteInfo] = {}
-    notes_by_wiki: dict[str, list[NoteInfo]] = defaultdict(list)
+    all_notes, notes_by_wiki = _scan_notes(discover_wikis(None))
+    _build_link_graph(all_notes, notes_by_wiki)
+    all_issues = _collect_issues(wikis, all_notes, notes_by_wiki)
 
-    # Phase 1: discover and parse every note across every wiki
-    for wiki_path in all_wikis:
-        wiki_name = wiki_path.name
-        for fpath in discover_notes(wiki_path):
-            text = fpath.read_text(errors="replace")
-            fm = parse_frontmatter(text)
-            links = extract_wikilinks(text)
-            rel_path = str(fpath.relative_to(wiki_path))
-
-            parts = fpath.relative_to(wiki_path).parts
-            parent_folder: str | None = None
-            if len(parts) >= 3 and parts[0] in KNOWLEDGE_DIRS:
-                parent_folder = parts[1]
-
-            note = NoteInfo(
-                path=rel_path,
-                filename=fpath.stem,
-                wiki=wiki_name,
-                note_type=fm.get("type"),
-                status=fm.get("status"),
-                lifecycle=compute_lifecycle(fm),
-                superseded_by=fm.get("superseded_by"),
-                description=fm.get("description"),
-                tags=fm.get("tags", []) or [],
-                created=str(fm["created"]) if fm.get("created") else None,
-                last_reviewed=str(fm["last_reviewed"]) if fm.get("last_reviewed") else None,
-                lines=count_lines(text),
-                links_out=links,
-                parent_folder=parent_folder,
-            )
-
-            if parent_folder and (
-                fpath.stem == parent_folder or fpath.stem.startswith(parent_folder + "-")
-            ):
-                note.is_index = True
-
-            all_notes[fpath.stem] = note
-            notes_by_wiki[wiki_name].append(note)
-
-    # Phase 2: link graph
-    for name, note in all_notes.items():
-        for link in note.links_out:
-            if link in all_notes:
-                all_notes[link].links_in.append(name)
-
-    for note in all_notes.values():
-        if note.is_index and note.parent_folder:
-            # parent_folder is just the basename; require sibling notes to
-            # share the index's full directory prefix so that, e.g.,
-            # ``concepts/lore/`` and ``decisions/lore/`` don't bleed
-            # children into each other's indexes.
-            note_dir = note.path.rsplit("/", 1)[0] + "/" if "/" in note.path else ""
-            note.children = [
-                n.filename
-                for n in notes_by_wiki[note.wiki]
-                if n.parent_folder == note.parent_folder
-                and n.filename != note.filename
-                and n.path.startswith(note_dir)
-            ]
-
-    # Phase 3: checks
-    all_issues: list[Issue] = []
-    for wiki_path in wikis:
-        wiki_name = wiki_path.name
-        for note in notes_by_wiki[wiki_name]:
-            text = (wiki_path / note.path).read_text(errors="replace")
-            fm = parse_frontmatter(text)
-            note_issues: list[Issue] = []
-            note_issues.extend(check_frontmatter(note, fm, wiki_name))
-            note_issues.extend(check_staleness(note, fm, wiki_name))
-            note_issues.extend(check_description(note, fm, wiki_name))
-            all_issues.extend(note_issues)
-            note.issues = [f"{i.check}: {i.message}" for i in note_issues]
-        all_issues.extend(check_hierarchy(notes_by_wiki, wiki_name, wiki_path))
-        all_issues.extend(check_agent_guidance_sync(wiki_path, wiki_name))
-
-    scoped_wiki_names = {w.name for w in wikis}
-    all_issues.extend(check_wikilinks(all_notes, scoped_wiki_names))
-
-    # Phase 4: regenerate catalogs + index, drop legacy filenames
     if not check_only:
         for wiki_path in wikis:
-            wiki_name = wiki_path.name
-            notes = notes_by_wiki[wiki_name]
+            _regenerate_wiki(wiki_path, notes_by_wiki[wiki_path.name], all_issues)
 
-            catalog = build_catalog(wiki_name, notes, all_issues)
-            # Slice 4 of PRD #65: cache the orphan set so the read-time
-            # freshness check can do an O(1) membership test instead of
-            # walking the whole wiki on every retrieval. Stored as
-            # wiki-relative paths for portability.
-            try:
-                from lore_core.wikilinks import find_orphan_links
-
-                orphan_paths = sorted({
-                    str(p.relative_to(wiki_path))
-                    for p, _slug, _off in find_orphan_links(wiki_path)
-                })
-            except Exception:
-                # Defensive: an orphan-scan failure must not break lint.
-                orphan_paths = []
-            catalog["orphan_set"] = orphan_paths
-
-            atomic_write_text(
-                wiki_path / "_catalog.json",
-                json.dumps(catalog, indent=2, default=str),
-            )
-
-            index_txt = generate_index_txt(wiki_name, notes)
-            atomic_write_text(wiki_path / "_index.txt", index_txt)
-
-            # Clean up legacy index files. Older lore versions wrote
-            # ``_index.md`` (god-object in Obsidian's graph) and
-            # ``llms.txt`` (markdown-in-txt mirror). Both are superseded
-            # by ``_index.txt`` — remove if present so vaults self-heal
-            # on the next lint after upgrade.
-            #
-            # Also clean legacy ``threads.md`` (replaced by ``_threads.txt``)
-            # and ``sessions/_recent.md`` (replaced by the ``.txt`` sibling).
-            # These ``.md`` collections used to be wikilink-graph nodes;
-            # the ``.txt`` version is not.
-            for legacy in ("_index.md", "llms.txt", "threads.md"):
-                stale = wiki_path / legacy
-                if stale.exists():
-                    stale.unlink()
-            legacy_recent = wiki_path / "sessions" / "_recent.md"
-            if legacy_recent.exists():
-                legacy_recent.unlink()
-
-            # sessions/_recent.txt — last 20 session notes as wikilinks
-            recent_txt = generate_recent_txt(wiki_path)
-            if recent_txt is not None:
-                atomic_write_text(wiki_path / "sessions" / "_recent.txt", recent_txt)
-
-            # _concepts.txt, _decisions.txt — flat per-type collections at
-            # wiki root. ``.txt`` extension excludes them from the wikilink
-            # graph (``wikilinks.py:49`` globs ``.md`` only), so they
-            # don't become god-nodes.
-            concepts_txt = generate_type_collection_txt(
-                wiki_name, notes, note_type="concept", title="Concepts",
-            )
-            if concepts_txt is not None:
-                atomic_write_text(wiki_path / "_concepts.txt", concepts_txt)
-
-            decisions_txt = generate_type_collection_txt(
-                wiki_name, notes, note_type="decision", title="Decisions",
-            )
-            if decisions_txt is not None:
-                atomic_write_text(wiki_path / "_decisions.txt", decisions_txt)
-
-    # Phase 5: build report
-    report = {
-        "generated": datetime.now().isoformat(timespec="seconds"),
-        "schema_version": 1,
-        "wikis_scanned": [w.name for w in wikis],
-        "total_notes": len(all_notes),
-        "total_issues": len(all_issues),
-        "by_severity": {
-            "errors": sum(1 for i in all_issues if i.severity == "ERROR"),
-            "warnings": sum(1 for i in all_issues if i.severity == "WARNING"),
-            "infos": sum(1 for i in all_issues if i.severity == "INFO"),
-        },
-        "issues": [asdict(i) for i in all_issues],
-    }
+    report = _build_report(wikis, all_notes, all_issues)
 
     if json_output:
         print(

--- a/lib/lore_core/lockfile.py
+++ b/lib/lore_core/lockfile.py
@@ -44,7 +44,7 @@ def flocked(path: Path, *, blocking: bool = True):
     lock held — no stale-lock recovery is needed.
 
     Replaces three near-identical call sites (this module's spawn lock,
-    ``spine`` rotation, ``install/_helpers._flocked``).
+    ``spine`` rotation, ``managed_files._flocked``).
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     fd: int | None = None

--- a/lib/lore_core/managed_files.py
+++ b/lib/lore_core/managed_files.py
@@ -1,0 +1,253 @@
+"""Primitives for writing into files and directories Lore does not own.
+
+Every integration Lore installs into (Claude Code, Cursor, …) keeps its
+config in files the *user* owns and hand-edits. Writing into them needs
+three things this module provides:
+
+  Atomic JSON merge      read-modify-write a shared config under flock,
+                         validated after write, symlink-preserving
+  Managed markers        a marker-delimited region inside a markdown file
+                         that Lore rewrites on upgrade and strips on
+                         uninstall, leaving user content outside intact
+  Sentinel-gated trees   directory copy / removal that refuses to touch a
+                         tree not carrying Lore's provenance marker
+
+Stdlib-only apart from `lore_core.io.atomic_write_text`. Imports nothing
+from `lore_cli` or `lore_core.install` — both import from here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from lore_core.io import atomic_write_text
+
+# `_lore_schema_version` field marker — distinguishes Lore-managed
+# blocks from user-authored ones inside shared JSON config files.
+SCHEMA_VERSION_KEY = "_lore_schema_version"
+
+# Standard Lore-managed-rules-file marker pair. Anything between these
+# two markers is replaced on upgrade and removed on uninstall; anything
+# outside the pair is preserved.
+MANAGED_BLOCK_START = (
+    "<!-- lore-managed-start; uninstall via lore uninstall -->"
+)
+MANAGED_BLOCK_END = "<!-- lore-managed-end -->"
+
+# Sentinel file written at the root of a lore-managed plugin tree.
+# uninstall refuses to remove a directory tree that lacks this marker
+# (defends against blowing away unrelated user content if a path
+# collision happens).
+PLUGIN_SENTINEL = ".lore-managed"
+
+
+class MalformedConfigError(RuntimeError):
+    pass
+
+
+class ConcurrentEditError(RuntimeError):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Atomic JSON merge
+# ---------------------------------------------------------------------------
+
+
+def content_hash(text: str) -> str:
+    """Stable SHA-256 of UTF-8 bytes, hex digest. Used for change detection."""
+    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+
+
+@contextlib.contextmanager
+def _flocked(path: Path) -> Iterator[None]:
+    """fcntl.flock context manager on a sibling lock file.
+
+    We lock a sibling ``.lock`` file so the lock survives ``os.replace``
+    (which ``atomic_write_text`` does) — locking the target path itself
+    would lose the lock when the file is replaced.
+
+    Thin wrapper over ``lore_core.lockfile.flocked``; kept for the
+    sibling-path convention specific to ``json_merge_atomic``.
+    """
+    from lore_core.lockfile import flocked
+
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with flocked(lock_path, blocking=True):
+        yield
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    """Read a JSON object from ``path``; ``{}`` when absent.
+
+    Refuses malformed JSON and non-object roots so the caller sees a
+    clean error instead of a merge that silently drops user config.
+    """
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise MalformedConfigError(f"{path} is not valid JSON: {e}") from e
+    if not isinstance(data, dict):
+        raise MalformedConfigError(
+            f"{path} root must be a JSON object, got {type(data).__name__}"
+        )
+    return data
+
+
+def json_merge_atomic(
+    path: Path,
+    mutator: callable,  # type: ignore[type-arg]
+    validate: callable | None = None,  # type: ignore[type-arg]
+) -> dict[str, Any]:
+    """Read-modify-write a JSON file under flock, with optional validation.
+
+    `mutator(data: dict) -> dict` returns the new data. If `validate`
+    is given, it runs on the freshly-read-back file after write; if
+    it returns False, retry the merge once. If still failing, raises
+    ConcurrentEditError.
+
+    Resolves symlinks before mutating (so chezmoi/Stow users don't
+    have their symlinks replaced with regular files by os.replace).
+    Refuses to load malformed JSON — the caller sees a clean error.
+    """
+    real_path = Path(os.path.realpath(path))
+    real_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _do_one_pass() -> dict[str, Any]:
+        new_data = mutator(_load_json_object(real_path))
+        atomic_write_text(real_path, json.dumps(new_data, indent=2) + "\n")
+        return new_data
+
+    with _flocked(real_path):
+        result = _do_one_pass()
+        if validate is None:
+            return result
+        if validate(result):
+            return result
+        # Validate-after-write failed — retry once
+        result = _do_one_pass()
+        if validate(result):
+            return result
+        raise ConcurrentEditError(
+            f"{real_path} keys missing after write; concurrent edit detected. "
+            "Quit Claude Code (or other writer) and retry."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Managed markdown blocks
+# ---------------------------------------------------------------------------
+
+_MANAGED_BLOCK_RE = re.compile(
+    re.escape(MANAGED_BLOCK_START)
+    + r"\n(.*?)\n"
+    + re.escape(MANAGED_BLOCK_END)
+    + r"\n?",
+    re.DOTALL,
+)
+
+
+def write_managed_markdown(path: Path, body: str) -> None:
+    """Write a markdown file wrapped in lore-managed-start/end markers.
+
+    Atomic. Creates parent dirs. Resolves symlinks before writing.
+    """
+    real_path = Path(os.path.realpath(path)) if path.exists() else path
+    real_path.parent.mkdir(parents=True, exist_ok=True)
+    full = (
+        f"{MANAGED_BLOCK_START}\n{body.rstrip()}\n{MANAGED_BLOCK_END}\n"
+    )
+    atomic_write_text(real_path, full)
+
+
+def remove_managed_block(path: Path) -> bool:
+    """Remove the lore-managed range from a markdown file.
+
+    Preserves any user content outside the managed markers. Returns
+    True if a block was removed, False if the file had no managed
+    block (no-op). If no content remains outside the block, the file
+    is removed entirely.
+    """
+    real_path = Path(os.path.realpath(path)) if path.exists() else path
+    if not real_path.exists():
+        return False
+    text = real_path.read_text()
+    new_text, n = _MANAGED_BLOCK_RE.subn("", text, count=1)
+    if n == 0:
+        return False
+    new_text = new_text.strip()
+    if not new_text:
+        real_path.unlink()
+    else:
+        atomic_write_text(real_path, new_text + "\n")
+    return True
+
+
+def managed_block_content(path: Path) -> str | None:
+    """Return the text inside lore-managed markers, or None if absent."""
+    if not path.exists():
+        return None
+    m = _MANAGED_BLOCK_RE.search(path.read_text())
+    return m.group(1) if m else None
+
+
+# ---------------------------------------------------------------------------
+# Sentinel-gated directory trees
+# ---------------------------------------------------------------------------
+
+
+def copy_dir_atomic(src: Path, dst: Path) -> None:
+    """Copy a directory tree from src to dst, idempotent on re-run.
+
+    Uses ``shutil.copytree(dirs_exist_ok=True)`` semantics: re-running
+    install overwrites, files removed from src disappear from dst on
+    next install only if we wipe-and-recopy, so we wipe first to keep
+    dst exactly mirroring src. The wipe is gated on the
+    ``PLUGIN_SENTINEL`` file at dst's parent (not dst itself — the
+    parent is the plugin root that owns the whole tree).
+
+    Resolves symlinks in src so the dst is always a real tree.
+    """
+    src_real = Path(os.path.realpath(src))
+    if not src_real.is_dir():
+        raise FileNotFoundError(f"copy source not found or not a dir: {src}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        # Refuse to wipe dst if the plugin root has no sentinel — that
+        # means we don't own this tree.
+        plugin_root = dst.parent
+        if not (plugin_root / PLUGIN_SENTINEL).exists():
+            raise PermissionError(
+                f"refusing to overwrite {dst}: plugin root {plugin_root} "
+                f"has no {PLUGIN_SENTINEL} sentinel (not lore-managed)"
+            )
+        shutil.rmtree(dst)
+    shutil.copytree(src_real, dst, symlinks=False)
+
+
+def remove_managed_dir(path: Path) -> None:
+    """Remove a lore-managed directory tree, gated on the sentinel.
+
+    Only removes ``path`` if a ``PLUGIN_SENTINEL`` file exists at
+    ``path`` itself (the plugin root). Any other path raises so we
+    never wipe user content by accident.
+    """
+    real = Path(os.path.realpath(path)) if path.exists() else path
+    if not real.exists():
+        return
+    if not (real / PLUGIN_SENTINEL).exists():
+        raise PermissionError(
+            f"refusing to remove {real}: no {PLUGIN_SENTINEL} sentinel "
+            f"(not lore-managed)"
+        )
+    shutil.rmtree(real)

--- a/lib/lore_core/source_root.py
+++ b/lib/lore_core/source_root.py
@@ -1,0 +1,132 @@
+"""Locate the Lore source tree and reconcile it with the installed package.
+
+The plugin (skills, hooks, MCP wiring) and the Python `lore` binary are on
+separate update channels: `claude plugin update` refreshes one, `pipx
+install` the other. Anything that needs to answer "which Lore is actually
+running here?" — the SessionStart banner, `lore doctor`, the Cursor
+installer — resolves the on-disk source root through this module and
+compares it against the installed distribution.
+
+Stdlib-only. Imported by `lore_cli` and `lore_core.install` alike, so it
+must stay free of both.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def resolve_lore_source_root(lore_repo: Path | None = None) -> Path | None:
+    """Locate the lore source-of-truth root containing skills/ + .claude-plugin/.
+
+    Resolution order:
+      1. ``lore_repo`` (passed by ``lore install --lore-repo`` for dev installs)
+      2. Walk up from this file looking for a directory containing both
+         ``skills/`` and ``.claude-plugin/plugin.json`` (editable pip install)
+      3. ``~/.claude/plugins/cache/lore/lore/<version>/`` (Claude Code
+         marketplace install — newest version dir wins)
+
+    Returns ``None`` if nothing resolves; callers decide whether that's
+    fatal or a warning.
+    """
+    if lore_repo:
+        candidate = Path(lore_repo).expanduser().resolve()
+        if _is_source_root(candidate):
+            return candidate
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if _is_source_root(parent):
+            return parent
+    return _newest_cached_plugin()
+
+
+def _is_source_root(path: Path) -> bool:
+    """A source root ships both the skills tree and the plugin manifest."""
+    return (path / "skills").is_dir() and (
+        path / ".claude-plugin" / "plugin.json"
+    ).is_file()
+
+
+def _newest_cached_plugin() -> Path | None:
+    """Newest usable version dir under Claude Code's marketplace plugin cache."""
+    cache_root = Path.home() / ".claude" / "plugins" / "cache" / "lore" / "lore"
+    if not cache_root.is_dir():
+        return None
+    version_dirs = sorted(
+        (d for d in cache_root.iterdir() if d.is_dir()),
+        key=lambda d: d.name,
+        reverse=True,
+    )
+    for version_dir in version_dirs:
+        if _is_source_root(version_dir):
+            return version_dir
+    return None
+
+
+def read_claude_manifest(source_root: Path) -> dict[str, Any]:
+    """Read ``.claude-plugin/plugin.json`` from a resolved source root."""
+    return json.loads(
+        (source_root / ".claude-plugin" / "plugin.json").read_text()
+    )
+
+
+def check_lore_version_match(
+    lore_repo: Path | str | None = None,
+) -> tuple[bool, str]:
+    """Compare the installed Python package version against the on-disk source.
+
+    Closes the install-side counterpart to ``tests/test_version_sync.py``:
+    that pytest guard catches drift between ``pyproject.toml``,
+    ``plugin.json``, and ``CHANGELOG.md`` *in the source tree*; this check
+    catches drift between the installed pipx/pip/uv binary and that
+    source tree on the user's machine.
+
+    The hook footgun: ``claude plugin update lore@lore`` refreshes the
+    Claude Code plugin (skills/hooks/MCP wiring) but does not reinstall
+    the Python ``lore`` CLI. SessionStart's status line reads via
+    ``importlib.metadata.version(\"lore\")`` — i.e. the installed binary
+    — so a stale binary silently shows the old version forever.
+
+    Returns (ok, message). The message includes a copy-pasteable fix
+    command tailored to the install method (editable vs. non-editable).
+    Returns (True, "...skipped...") when no on-disk source is available
+    to compare against (e.g. user installed from PyPI without a clone).
+    """
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        installed = version("lore")
+    except PackageNotFoundError:
+        return False, (
+            "lore Python package not installed in this environment. "
+            "Run: pipx install --force --editable <path-to-lore-repo>"
+        )
+
+    repo_path = Path(lore_repo).expanduser() if lore_repo else None
+    if repo_path is None or not (repo_path / "pyproject.toml").is_file():
+        return True, f"lore CLI version {installed} (no source tree to compare against)"
+
+    pyproject = repo_path / "pyproject.toml"
+    try:
+        import tomllib
+
+        on_disk = tomllib.loads(pyproject.read_text())["project"]["version"]
+    except (OSError, KeyError, tomllib.TOMLDecodeError) as exc:
+        return True, (
+            f"lore CLI version {installed} "
+            f"(could not read on-disk pyproject.toml: {exc})"
+        )
+
+    if installed == on_disk:
+        return True, f"lore CLI version {installed} (matches source)"
+
+    # The installed and on-disk versions disagree. Pick the right fix
+    # command based on whether the install looks editable or not.
+    fix_cmd = f"pipx install --force --editable {repo_path}"
+    return False, (
+        f"lore CLI version drift: installed {installed}, source at {repo_path} "
+        f"is {on_disk}. The Claude Code plugin will silently use the older "
+        f"installed binary for `lore hook session-start` etc. Run: {fix_cmd}"
+    )

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -498,6 +498,279 @@ def _rename_to_topic_slug(buffer: Buffer, note_path: Path, chapter: nd.Chapter) 
     return new_path
 
 
+@dataclass(frozen=True)
+class _ApplyContext:
+    """Inputs every outcome handler in one `_apply_outcome` call shares."""
+
+    buffer: Buffer
+    note_path: Path
+    slice_from: int
+    slice_to: int
+    rb: ReplayedBuffer
+    close: bool
+    wiki_root: Path
+    lore_root: Path
+    logger: RunLogger | None
+    sidecar: Sidecar
+    facts: Any
+    linkage: Any
+    store: FlushStore
+
+
+def _apply_composed(ctx: _ApplyContext, out: FlushOutcome, compose_result, flush_rec) -> bool:
+    """Fold a composed chapter into the note.
+
+    Returns False when the append hit the disk and failed — the note must
+    not then be closed, and no further writes are attempted.
+    """
+    try:
+        out.chapter_n = nd.append_chapter(
+            ctx.note_path,
+            compose_result.chapter,
+            slice_from_turn=ctx.slice_from,
+            slice_to_turn=ctx.slice_to,
+            facts=ctx.facts,
+            linkage=ctx.linkage,
+            wiki_root=ctx.wiki_root,
+            title=_topic_title(ctx.sidecar.scope, compose_result.chapter),
+        )
+    except OSError:
+        # A note write that fails on disk is a dead-letter, not a crash:
+        # record it and stop writing to a failing filesystem.
+        ctx.store.transition(
+            flush_rec, FlushState.DEAD_LETTERED, reason=ErrorCode.CHAPTER_APPEND_FAILED
+        )
+        out.status = "failed"
+        return False
+
+    if out.chapter_n == 1:
+        # The note was born with a placeholder slug; its first chapter is
+        # what finally names it.
+        note_path = _rename_to_topic_slug(ctx.buffer, ctx.note_path, compose_result.chapter)
+        out.note_path = note_path
+        out.wikilink = f"[[{note_path.stem}]]"
+    out.status = "composed"
+    _clear_after_progress(ctx.buffer, close=ctx.close)
+    ctx.store.transition(flush_rec, FlushState.PUBLISHED)
+    return True
+
+
+def _apply_empty(ctx: _ApplyContext, out: FlushOutcome, flush_rec) -> bool:
+    """Record a span the composer judged substance-free."""
+    out.status = "empty"
+    if ctx.close:
+        if _flushed_to(ctx.note_path) < 0:
+            # The whole session produced nothing of substance: the stub
+            # note is removed rather than closed empty.
+            with contextlib.suppress(OSError):
+                ctx.note_path.unlink()
+            out.discarded = True
+            out.wikilink = ""
+    else:
+        # Consume the span (buffer reset, watermark kept) so the same turns
+        # are never recomposed; the session stays live.
+        _reset_buffer_fresh(ctx.buffer)
+
+    if ctx.logger is not None:
+        ctx.logger.emit(
+            "flush-empty",
+            buffer_stem=ctx.buffer.stem,
+            transcript_id=ctx.sidecar.transcript_id,
+            discarded=out.discarded,
+        )
+    # "Nothing of substance" is a completed flush, not a failure.
+    ctx.store.transition(flush_rec, FlushState.PUBLISHED)
+    return True
+
+
+def _apply_withheld(ctx: _ApplyContext, out: FlushOutcome, compose_result, flush_rec) -> bool:
+    """Quarantine unsafe composed text and leave a marker in its place."""
+    verdict = GateResult.withheld(
+        compose_result.withheld_category,
+        compose_result.withheld_feedback,
+    )
+    w = pg.apply_withhold(
+        ctx.note_path,
+        result=verdict,
+        composed_text=compose_result.withheld_text,
+        slice_from_turn=ctx.slice_from,
+        slice_to_turn=ctx.slice_to,
+        lore_root=ctx.lore_root,
+        wiki_root=ctx.wiki_root,
+    )
+    out.chapter_n = w.chapter_n
+    out.status = "withheld"
+    _clear_after_progress(ctx.buffer, close=ctx.close)
+    if ctx.logger is not None:
+        ctx.logger.emit(
+            "flush-withheld",
+            buffer_stem=ctx.buffer.stem,
+            transcript_id=ctx.sidecar.transcript_id,
+            category=verdict.category,
+        )
+    ctx.store.transition(flush_rec, FlushState.WITHHELD)
+    return True
+
+
+def _mark_failed_span(ctx: _ApplyContext, out: FlushOutcome, reason: str) -> None:
+    """Record an uncomposable span as a marker chapter, best-effort."""
+    with contextlib.suppress(OSError):
+        out.chapter_n = nd.append_marker_chapter(
+            ctx.note_path,
+            kind=nd.MARKER_FAILED,
+            reason=reason,
+            slice_from_turn=ctx.slice_from,
+            slice_to_turn=ctx.slice_to,
+            facts=ctx.facts,
+            linkage=ctx.linkage,
+            wiki_root=ctx.wiki_root,
+        )
+
+
+def _apply_failed(ctx: _ApplyContext, out: FlushOutcome, flush_rec) -> bool:
+    """Handle a failed composition — mark at close, else retry with backoff."""
+    if ctx.close:
+        # Last chance: no retry left, so the span is recorded as it stands.
+        _mark_failed_span(ctx, out, "composition failed at session end")
+        out.status = "failed"
+        ctx.store.transition(
+            flush_rec, FlushState.DEAD_LETTERED, reason=ErrorCode.COMPOSE_FAILED
+        )
+        return True
+
+    # Bounded retry with backoff. record_failure() re-queues with a scheduled
+    # next-eligible-retry (emitting a spine event — never silent) until
+    # MAX_ATTEMPTS failures, then dead-letters.
+    flush_rec = ctx.store.record_failure(flush_rec, error_code=ErrorCode.COMPOSE_FAILED)
+    ctx.buffer.patch(
+        flush_attempts=ctx.sidecar.flush_attempts + 1,
+        last_error="compose-failed",
+        flush_requested=None,
+    )
+
+    if FlushState(flush_rec.state) is FlushState.DEAD_LETTERED:
+        # Retries exhausted: record the failed span with a marker and reset
+        # the buffer — the note stays open, one session one note.
+        _mark_failed_span(
+            ctx, out, "composition failed after retries; span recorded and buffer reset"
+        )
+        _reset_buffer_fresh(ctx.buffer)
+        out.status = "gave-up"
+        if ctx.logger is not None:
+            ctx.logger.emit(
+                "flush-gave-up",
+                buffer_stem=ctx.buffer.stem,
+                transcript_id=ctx.sidecar.transcript_id,
+                turn_count=ctx.rb.turn_count,
+                prompt_chars=ctx.rb.prompt_chars,
+            )
+        return True
+
+    out.status = "deferred"
+    if ctx.logger is not None:
+        ctx.logger.emit(
+            "flush-deferred",
+            buffer_stem=ctx.buffer.stem,
+            transcript_id=ctx.sidecar.transcript_id,
+            flush_attempts=ctx.sidecar.flush_attempts + 1,
+        )
+    return True
+
+
+def _back_off_if_covered(
+    buffer: Buffer,
+    sidecar: Sidecar,
+    note_path: Path,
+    slice_to: int,
+    out: FlushOutcome,
+) -> bool:
+    """True when a concurrent flush already published this span.
+
+    The in-place cap-trip can race the reaper: both read the same buffer and
+    one publishes while the other is still composing. The loser re-reads the
+    note watermark here and drops its own write, or the same turns land as
+    two chapters. Only meaningful mid-session — a closing flush has no peer.
+    """
+    if _flushed_to(note_path) < slice_to:
+        return False
+    out.status = "skipped"
+    out.skipped_reason = "span-already-covered"
+    if sidecar.flush_requested is not None:
+        buffer.patch(flush_requested=None)
+    return True
+
+
+def _begin_apply(
+    *,
+    buffer: Buffer,
+    note_path: Path,
+    sidecar: Sidecar,
+    slice_from: int,
+    slice_to: int,
+    rb: ReplayedBuffer,
+    close: bool,
+    wiki_root: Path,
+    lore_root: Path,
+    logger: RunLogger | None,
+) -> tuple[_ApplyContext, Any]:
+    """Open a flush record and bundle the inputs the outcome handlers share.
+
+    Returns the context plus the flush record, which every branch drives to
+    a terminal state.
+    """
+    facts = facts_from_replay(rb)
+    # The logger carries this flush's trace_id (minted at spawn, delivered via
+    # env). Stamp it onto the note's linkage and the flush record so run
+    # events, the drain event and the note all share one id.
+    trace_id = logger.trace_id if logger is not None else None
+    linkage = replace(
+        linkage_from_replay(
+            rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=sidecar.handle
+        ),
+        trace_id=trace_id,
+    )
+
+    # Track this flush as an explicit, queryable state machine: begin (queued)
+    # -> running for this attempt, then a terminal published / withheld /
+    # dead-lettered transition. The record is the source of truth for "what is
+    # in-flight right now"; every transition also emits a spine event.
+    store = FlushStore(lore_root)
+    flush_rec = store.begin(buffer.stem, wiki=sidecar.wiki, trace_id=trace_id)
+    if FlushState(flush_rec.state) is FlushState.QUEUED:
+        flush_rec = store.transition(flush_rec, FlushState.RUNNING)
+
+    ctx = _ApplyContext(
+        buffer=buffer,
+        note_path=note_path,
+        slice_from=slice_from,
+        slice_to=slice_to,
+        rb=rb,
+        close=close,
+        wiki_root=wiki_root,
+        lore_root=lore_root,
+        logger=logger,
+        sidecar=sidecar,
+        facts=facts,
+        linkage=linkage,
+        store=store,
+    )
+    return ctx, flush_rec
+
+
+def _seal_note(ctx: _ApplyContext, out: FlushOutcome) -> None:
+    """Close the note and the buffer at session end."""
+    # out.note_path, not ctx.note_path: a first chapter renames the note.
+    if not out.discarded and not nd.is_closed(out.note_path):
+        nd.close_note(
+            out.note_path,
+            facts=ctx.facts,
+            linkage=ctx.linkage,
+            wiki_root=ctx.wiki_root,
+        )
+    ctx.buffer.transition("closed")
+    out.closed = True
+
+
 def _apply_outcome(
     *,
     buffer: Buffer,
@@ -512,14 +785,12 @@ def _apply_outcome(
     lore_root: Path,
     logger: RunLogger | None,
 ) -> FlushOutcome:
+    """Fold one compose result into the note and the buffer.
+
+    Dispatches on the compose status; every branch drives the flush record
+    to a terminal state, and `close` then seals the note.
+    """
     sidecar = buffer.read_sidecar() or Sidecar(transcript_id=buffer.stem)
-    facts = facts_from_replay(rb)
-    linkage = linkage_from_replay(rb, cwd=sidecar.cwd, wiki_root=wiki_root, handle=sidecar.handle)
-    # The logger carries this flush's trace_id (minted at spawn, delivered via
-    # env). Stamp it onto the note's linkage and the flush record so run
-    # events, the drain event and the note all share one id (#188).
-    trace_id = logger.trace_id if logger is not None else None
-    linkage = replace(linkage, trace_id=trace_id)
     out = FlushOutcome(
         buffer_stem=buffer.stem,
         state_before=state_before,
@@ -528,167 +799,34 @@ def _apply_outcome(
     )
     out.attempts = getattr(compose_result, "attempts", 0)
 
-    # Guard against a concurrent flush having already covered this span
-    # (in-place cap-trip racing the reaper): re-read the note watermark.
-    if _flushed_to(note_path) >= slice_to and not close:
-        out.status = "skipped"
-        out.skipped_reason = "span-already-covered"
-        if sidecar.flush_requested is not None:
-            buffer.patch(flush_requested=None)
+    if not close and _back_off_if_covered(buffer, sidecar, note_path, slice_to, out):
         return out
 
+    ctx, flush_rec = _begin_apply(
+        buffer=buffer,
+        note_path=note_path,
+        sidecar=sidecar,
+        slice_from=slice_from,
+        slice_to=slice_to,
+        rb=rb,
+        close=close,
+        wiki_root=wiki_root,
+        lore_root=lore_root,
+        logger=logger,
+    )
+
     status = compose_result.status if compose_result is not None else ComposeStatus.FAILED
-
-    # Track this flush as an explicit, queryable state machine: begin (queued)
-    # -> running for this attempt, then a terminal published / withheld /
-    # dead-lettered transition below. The record is the source of truth for
-    # "what is in-flight right now"; every transition also emits a spine event.
-    store = FlushStore(lore_root)
-    flush_rec = store.begin(buffer.stem, wiki=sidecar.wiki, trace_id=trace_id)
-    if FlushState(flush_rec.state) is FlushState.QUEUED:
-        flush_rec = store.transition(flush_rec, FlushState.RUNNING)
-
     if status is ComposeStatus.COMPOSED:
-        try:
-            out.chapter_n = nd.append_chapter(
-                note_path,
-                compose_result.chapter,
-                slice_from_turn=slice_from,
-                slice_to_turn=slice_to,
-                facts=facts,
-                linkage=linkage,
-                wiki_root=wiki_root,
-                title=_topic_title(sidecar.scope, compose_result.chapter),
-            )
-        except OSError:
-            # A note write that fails on disk is a dead-letter, not a crash:
-            # record it and stop writing to a failing filesystem.
-            store.transition(
-                flush_rec, FlushState.DEAD_LETTERED, reason=ErrorCode.CHAPTER_APPEND_FAILED
-            )
-            out.status = "failed"
-            return out
-        if out.chapter_n == 1:
-            note_path = _rename_to_topic_slug(buffer, note_path, compose_result.chapter)
-            out.note_path = note_path
-            out.wikilink = f"[[{note_path.stem}]]"
-        out.status = "composed"
-        _clear_after_progress(buffer, close=close)
-        store.transition(flush_rec, FlushState.PUBLISHED)
+        sealable = _apply_composed(ctx, out, compose_result, flush_rec)
     elif status is ComposeStatus.EMPTY:
-        out.status = "empty"
-        if close:
-            if _flushed_to(note_path) < 0:
-                # The whole session produced nothing of substance: the
-                # stub note is removed rather than closed empty.
-                with contextlib.suppress(OSError):
-                    note_path.unlink()
-                out.discarded = True
-                out.wikilink = ""
-        else:
-            # The span was judged substance-free: consume it (buffer
-            # reset, watermark kept) so the same turns are never
-            # recomposed; the session stays live.
-            _reset_buffer_fresh(buffer)
-        if logger is not None:
-            logger.emit(
-                "flush-empty",
-                buffer_stem=buffer.stem,
-                transcript_id=sidecar.transcript_id,
-                discarded=out.discarded,
-            )
-        # "Nothing of substance" is a completed flush, not a failure.
-        store.transition(flush_rec, FlushState.PUBLISHED)
+        sealable = _apply_empty(ctx, out, flush_rec)
     elif status is ComposeStatus.WITHHELD:
-        verdict = GateResult.withheld(
-            compose_result.withheld_category,
-            compose_result.withheld_feedback,
-        )
-        w = pg.apply_withhold(
-            note_path,
-            result=verdict,
-            composed_text=compose_result.withheld_text,
-            slice_from_turn=slice_from,
-            slice_to_turn=slice_to,
-            lore_root=lore_root,
-            wiki_root=wiki_root,
-        )
-        out.chapter_n = w.chapter_n
-        out.status = "withheld"
-        _clear_after_progress(buffer, close=close)
-        if logger is not None:
-            logger.emit(
-                "flush-withheld",
-                buffer_stem=buffer.stem,
-                transcript_id=sidecar.transcript_id,
-                category=verdict.category,
-            )
-        store.transition(flush_rec, FlushState.WITHHELD)
-    else:  # FAILED
-        if close:
-            with contextlib.suppress(OSError):
-                out.chapter_n = nd.append_marker_chapter(
-                    note_path,
-                    kind=nd.MARKER_FAILED,
-                    reason="composition failed at session end",
-                    slice_from_turn=slice_from,
-                    slice_to_turn=slice_to,
-                    facts=facts,
-                    linkage=linkage,
-                    wiki_root=wiki_root,
-                )
-            out.status = "failed"
-            store.transition(flush_rec, FlushState.DEAD_LETTERED, reason=ErrorCode.COMPOSE_FAILED)
-        else:
-            # Bounded retry with backoff replaces the old silent-defer /
-            # give-up-at-2x-cap heuristic. record_failure() re-queues with a
-            # scheduled next-eligible-retry (emitting a spine event — never
-            # silent) until MAX_ATTEMPTS failures, then dead-letters.
-            flush_rec = store.record_failure(flush_rec, error_code=ErrorCode.COMPOSE_FAILED)
-            buffer.patch(
-                flush_attempts=sidecar.flush_attempts + 1,
-                last_error="compose-failed",
-                flush_requested=None,
-            )
-            if FlushState(flush_rec.state) is FlushState.DEAD_LETTERED:
-                # Retries exhausted: record the failed span with a marker and
-                # reset the buffer — the note stays open, one session one note.
-                with contextlib.suppress(OSError):
-                    out.chapter_n = nd.append_marker_chapter(
-                        note_path,
-                        kind=nd.MARKER_FAILED,
-                        reason="composition failed after retries; span recorded and buffer reset",
-                        slice_from_turn=slice_from,
-                        slice_to_turn=slice_to,
-                        facts=facts,
-                        linkage=linkage,
-                        wiki_root=wiki_root,
-                    )
-                _reset_buffer_fresh(buffer)
-                out.status = "gave-up"
-                if logger is not None:
-                    logger.emit(
-                        "flush-gave-up",
-                        buffer_stem=buffer.stem,
-                        transcript_id=sidecar.transcript_id,
-                        turn_count=rb.turn_count,
-                        prompt_chars=rb.prompt_chars,
-                    )
-            else:
-                out.status = "deferred"
-                if logger is not None:
-                    logger.emit(
-                        "flush-deferred",
-                        buffer_stem=buffer.stem,
-                        transcript_id=sidecar.transcript_id,
-                        flush_attempts=sidecar.flush_attempts + 1,
-                    )
+        sealable = _apply_withheld(ctx, out, compose_result, flush_rec)
+    else:
+        sealable = _apply_failed(ctx, out, flush_rec)
 
-    if close:
-        if not out.discarded and not nd.is_closed(note_path):
-            nd.close_note(note_path, facts=facts, linkage=linkage, wiki_root=wiki_root)
-        buffer.transition("closed")
-        out.closed = True
+    if sealable and close:
+        _seal_note(ctx, out)
     return out
 
 

--- a/lib/lore_curator/hygiene.py
+++ b/lib/lore_curator/hygiene.py
@@ -71,13 +71,6 @@ class CuratorReport:
 
 
 @dataclass(frozen=True)
-class PassContext:
-    """Shared inputs passed to every hygiene pass."""
-
-    today: date
-
-
-@dataclass(frozen=True)
 class PassResult:
     """Output bundle — passes may produce actions, hints, or both."""
 
@@ -90,7 +83,7 @@ class HygienePass:
     """One curator hygiene pass — a named, frontmatter-only wiki walk."""
 
     name: str
-    run: Callable[[Path, PassContext], PassResult]
+    run: Callable[[Path], PassResult]
 
 
 # ---------------------------------------------------------------------------
@@ -379,31 +372,15 @@ def _pass_git_backfill(wiki_path: Path) -> list[CuratorAction]:
 
 
 # ---------------------------------------------------------------------------
-# Pass-protocol adapters + registry
+# Pass registry
 # ---------------------------------------------------------------------------
 
 
-def _run_supersession(wiki_path: Path, ctx: PassContext) -> PassResult:
-    return PassResult(actions=_pass_supersession(wiki_path))
-
-
-def _run_implements(wiki_path: Path, ctx: PassContext) -> PassResult:
-    return PassResult(actions=_pass_implements(wiki_path))
-
-
-def _run_git_backfill(wiki_path: Path, ctx: PassContext) -> PassResult:
-    return PassResult(actions=_pass_git_backfill(wiki_path))
-
-
-def _run_team_mode_hint(wiki_path: Path, ctx: PassContext) -> PassResult:
-    return PassResult(hints=_pass_team_mode_hint(wiki_path))
-
-
 HYGIENE_PASSES: list[HygienePass] = [
-    HygienePass("supersession", _run_supersession),
-    HygienePass("implements", _run_implements),
-    HygienePass("git_backfill", _run_git_backfill),
-    HygienePass("team_mode_hint", _run_team_mode_hint),
+    HygienePass("supersession", lambda w: PassResult(actions=_pass_supersession(w))),
+    HygienePass("implements", lambda w: PassResult(actions=_pass_implements(w))),
+    HygienePass("git_backfill", lambda w: PassResult(actions=_pass_git_backfill(w))),
+    HygienePass("team_mode_hint", lambda w: PassResult(hints=_pass_team_mode_hint(w))),
 ]
 
 # ---------------------------------------------------------------------------
@@ -454,7 +431,6 @@ def run_hygiene(
 
     wikis = discover_wikis(wiki_filter)
     reports: list[CuratorReport] = []
-    today = date.today()
     now = _dt.now(UTC)
     rid = run_id or now.strftime("%Y-%m-%dT%H-%M-%S")
 
@@ -492,9 +468,8 @@ def run_hygiene(
                 )
 
             report = CuratorReport(wiki=wiki_path.name)
-            pass_ctx = PassContext(today=today)
             for pass_def in HYGIENE_PASSES:
-                result = pass_def.run(wiki_path, pass_ctx)
+                result = pass_def.run(wiki_path)
                 report.actions.extend(result.actions)
                 report.hints.extend(result.hints)
             reports.append(report)

--- a/tests/test_chapter_flush.py
+++ b/tests/test_chapter_flush.py
@@ -721,3 +721,60 @@ def test_inplace_empty_compose_consumes_the_slice(tmp_path):
     sidecar = buf.read_sidecar()
     assert sidecar.state == "accumulating"
     assert buf.replay().turn_count == 0  # slice consumed, not re-queued
+
+
+def test_concurrent_flush_covering_the_span_is_skipped(tmp_path):
+    """A span another flush already published is dropped, not appended twice.
+
+    The in-place cap-trip can race the reaper: both read the same buffer,
+    one publishes while the other is still inside its (slow) compose call.
+    The loser re-reads the note watermark before writing and must back off,
+    or the same turns land as two chapters.
+    """
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    all_turns = _turns(0, 4)
+    buf = _append(lore_root, all_turns)
+
+    sessions = wiki_root / "sessions"
+
+    class _Racing(_Messages):
+        """Land a competing chapter on the note while this compose is in flight."""
+
+        def create(self, **kwargs: Any) -> _Resp:
+            resp = super().create(**kwargs)
+            note = next(sessions.rglob("*.md"))
+            nd.append_marker_chapter(
+                note,
+                kind=nd.MARKER_FAILED,
+                reason="published by a concurrent flush",
+                slice_from_turn=0,
+                slice_to_turn=4,
+                wiki_root=wiki_root,
+            )
+            return resp
+
+    client = _Client([_chapter_payload("Traced the flush race", "prose.", 2)])
+    client.messages = _Racing([_chapter_payload("Traced the flush race", "prose.", 2)])
+
+    outcome = synth_in_place(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+        auto_commit=False,
+    )
+
+    assert outcome.status == "skipped"
+    assert outcome.skipped_reason == "span-already-covered"
+
+    # Only the winner's chapter is on the note — the loser appended nothing.
+    view = nd.read_note(outcome.note_path)
+    assert len(view.chapters) == 1
+    assert view.chapters[0]["marker"] == nd.MARKER_FAILED
+    assert "Traced the flush race" not in view.body
+
+    # The buffer is untouched: the session stays live and keeps accumulating.
+    assert buf.read_sidecar().state == "accumulating"

--- a/tests/test_doctor_cursor.py
+++ b/tests/test_doctor_cursor.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 from lore_cli import doctor_cmd
-from lore_core.install._helpers import PLUGIN_SENTINEL
+from lore_core.managed_files import PLUGIN_SENTINEL
 
 
 @pytest.fixture

--- a/tests/test_install_cursor.py
+++ b/tests/test_install_cursor.py
@@ -10,13 +10,13 @@ from pathlib import Path
 import pytest
 from lore_core.install import _helpers, cursor
 from lore_core.install._helpers import execute_action
+from lore_core.install.base import InstallContext
 from lore_core.managed_files import (
     MANAGED_BLOCK_END,
     MANAGED_BLOCK_START,
     SCHEMA_VERSION_KEY,
     write_managed_markdown,
 )
-from lore_core.install.base import InstallContext
 
 
 @pytest.fixture

--- a/tests/test_install_cursor.py
+++ b/tests/test_install_cursor.py
@@ -9,11 +9,12 @@ from pathlib import Path
 
 import pytest
 from lore_core.install import _helpers, cursor
-from lore_core.install._helpers import (
+from lore_core.install._helpers import execute_action
+from lore_core.managed_files import (
     MANAGED_BLOCK_END,
     MANAGED_BLOCK_START,
     SCHEMA_VERSION_KEY,
-    execute_action,
+    write_managed_markdown,
 )
 from lore_core.install.base import InstallContext
 
@@ -35,7 +36,7 @@ def cursor_home(tmp_path, monkeypatch):
     (tmp_path / ".cursor" / "rules").mkdir()
     # By default, no source root resolved — tests that want plugin
     # packaging exercised will override this.
-    monkeypatch.setattr(_helpers, "resolve_lore_source_root", lambda *a, **kw: None)
+    monkeypatch.setattr(cursor, "resolve_lore_source_root", lambda *a, **kw: None)
     return tmp_path
 
 
@@ -103,7 +104,7 @@ def test_plan_present_same_schema_emits_only_check(cursor_home):
         / "integration-rules"
         / "default.md"
     ).read_text().rstrip("\n")
-    _helpers.write_managed_markdown(rules_path, body)
+    write_managed_markdown(rules_path, body)
     actions = cursor.plan(InstallContext())
     # No merge, no new — only the trailing check
     kinds = [a.kind for a in actions]
@@ -278,7 +279,7 @@ def test_plan_emits_plugin_dir_actions(cursor_home, fake_source_root, monkeypatc
     """When source resolves, plan() emits actions to materialize the
     Cursor plugin dir (sentinel, manifest, skills, rules, mcp, hooks)."""
     monkeypatch.setattr(
-        _helpers, "resolve_lore_source_root",
+        cursor, "resolve_lore_source_root",
         lambda *a, **kw: fake_source_root,
     )
     actions = cursor.plan(InstallContext())
@@ -297,7 +298,7 @@ def test_plugin_manifest_mirrors_claude_manifest_version(
     """The generated Cursor plugin manifest carries the Claude
     manifest's version (single source of truth)."""
     monkeypatch.setattr(
-        _helpers, "resolve_lore_source_root",
+        cursor, "resolve_lore_source_root",
         lambda *a, **kw: fake_source_root,
     )
     actions = cursor.plan(InstallContext())
@@ -345,7 +346,7 @@ def test_skills_copied_as_real_dir(cursor_home, fake_source_root, monkeypatch):
     """After install, the plugin's skills/ is a real dir (not a
     symlink) and the parent has a .lore-managed sentinel."""
     monkeypatch.setattr(
-        _helpers, "resolve_lore_source_root",
+        cursor, "resolve_lore_source_root",
         lambda *a, **kw: fake_source_root,
     )
     for a in cursor.plan(InstallContext()):
@@ -364,7 +365,7 @@ def test_uninstall_removes_plugin_dir_only_with_sentinel(
     """Uninstall removes the plugin dir when the sentinel is present;
     refuses (and leaves contents intact) when sentinel is missing."""
     monkeypatch.setattr(
-        _helpers, "resolve_lore_source_root",
+        cursor, "resolve_lore_source_root",
         lambda *a, **kw: fake_source_root,
     )
     # Install so the plugin dir exists with the sentinel
@@ -398,7 +399,7 @@ def test_global_mcp_entry_skipped_when_plugin_packages(
     mcpServers.lore to the global mcp.json — only the plugin-local
     one is canonical."""
     monkeypatch.setattr(
-        _helpers, "resolve_lore_source_root",
+        cursor, "resolve_lore_source_root",
         lambda *a, **kw: fake_source_root,
     )
     actions = cursor.plan(InstallContext())
@@ -416,7 +417,7 @@ def test_global_mcp_entry_deleted_when_legacy_present(
     """When plugin packaging runs and a legacy global entry exists,
     plan() emits a delete to dedupe."""
     monkeypatch.setattr(
-        _helpers, "resolve_lore_source_root",
+        cursor, "resolve_lore_source_root",
         lambda *a, **kw: fake_source_root,
     )
     global_mcp_path = cursor_home / ".cursor" / "mcp.json"

--- a/tests/test_install_helpers.py
+++ b/tests/test_install_helpers.py
@@ -1,27 +1,30 @@
-"""Tests for `lore_core.install._helpers` — the JSON merge, flock,
-managed-markers, pipx cascade, per-platform path resolution, and
-content-hash primitives that everything else builds on.
+"""Tests for the install helpers and the file primitives under them.
+
+Covers `lore_core.install._helpers` (pipx cascade, per-platform path
+resolution, MCP entry) and `lore_core.managed_files` (JSON merge, flock,
+managed markers, content hash) — the primitives everything else builds on.
 """
 
 from __future__ import annotations
 
 import json
-import multiprocessing
 import os
 from pathlib import Path
 
 import pytest
 from lore_core.install import _helpers
 from lore_core.install._helpers import (
+    cursor_config_dir,
+    cursor_rules_dir,
+    install_self_via,
+    lore_mcp_entry,
+)
+from lore_core.managed_files import (
     MANAGED_BLOCK_END,
     MANAGED_BLOCK_START,
     MalformedConfigError,
     content_hash,
-    cursor_config_dir,
-    cursor_rules_dir,
-    install_self_via,
     json_merge_atomic,
-    lore_mcp_entry,
     managed_block_content,
     remove_managed_block,
     write_managed_markdown,

--- a/tests/test_install_version_drift.py
+++ b/tests/test_install_version_drift.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
-from lore_core.install._helpers import check_lore_version_match
+from lore_core.source_root import check_lore_version_match
 
 
 def _write_pyproject(repo: Path, version: str) -> None:
@@ -128,13 +128,13 @@ def test_banner_version_prefers_source_manifest(
     """With a resolvable source tree the banner reads plugin.json, not the
     (possibly stale) installed package metadata."""
     from lore_cli import hooks
-    from lore_core.install import _helpers
+    from lore_core import source_root
 
     monkeypatch.setattr(
-        _helpers, "resolve_lore_source_root", lambda lore_repo=None: tmp_path
+        source_root, "resolve_lore_source_root", lambda lore_repo=None: tmp_path
     )
     monkeypatch.setattr(
-        _helpers, "read_claude_manifest", lambda root: {"version": "1.2.3"}
+        source_root, "read_claude_manifest", lambda root: {"version": "1.2.3"}
     )
     # Installed metadata deliberately differs — source must win.
     monkeypatch.setattr("importlib.metadata.version", lambda name: "0.0.1")
@@ -147,10 +147,10 @@ def test_banner_version_falls_back_to_metadata_without_source(
     """A plain PyPI install (no resolvable source tree) reports the installed
     package version."""
     from lore_cli import hooks
-    from lore_core.install import _helpers
+    from lore_core import source_root
 
     monkeypatch.setattr(
-        _helpers, "resolve_lore_source_root", lambda lore_repo=None: None
+        source_root, "resolve_lore_source_root", lambda lore_repo=None: None
     )
     monkeypatch.setattr("importlib.metadata.version", lambda name: "0.9.9")
     assert hooks._lore_version() == "0.9.9"
@@ -162,14 +162,14 @@ def test_banner_version_falls_back_when_manifest_unreadable(
     """A resolvable source root with a corrupt plugin.json degrades to the
     installed metadata rather than crashing the SessionStart hook."""
     from lore_cli import hooks
-    from lore_core.install import _helpers
+    from lore_core import source_root
 
     def _boom(root: Path) -> dict:
         raise ValueError("bad json")
 
     monkeypatch.setattr(
-        _helpers, "resolve_lore_source_root", lambda lore_repo=None: tmp_path
+        source_root, "resolve_lore_source_root", lambda lore_repo=None: tmp_path
     )
-    monkeypatch.setattr(_helpers, "read_claude_manifest", _boom)
+    monkeypatch.setattr(source_root, "read_claude_manifest", _boom)
     monkeypatch.setattr("importlib.metadata.version", lambda name: "0.9.9")
     assert hooks._lore_version() == "0.9.9"


### PR DESCRIPTION
Closes #264.

Behaviour-preserving decomposition of the three maintenance hotspots plus the wrapper collapse. Three commits: characterization test, then the relocation (import churn, reviewable on its own), then the logic splits.

## The `_helpers.py` relocation

`install/_helpers.py` (985 lines) was half install mechanics, half primitives with nothing install-specific about them that `lore_cli` reached *under* `install/` to borrow. Split into two `lore_core` modules named for what they hold:

| new module | holds | why that name |
|---|---|---|
| `lore_core/managed_files.py` | atomic JSON merge under flock, managed-marker markdown regions, sentinel-gated plugin trees, `content_hash` | every one of these exists to **write into a file or directory the user owns** — that is the single idea the module is about, and the reason each carries a lock, a marker, or a sentinel |
| `lore_core/source_root.py` | `resolve_lore_source_root`, `read_claude_manifest`, `check_lore_version_match` | answers **"which Lore is actually running here?"** — the plugin and the `lore` binary are on separate update channels, and the banner, `lore doctor` and the Cursor installer all need to reconcile them |

`_helpers.py` (698 lines) keeps only what an *installer* needs: per-platform config paths, the installer cascade, Cursor manifest/hooks generation, install.sh legacy detection, and the Action executors. It **imports** the new modules rather than re-exporting them, so nothing reaches through `install/` for a primitive any more.

**Importers updated** (grepped fresh — the handed-over list was stale; `init_cmd.py` and `install/__init__.py` do not import `_helpers`):

- `lib/lore_core/install/cursor.py` — primitives → `managed_files`, resolver → `source_root`
- `lib/lore_cli/doctor_cmd.py` — `check_lore_version_match` → `source_root`, `PLUGIN_SENTINEL` → `managed_files` (`cursor_plugin_dir` stays in `_helpers`, it is Cursor-install path resolution)
- `lib/lore_cli/hooks.py` — **import statement only**, as agreed (#263 owns this file)
- `lib/lore_core/lockfile.py` — stale docstring pointer `install/_helpers._flocked` → `managed_files._flocked`
- `CONTRIBUTING.md` — the new-host guide *instructs contributors in prose* to import `json_merge_atomic` / `write_managed_markdown` from `_helpers.py`. That is a caller that no grep for code would have caught; rewritten to point at the new homes.
- tests: `test_install_helpers.py`, `test_install_cursor.py`, `test_doctor_cursor.py`, `test_install_version_drift.py` (import paths + monkeypatch targets only)

`lib/lore_core/install/claude.py`, `lib/lore_cli/install_cmd.py`, `tests/test_install_claude.py` and `tests/test_install_dispatcher.py` needed **no** change — every symbol they pull from `_helpers` legitimately stayed there.

**No import cycle.** `managed_files` and `source_root` import nothing from `lore_cli` or `lore_core.install`; the fence (`lore_cli → lore_core`, never the reverse) is intact. Verified by importing all five packages and every touched module in a clean interpreter.

## Decomposition

Every function the issue names is now under the ~60-line bar:

| function | before | after |
|---|---|---|
| `run_lint` | 195 | 33 (phases: `_scan_notes`, `_build_link_graph`, `_collect_issues`, `_regenerate_wiki`, `_build_report`) |
| `check_agent_guidance_sync` | 107 | 48 (ran the same drift check twice for two project layouts; `_orientation_notes` yields both, the check runs once) |
| `_apply_outcome` | 160 | 57 (per-outcome handlers over a shared `_ApplyContext`) |
| `execute_action` | 150 | 10 (per-kind executors behind a registry) |
| `detect_install_sh_artifacts` | 97 | 21 (the skill- and agent-symlink scans were the same loop twice) |
| hygiene `_run_*` wrappers | 4 fns | 0 |

The hygiene wrappers existed only to swallow a `PassContext` that **no pass has read since #258 removed the staleness pass**, and to box a bare list into a `PassResult`. The registry does the boxing; `PassContext` is deleted. Four passes, four functions.

`_apply_outcome`'s concurrent-flush back-off now has a name — `_back_off_if_covered`. It was the subtlest thing in the function and the easiest to delete by accident, which is exactly why it got the characterization test below.

## Evidence

**Characterization first.** `_apply_outcome`'s `span-already-covered` guard was the one branch with no test. Commit 1 adds `test_concurrent_flush_covering_the_span_is_skipped` — it drives the real pipeline with an LLM stub that lands a competing chapter on the note mid-compose. It passes against unmodified code (that is the contract), and it genuinely pins the guard:

```
# guard mutated to `if False:`
FAILED test_concurrent_flush_covering_the_span_is_skipped
  AssertionError: assert 'composed' == 'skipped'      # the same turns land as two chapters
# guard restored
1 passed
```

**Fixture vault, before vs after.** A probe builds a fixture vault and runs `lore lint` (rich + `--json`), `lore curator` (dry-run + `--apply`), dumps every generated artefact (`_catalog.json`, `_index.txt`, `_concepts.txt`, `_decisions.txt`, `sessions/_recent.txt`, `_review.md`), then drives `chapter_flush` through **all eight** `_apply_outcome` branches with a stub LLM — composed, withheld-by-gate, deferred, gave-up-after-retries, empty, composed+close, failed-at-close, empty-at-close — dumping the `FlushOutcome`, the note and the sidecar for each.

```
$ diff BEFORE.txt AFTER.txt
$ echo $?
0
```

**Byte-identical across 1255 lines of lint + curator + flush output.** (Run-to-run noise — scratch path, the wall-clock minute baked into a note slug, pid — is scrubbed; nothing semantic is.)

**Suite:** `2665 passed` (2664 at base + the new characterization test). The 4 failures are the known pre-existing local ANSI/rich-rendering artifacts (`test_cli_scopes`, `test_core_llm_wiring` ×2, `test_install_dispatcher`) — they reproduce unchanged on `epic/257` head.

**ruff:** clean on every file touched. Both new modules pass; every other touched file has ruff findings identical to the epic base — *except* `tests/test_install_cursor.py`, where the new `managed_files` import block landed out of alphabetical order and introduced one `I001`. Caught in crosscheck and fixed in `3466118` (`ruff --fix`; the file's 20 tests still pass). An earlier revision of this PR body claimed "zero new findings" — that was wrong on that one file. No repo-wide reformat.

## Found but not touched (sibling-owned / out of scope)

- `lib/lore_cli/hooks.py` — only its `_helpers` import line changed, as instructed. Nothing else restructured (#263).
- `docs/prd/0007-substrate-trim.md:90` refers to "the install `_helpers` grab-bag". Accurate as a record of intent, and `docs/` is #266's. Left alone.
- **Over the 60-line bar but not named as targets by the issue**, so deliberately left: `check_hierarchy` (115) and `generate_index_txt` (81) in `lint.py` — the issue states lint.py is "otherwise justified"; `flush_chapter` (169) and `sweep_dead_sessions` (103) in `chapter_flush.py` — the issue says `flush_chapter` "may also benefit but `_apply_outcome` is the priority"; `_pass_implements` (97) and `run_hygiene` (91) in `hygiene.py`. Flagging for a follow-up call rather than expanding this diff.
- Two pre-existing `F541` (f-string without placeholders) in `install/cursor.py` at lines 333–334, untouched to keep the diff to the relocation.

