### PR TITLE
docs: align Diátaxis docs with the substrate-trim surface (epic #257)

### DIFF
--- a/docs/architecture/cli-contract.md
+++ b/docs/architecture/cli-contract.md
@@ -96,6 +96,16 @@ lower-layer module. If you find yourself writing a real function in
 `<verb>_cmd.py`, that function should live in `lore_<package>` and be
 imported.
 
+**5. Only the root app enables shell completion.**
+The `<verb>_cmd.py` skeleton above sets `add_completion=False`, and every
+sub-app keeps it that way — a sub-app that offered `--install-completion`
+would install a competing script for the same `lore` binary. The root
+`typer.Typer` in `__main__.py` sets `add_completion=True`, and that single
+flag is the entire shell-completion surface: it completes the whole command
+tree, sub-verbs included. Flipping it off silently removes completion for
+users with no error anywhere — do not copy the sub-app template's value onto
+the root.
+
 ## The seam helpers
 
 Two small helpers smooth the boundary between typer and the test

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -87,3 +87,33 @@ These are gone, not renamed under a flag — `lore trace` and `lore status`
 fully absorbed their role (see `CHANGELOG.md`'s `### Removed` entry). Reach
 for `lore trace <selector>` for the correlated flush story these used to
 print, or `lore status` for the health snapshot.
+
+Other verbs that moved rather than vanished:
+
+| You typed | Use instead |
+| :--- | :--- |
+| `lore detach` | `lore attach remove` |
+| `lore attachments <sub>` | `lore attach attachments <sub>` |
+| `lore registry ls` / `lore registry doctor` | `lore scopes wikis` / `lore scopes doctor` |
+| `lore curator backfill-slugs` | `lore migrate slugs` |
+| `lore curator --migrate-open-items` | `lore migrate open-items` |
+| `lore migrate --add-schema-version` | `lore migrate frontmatter --add-schema-version` |
+
+`lore journal` still works; it is only hidden from `lore --help` while the
+feature stays parked.
+
+## "No such command: completions" — shell completion
+
+`lore completions <shell>` is gone. Shell completion now comes from Typer's
+native flags on the root command, which cover every verb including the
+folded ones:
+
+```bash
+lore --install-completion     # install into your shell's rc
+lore --show-completion        # print the script, to source or inspect
+```
+
+If your shell rc carries `eval "$(lore completions bash)"` from an earlier
+version, that line now fails on startup. Replace it — `lore
+--install-completion` writes the wiring for you, so no `eval` line is needed
+at all.

--- a/lib/lore_cli/context_cache.py
+++ b/lib/lore_cli/context_cache.py
@@ -85,7 +85,7 @@ def _proc_cmdline(pid: int) -> str:
 def _claude_code_pid() -> int | None:
     """Walk process ancestry to find the Claude Code process PID.
 
-    Works from any descendant (the hook process, or `lore hook why`
+    Works from any descendant (the hook process, or `lore hook context-log`
     invoked via the Bash tool). Returns None if /proc is unavailable or
     no Claude Code ancestor is found.
 

--- a/tests/test_backfill_slugs.py
+++ b/tests/test_backfill_slugs.py
@@ -1,4 +1,4 @@
-"""Tests for the one-shot ``lore curator backfill-slugs`` pass."""
+"""Tests for the one-shot ``lore migrate slugs`` pass."""
 from __future__ import annotations
 
 from pathlib import Path


### PR DESCRIPTION
Documentation pass for merged epic #257 (PRD 0007, substrate trim — merged as 240af2b, released 0.62.0).

The epic's own #266 slice already aligned `CONTEXT.md`, `README.md`, `CHANGELOG.md`, and the architecture/how-to pages that named removed verbs and MCP tools. This PR covers what that sweep's criteria could not see — it was grepping for *removed verbs and tool names*, so a config flag and two docstrings fell through.

## Edit plan (Diátaxis)

| Quadrant | Path | Why |
|---|---|---|
| how-to | `docs/how-to/troubleshooting.md` | Moved-verb table + shell-completion entry |
| explanation/architecture | `docs/architecture/cli-contract.md` | Why only the root app enables completion |
| reference (docstrings) | `lib/lore_cli/context_cache.py` | Named a command that does not exist |
| reference (docstrings) | `tests/test_backfill_slugs.py` | Named the pre-fold verb |

No `docs/prd/**` or `docs/adr/**` path is touched — the classifier excludes them and the diff confirms it. PRD 0007 keeps its original text as the canonical record of intent, including its "~15 groups" figure (the real outcome was 40 → 31; see the correction on #257).

## What each edit says

**how-to — `troubleshooting.md`.** Two additions. A table mapping every folded verb to its new home (`lore detach` → `lore attach remove`, `lore registry ls` → `lore scopes wikis`, `lore curator backfill-slugs` → `lore migrate slugs`, and the rest), noting that `lore journal` still works and is merely hidden from `--help`. And a shell-completion section: **`lore completions <shell>` is gone**, superseded by Typer's native `lore --install-completion` / `--show-completion`. This matters beyond a rename — anyone whose shell rc carries `eval "$(lore completions bash)"` now gets a hard error on every shell startup, and the fix is to delete the line entirely rather than replace it, since `--install-completion` writes the wiring itself.

**architecture — `cli-contract.md`.** A fifth rule: only the root Typer app sets `add_completion=True`; every `<verb>_cmd.py` sub-app keeps `False`, because a sub-app offering `--install-completion` would install a competing script for the same `lore` binary. The rule exists because this epic *lost* shell completion exactly once: `lore completions` was deleted on the stated justification that Typer's built-in covered it, while the root app still had `add_completion=False` — so it did not, and completion vanished with no error anywhere. The contract doc now names that hazard so the sub-app skeleton doesn't get copied onto the root.

**reference — docstrings.** `context_cache.py` referenced `lore hook why`, which does not exist (it is `lore hook context-log`); `tests/test_backfill_slugs.py` still described itself as testing `lore curator backfill-slugs`, now `lore migrate slugs`. Neither was introduced by the epic — both rode along from `main`.

## Verification

Every verb in the new how-to table was driven against the real CLI, not read off the diff: `lore attach remove`, `lore attach attachments ls`, `lore scopes wikis`, `lore scopes doctor`, `lore migrate slugs`, `lore migrate open-items`, `lore migrate frontmatter` all resolve; `lore journal status` still runs while hidden; `--install-completion` and `--show-completion` are both present on the root. Confirmed `__main__.py` is `add_completion=True` and sub-apps are `False`, so the new rule describes the code as it stands.

66 tests pass across the touched and drift-guard files (`test_backfill_slugs`, `test_workflow_docs_drift`, `test_cli_group_folds`, `test_cli_contract`). Ruff introduces no new findings — the one `I001` in `test_backfill_slugs.py` is pre-existing on `main` and fires with the old docstring too.

Epic #257 · sub-issues #258 #259 #260 #261 #262 #263 #264 #265 #266
