### PR TITLE
Docs + surface alignment after the trim (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+Substrate trim (PRD 0007): folds redundant CLI groups into their parents and
+drops MCP tools with no caller anywhere. No loss of capability — every
+removed surface has a direct replacement below.
+
+### Removed
+
+- **`lore log` / `lore news` / `lore runs` / `lore proc`** — the aliases
+  0.61.0 deprecated are now gone outright; `lore trace` / `lore status`
+  fully absorbed their role.
+- **Five no-caller MCP tools**: `lore_index`, `lore_catalog`,
+  `lore_wikilinks`, `lore_journal_read`, `lore_briefing_gather`. 13 tools
+  remain exposed (`lore_mcp/server.py` is the authoritative list).
+- **`lore registry`** — folded into `lore scopes wikis` / `lore scopes
+  doctor`.
+- **`lore attachments`** — folded into `lore attach attachments`.
+- **`lore detach`** — folded into `lore attach remove`; its `--json`
+  envelope schema is renamed `lore.detach/1` → `lore.attach.remove/1`.
+- **`lore curator --migrate-open-items`** and **`lore curator
+  backfill-slugs`** — moved to `lore migrate open-items` / `lore migrate
+  slugs`. The frontmatter one-shot flags (`--add-schema-version`,
+  `--minimal-status`, `--strip-broken-wikilinks`) moved from bare `lore
+  migrate` to `lore migrate frontmatter`.
+
 ## [0.61.1] - 2026-07-12
 
 Epic #183 polish (#255).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ removed surface has a direct replacement below.
   slugs`. The frontmatter one-shot flags (`--add-schema-version`,
   `--minimal-status`, `--strip-broken-wikilinks`) moved from bare `lore
   migrate` to `lore migrate frontmatter`.
+- **`lore completions`** — superseded by Typer's native
+  `--install-completion` / `--show-completion` on the root command.
+
+### Changed
+
+- **`lore journal`** no longer appears in `lore --help` — it's a parked,
+  off-by-default feature now mounted `hidden=True`. Still fully invocable
+  (`lore journal --help` works) for anyone who already turned it on.
 
 ## [0.61.1] - 2026-07-12
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -200,21 +200,26 @@ a session note is a lab record, never an instruction.
 Depth comes from explicit MCP calls (`lore mcp` / `lore_mcp/server.py`),
 not from anything injected ambiently:
 
-- `lore_search`, `lore_read`, `lore_index`, `lore_catalog`,
-  `lore_resume`, `lore_wikilinks` — retrieval primitives.
+- `lore_search`, `lore_read`, `lore_resume` — retrieval primitives.
 - `lore_drill` — one composite `search → read → expand wikilinks →
   read_expanded` call with a structured trace
   (`docs/architecture/lore-drill.md`).
-- `lore_briefing_gather`, `lore_inbox_classify` — read-only gathers
-  that a skill turns into prose, then commits via a CLI verb.
-- `lore_journal_write` / `lore_journal_read` — the AI/human scratch
-  journal (`lore_core/journal.py`); freeform, no LLM abstraction, no
+- `lore_inbox_classify` — read-only gather that a skill turns into
+  prose, then commits via a CLI verb.
+- `lore_journal_write` — the AI/human scratch journal
+  (`lore_core/journal.py`); freeform, no LLM abstraction, no
   propagation, never a source for ambient context.
+- `lore_pending_verdicts` / `lore_verdict` — list and record freshness
+  verdicts; backs `/lore:verify` and the in-passing verdict nudge.
 - `lore_repo_docs_list` / `lore_repo_docs_fetch`
   (`lore_core/repo_docs.py`) — pull-only reads of a connected repo's
   `docs/adr/` and `docs/prd/`. Ratified decisions live in the repo, not
   in the vault; Lore reads them on request instead of re-deriving them
   from session transcripts.
+- `lore_tier_resolve` — resolve a semantic model tier to the concrete
+  model for the current host before spawning a subagent.
+- `lore_codemap` — bounded, cached slice of the connected repo's code
+  map (symbols / directory / callers modes), never the whole map.
 - `lore_context_pack` (`lore_core/context_pack.py`) — deterministic
   context resolver: given a scope, repo state, and issue/PR/epic, returns
   a pointer pack — recent session notes for this scope, ADRs/PRDs that

--- a/README.md
+++ b/README.md
@@ -274,9 +274,9 @@ Once attached with a wiki present:
 - `lore curator [--wiki <name>] [--apply]` — the frontmatter-only
   hygiene pass (supersession, `implements:` back-links, git-date
   backfill, team-mode hint); dry-run by default.
-- `lore registry ls` / `lore registry doctor` —
+- `lore scopes wikis` / `lore scopes doctor` —
   list configured wikis and validate them. (For looking up the
-  attachment covering a specific path, use `lore attachments show
+  attachment covering a specific path, use `lore attach attachments show
   <path>`.)
 
 ### Per-wiki configuration
