### PR TITLE
feat(curator): beat-aligned session segmentation — indices only, deterministic lints, fixed-window fallback (#283)

### DIFF
--- a/lib/lore_curator/chunker.py
+++ b/lib/lore_curator/chunker.py
@@ -1,0 +1,420 @@
+"""Beat-aligned session segmentation — the model emits indices, nothing else.
+
+One cheap LLM call reads a *collapsed* view of the replayed session
+(thinking dropped, tool calls named, tool results folded to line counts)
+and proposes the turn indices at which a new logical chunk begins.
+Deterministic code does the rest.
+
+The model's entire output surface is a list of integers. It makes no
+claims, so its errors degrade to suboptimal windows — never to false
+facts. Nothing else it might emit is parsed or passed on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from lore_core.types import Turn
+
+if TYPE_CHECKING:
+    from lore_core.run_log import RunLogger
+
+__all__ = [
+    "Chunk",
+    "boundary_lint",
+    "collapsed_view",
+    "normalize_chunks",
+    "segment_session",
+    "segment_tool_schema",
+    "SEGMENT_MAX_ATTEMPTS",
+    "SEGMENT_MAX_VIEW_CHARS",
+    "FALLBACK_WINDOW_TURNS",
+    "CHUNK_MIN_TURNS",
+    "CHUNK_MAX_TURNS",
+]
+
+_TOOL_NAME = "segment_session"
+
+# Two attempts, exactly as the chapter composer: one corrective retry on a
+# deterministic lint miss, then the caller degrades instead of looping.
+SEGMENT_MAX_ATTEMPTS = 2
+SEGMENT_MAX_OUTPUT_TOKENS = 1000
+
+# Collapsed-view budget for ONE segmentation call. A longer session is
+# segmented in windows and the boundary lists are stitched. Deliberately far
+# under the model's context: a local backend can silently return nothing on
+# an oversized prompt, which would look exactly like a segmentation failure.
+SEGMENT_MAX_VIEW_CHARS = 24_000
+
+# Size band, in turns. A chunk is one extraction call downstream, so the
+# band is what keeps that call worth its cost (a two-turn "beat" is not) and
+# inside a small model's context (a 90-turn one is not). MAX >= 2*MIN, so an
+# even split of an oversized chunk can never land back under MIN.
+CHUNK_MIN_TURNS = 6
+CHUNK_MAX_TURNS = 40
+
+# What segmentation degrades to when the model fails or keeps returning
+# unusable indices: plain fixed-size windows. Suboptimal beats, never a
+# blocked pipeline. Sized inside the band so the normalizer leaves them be.
+FALLBACK_WINDOW_TURNS = 30
+
+_MALFORMED_FEEDBACK = (
+    "The previous response carried no `boundaries` array. Call the tool with "
+    "`boundaries` set to the turn indices where a new chunk begins — integers "
+    "only, no text."
+)
+
+
+@dataclass(frozen=True)
+class Chunk:
+    """One logical chunk: an inclusive span of turn indices."""
+
+    from_turn: int
+    to_turn: int
+
+
+# ---------------------------------------------------------------------------
+# Boundary lint (deterministic)
+# ---------------------------------------------------------------------------
+
+
+def boundary_lint(boundaries: Sequence[Any], *, indices: list[int]) -> str:
+    """Return corrective feedback for unusable boundaries, ``""`` when clean.
+
+    A boundary is the index of the turn that *opens* a new chunk. It must be
+    an integer turn index from the slice, must not be the first one (that
+    turn always opens chunk 1, and listing it would cut an empty leading
+    chunk), and the list must be strictly increasing. Coverage needs no lint:
+    chunks are cut from the slice itself, so every turn always lands in
+    exactly one chunk.
+
+    An empty list is clean — it says the session is a single beat.
+    """
+    lo, hi = indices[0], indices[-1]
+    valid = set(indices[1:])
+    bad = [b for b in boundaries if not _is_index(b) or b not in valid]
+    if bad:
+        shown = ", ".join(str(b) for b in bad)
+        return (
+            f"Boundaries must be turn indices shown in the transcript, in the "
+            f"range {lo + 1}-{hi} (the first turn @{lo} always opens the first "
+            f"chunk and is never listed). These were not: {shown}."
+        )
+    if any(b <= a for a, b in zip(boundaries, boundaries[1:], strict=False)):
+        shown = ", ".join(str(b) for b in boundaries)
+        return (
+            f"Boundaries must be strictly increasing — each one opens the next "
+            f"chunk in order. The previous attempt returned: {shown}."
+        )
+    return ""
+
+
+def _is_index(value: Any) -> bool:
+    # bool is an int subclass — never a turn index.
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+# ---------------------------------------------------------------------------
+# Segmentation
+# ---------------------------------------------------------------------------
+
+
+def segment_session(
+    *,
+    turns: list[Turn],
+    llm_client: Any,
+    model: str,
+    logger: RunLogger | None = None,
+    transcript_id: str = "",
+) -> list[Chunk]:
+    """Segment the replayed turns into beat-aligned chunks.
+
+    A session whose collapsed view exceeds one call's budget is segmented in
+    windows; the per-window chunks are concatenated (a window seam is itself
+    a boundary — no chunk spans two windows) and the size band then runs over
+    the whole stitched list, so a stub chunk at a seam merges away.
+
+    Never raises and never returns nothing for a non-empty session: a model
+    failure or unusable output degrades that window to fixed-size windows.
+    """
+    if not turns:
+        return []
+    stitched: list[Chunk] = []
+    for window in _view_windows(turns):
+        w_indices = [t.index for t in window]
+        boundaries = _propose_boundaries(turns=window, llm_client=llm_client, model=model)
+        if boundaries is None:
+            if logger is not None:
+                logger.emit(
+                    "warning",
+                    call="segment-session",
+                    transcript_id=transcript_id,
+                    message=(
+                        f"no usable boundaries after {SEGMENT_MAX_ATTEMPTS} attempts; "
+                        f"turns {w_indices[0]}-{w_indices[-1]} fall back to "
+                        f"{FALLBACK_WINDOW_TURNS}-turn windows"
+                    ),
+                )
+            stitched.extend(_fixed_windows(w_indices))
+        else:
+            stitched.extend(_chunks_from_boundaries(w_indices, boundaries))
+    return normalize_chunks(stitched, indices=[t.index for t in turns])
+
+
+def _view_windows(turns: list[Turn]) -> list[list[Turn]]:
+    """Cut the turns into windows whose collapsed views fit one call.
+
+    Greedy and deterministic. A single turn larger than the budget still gets
+    its own window rather than being dropped — the per-turn truncation in the
+    collapsed view already bounds how bad that can be.
+    """
+    windows: list[list[Turn]] = []
+    current: list[Turn] = []
+    size = 0
+    for t in turns:
+        cost = len(_collapse_turn(t)) + len(f"[{t.role}@{t.index}] \n")
+        if current and size + cost > SEGMENT_MAX_VIEW_CHARS:
+            windows.append(current)
+            current, size = [], 0
+        current.append(t)
+        size += cost
+    if current:
+        windows.append(current)
+    return windows
+
+
+def _propose_boundaries(*, turns: list[Turn], llm_client: Any, model: str) -> list[int] | None:
+    """Model-proposed boundaries, linted. ``None`` means "use the fallback".
+
+    An empty *clean* list is a real answer — the session is one beat.
+    """
+    indices = [t.index for t in turns]
+    feedback = ""
+    for _ in range(SEGMENT_MAX_ATTEMPTS):
+        prompt = _build_prompt(turns, retry_feedback=feedback)
+        try:
+            resp = llm_client.messages.create(
+                model=model,
+                max_tokens=SEGMENT_MAX_OUTPUT_TOKENS,
+                tools=[segment_tool_schema()],
+                tool_choice={"type": "tool", "name": _TOOL_NAME},
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception:  # noqa: BLE001 - segmentation never blocks the pipeline
+            continue
+        raw = _extract_boundaries(resp)
+        if raw is None:
+            feedback = _MALFORMED_FEEDBACK
+            continue
+        feedback = boundary_lint(raw, indices=indices)
+        if not feedback:
+            return [int(b) for b in raw]
+    return None
+
+
+def normalize_chunks(
+    chunks: list[Chunk],
+    *,
+    indices: list[int],
+    min_turns: int = CHUNK_MIN_TURNS,
+    max_turns: int = CHUNK_MAX_TURNS,
+) -> list[Chunk]:
+    """Force ``chunks`` into the size band. Pure, deterministic, total.
+
+    Merging runs before splitting: a merge can push a chunk over the ceiling,
+    while an even split can never drop a part under the floor, so this order
+    needs one pass each. A single undersized chunk (a short session) has no
+    neighbour to merge into and survives as it is.
+    """
+    positions = {idx: pos for pos, idx in enumerate(indices)}
+    spans = [(positions[c.from_turn], positions[c.to_turn] + 1) for c in chunks]
+
+    merged: list[tuple[int, int]] = []
+    for lo, hi in spans:
+        if merged and hi - lo < min_turns:
+            merged[-1] = (merged[-1][0], hi)
+        else:
+            merged.append((lo, hi))
+    # An undersized leading chunk has no predecessor: fold it forward instead.
+    if len(merged) > 1 and merged[0][1] - merged[0][0] < min_turns:
+        merged[1] = (merged[0][0], merged[1][1])
+        merged.pop(0)
+
+    out: list[Chunk] = []
+    for lo, hi in merged:
+        for split_lo, split_hi in _even_split(lo, hi, max_turns):
+            out.append(Chunk(indices[split_lo], indices[split_hi - 1]))
+    return out
+
+
+def _even_split(lo: int, hi: int, max_turns: int) -> list[tuple[int, int]]:
+    """Cut ``[lo, hi)`` into the fewest parts that fit ``max_turns``, evenly.
+
+    Even parts rather than max-size ones plus a remainder: the remainder is
+    the shape that produces a stub last chunk (41 turns -> 40 + 1).
+    """
+    size = hi - lo
+    if size <= max_turns:
+        return [(lo, hi)]
+    parts = -(-size // max_turns)  # ceil
+    base, extra = divmod(size, parts)
+    out: list[tuple[int, int]] = []
+    start = lo
+    for i in range(parts):
+        end = start + base + (1 if i < extra else 0)
+        out.append((start, end))
+        start = end
+    return out
+
+
+def _fixed_windows(indices: list[int]) -> list[Chunk]:
+    """The fallback: cut the slice into fixed-size windows of turns."""
+    return [
+        Chunk(window[0], window[-1])
+        for window in (
+            indices[i : i + FALLBACK_WINDOW_TURNS]
+            for i in range(0, len(indices), FALLBACK_WINDOW_TURNS)
+        )
+    ]
+
+
+def _chunks_from_boundaries(indices: list[int], boundaries: list[int]) -> list[Chunk]:
+    """Cut ``indices`` at every boundary; full coverage is structural."""
+    cuts = [0] + [indices.index(b) for b in boundaries] + [len(indices)]
+    return [
+        Chunk(indices[lo], indices[hi - 1])
+        for lo, hi in zip(cuts, cuts[1:], strict=False)
+        if hi > lo
+    ]
+
+
+def _extract_boundaries(resp: Any) -> list[Any] | None:
+    """The `boundaries` array as the model sent it; ``None`` when malformed.
+
+    Values are NOT coerced or filtered here — the lint judges them, so a
+    model that answers with words instead of indices earns its corrective
+    retry instead of having its output quietly reinterpreted. Every other
+    key in the payload is ignored: indices are the only output surface.
+    """
+    for block in getattr(resp, "content", []) or []:
+        if getattr(block, "type", None) == "tool_use":
+            inp = getattr(block, "input", None)
+            if isinstance(inp, dict) and isinstance(inp.get("boundaries"), list):
+                return list(inp["boundaries"])
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Collapsed view
+# ---------------------------------------------------------------------------
+
+# Enough of a turn to recognise the beat it belongs to, not enough for one
+# pasted file to dominate the view (or the segmentation model's context).
+_TURN_MAX_CHARS = 400
+
+
+def collapsed_view(turns: list[Turn]) -> str:
+    """The cheap, low-token rendering of a session the segmenter reads.
+
+    Thinking is dropped (deliberation is not a beat of the work), tool calls
+    are named without their payload (a Write's `content` is the file, not a
+    topic signal), and tool results are folded to a line count. What remains
+    is the conversational spine — which is where topic shifts actually show.
+    Turn indices are preserved verbatim: they are the only thing the model
+    gives back.
+    """
+    lines: list[str] = []
+    for t in turns:
+        rendered = _collapse_turn(t)
+        if rendered:
+            lines.append(f"[{t.role}@{t.index}] {rendered}")
+    return "\n".join(lines)
+
+
+def _collapse_turn(turn: Turn) -> str:
+    if turn.tool_call is not None:
+        return f"<tool: {turn.tool_call.name}>"
+    if turn.tool_result is not None:
+        n = len((turn.tool_result.output or "").splitlines())
+        flag = "error, " if turn.tool_result.is_error else ""
+        return f"<result: {flag}{n} line{'' if n == 1 else 's'}>"
+    text = (turn.text or "").strip()
+    if not text:
+        return ""  # thinking-only turns land here and are dropped
+    if len(text) > _TURN_MAX_CHARS:
+        dropped = len(text[_TURN_MAX_CHARS:].splitlines())
+        text = text[:_TURN_MAX_CHARS].rstrip() + f"… (+{dropped} more lines)"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Prompt + tool schema
+# ---------------------------------------------------------------------------
+
+
+def _build_prompt(turns: list[Turn], *, retry_feedback: str = "") -> str:
+    parts: list[str] = []
+    if retry_feedback:
+        parts.extend(
+            [
+                "The previous attempt was rejected.",
+                retry_feedback,
+                "Return the boundaries again, corrected.",
+                "",
+            ]
+        )
+    first, last = turns[0].index, turns[-1].index
+    parts.extend(
+        [
+            "Split this work session into its logical chunks — the beats of "
+            "the work itself. A new chunk begins where the session turns to a "
+            "different problem, artefact, or goal: a new task the user asks "
+            "for, a pivot after something failed, a move from one file or "
+            "system to another. Continuing the same problem — debugging it, "
+            "reviewing it, discussing it — is the SAME chunk.",
+            "",
+            "Return ONLY the turn indices at which a new chunk begins, "
+            "strictly increasing. Nothing else: no titles, no summaries, no "
+            "labels. Do not list the first turn — it always opens the first "
+            f"chunk. Every index must be between {first + 1} and {last}. If "
+            "the whole session is one continuous beat, return an empty list.",
+            "",
+            "SESSION (each line is [role@turn]; thinking is omitted, tool "
+            "results are folded to line counts):",
+            "<<<SESSION BEGIN>>>",
+            collapsed_view(turns),
+            "<<<SESSION END>>>",
+            "",
+            f"Call the `{_TOOL_NAME}` tool exactly once.",
+        ]
+    )
+    return "\n".join(parts)
+
+
+def segment_tool_schema() -> dict[str, Any]:
+    """Tool schema for the segmentation call — integers, nothing else."""
+    return {
+        "name": _TOOL_NAME,
+        "description": (
+            "Emit the turn indices at which a new logical chunk of the "
+            "session begins. Indices only — no text of any kind."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "boundaries": {
+                    "type": "array",
+                    "description": (
+                        "Turn indices where a new chunk starts, strictly "
+                        "increasing. The first turn always starts chunk 1 "
+                        "and must not be listed."
+                    ),
+                    "items": {"type": "integer"},
+                }
+            },
+            "additionalProperties": False,
+            "required": ["boundaries"],
+        },
+    }

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,510 @@
+"""Beat-aligned session segmentation — stub-LLM replay contract tests.
+
+Every LLM interaction is faked. The segmenter's whole model-output surface
+is a list of turn indices, so these tests assert boundary handling: lints,
+the single corrective retry, the size band, windowed stitching, and the
+fixed-window fallback. No prose ever crosses the boundary, and nothing here
+judges model quality.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from lore_core.types import ToolCall, ToolResult, Turn
+from lore_curator.chunker import (
+    CHUNK_MAX_TURNS,
+    CHUNK_MIN_TURNS,
+    FALLBACK_WINDOW_TURNS,
+    SEGMENT_MAX_ATTEMPTS,
+    SEGMENT_MAX_VIEW_CHARS,
+    Chunk,
+    boundary_lint,
+    collapsed_view,
+    normalize_chunks,
+    segment_session,
+    segment_tool_schema,
+)
+
+# ---------------------------------------------------------------------------
+# Stub LLM (records call kwargs, replays queued tool_use payloads)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBlock:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.type = "tool_use"
+        self.input = payload
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any], model: str = "test-model") -> None:
+        self.content = [_FakeBlock(payload)]
+        self.model = model
+
+
+class _RecordingMessages:
+    """Queue of payloads; ``None`` in the queue simulates a raising call."""
+
+    def __init__(self, payloads: list[dict[str, Any] | None]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> _FakeResponse:
+        self.calls.append(kwargs)
+        payload = self._payloads.pop(0) if self._payloads else {}
+        if payload is None:
+            raise RuntimeError("simulated LLM failure")
+        return _FakeResponse(payload)
+
+
+class _FakeClient:
+    def __init__(self, payloads: list[dict[str, Any] | None]) -> None:
+        self.messages = _RecordingMessages(payloads)
+
+
+def _prompt_text(call: dict[str, Any]) -> str:
+    return call["messages"][0]["content"]
+
+
+def _turns(count: int, *, start: int = 0) -> list[Turn]:
+    """A plain text-turn transcript, alternating roles."""
+    return [
+        Turn(
+            index=i,
+            timestamp=datetime.now(UTC),
+            role="user" if i % 2 == 0 else "assistant",
+            text=f"turn {i} text",
+        )
+        for i in range(start, start + count)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Segmentation (the beat-aligned happy path)
+# ---------------------------------------------------------------------------
+
+
+def test_segments_at_the_boundaries_the_model_proposes():
+    turns = _turns(30)
+    client = _FakeClient([{"boundaries": [10, 20]}])
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert chunks == [Chunk(0, 9), Chunk(10, 19), Chunk(20, 29)]
+    assert len(client.messages.calls) == 1
+
+
+def _topic_shift_transcript() -> list[Turn]:
+    """A replayed session with three unmistakable beats.
+
+    Beat 1 (@0-@7) chases a token-refresh bug, beat 2 (@8-@15) switches to
+    the deploy docs, beat 3 (@16-@23) to a flaky CI job. The shift turns are
+    @8 and @16 — the two the segmenter should propose.
+    """
+    beats = [
+        [
+            "the refresh token expires an hour early in staging",
+            "reading the token issuer",
+            "the clock skew allowance is subtracted twice",
+            "confirming against the staging logs",
+            "yes — both the issuer and the validator subtract it",
+            "dropping the subtraction in the validator",
+            "tests pass",
+            "committed as 4f2ab1c",
+        ],
+        [
+            "different thing now: the deploy doc is out of date",
+            "reading docs/deploy.md",
+            "it still names the old bastion host",
+            "and the secret is described as env-only",
+            "rewriting both sections",
+            "also adding the trust-boundary note we discussed",
+            "docs read cleanly now",
+            "pushed to the docs branch",
+        ],
+        [
+            "last thing — the nightly CI job is flaky",
+            "pulling the last ten runs",
+            "it only fails when the fixture DB is seeded in parallel",
+            "so it is a real race, not infrastructure",
+            "serialising the seed step",
+            "ten green runs in a row",
+            "opened PR #61 with the fix",
+            "that closes it",
+        ],
+    ]
+    flat = [line for beat in beats for line in beat]
+    return [
+        Turn(
+            index=i,
+            timestamp=datetime.now(UTC),
+            role="user" if i % 2 == 0 else "assistant",
+            text=line,
+        )
+        for i, line in enumerate(flat)
+    ]
+
+
+def test_beat_aligned_bounds_for_a_topic_shifting_transcript():
+    turns = _topic_shift_transcript()
+    client = _FakeClient([{"boundaries": [8, 16]}])
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert chunks == [Chunk(0, 7), Chunk(8, 15), Chunk(16, 23)]
+    # The shift turns are visible to the model — it can only propose what it sees.
+    prompt = _prompt_text(client.messages.calls[0])
+    assert "[user@8] different thing now: the deploy doc is out of date" in prompt
+    assert "[user@16] last thing — the nightly CI job is flaky" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Boundary lint (deterministic, no LLM)
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_lint_accepts_in_range_monotone_indices():
+    assert boundary_lint([10, 20], indices=list(range(30))) == ""
+
+
+def test_boundary_lint_rejects_non_monotone_indices():
+    assert "increasing" in boundary_lint([20, 10], indices=list(range(30)))
+
+
+def test_boundary_lint_rejects_repeated_indices():
+    assert "increasing" in boundary_lint([10, 10], indices=list(range(30)))
+
+
+def test_boundary_lint_rejects_out_of_range_indices():
+    assert "range" in boundary_lint([10, 99], indices=list(range(30)))
+
+
+def test_boundary_lint_rejects_the_first_turn_as_a_boundary():
+    # The first turn always opens chunk 1; listing it would cut an empty chunk.
+    assert boundary_lint([0, 10], indices=list(range(30))) != ""
+
+
+def test_dirty_boundaries_earn_one_corrective_retry():
+    turns = _turns(30)
+    client = _FakeClient([{"boundaries": [20, 10]}, {"boundaries": [12, 24]}])
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert chunks == [Chunk(0, 11), Chunk(12, 23), Chunk(24, 29)]
+    assert len(client.messages.calls) == 2
+    retry_prompt = _prompt_text(client.messages.calls[1])
+    assert "increasing" in retry_prompt
+
+
+# ---------------------------------------------------------------------------
+# Fallback: the pipeline never blocks on segmentation quality
+# ---------------------------------------------------------------------------
+
+
+def test_two_dirty_attempts_fall_back_to_fixed_windows():
+    turns = _turns(70)
+    client = _FakeClient([{"boundaries": [99]}, {"boundaries": [40, 5]}])
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert len(client.messages.calls) == SEGMENT_MAX_ATTEMPTS
+    assert chunks == [Chunk(0, 29), Chunk(30, 59), Chunk(60, 69)]
+    assert FALLBACK_WINDOW_TURNS == 30
+
+
+def test_model_failure_yields_fixed_windows_and_never_raises():
+    turns = _turns(70)
+    client = _FakeClient([None, None])
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert chunks == [Chunk(0, 29), Chunk(30, 59), Chunk(60, 69)]
+
+
+def test_malformed_payload_yields_fixed_windows():
+    # No boundaries key at all, then prose where indices belong.
+    turns = _turns(70)
+    client = _FakeClient([{"chunks": "one, two"}, {"boundaries": ["ten", "twenty"]}])
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert chunks == [Chunk(0, 29), Chunk(30, 59), Chunk(60, 69)]
+
+
+def test_a_short_session_is_one_chunk():
+    turns = _turns(4)
+    client = _FakeClient([None])
+
+    assert segment_session(turns=turns, llm_client=client, model="m") == [Chunk(0, 3)]
+
+
+def test_no_turns_yields_no_chunks_and_no_llm_call():
+    client = _FakeClient([])
+
+    assert segment_session(turns=[], llm_client=client, model="m") == []
+    assert client.messages.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Size band (deterministic, no LLM)
+# ---------------------------------------------------------------------------
+
+
+def _sizes(chunks: list[Chunk]) -> list[int]:
+    return [c.to_turn - c.from_turn + 1 for c in chunks]
+
+
+def test_undersized_chunk_merges_into_its_predecessor():
+    indices = list(range(30))
+    chunks = [Chunk(0, 9), Chunk(10, 11), Chunk(12, 29)]  # middle chunk: 2 turns
+
+    assert normalize_chunks(chunks, indices=indices) == [Chunk(0, 11), Chunk(12, 29)]
+
+
+def test_undersized_leading_chunk_merges_into_its_successor():
+    indices = list(range(30))
+    chunks = [Chunk(0, 1), Chunk(2, 15), Chunk(16, 29)]
+
+    assert normalize_chunks(chunks, indices=indices) == [Chunk(0, 15), Chunk(16, 29)]
+
+
+def test_a_lone_undersized_chunk_survives():
+    # A four-turn session is still a session; there is nothing to merge into.
+    assert normalize_chunks([Chunk(0, 3)], indices=list(range(4))) == [Chunk(0, 3)]
+
+
+def test_oversized_chunk_splits_into_even_parts():
+    indices = list(range(100))
+
+    chunks = normalize_chunks([Chunk(0, 99)], indices=indices)
+
+    # 100 turns / 40-turn ceiling -> three parts, as even as they divide.
+    assert _sizes(chunks) == [34, 33, 33]
+    assert chunks == [Chunk(0, 33), Chunk(34, 66), Chunk(67, 99)]
+    assert all(size <= CHUNK_MAX_TURNS for size in _sizes(chunks))
+
+
+def test_normalization_is_deterministic():
+    indices = list(range(100))
+    dirty = [Chunk(0, 2), Chunk(3, 88), Chunk(89, 99)]
+
+    first = normalize_chunks(dirty, indices=indices)
+    second = normalize_chunks(dirty, indices=indices)
+
+    assert first == second
+    assert all(CHUNK_MIN_TURNS <= size <= CHUNK_MAX_TURNS for size in _sizes(first))
+
+
+def test_the_band_is_enforced_on_model_boundaries():
+    turns = _turns(60)
+    # Model proposes a 2-turn beat and a 56-turn monster.
+    client = _FakeClient([{"boundaries": [2, 4]}])
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert chunks[0].from_turn == 0
+    assert chunks[-1].to_turn == 59
+    assert all(size <= CHUNK_MAX_TURNS for size in _sizes(chunks))
+    assert all(size >= CHUNK_MIN_TURNS for size in _sizes(chunks))
+
+
+# ---------------------------------------------------------------------------
+# Collapsed view (what the model actually reads)
+# ---------------------------------------------------------------------------
+
+
+def _turn(index: int, **kw: Any) -> Turn:
+    kw.setdefault("role", "assistant")
+    return Turn(index=index, timestamp=datetime.now(UTC), **kw)
+
+
+def test_collapsed_view_drops_thinking():
+    turns = [
+        _turn(0, role="user", text="segment this"),
+        _turn(1, reasoning="the user probably wants X, but maybe Y, let me weigh…"),
+        _turn(2, text="done"),
+    ]
+
+    view = collapsed_view(turns)
+
+    assert "weigh" not in view
+    assert "@1" not in view
+    assert "[user@0] segment this" in view
+    assert "[assistant@2] done" in view
+
+
+def test_collapsed_view_folds_tool_results_to_line_counts():
+    turns = [
+        _turn(0, role="user", text="run the tests"),
+        _turn(
+            1,
+            role="tool_result",
+            tool_result=ToolResult(
+                tool_call_id="t1", output="\n".join(f"line {i}" for i in range(12))
+            ),
+        ),
+    ]
+
+    view = collapsed_view(turns)
+
+    assert "12 lines" in view
+    assert "line 7" not in view
+
+
+def test_collapsed_view_names_tool_calls_without_their_payload():
+    turns = [
+        _turn(
+            0,
+            tool_call=ToolCall(name="Write", input={"content": "SECRET PAYLOAD BODY"}, id="t1"),
+        )
+    ]
+
+    view = collapsed_view(turns)
+
+    assert "Write" in view
+    assert "SECRET PAYLOAD BODY" not in view
+
+
+def test_collapsed_view_truncates_a_long_pasted_turn():
+    turns = [_turn(0, role="user", text="x" * 5000)]
+
+    view = collapsed_view(turns)
+
+    assert len(view) < 1000
+
+
+def test_the_prompt_carries_the_collapsed_view_not_the_raw_turns():
+    turns = [
+        _turn(0, role="user", text="start"),
+        _turn(1, reasoning="private deliberation"),
+        *_turns(10, start=2),
+    ]
+    client = _FakeClient([{"boundaries": []}])
+
+    segment_session(turns=turns, llm_client=client, model="m")
+
+    prompt = _prompt_text(client.messages.calls[0])
+    assert "private deliberation" not in prompt
+    assert "[user@0] start" in prompt
+
+
+# ---------------------------------------------------------------------------
+# The output surface is integers, and nothing else
+# ---------------------------------------------------------------------------
+
+
+def test_tool_schema_accepts_integers_only():
+    schema = segment_tool_schema()
+    props = schema["input_schema"]["properties"]
+
+    assert list(props) == ["boundaries"]
+    assert props["boundaries"]["items"] == {"type": "integer"}
+    assert schema["input_schema"]["additionalProperties"] is False
+
+
+def test_prose_alongside_the_indices_is_never_consumed():
+    turns = _turns(30)
+    client = _FakeClient(
+        [
+            {
+                "boundaries": [10, 20],
+                "summary": "The session refactored the widget and shipped it.",
+                "titles": ["Refactor", "Ship"],
+            }
+        ]
+    )
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert chunks == [Chunk(0, 9), Chunk(10, 19), Chunk(20, 29)]
+    # Chunks carry turn indices — there is nowhere for the prose to go.
+    assert all(isinstance(v, int) for c in chunks for v in (c.from_turn, c.to_turn))
+
+
+# ---------------------------------------------------------------------------
+# Windowed segmentation (a collapsed view too big for one call)
+# ---------------------------------------------------------------------------
+
+
+def _fat_turns(count: int) -> list[Turn]:
+    """Turns whose collapsed view overflows one segmentation call."""
+    return [
+        Turn(
+            index=i,
+            timestamp=datetime.now(UTC),
+            role="user" if i % 2 == 0 else "assistant",
+            text=f"turn {i} " + "padding " * 200,
+        )
+        for i in range(count)
+    ]
+
+
+def _covers(chunks: list[Chunk], indices: list[int]) -> bool:
+    """Chunks tile the slice exactly: no gap, no overlap, no reorder."""
+    if not chunks:
+        return not indices
+    if chunks[0].from_turn != indices[0] or chunks[-1].to_turn != indices[-1]:
+        return False
+    return all(b.from_turn == a.to_turn + 1 for a, b in zip(chunks, chunks[1:], strict=False))
+
+
+def test_an_oversized_view_is_segmented_in_windows_and_stitched():
+    turns = _fat_turns(120)
+    assert len(collapsed_view(turns)) > SEGMENT_MAX_VIEW_CHARS
+
+    # One payload per window; boundaries are relative to nothing — they are
+    # absolute turn indices, and each window only ever sees its own.
+    client = _FakeClient([{"boundaries": [30]}, {"boundaries": [90]}, {"boundaries": []}])
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert len(client.messages.calls) > 1
+    assert _covers(chunks, [t.index for t in turns])
+    assert all(size <= CHUNK_MAX_TURNS for size in _sizes(chunks))
+    # The model's beats survive stitching: 30 and 90 still open chunks.
+    starts = {c.from_turn for c in chunks}
+    assert {30, 90} <= starts
+
+
+def test_each_window_only_sees_its_own_turns():
+    turns = _fat_turns(120)
+    client = _FakeClient([{"boundaries": []}, {"boundaries": []}, {"boundaries": []}])
+
+    segment_session(turns=turns, llm_client=client, model="m")
+
+    prompts = [_prompt_text(c) for c in client.messages.calls]
+    assert "[user@0]" in prompts[0]
+    assert "[user@0]" not in prompts[1]
+    assert all(len(p) < SEGMENT_MAX_VIEW_CHARS * 2 for p in prompts)
+
+
+def test_the_fallback_reports_itself():
+    # A silent degrade is an invisible quality regression: the close path's
+    # logger must see that these chunks are windows, not beats.
+    class _Logger:
+        def __init__(self) -> None:
+            self.events: list[tuple[str, dict[str, Any]]] = []
+
+        def emit(self, event: str, **fields: Any) -> None:
+            self.events.append((event, fields))
+
+    logger = _Logger()
+    client = _FakeClient([None, None])
+
+    segment_session(turns=_turns(70), llm_client=client, model="m", logger=logger)
+
+    assert any(event == "warning" for event, _ in logger.events)
+    assert any(f.get("call") == "segment-session" for _, f in logger.events)
+
+
+def test_a_failed_window_falls_back_without_losing_the_others():
+    turns = _fat_turns(120)
+    # First window: two failed attempts. Later windows answer cleanly.
+    client = _FakeClient([None, None, {"boundaries": [90]}, {"boundaries": []}])
+
+    chunks = segment_session(turns=turns, llm_client=client, model="m")
+
+    assert _covers(chunks, [t.index for t in turns])
+    assert 90 in {c.from_turn for c in chunks}


### PR DESCRIPTION
Closes #283. Part of the epic in #282; targets `epic/282`.

## What this is

The first link in the typed-fact chain: a session-end pass that turns replayed turns into
**beat-aligned logical chunks**. A cheap model call reads a *collapsed* view of the session and
returns **turn indices only** — its entire output surface is a list of integers. Deterministic code
owns everything else. Nothing downstream can consume prose from this step, because none crosses the
boundary.

New module `lib/lore_curator/chunker.py`, new suite `tests/test_chunker.py`. Nothing else is touched:
the flush lifecycle is unchanged, and `segment_session` is wired in by #284 when extraction exists.

**Public surface:** `segment_session(turns=, llm_client=, model=, logger=, transcript_id=) -> list[Chunk]`,
plus the deterministic pieces it composes — `collapsed_view`, `boundary_lint`, `normalize_chunks`,
`segment_tool_schema`.

## Planning decisions (TDD gates, resolved autonomously)

- **Boundaries, not spans.** The model returns the turn indices at which a new chunk *begins*, never
  `(from, to)` pairs. Chunks are then cut from the slice itself, which makes **full coverage
  structural** — there is no coverage lint to fail, and no way to emit a gap or an overlap. The
  cheapest lint is the one you delete.
- **Size band: `CHUNK_MIN_TURNS = 6`, `CHUNK_MAX_TURNS = 40`.** A chunk is one extraction call
  downstream, so the floor is "worth its cost" (a two-turn beat is not) and the ceiling is "fits a
  small model" (a 90-turn one does not). `MAX >= 2*MIN` is load-bearing: it means an even split can
  never land a part back under the floor.
- **Merge before split.** A merge can push a chunk over the ceiling; an even split can never drop a
  part under the floor. In that order each needs exactly one pass.
- **Oversized chunks split into even parts, not max-size ones plus a remainder** — the remainder is
  precisely the shape that produces a stub last chunk (41 turns → 40 + 1).
- **Fallback window: 30 turns**, sized *inside* the band so the normalizer leaves it alone.
- **Windowing budget: 24k chars of collapsed view**, deliberately far under the model's context: a
  local backend can silently return nothing on an oversized prompt, which would be indistinguishable
  from a segmentation failure.
- **Stitching:** each window is segmented independently and its chunks concatenated — a window seam
  is itself a boundary, so no chunk spans two windows. The size band then runs over the *whole*
  stitched list, which is what merges a stub chunk at a seam away into one coherent list. A window
  whose model call fails degrades to fixed windows **on its own**, without discarding the boundaries
  the other windows produced.
- **Malformed output is linted, never coerced.** `"boundaries": ["ten", "twenty"]` earns its
  corrective retry instead of being quietly filtered to `[]` — which would otherwise masquerade as
  the legitimate "this session is one beat" answer.
- **The fallback logs.** A silent degrade is an invisible quality regression, so the optional
  `RunLogger` (the same seam `compose_chapter` takes) gets a warning naming the span that fell back.

Deliberately *not* built: config plumbing for the band (no curator section exists in
`config_schema.py`; module constants with kwarg overrides carry it until a caller needs more),
and any wiring into `chapter_flush` (that is #284's, once there is something to extract).

## Red → green evidence

Strict TDD, vertical slices — one test, one implementation, repeat. Each cycle's red is the failure
that drove the next commit of code.

**Cycle 1 — tracer bullet (`segment_session` returns the model's chunk bounds):**
```
tests/test_chunker.py:16: in <module>
    from lore_curator.chunker import (
E   ModuleNotFoundError: No module named 'lore_curator.chunker'
1 error in 0.35s
```
→ green: `1 passed`

**Cycle 2 — boundary lint + one corrective retry:**
```
E   ImportError: cannot import name 'boundary_lint' from 'lore_curator.chunker'
1 error in 0.37s
```
→ green: `7 passed`

**Cycle 3 — fixed-window fallback (dirty retry, raising client, malformed payload):**
```
E   ImportError: cannot import name 'FALLBACK_WINDOW_TURNS' from 'lore_curator.chunker'
```
Then, mid-cycle, the malformed-payload test caught a real design bug — the parser was silently
filtering `["ten", "twenty"]` down to `[]`, which passed the lint as "one beat" instead of falling
back. Moved the type check into the lint.
→ green: `12 passed`

**Cycle 4 — size band (`CHUNK_MIN_TURNS` / `CHUNK_MAX_TURNS` / `normalize_chunks`):**
```
E   ImportError: cannot import name 'CHUNK_MAX_TURNS' from 'lore_curator.chunker'
```
→ green: `18 passed`

**Cycle 5 — collapsed view (`collapsed_view`) + the real segmentation prompt:**
```
E   ImportError: cannot import name 'collapsed_view' from 'lore_curator.chunker'
```
→ green: `25 passed`

**Cycle 6 — windowed segmentation + stitching (`SEGMENT_MAX_VIEW_CHARS`):**
```
E   ImportError: cannot import name 'SEGMENT_MAX_VIEW_CHARS' from 'lore_curator.chunker'
```
→ green: `28 passed`

**Refactor — the fallback reports itself:**
```
FAILED tests/test_chunker.py::test_the_fallback_reports_itself
  - TypeError: segment_session() got an unexpected keyword argument 'logger'
1 failed, 29 deselected in 0.30s
```
→ green: `30 passed`

## Acceptance criteria → test

| AC | Test |
|----|------|
| Beat-aligned bounds on a replay fixture with clear topic shifts | `test_beat_aligned_bounds_for_a_topic_shifting_transcript` (three-beat transcript: token bug → deploy docs → flaky CI; asserts the shift turns are visible in the prompt, so the model can only propose what it sees) |
| Lint rejects non-monotone / out-of-range, one corrective retry, then fallback | `test_boundary_lint_rejects_*` (5), `test_dirty_boundaries_earn_one_corrective_retry`, `test_two_dirty_attempts_fall_back_to_fixed_windows` |
| Size band: tiny merged, oversized split deterministically | `test_undersized_chunk_merges_into_its_predecessor`, `test_undersized_leading_chunk_merges_into_its_successor`, `test_a_lone_undersized_chunk_survives`, `test_oversized_chunk_splits_into_even_parts`, `test_normalization_is_deterministic`, `test_the_band_is_enforced_on_model_boundaries` |
| Windowed segmentation stitches to one coherent boundary list | `test_an_oversized_view_is_segmented_in_windows_and_stitched`, `test_each_window_only_sees_its_own_turns`, `test_a_failed_window_falls_back_without_losing_the_others` |
| Model failure yields fixed-size windows, no exception escapes | `test_model_failure_yields_fixed_windows_and_never_raises`, `test_malformed_payload_yields_fixed_windows`, `test_the_fallback_reports_itself` |
| No LLM output other than indices is consumed downstream | `test_tool_schema_accepts_integers_only` (schema declares one `integer` array, `additionalProperties: false`), `test_prose_alongside_the_indices_is_never_consumed` (a payload carrying `summary` + `titles` yields the same chunks; `Chunk` has nowhere to put prose), `test_collapsed_view_drops_thinking`, `test_collapsed_view_names_tool_calls_without_their_payload` |

## Verification

- `tests/test_chunker.py`: **30 passed**.
- Full suite: **2734 passed, 16 skipped, 4 failed** — the 4 failures are in `test_core_llm_wiring.py`
  and `test_install_dispatcher.py` and reproduce identically on the base checkout without this branch
  (environment-dependent string assertions), so they are pre-existing and untouched by this diff,
  which adds only two new files.
- `ruff check` and `ruff format --check` clean on both new files.