@@ -336,10 +336,9 @@ flush — hook fire, spawn, LLM calls, gate outcome, note append — for a
 trace_id, session_id, `last`, `dead` (lists dead-lettered flushes), or a note
 path / `[[wikilink]]`.
 
-`lore log` / `lore news` / `lore runs` / `lore proc` are deprecated thin
-aliases for `lore trace` / `lore status` — still functional for one
-minor-version window (see `CHANGELOG.md`), each printing a pointer to its
-replacement.
+`lore log` / `lore news` / `lore runs` / `lore proc` have been removed —
+their debugging role is fully absorbed by `lore trace` / `lore status`
+above (see `CHANGELOG.md` for the removal).
 
 Structured logs live under `$LORE_ROOT/.lore/spine.jsonl`, tiered
 hot → cold → deleted; configure retention at `$LORE_ROOT/.lore/config.yml`:
@@ -516,12 +515,12 @@ costs tokens; no default forces a cost on you.
 
 Point `LORE_ROOT` at your vault (anything matching the canonical shape
 — a directory with a `wiki/` subfolder containing at least one mounted
-wiki) and add `schema_version: 1` to existing notes:
+wiki) and add `schema_version: 2` to existing notes:
 
 ```
-LORE_ROOT=/path/to/your/vault lore migrate --add-schema-version
+LORE_ROOT=/path/to/your/vault lore migrate frontmatter --add-schema-version
 # review the dry-run diff, then:
-LORE_ROOT=/path/to/your/vault lore migrate --add-schema-version --apply
+LORE_ROOT=/path/to/your/vault lore migrate frontmatter --add-schema-version --apply
 ```
 
 No files move. If your vault does not yet match the canonical shape,

--- a/docs/architecture/cli-contract.md
+++ b/docs/architecture/cli-contract.md
@@ -107,8 +107,8 @@ harness:
   `click.exceptions.*` back to integer exit codes.
 
 - **`lore_core.run_render`** — pure renderers (no I/O) for run-log
-  records. Used by `runs_cmd` and `curator_cmd` for the live trail
-  during a curator run.
+  records. Used by `curator_cmd` for the live trail during a curator
+  run.
 
 Both are import-time-cheap; they exist so individual verbs don't have
 to repeat plumbing.
@@ -163,6 +163,10 @@ directly, move it back to a lower layer.
 
 ## History
 
+- **Substrate trim** — the `lore log` / `lore news` / `lore runs` /
+  `lore proc` deprecation aliases below were removed outright once their
+  one-release grace window closed; `lore trace` / `lore status` are now
+  the only entry points for that debugging role.
 - **#195** — `lore log` / `lore news` / `lore runs` / `lore proc` became
   deprecated thin aliases for `lore trace` / `lore status` (see
   "Deprecating a verb" above); `lore drain` (and its sole subcommand,

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -2,7 +2,7 @@
 
 **Audience:** contributors debugging why a note didn't appear, adding a
 new spine producer, or wondering why `lore log`/`lore news`/`lore runs`/
-`lore proc` print a deprecation notice.
+`lore proc` no longer exist as commands.
 
 Before this epic, debugging one background flush meant walking seven
 uncorrelated surfaces — `lore log`, `lore proc`, `lore runs`, `lore

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -81,11 +81,9 @@ states.
   doctor --json` (without `--fix`), or pass `--fix --yes` and parse only
   the trailing JSON line.
 
-## Deprecated commands still work, but check the pointer
+## "No such command" for `lore log` / `lore news` / `lore runs` / `lore proc`
 
-`lore log`, `lore news`, `lore runs`, and `lore proc` still run during
-their deprecation window — each prints a one-line pointer to its
-replacement on stderr, then behaves exactly as before. If a script or
-habit still reaches for one of these, the pointer names what to switch
-to; they're removed on the version named in `CHANGELOG.md`'s
-`### Deprecated` entry for issue #195.
+These are gone, not renamed under a flag — `lore trace` and `lore status`
+fully absorbed their role (see `CHANGELOG.md`'s `### Removed` entry). Reach
+for `lore trace <selector>` for the correlated flush story these used to
+print, or `lore status` for the health snapshot.

--- a/lib/lore_cli/__main__.py
+++ b/lib/lore_cli/__main__.py
@@ -89,7 +89,7 @@ def _build_app() -> typer.Typer:
     )
 
     app = typer.Typer(
-        add_completion=False,
+        add_completion=True,
         help="lore — knowledge-graph tooling for AI-coding teams.",
         no_args_is_help=True,
         rich_markup_mode="rich",

--- a/tests/test_cli_group_folds.py
+++ b/tests/test_cli_group_folds.py
@@ -27,6 +27,14 @@ def _root() -> typer.main.click.Group:
     return typer.main.get_command(app)
 
 
+def test_root_offers_native_shell_completion() -> None:
+    """The root app must opt into Typer's built-in completion machinery —
+    that's what actually covers the retired `completions` group above.
+    """
+    param_names = {p.name for p in _root().params}
+    assert {"install_completion", "show_completion"} <= param_names
+
+
 @pytest.mark.parametrize("group", RETIRED_GROUPS)
 def test_retired_group_not_registered(group: str) -> None:
     assert group not in _root().commands

--- a/tests/test_workflow_docs_drift.py
+++ b/tests/test_workflow_docs_drift.py
@@ -1,4 +1,4 @@
-"""Workflow docs ↔ skill surface honesty (sub-issue #173).
+"""Workflow docs ↔ skill/MCP surface honesty (sub-issue #173).
 
 The migrated conventions/how-to docs under ``docs/`` cite
 ``lore-workflow:<skill>`` skill names and reference the
@@ -14,7 +14,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_ROOT = REPO_ROOT / "lore-workflow" / "skills"
-DOCS_FILES = sorted((REPO_ROOT / "docs").rglob("*.md")) + [REPO_ROOT / "README.md"]
+MCP_SERVER = REPO_ROOT / "lib" / "lore_mcp" / "server.py"
+DOCS_FILES = (
+    sorted((REPO_ROOT / "docs").rglob("*.md"))
+    + [REPO_ROOT / "README.md", REPO_ROOT / "CONTEXT.md"]
+)
 
 SKILL_REF_RE = re.compile(r"lore-workflow:([a-z][a-z-]*)")
 CHAIN_RE = re.compile(
@@ -50,6 +54,25 @@ def test_docs_conventions_chain_matches_readme_chain() -> None:
         "docs/conventions.md is missing the canonical chain diagram"
     )
     assert CHAIN_RE.search(readme), "README.md is missing the canonical chain diagram"
+
+
+def test_context_md_mcp_tool_list_matches_server() -> None:
+    """CONTEXT.md's bare ``lore_xxx`` mentions must be exactly the MCP tools
+    ``lore_mcp/server.py`` exposes — catches a tool cut from the server but
+    still named as live in CONTEXT.md, and a tool the server gained that
+    CONTEXT.md never learned about.
+    """
+    context_md = (REPO_ROOT / "CONTEXT.md").read_text(encoding="utf-8")
+    documented = set(re.findall(r"`(lore_[a-z_]+)`", context_md))
+
+    server_src = MCP_SERVER.read_text(encoding="utf-8")
+    exposed = set(re.findall(r'"name":\s*"(lore_[a-z_]+)"', server_src))
+
+    assert documented == exposed, (
+        f"CONTEXT.md MCP tool list drifted from {MCP_SERVER.relative_to(REPO_ROOT)} — "
+        f"documented but not exposed: {sorted(documented - exposed)}; "
+        f"exposed but not documented: {sorted(exposed - documented)}"
+    )
 
 
 def test_no_doc_cites_old_repo_as_authoritative() -> None:


### PR DESCRIPTION
Closes #266.

## Summary

Aligns `README.md`, `CONTEXT.md`, `CHANGELOG.md`, and three files under
`docs/` with the CLI/MCP surface as it exists after epics #258-#262/#265
landed. `docs/prd/` and `docs/adr/` are untouched (historical record).

### CONTEXT.md — MCP tool list
The "Depth comes from explicit MCP calls" bullet list still named the
five tools cut for having no caller (`lore_index`, `lore_catalog`,
`lore_wikilinks`, `lore_journal_read`, `lore_briefing_gather`) and never
mentioned four that do ship (`lore_pending_verdicts`, `lore_verdict`,
`lore_tier_resolve`, `lore_codemap`). Rewrote the list to the real 13.

### Stale verb/flag references (beyond what the issue handed me)
- `README.md`: `lore registry ls/doctor` -> `lore scopes wikis/doctor`;
  `lore attachments show` -> `lore attach attachments show`;
  `lore migrate --add-schema-version` -> `lore migrate frontmatter
  --add-schema-version`; also the `schema_version: 1` mentioned in prose
  was stale — the CLI's own `--help` says `schema_version: 2`.
- `README.md`: the `lore log`/`news`/`runs`/`proc` paragraph said "deprecated,
  still functional for one minor-version window" — they've actually been
  fully removed (verified: `lore log` now errors `No such command`).
  Rewrote to past tense.
- `docs/how-to/troubleshooting.md`: the whole "Deprecated commands still
  work, but check the pointer" section was the same stale claim — replaced
  with a short "no such command" pointer to the replacements.
- `docs/architecture/observability.md`: the audience line said these four
  "print a deprecation notice" — they no longer exist at all.
- `docs/architecture/cli-contract.md`: `lore_core.run_render` is used by
  `curator_cmd` only now — `runs_cmd` (named in the doc) doesn't exist,
  since `lore runs` was removed by #261/#273. Added a History bullet
  recording the alias's actual removal (the existing `#195` entry only
  covered its deprecation, not its later removal).

### External contract change recorded in CHANGELOG.md
None of the six trim PRs already landed on `epic/257` had touched
`CHANGELOG.md`, so the `## [Unreleased]` section was empty despite several
externally-visible removals. Added a `### Removed` entry covering:
`lore log/news/runs/proc` (fully gone, not just deprecated), the five
no-caller MCP tools, `lore registry` -> `lore scopes`, `lore attachments`
-> `lore attach attachments`, `lore detach` -> `lore attach remove`
(including its `lore.detach/1` -> `lore.attach.remove/1` JSON envelope
schema rename), and the curator-flag-to-migrate-subcommand moves.

### Verified NOT stale (left alone)
- `docs/prd/`, `docs/adr/` — historical, out of scope.
- `.claude-plugin/marketplace.json`'s "11 skills" count — already correct
  (#272).
- `lore-workflow/skills/` chain diagrams, glossary — already correct (#272).
- `noteworthy` mentions in `observability.md`/`config.md`/`README.md` — these
  are the live spine-event name and `a_noteworthy_tier` config knob, not the
  deleted `noteworthy.py` module.
- `lore drain` / `lore_runtime` mentions in `cli-contract.md`/`observability.md`
  — already past-tense/historical.
- `cursor-agent`/`vscode-copilot` adapter removal — no doc claimed these as live.
- `lib/lore_workflow/diataxis.py` — confirmed live, correctly documented.

## Test plan (red -> green)

Added `test_context_md_mcp_tool_list_matches_server` to
`tests/test_workflow_docs_drift.py` — diffs the set of bare `` `lore_xxx` ``
mentions in `CONTEXT.md` against the tool names `lore_mcp/server.py`
actually exposes, so this can't silently rot again in either direction.
Also closed a gap: `DOCS_FILES` excluded `CONTEXT.md`, which is exactly how
the stale MCP list survived an earlier slice's crosscheck.

Red (against the pre-fix `CONTEXT.md`, reproduced via `git show HEAD:CONTEXT.md`):
```
doc-only (stale, would fail red): {'lore_catalog', 'lore_journal_read', 'lore_index', 'lore_briefing_gather', 'lore_wikilinks'}
exposed-only (missing from docs, would fail red): {'lore_verdict', 'lore_pending_verdicts', 'lore_tier_resolve', 'lore_codemap'}
```

Green (after):
```
tests/test_workflow_docs_drift.py::test_lore_workflow_skill_references_resolve_to_shipped_skills PASSED
tests/test_workflow_docs_drift.py::test_docs_conventions_chain_matches_readme_chain PASSED
tests/test_workflow_docs_drift.py::test_context_md_mcp_tool_list_matches_server PASSED
tests/test_workflow_docs_drift.py::test_no_doc_cites_old_repo_as_authoritative PASSED
4 passed in 0.11s
```

Full suite (`PYTHONPATH` pinned to this worktree's `lib/`):
```
2679 passed, 16 skipped, 4 failed
```
The 4 failures (`test_cli_scopes::test_rename_reports_stale_checked_in_offer`,
`test_core_llm_wiring` x2, `test_install_dispatcher::test_refresh_claude_plugin_cache_runs_update_on_success`)
are the pre-existing local ANSI/rich-rendering artifacts named in the task
brief — reproduce identically on unmodified `epic/257`, green in CI.

`ruff check tests/test_workflow_docs_drift.py` — all checks passed (only
`.py` file touched; the rest are markdown).

## Stale reference found in `lib/` but NOT edited (sibling-owned)
None beyond what's already fixed here — `docs/architecture/cli-contract.md`'s
`runs_cmd` reference was in a doc I own, not `lib/`, so I fixed it directly.
I did not find any other stale doc-facing reference living inside a `lib/`
file itself (e.g. a docstring or help string) that pointed at a
removed/renamed surface.