### PR TITLE
Typed-fact extraction per chunk: kind/thread/refs schema, lints, fact-table threading, headline call (#284)

### DIFF
--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -24,7 +24,9 @@ seams here.
 
 from __future__ import annotations
 
+import json
 import os
+import re
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
@@ -43,17 +45,25 @@ __all__ = [
     "NoteClosedError",
     "TopicBlock",
     "Chapter",
+    "Ref",
+    "Fact",
+    "FACT_KINDS",
+    "REF_TYPES",
     "SessionFacts",
     "Linkage",
     "NoteView",
     "create_note",
     "append_chapter",
+    "append_facts",
     "append_marker_chapter",
     "close_note",
     "reopen_note",
     "is_closed",
     "read_note",
+    "read_facts",
+    "parse_facts",
     "render_chapter_body",
+    "render_fact_body",
 ]
 
 
@@ -116,6 +126,48 @@ class Chapter:
     blocks: list[TopicBlock] = field(default_factory=list)
 
 
+# The fact vocabulary. `progress` is en route, `done` is a terminal state
+# (a commit, a merged PR, a verified-green run), `decision` carries a
+# mandatory ``why``, `finding` is something learned, `open` is unresolved.
+FACT_KINDS = ("progress", "done", "decision", "finding", "open")
+
+# Ref types a fact may carry. Each is verifiable by code downstream —
+# which is what lets a rendered line earn authoritative phrasing.
+REF_TYPES = ("pr", "commit", "file", "tag", "issue")
+
+
+@dataclass(frozen=True)
+class Ref:
+    """A structured pointer from a fact to something checkable."""
+
+    type: str
+    value: str
+
+
+@dataclass
+class Fact:
+    """One extracted fact — the unit of the typed ledger.
+
+    ``kind`` is one of :data:`FACT_KINDS`; ``thread`` (optional) keys facts
+    of one line of work together across chunks; ``refs`` are the checkable
+    pointers; ``why`` is mandatory for a ``decision``; ``anchor_turn`` is
+    the single transcript turn the fact came from. ``quote`` is a verbatim
+    excerpt of that turn, code-attached from the transcript and never
+    model-authored.
+
+    The fields carry no phrasing that asserts authority — rendering owns
+    that, keyed on what code could verify.
+    """
+
+    kind: str
+    text: str
+    anchor_turn: int = 0
+    thread: str = ""
+    refs: list[Ref] = field(default_factory=list)
+    why: str = ""
+    quote: str = ""
+
+
 @dataclass
 class SessionFacts:
     """Deterministic session facts stored in frontmatter only.
@@ -163,6 +215,91 @@ def _render_block(block: TopicBlock) -> str:
     if block.anchor_turn:
         parts.append(f"@{int(block.anchor_turn)}")
     return "\n\n".join(parts)
+
+
+_FACT_MARKER_RE = re.compile(r"<!--\s*lore:fact\s+(\{.*?\})\s*-->", re.DOTALL)
+
+
+def _fact_marker(fact: Fact) -> str:
+    """The machine-readable copy of a fact, as an HTML-comment marker.
+
+    Sorted keys and dropped empty fields keep the marker byte-stable for a
+    given fact, so a re-render of the same ledger produces the same file.
+    ``-->`` inside any string would close the comment early, so it is
+    written as its JSON escape — ``json.loads`` restores it verbatim.
+    """
+    payload: dict[str, Any] = {
+        "kind": fact.kind,
+        "text": fact.text,
+        "anchor": int(fact.anchor_turn),
+    }
+    if fact.thread:
+        payload["thread"] = fact.thread
+    if fact.refs:
+        payload["refs"] = [{"type": r.type, "value": r.value} for r in fact.refs]
+    if fact.why:
+        payload["why"] = fact.why
+    if fact.quote:
+        payload["quote"] = fact.quote
+    dumped = json.dumps(payload, sort_keys=True, ensure_ascii=False).replace("-->", "--\\u003e")
+    return f"<!-- lore:fact {dumped} -->"
+
+
+def _render_fact(fact: Fact) -> str:
+    marker = _fact_marker(fact)
+    line = f"**{fact.text.strip()}**"
+    if fact.why.strip():
+        line = f"{line} Why: {fact.why.strip()}"
+    parts = [marker, line]
+    quote = fact.quote.strip()
+    if quote:
+        parts.append(f'> "{quote}"')
+    parts.append(f"@{int(fact.anchor_turn)}")
+    return "\n\n".join(parts)
+
+
+def render_fact_body(facts: list[Fact]) -> str:
+    """Render facts to the ledger text that lands in the note body.
+
+    The publish gate scans exactly this string — marker included — so a
+    secret cannot hide in the machine-readable copy of a fact.
+    """
+    return "\n\n".join(_render_fact(f) for f in facts)
+
+
+def parse_facts(body: str) -> list[Fact]:
+    """Read every typed fact back out of a note body.
+
+    Marker-driven: a note written before typed facts existed carries no
+    markers and yields no facts, which is how pre-existing notes keep
+    parsing. A marker whose payload is corrupt is skipped rather than
+    raising — one bad fact never costs a reader the rest of the ledger.
+    """
+    out: list[Fact] = []
+    for match in _FACT_MARKER_RE.finditer(body):
+        try:
+            data = json.loads(match.group(1))
+        except ValueError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        refs = [
+            Ref(str(r.get("type", "")), str(r.get("value", "")))
+            for r in data.get("refs") or []
+            if isinstance(r, dict)
+        ]
+        out.append(
+            Fact(
+                kind=str(data.get("kind", "")),
+                text=str(data.get("text", "")),
+                anchor_turn=int(data.get("anchor", 0)),
+                thread=str(data.get("thread", "")),
+                refs=refs,
+                why=str(data.get("why", "")),
+                quote=str(data.get("quote", "")),
+            )
+        )
+    return out
 
 
 def _chapter_delimiter(n: int, from_turn: int, to_turn: int, *, marker: str | None = None) -> str:
@@ -397,6 +534,51 @@ def append_chapter(
     return n
 
 
+def append_facts(
+    path: Path,
+    facts: list[Fact],
+    *,
+    slice_from_turn: int,
+    slice_to_turn: int,
+    session_facts: SessionFacts | None = None,
+    linkage: Linkage | None = None,
+    wiki_root: Path | None = None,
+) -> int:
+    """Append one chunk's typed facts to the ledger; record its turn span.
+
+    The ledger is append-only, exactly as chapters are: each call adds a
+    ``facts`` chapter carrying the extracted facts with their typed
+    markers. Returns the 1-based chapter number. Raises
+    :class:`NoteClosedError` if the note is closed.
+    """
+    fm, body = _load(path)
+    _guard_open(fm, path)
+
+    n = _next_chapter_n(fm)
+    delimiter = _chapter_delimiter(n, slice_from_turn, slice_to_turn)
+    rendered = render_fact_body(facts)
+    segment = f"{delimiter}\n\n{rendered}" if rendered else delimiter
+    new_body = f"{body.rstrip()}\n\n{segment}"
+
+    chapters = list(fm.get("chapters") or [])
+    chapters.append(
+        {
+            "n": n,
+            "kind": "facts",
+            "from_turn": int(slice_from_turn),
+            "to_turn": int(slice_to_turn),
+            "count": len(facts),
+        }
+    )
+    fm["chapters"] = chapters
+    _apply_facts(fm, session_facts)
+    _apply_linkage(fm, linkage)
+    fm["last_reviewed"] = _today()
+
+    _write(path, fm, new_body, wiki_root=wiki_root)
+    return n
+
+
 def append_marker_chapter(
     path: Path,
     *,
@@ -509,3 +691,9 @@ def read_note(path: Path) -> NoteView:
         chapters=list(fm.get("chapters") or []),
         closed=fm.get("note_status") == _CLOSED,
     )
+
+
+def read_facts(path: Path) -> list[Fact]:
+    """Every typed fact in the note's ledger, in file order."""
+    _, body = _load(path)
+    return parse_facts(body)

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -245,15 +245,30 @@ def _fact_marker(fact: Fact) -> str:
     return f"<!-- lore:fact {dumped} -->"
 
 
+def _neutralize_marker(text: str) -> str:
+    """Defuse a comment opener carried inside a fact's own content.
+
+    A fact's text, why, and quote come from the transcript — model output,
+    file contents, tool results — so any of them can carry a literal
+    ``<!-- lore:fact ...`` string the session never authored. Rendered raw
+    into the body, it parses back as an extra forged fact with an invented
+    ref and a self-authored quote, or (left unclosed) swallows the next
+    real fact up to its closer. Escaping the OPENER kills both: nothing but
+    a marker this module wrote can open one. The marker payload itself
+    needs no such treatment — it is JSON, where ``-->`` is already escaped.
+    """
+    return text.replace("<!--", "&lt;!--")
+
+
 def _render_fact(fact: Fact) -> str:
     marker = _fact_marker(fact)
-    line = f"**{fact.text.strip()}**"
+    line = f"**{_neutralize_marker(fact.text.strip())}**"
     if fact.why.strip():
-        line = f"{line} Why: {fact.why.strip()}"
+        line = f"{line} Why: {_neutralize_marker(fact.why.strip())}"
     parts = [marker, line]
     quote = fact.quote.strip()
     if quote:
-        parts.append(f'> "{quote}"')
+        parts.append(f'> "{_neutralize_marker(quote)}"')
     parts.append(f"@{int(fact.anchor_turn)}")
     return "\n\n".join(parts)
 

--- a/lib/lore_curator/fact_extract.py
+++ b/lib/lore_curator/fact_extract.py
@@ -1,0 +1,929 @@
+"""Typed-fact extraction — the only generative step in a session note.
+
+One first-generation LLM call per logical chunk (chunks come from the
+segmenter) reads the raw transcript turns of that chunk and returns TYPED
+FACTS: a ``kind``, an optional ``thread`` key, structured ``refs``, a
+short ``text``, a ``why`` (mandatory for decisions), and one ``@turn``
+anchor. That is the model's whole output surface. It never writes a
+quote — quotes are code-attached from the anchor turn — and it never
+writes the phrasing that carries authority in the rendered note; code
+downstream owns that, keyed on what it could verify.
+
+Calls run sequentially. Call *n* is handed the compact fact table from
+calls 1..n-1 for two purposes only: keeping a thread key continuous
+across chunks, and not restating what an earlier chunk already recorded.
+Facts must come from the transcript chunk, never from the table — no LLM
+ever re-reads LLM prose as source material. Two guards make that
+structural rather than hopeful: the anchor lint rejects any fact
+anchored outside the chunk (which every table entry is), and a
+deterministic dedup drops an echo that was re-anchored to slip past it.
+
+Bounded corrective retries mirror the chapter composer's contract:
+attempt one extracts, three deterministic lints (anchor in chunk, kind in
+enum, decision carries a why) and the injected publish gate judge the
+result, and any miss feeds corrective text into exactly one more attempt.
+
+After the final chunk, one bounded call writes a single headline sentence
+from the fact table — the only cross-chunk synthesis in the pipeline. A
+deterministic lint rejects a headline naming a ref or thread absent from
+the table, and a headline that cannot pass it is dropped rather than
+published.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from lore_core.note_document import FACT_KINDS, REF_TYPES, Fact, Ref, render_fact_body
+
+from lore_curator.chapter_compose import Gate, PassThroughGate
+from lore_curator.chunker import Chunk
+
+if TYPE_CHECKING:
+    from lore_core.run_log import RunLogger
+    from lore_core.types import Turn
+
+__all__ = [
+    "ExtractStatus",
+    "ExtractResult",
+    "SessionExtraction",
+    "chunk_view",
+    "compose_headline",
+    "decision_why_lint",
+    "extract_chunk",
+    "extract_session",
+    "fact_anchor_lint",
+    "fact_kind_lint",
+    "fact_table",
+    "fact_tool_schema",
+    "headline_lint",
+    "headline_tool_schema",
+    "EXTRACT_MAX_ATTEMPTS",
+    "EXTRACT_MAX_OUTPUT_TOKENS",
+    "HEADLINE_MAX_ATTEMPTS",
+]
+
+# Two attempts, exactly as the chapter composer: one corrective retry on a
+# deterministic miss, then the caller degrades instead of looping.
+EXTRACT_MAX_ATTEMPTS = 2
+EXTRACT_MAX_OUTPUT_TOKENS = 2000
+
+HEADLINE_MAX_ATTEMPTS = 2
+HEADLINE_MAX_OUTPUT_TOKENS = 300
+
+# Sentinel for a fact whose payload carried no usable turn index. It can
+# never satisfy the in-chunk lint (turn indices are >= 0), so a missing
+# anchor is treated exactly like an out-of-chunk one.
+_ANCHOR_MISSING = -1
+
+_QUOTE_MAX_CHARS = 240
+
+# Per-turn budget for the extraction view. Richer than the segmenter's,
+# because refs live inside tool payloads (a commit sha is in a Bash
+# result, a PR number in a `gh` call) — but still bounded, so one pasted
+# file cannot push the prompt past a local backend's capacity ceiling.
+# ponytail: per-turn clip only; the chunk size band already caps the turn
+# count. Add a whole-view budget if a backend starts truncating.
+_TURN_MAX_CHARS = 800
+
+_TOOL_NAME = "extract_facts"
+_HEADLINE_TOOL_NAME = "write_headline"
+
+_MALFORMED_FEEDBACK = (
+    "The previous response carried no `facts` array. Call the tool with "
+    "`facts` set to the typed facts of this chunk (an empty array if the "
+    "chunk holds nothing worth recording)."
+)
+
+
+class ExtractStatus(Enum):
+    EXTRACTED = "extracted"
+    EMPTY = "empty"  # the model answered "nothing worth recording"
+    WITHHELD = "withheld"
+    FAILED = "failed"
+
+
+@dataclass
+class ExtractResult:
+    """Terminal outcome of one chunk's extraction.
+
+    ``EXTRACTED`` carries the ``facts``. ``WITHHELD`` carries the gate's
+    verdict and the rendered ``withheld_text`` (for quarantine).
+    ``FAILED`` carries a ``failure_reason`` — the chunk becomes a coverage
+    gap in the note.
+    """
+
+    status: ExtractStatus
+    chunk: Chunk
+    facts: list[Fact] = field(default_factory=list)
+    attempts: int = 0
+    withheld_category: str = ""
+    withheld_feedback: str = ""
+    withheld_text: str = ""
+    failure_reason: str = ""
+
+
+@dataclass
+class SessionExtraction:
+    """Every fact of a session, its headline, and the per-chunk outcomes."""
+
+    facts: list[Fact] = field(default_factory=list)
+    headline: str = ""
+    results: list[ExtractResult] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Lints (deterministic)
+# ---------------------------------------------------------------------------
+
+
+def fact_anchor_lint(facts: list[Fact], *, from_turn: int, to_turn: int) -> list[tuple[int, int]]:
+    """Return ``(fact_index, anchor)`` for anchors outside the chunk.
+
+    A fact must come from the transcript chunk it was extracted from, and
+    its anchor is the proof: an anchor outside ``[from_turn, to_turn]``
+    means the fact was not read from these turns — which is exactly the
+    shape of a fact copied out of the prior-chunk table. A missing anchor
+    (sentinel ``-1``) fails the same way.
+    """
+    lo, hi = min(from_turn, to_turn), max(from_turn, to_turn)
+    return [(i, f.anchor_turn) for i, f in enumerate(facts) if not lo <= f.anchor_turn <= hi]
+
+
+def fact_kind_lint(facts: list[Fact]) -> list[tuple[int, str]]:
+    """Return ``(fact_index, kind)`` for kinds outside the enum."""
+    return [(i, f.kind) for i, f in enumerate(facts) if f.kind not in FACT_KINDS]
+
+
+def decision_why_lint(facts: list[Fact]) -> list[int]:
+    """Return the indices of ``decision`` facts carrying no ``why``.
+
+    A decision without its reason is the most poison-prone line in a note:
+    later sessions read it as settled and cannot check the reasoning. It
+    is the one field the model must not omit.
+    """
+    return [i for i, f in enumerate(facts) if f.kind == "decision" and not f.why.strip()]
+
+
+# A headline may only name what the fact table licensed. Checked token
+# shapes: `#123` refs, commit-shaped hex, `backticked` spans, and
+# path-shaped tokens — the forms that carry authority and can be
+# hallucinated. ponytail: plain unquoted prose is not checked; a headline
+# naming a thread in bare words slips through. Tighten only if it happens.
+_HEADLINE_TOKENS = (
+    re.compile(r"#\d+"),
+    re.compile(r"`[^`]+`"),
+    re.compile(r"\b[0-9a-f]{7,40}\b"),
+    re.compile(r"\S*/\S*"),
+)
+
+
+def headline_lint(headline: str, facts: list[Fact]) -> str:
+    """Return corrective feedback for a headline over-reaching the table.
+
+    The fact table is the headline's entire licensed source, so any ref,
+    identifier, or path it names must appear there. Clean returns ``""``.
+    """
+    licensed = fact_table(facts).lower()
+    offenders: list[str] = []
+    for pattern in _HEADLINE_TOKENS:
+        for raw in pattern.findall(headline):
+            needle = raw.strip("`#").lower()
+            if not needle or (pattern.pattern.startswith(r"\b[0-9a-f]") and not _has_digit(needle)):
+                continue
+            if needle not in licensed and raw not in offenders:
+                offenders.append(raw)
+    if not offenders:
+        return ""
+    shown = ", ".join(offenders)
+    return (
+        f"The headline names {shown}, which the fact table does not contain. "
+        "Write the headline using only what the table records — never a "
+        "reference, file, or name that is not in it."
+    )
+
+
+def _has_digit(text: str) -> bool:
+    return any(c.isdigit() for c in text)
+
+
+# ---------------------------------------------------------------------------
+# The fact table (the only thing carried forward between calls)
+# ---------------------------------------------------------------------------
+
+
+def fact_table(facts: list[Fact]) -> str:
+    """Compact rendering of the facts recorded so far.
+
+    Carried into the next extraction call for thread continuity and dedup,
+    and into the headline call as its only source. Deliberately terse:
+    it is context, never material to extract from.
+    """
+    lines: list[str] = []
+    for f in facts:
+        thread = f"[{f.thread}] " if f.thread else ""
+        refs = " (" + ", ".join(f"{r.type}:{r.value}" for r in f.refs) + ")" if f.refs else ""
+        lines.append(f"{thread}{f.kind} @{f.anchor_turn} — {f.text}{refs}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# The transcript view one extraction call reads
+# ---------------------------------------------------------------------------
+
+
+def chunk_view(turns: list[Turn]) -> str:
+    """Render a chunk's turns for extraction.
+
+    Unlike the segmenter's collapsed view, tool payloads are KEPT: a
+    `done` fact's ref — a commit sha, a merged PR number — exists nowhere
+    else in the transcript. Each turn is clipped, so a pasted file bounds
+    its own cost.
+    """
+    lines: list[str] = []
+    for t in turns:
+        rendered = _render_turn(t)
+        if rendered:
+            lines.append(f"[{t.role}@{t.index}] {rendered}")
+    return "\n".join(lines)
+
+
+def _render_turn(turn: Turn) -> str:
+    if turn.tool_call is not None:
+        payload = json.dumps(turn.tool_call.input or {}, ensure_ascii=False)
+        return f"<tool: {turn.tool_call.name}> {_clip(payload)}"
+    if turn.tool_result is not None:
+        flag = " error" if turn.tool_result.is_error else ""
+        return f"<result{flag}> {_clip(turn.tool_result.output or '')}"
+    return _clip((turn.text or "").strip())
+
+
+def _clip(text: str, limit: int = _TURN_MAX_CHARS) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "…"
+
+
+def _quote_source(turns: list[Turn]) -> dict[int, str]:
+    """Verbatim quotable text per turn index — the code-attached quotes."""
+    return {t.index: _clip(_render_turn(t), _QUOTE_MAX_CHARS) for t in turns}
+
+
+def _attach_quotes(facts: list[Fact], quotes: dict[int, str]) -> None:
+    """Fill each fact's quote from its anchor turn. The model never writes one.
+
+    Called after the anchor lint passes, so every anchor is a valid key,
+    and before the facts are rendered for the gate, so the same single
+    scan covers the quote too.
+    """
+    for f in facts:
+        f.quote = quotes.get(f.anchor_turn, "")
+
+
+# ---------------------------------------------------------------------------
+# One chunk
+# ---------------------------------------------------------------------------
+
+
+def extract_chunk(
+    *,
+    chunk: Chunk,
+    turns: list[Turn],
+    prior_facts: list[Fact] | None = None,
+    llm_client: Any,
+    model: str,
+    gate: Gate | None = None,
+    logger: RunLogger | None = None,
+    transcript_id: str = "",
+) -> ExtractResult:
+    """Extract one chunk's typed facts in a single LLM call, with one retry.
+
+    ``turns`` is the whole replayed session; the chunk's own span is cut
+    from it here. ``prior_facts`` are the facts of chunks 1..n-1 — context
+    for thread keys and dedup, never material to extract from.
+
+    * lint-clean and gate-passed → ``EXTRACTED``.
+    * zero facts (or only echoes of the table) → ``EMPTY``: the model
+      answered "nothing worth recording", which is never retried.
+    * gate withheld on the final attempt → ``WITHHELD``, carrying the
+      rendered text for quarantine.
+    * still failing a lint after the retry → ``FAILED``; the chunk becomes
+      a coverage gap rather than a note full of unusable facts. ponytail:
+      whole-chunk failure, not per-fact salvage — revisit if weak local
+      models turn out to miss one lint out of many good facts.
+    """
+    gate = gate or PassThroughGate()
+    prior = list(prior_facts or [])
+    span = [t for t in turns if chunk.from_turn <= t.index <= chunk.to_turn]
+    quotes = _quote_source(span)
+    seen = {_norm(f.text) for f in prior}
+
+    retry_feedback = ""
+    last_withheld_category = ""
+    last_withheld_feedback = ""
+    last_withheld_text = ""
+    attempts = 0
+
+    while attempts < EXTRACT_MAX_ATTEMPTS:
+        attempts += 1
+        facts = _extract_once(
+            span=span,
+            chunk=chunk,
+            prior=prior,
+            retry_feedback=retry_feedback,
+            llm_client=llm_client,
+            model=model,
+            logger=logger,
+            transcript_id=transcript_id,
+        )
+        if facts is None:
+            # LLM failure / malformed: nothing structured to correct.
+            retry_feedback = _MALFORMED_FEEDBACK
+            continue
+        if not facts:
+            return ExtractResult(status=ExtractStatus.EMPTY, chunk=chunk, attempts=attempts)
+
+        feedback = _lint_feedback(facts, chunk)
+        if feedback:
+            retry_feedback = feedback
+            if logger is not None:
+                logger.emit(
+                    "warning",
+                    call="fact-lint",
+                    transcript_id=transcript_id,
+                    chunk=[chunk.from_turn, chunk.to_turn],
+                    message=feedback,
+                )
+            continue
+
+        # The table is context, not source material: an entry echoed back
+        # (re-anchored into this chunk, so the anchor lint let it through)
+        # is dropped, never appended a second time.
+        facts = [f for f in facts if _norm(f.text) not in seen]
+        if not facts:
+            return ExtractResult(status=ExtractStatus.EMPTY, chunk=chunk, attempts=attempts)
+
+        _attach_quotes(facts, quotes)
+        text = render_fact_body(facts)
+        verdict = gate.evaluate(text)
+        if verdict.passed:
+            return ExtractResult(
+                status=ExtractStatus.EXTRACTED, chunk=chunk, facts=facts, attempts=attempts
+            )
+        last_withheld_category = verdict.category
+        last_withheld_feedback = verdict.feedback
+        last_withheld_text = text
+        retry_feedback = verdict.feedback
+        if logger is not None:
+            logger.emit(
+                "chapter-withheld",
+                call="publish-gate",
+                transcript_id=transcript_id,
+                category=verdict.category,
+            )
+
+    if last_withheld_text:
+        return ExtractResult(
+            status=ExtractStatus.WITHHELD,
+            chunk=chunk,
+            attempts=attempts,
+            withheld_category=last_withheld_category,
+            withheld_feedback=last_withheld_feedback,
+            withheld_text=last_withheld_text,
+        )
+    return ExtractResult(
+        status=ExtractStatus.FAILED,
+        chunk=chunk,
+        attempts=attempts,
+        failure_reason="no lint-clean facts extracted",
+    )
+
+
+def _norm(text: str) -> str:
+    return " ".join(text.lower().split()).strip(" .")
+
+
+def _lint_feedback(facts: list[Fact], chunk: Chunk) -> str:
+    """All three lints at once — one retry corrects every miss it names."""
+    parts: list[str] = []
+    lo, hi = chunk.from_turn, chunk.to_turn
+    bad_anchors = fact_anchor_lint(facts, from_turn=lo, to_turn=hi)
+    if bad_anchors:
+        shown = ", ".join(str(a) for _, a in bad_anchors)
+        parts.append(
+            f"Every fact must be anchored to a turn of THIS chunk, in the "
+            f"range {lo}-{hi}. These anchors were outside it: {shown}. A fact "
+            f"you cannot anchor inside {lo}-{hi} does not belong in this "
+            f"chunk — drop it."
+        )
+    bad_kinds = fact_kind_lint(facts)
+    if bad_kinds:
+        shown = ", ".join(repr(k) for _, k in bad_kinds)
+        parts.append(f"`kind` must be one of {', '.join(FACT_KINDS)}. These were not: {shown}.")
+    why_less = decision_why_lint(facts)
+    if why_less:
+        parts.append(
+            f"A `decision` fact must carry its `why` — the reason the choice "
+            f"was made. {len(why_less)} decision(s) had none. Give the reason, "
+            f"or record it as a different kind."
+        )
+    return " ".join(parts)
+
+
+def _extract_once(
+    *,
+    span: list[Turn],
+    chunk: Chunk,
+    prior: list[Fact],
+    retry_feedback: str,
+    llm_client: Any,
+    model: str,
+    logger: RunLogger | None,
+    transcript_id: str,
+) -> list[Fact] | None:
+    """One call. ``None`` means malformed or failed (retryable)."""
+    prompt = _build_prompt(span=span, chunk=chunk, prior=prior, retry_feedback=retry_feedback)
+    if logger is not None:
+        logger.emit(
+            "llm-prompt",
+            call="fact-extract",
+            transcript_id=transcript_id,
+            prompt_chars=len(prompt),
+            chunk=[chunk.from_turn, chunk.to_turn],
+            is_retry=bool(retry_feedback),
+        )
+    t0 = time.monotonic()
+    try:
+        resp = llm_client.messages.create(
+            model=model,
+            max_tokens=EXTRACT_MAX_OUTPUT_TOKENS,
+            tools=[fact_tool_schema()],
+            tool_choice={"type": "tool", "name": _TOOL_NAME},
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except Exception as exc:  # noqa: BLE001 - never crash a close on the LLM
+        if logger is not None:
+            logger.emit(
+                "warning",
+                call="fact-extract",
+                transcript_id=transcript_id,
+                message=f"LLM call raised: {type(exc).__name__}: {exc}",
+            )
+        return None
+    latency_ms = int((time.monotonic() - t0) * 1000)
+
+    raw = _tool_input(resp).get("facts")
+    if not isinstance(raw, list):
+        return None
+    facts = _parse_facts(raw)
+    if logger is not None:
+        logger.emit(
+            "llm-response",
+            call="fact-extract",
+            transcript_id=transcript_id,
+            latency_ms=latency_ms,
+            fact_count=len(facts),
+            model_resolved=getattr(resp, "model", "") or "",
+        )
+    return facts
+
+
+def _tool_input(resp: Any) -> dict[str, Any]:
+    for block in getattr(resp, "content", []) or []:
+        if getattr(block, "type", None) == "tool_use":
+            inp = getattr(block, "input", None)
+            if isinstance(inp, dict):
+                return inp
+    return {}
+
+
+def _parse_facts(raw: list[Any]) -> list[Fact]:
+    """Parse the tool payload into facts. Values are NOT corrected here.
+
+    A bogus kind or anchor round-trips as it was sent, so the lints judge
+    the model's actual output instead of a quietly repaired version of it.
+    Any `quote` the model sent is ignored: quotes are code-attached.
+    """
+    facts: list[Fact] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        facts.append(
+            Fact(
+                kind=str(item.get("kind") or "").strip(),
+                text=text,
+                anchor_turn=_coerce_anchor(item.get("anchor")),
+                thread=str(item.get("thread") or "").strip(),
+                refs=_parse_refs(item.get("refs")),
+                why=str(item.get("why") or "").strip(),
+            )
+        )
+    return facts
+
+
+def _parse_refs(raw: Any) -> list[Ref]:
+    if not isinstance(raw, list):
+        return []
+    refs: list[Ref] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        rtype = str(item.get("type") or "").strip()
+        value = str(item.get("value") or "").strip()
+        if rtype in REF_TYPES and value:
+            refs.append(Ref(rtype, value))
+    return refs
+
+
+def _coerce_anchor(value: Any) -> int:
+    if isinstance(value, bool):  # bool is an int subclass — never an index
+        return _ANCHOR_MISSING
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        s = value.strip().lstrip("@")
+        if s.isdigit():
+            return int(s)
+    return _ANCHOR_MISSING
+
+
+# ---------------------------------------------------------------------------
+# The whole session
+# ---------------------------------------------------------------------------
+
+
+def extract_session(
+    *,
+    chunks: list[Chunk],
+    turns: list[Turn],
+    llm_client: Any,
+    model: str,
+    gate: Gate | None = None,
+    logger: RunLogger | None = None,
+    transcript_id: str = "",
+    headline: bool = True,
+) -> SessionExtraction:
+    """Extract every chunk in order, then write one headline from the table.
+
+    Sequential by design: each call is handed the facts recorded so far so
+    a thread key stays continuous across chunk boundaries and nothing is
+    restated. A chunk that fails or is withheld does not stop the ones
+    after it — its outcome rides along in ``results`` for the caller to
+    record as a coverage gap.
+    """
+    facts: list[Fact] = []
+    results: list[ExtractResult] = []
+    for chunk in chunks:
+        result = extract_chunk(
+            chunk=chunk,
+            turns=turns,
+            prior_facts=facts,
+            llm_client=llm_client,
+            model=model,
+            gate=gate,
+            logger=logger,
+            transcript_id=transcript_id,
+        )
+        results.append(result)
+        facts.extend(result.facts)
+
+    line = ""
+    if headline and facts:
+        line = compose_headline(
+            facts,
+            llm_client=llm_client,
+            model=model,
+            gate=gate,
+            logger=logger,
+            transcript_id=transcript_id,
+        )
+    return SessionExtraction(facts=facts, headline=line, results=results)
+
+
+def compose_headline(
+    facts: list[Fact],
+    *,
+    llm_client: Any,
+    model: str,
+    gate: Gate | None = None,
+    logger: RunLogger | None = None,
+    transcript_id: str = "",
+) -> str:
+    """One bounded call: a single sentence written from the fact table.
+
+    The one cross-chunk synthesis in the pipeline, and the one place a
+    model may generalise. It is fenced in accordingly: the table is its
+    only source, a deterministic lint rejects any ref or name absent from
+    it, and a headline that still over-reaches after its one corrective
+    retry is dropped — a note with no headline beats a headline with a
+    ref that does not exist.
+    """
+    gate = gate or PassThroughGate()
+    retry_feedback = ""
+    for _ in range(HEADLINE_MAX_ATTEMPTS):
+        prompt = _build_headline_prompt(facts, retry_feedback=retry_feedback)
+        try:
+            resp = llm_client.messages.create(
+                model=model,
+                max_tokens=HEADLINE_MAX_OUTPUT_TOKENS,
+                tools=[headline_tool_schema()],
+                tool_choice={"type": "tool", "name": _HEADLINE_TOOL_NAME},
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception:  # noqa: BLE001 - a headline never blocks the note
+            continue
+        line = str(_tool_input(resp).get("headline") or "").strip()
+        if not line:
+            continue
+        retry_feedback = headline_lint(line, facts)
+        if retry_feedback:
+            if logger is not None:
+                logger.emit(
+                    "warning",
+                    call="headline-lint",
+                    transcript_id=transcript_id,
+                    message=retry_feedback,
+                )
+            continue
+        verdict = gate.evaluate(line)
+        if verdict.passed:
+            return line
+        retry_feedback = verdict.feedback
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Prompts + tool schemas
+# ---------------------------------------------------------------------------
+
+
+def _build_prompt(*, span: list[Turn], chunk: Chunk, prior: list[Fact], retry_feedback: str) -> str:
+    lo, hi = chunk.from_turn, chunk.to_turn
+    parts: list[str] = []
+    if retry_feedback:
+        parts.extend(
+            [
+                "The previous attempt was rejected.",
+                retry_feedback,
+                "Extract the facts again, corrected.",
+                "",
+            ]
+        )
+    parts.extend(
+        [
+            "Extract the FACTS of one chunk of a work session. A colleague "
+            "reads them months later to learn what the work established.",
+            "",
+            "Record the WORK, not the WORKING. The subject is the problem, "
+            "the system, and what was settled about it — never the session "
+            "itself. Session mechanics are noise: greetings, slash commands, "
+            "tool and sandbox hiccups, permission chatter. Leave them out "
+            "unless the tooling was itself the subject of the work.",
+            "",
+            "THE MONTH TEST. A fact earns its place only if it would change "
+            "what a colleague does or believes a month from now. Everything "
+            "else — however busy the session was — is left out. Few facts, or "
+            "none, is the normal answer for a chunk.",
+            "",
+            "THE TERMINAL-STATE RULE. `done` is for a TERMINAL state and "
+            "nothing else: a commit landed, a PR merged, a test suite "
+            "verified green, an artefact released. Work en route to that — an "
+            "edit made, a file written, a draft opened, a review requested — "
+            "is `progress`, even when it felt like a milestone at the time. "
+            "If you cannot point at the turn where the thing actually "
+            "concluded, it is not `done`.",
+            "",
+            "THE SUPERVISION CLAUSE. When this session supervises other "
+            "agents, the subject is the DELIVERABLE, not the choreography. "
+            "Dispatching a teammate, posting a status comment, preparing a "
+            "worktree — none of that is a fact. What the teammate delivered, "
+            "and whether it landed, is.",
+            "",
+            "Quoted and reference material is NOT the session's work. When "
+            "the user pastes a block as an exemplar, a reference, or a "
+            "comparison — a formatting sample, an older note of their own, an "
+            "example to imitate — its content describes that material, not "
+            "this session. Never report the claims, tools, or paths inside it "
+            "as facts of this session. The exception is when working on that "
+            "material WAS the task.",
+            "",
+            "Each fact carries:",
+            "- `kind`: one of "
+            "`progress` (work en route), "
+            "`done` (a terminal state, per the rule above), "
+            "`decision` (a choice made — `why` is MANDATORY), "
+            "`finding` (something learned about the system), "
+            "`open` (something unresolved, stated as a fact, never as an "
+            "instruction or a TODO).",
+            "- `thread`: a short stable key for the line of work this fact "
+            "belongs to (e.g. `chunker`, `auth-refactor`). Reuse the SAME key "
+            "when a fact continues a thread already in the table below.",
+            "- `refs`: the checkable pointers — pr, commit, file, tag, issue. "
+            "Take them verbatim from the transcript (a sha from a commit "
+            "result, a number from a `gh` call). NEVER invent or guess one: a "
+            "ref that does not exist is worse than no ref.",
+            "- `text`: one short, self-sufficient sentence. Plain statement of "
+            "what is so — no hedging, no flourish, no markdown.",
+            "- `why`: the reason behind a `decision`.",
+            f"- `anchor`: the ONE turn index this fact came from, between {lo} and {hi}.",
+            "",
+        ]
+    )
+    if prior:
+        parts.extend(
+            [
+                "FACTS ALREADY RECORDED (earlier chunks of this session). This "
+                "table is CONTEXT ONLY, for two purposes: reuse a `thread` key "
+                "it already established, and do not restate what it already "
+                "records. It is NOT source material — never extract a fact "
+                "from it. Every fact you emit must come from the transcript "
+                "below and be anchored in it.",
+                "<<<TABLE BEGIN>>>",
+                fact_table(prior),
+                "<<<TABLE END>>>",
+                "",
+            ]
+        )
+    parts.extend(
+        [
+            f"TRANSCRIPT CHUNK, turns {lo}-{hi} (each line is [role@N]):",
+            "<<<TRANSCRIPT BEGIN>>>",
+            chunk_view(span),
+            "<<<TRANSCRIPT END>>>",
+            "",
+            "If this chunk holds nothing that passes the month test, return "
+            "an EMPTY facts array. No fact is better than a noisy one.",
+            "",
+            f"Call the `{_TOOL_NAME}` tool exactly once.",
+        ]
+    )
+    return "\n".join(parts)
+
+
+def _build_headline_prompt(facts: list[Fact], *, retry_feedback: str) -> str:
+    parts: list[str] = []
+    if retry_feedback:
+        parts.extend(
+            [
+                "The previous attempt was rejected.",
+                retry_feedback,
+                "Write the headline again, corrected.",
+                "",
+            ]
+        )
+    parts.extend(
+        [
+            "Write ONE sentence naming what this work session actually "
+            "achieved — the thing a colleague would say if asked what came of "
+            "it. Prefer the terminal outcomes (`done`) over the work en route "
+            "(`progress`); when several threads closed, name what they add up "
+            "to rather than listing them.",
+            "",
+            "The fact table below is your ONLY source. Do not name a "
+            "reference, file, number, or identifier that is not in it — a "
+            "detail you add from imagination is a false claim. Plain "
+            "statement, no markdown, no hedging.",
+            "",
+            "<<<TABLE BEGIN>>>",
+            fact_table(facts),
+            "<<<TABLE END>>>",
+            "",
+            f"Call the `{_HEADLINE_TOOL_NAME}` tool exactly once.",
+        ]
+    )
+    return "\n".join(parts)
+
+
+def fact_tool_schema() -> dict[str, Any]:
+    """Tool schema for one chunk's extraction — typed data, no prose.
+
+    There is deliberately no `quote` field: quotes are code-attached from
+    the anchor turn, so a model cannot author the verbatim evidence for
+    its own claim.
+    """
+    return {
+        "name": _TOOL_NAME,
+        "description": (
+            "Emit the typed facts of one chunk of a work session. An empty "
+            "facts array is the correct output when the chunk holds nothing "
+            "worth recording a month from now."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "facts": {
+                    "type": "array",
+                    "description": (
+                        "The chunk's facts, in chronological order. Few or none is normal."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "kind": {
+                                "type": "string",
+                                "enum": list(FACT_KINDS),
+                                "description": (
+                                    "progress = work en route; done = a "
+                                    "terminal state (commit landed, PR "
+                                    "merged, suite verified green); decision "
+                                    "= a choice made (why is mandatory); "
+                                    "finding = something learned; open = "
+                                    "something unresolved."
+                                ),
+                            },
+                            "text": {
+                                "type": "string",
+                                "description": (
+                                    "One short self-sufficient sentence "
+                                    "stating what is so. Plain text."
+                                ),
+                            },
+                            "thread": {
+                                "type": "string",
+                                "description": (
+                                    "Short stable key for the line of work "
+                                    "this fact belongs to. Reuse the key an "
+                                    "earlier chunk established."
+                                ),
+                            },
+                            "refs": {
+                                "type": "array",
+                                "description": (
+                                    "Checkable pointers, taken verbatim from "
+                                    "the transcript. Never invented."
+                                ),
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": list(REF_TYPES),
+                                        },
+                                        "value": {
+                                            "type": "string",
+                                            "description": (
+                                                "The PR/issue number, commit "
+                                                "sha, tag, or file path."
+                                            ),
+                                        },
+                                    },
+                                    "required": ["type", "value"],
+                                },
+                            },
+                            "why": {
+                                "type": "string",
+                                "description": (
+                                    "The reason behind a decision — mandatory "
+                                    "for kind=decision, omitted otherwise."
+                                ),
+                            },
+                            "anchor": {
+                                "type": "integer",
+                                "description": (
+                                    "The one turn index this fact came from. "
+                                    "Must be inside this chunk."
+                                ),
+                            },
+                        },
+                        "required": ["kind", "text", "anchor"],
+                    },
+                }
+            },
+            "additionalProperties": False,
+            "required": ["facts"],
+        },
+    }
+
+
+def headline_tool_schema() -> dict[str, Any]:
+    """Tool schema for the single headline call."""
+    return {
+        "name": _HEADLINE_TOOL_NAME,
+        "description": (
+            "Emit one sentence naming what the session achieved, using only "
+            "what the fact table records."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "headline": {
+                    "type": "string",
+                    "description": (
+                        "One plain sentence. Names no reference, file, or "
+                        "identifier absent from the fact table."
+                    ),
+                }
+            },
+            "additionalProperties": False,
+            "required": ["headline"],
+        },
+    }

--- a/tests/test_fact_extract.py
+++ b/tests/test_fact_extract.py
@@ -1,0 +1,541 @@
+"""Typed-fact extraction — stub-LLM replay contract tests.
+
+Every LLM interaction is faked. These tests assert the *call contract* —
+one call per chunk, the fact table threaded forward, one corrective retry
+per deterministic lint, quotes code-attached from the anchor turn, the
+gate in the path, one bounded headline call at the end — and NEVER the
+quality of an extracted fact. No LLM-as-judge appears here.
+
+The model's output surface is structured data only: kinds, thread keys,
+refs, a short text, a why, and one anchor. It never writes a quote and it
+never writes the note's authority phrasing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from lore_core.note_document import Fact, Ref
+from lore_core.publish_gate import GateResult
+from lore_core.types import ToolCall, ToolResult, Turn
+from lore_curator.chunker import Chunk
+from lore_curator.fact_extract import (
+    EXTRACT_MAX_ATTEMPTS,
+    ExtractStatus,
+    chunk_view,
+    decision_why_lint,
+    extract_chunk,
+    extract_session,
+    fact_anchor_lint,
+    fact_kind_lint,
+    fact_table,
+    fact_tool_schema,
+    headline_lint,
+)
+
+# ---------------------------------------------------------------------------
+# Stub LLM (records call kwargs, replays queued tool_use payloads)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBlock:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.type = "tool_use"
+        self.input = payload
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any], model: str = "test-model") -> None:
+        self.content = [_FakeBlock(payload)]
+        self.model = model
+
+
+class _RecordingMessages:
+    """Queue of payloads; ``None`` in the queue simulates a raising call."""
+
+    def __init__(self, payloads: list[dict[str, Any] | None]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> _FakeResponse:
+        self.calls.append(kwargs)
+        payload = self._payloads.pop(0) if self._payloads else {}
+        if payload is None:
+            raise RuntimeError("simulated LLM failure")
+        return _FakeResponse(payload)
+
+
+class _FakeClient:
+    def __init__(self, messages: _RecordingMessages) -> None:
+        self.messages = messages
+
+
+def _client(payloads: list[dict[str, Any] | None]) -> tuple[_FakeClient, _RecordingMessages]:
+    messages = _RecordingMessages(payloads)
+    return _FakeClient(messages), messages
+
+
+def _prompt_text(call: dict[str, Any]) -> str:
+    return call["messages"][0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Turn fixtures
+# ---------------------------------------------------------------------------
+
+
+def _turn(index: int, role: str = "user", text: str | None = "t") -> Turn:
+    return Turn(index=index, timestamp=datetime(2026, 7, 12, tzinfo=UTC), role=role, text=text)
+
+
+def _tool_turn(index: int, name: str, **inp: Any) -> Turn:
+    return Turn(
+        index=index,
+        timestamp=datetime(2026, 7, 12, tzinfo=UTC),
+        role="assistant",
+        tool_call=ToolCall(name=name, input=dict(inp)),
+    )
+
+
+def _result_turn(index: int, output: str, *, is_error: bool = False) -> Turn:
+    return Turn(
+        index=index,
+        timestamp=datetime(2026, 7, 12, tzinfo=UTC),
+        role="tool_result",
+        tool_result=ToolResult(tool_call_id=None, output=output, is_error=is_error),
+    )
+
+
+def _turns(n: int = 12) -> list[Turn]:
+    return [_turn(i, text=f"turn {i} text") for i in range(1, n + 1)]
+
+
+def _fact_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "kind": "done",
+        "text": "Segmentation landed as an indices-only call.",
+        "thread": "segmentation",
+        "refs": [{"type": "pr", "value": "288"}],
+        "anchor": 3,
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Lints (deterministic, no LLM)
+# ---------------------------------------------------------------------------
+
+
+def test_anchor_lint_flags_anchors_outside_the_chunk():
+    facts = [
+        Fact(kind="done", text="in", anchor_turn=5),
+        Fact(kind="done", text="out", anchor_turn=99),
+        Fact(kind="done", text="missing", anchor_turn=-1),
+    ]
+    assert fact_anchor_lint(facts, from_turn=1, to_turn=10) == [(1, 99), (2, -1)]
+
+
+def test_kind_lint_flags_kinds_outside_the_enum():
+    facts = [
+        Fact(kind="done", text="ok", anchor_turn=1),
+        Fact(kind="milestone", text="invented", anchor_turn=2),
+        Fact(kind="", text="absent", anchor_turn=3),
+    ]
+    assert fact_kind_lint(facts) == [(1, "milestone"), (2, "")]
+
+
+def test_decision_why_lint_flags_decisions_with_no_why():
+    facts = [
+        Fact(kind="decision", text="End-mode extraction.", anchor_turn=1, why="Backward only."),
+        Fact(kind="decision", text="Sequential calls.", anchor_turn=2),
+        Fact(kind="finding", text="A finding needs no why.", anchor_turn=3),
+    ]
+    assert decision_why_lint(facts) == [1]
+
+
+def test_headline_lint_rejects_a_ref_absent_from_the_fact_table():
+    facts = [Fact(kind="done", text="Segmentation landed.", anchor_turn=3, refs=[Ref("pr", "288")])]
+
+    assert headline_lint("Segmentation landed in #288.", facts) == ""
+    feedback = headline_lint("Segmentation landed in #999.", facts)
+    assert "#999" in feedback
+
+
+def test_headline_lint_rejects_a_thread_absent_from_the_fact_table():
+    facts = [Fact(kind="done", text="Segmentation landed.", anchor_turn=3, thread="segmentation")]
+
+    assert headline_lint("Work on `segmentation` closed out.", facts) == ""
+    assert "`auth-refactor`" in headline_lint("Work on `auth-refactor` closed out.", facts)
+
+
+# ---------------------------------------------------------------------------
+# Chunk view — the transcript the extractor reads
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_view_keeps_tool_payloads_where_refs_actually_live():
+    turns = [
+        _turn(1, text="ship it"),
+        _tool_turn(2, "Bash", command="git commit -m 'beat-aligned segmentation'"),
+        _result_turn(3, "[main 41cab11] beat-aligned segmentation"),
+    ]
+    view = chunk_view(turns)
+
+    assert "git commit -m 'beat-aligned segmentation'" in view
+    assert "41cab11" in view
+    assert "@2" in view
+
+
+# ---------------------------------------------------------------------------
+# One extraction call per chunk
+# ---------------------------------------------------------------------------
+
+
+def test_extraction_yields_typed_facts_with_kinds_threads_refs_and_anchors():
+    client, messages = _client(
+        [
+            {
+                "facts": [
+                    _fact_payload(),
+                    _fact_payload(
+                        kind="decision",
+                        text="Extraction runs at session end.",
+                        thread="pipeline",
+                        refs=[],
+                        why="Which facts matter is only knowable backward.",
+                        anchor=5,
+                    ),
+                ]
+            }
+        ]
+    )
+    result = extract_chunk(
+        chunk=Chunk(1, 12),
+        turns=_turns(),
+        llm_client=client,
+        model="m",
+    )
+
+    assert result.status is ExtractStatus.EXTRACTED
+    assert len(messages.calls) == 1
+    assert [f.kind for f in result.facts] == ["done", "decision"]
+    assert [f.thread for f in result.facts] == ["segmentation", "pipeline"]
+    assert result.facts[0].refs == [Ref("pr", "288")]
+    assert [f.anchor_turn for f in result.facts] == [3, 5]
+    assert result.facts[1].why == "Which facts matter is only knowable backward."
+
+
+def test_quotes_are_code_attached_verbatim_from_the_anchor_turn():
+    """The model has no quote field; the quote comes from the transcript."""
+    turns = [
+        _turn(1, text="ship it"),
+        _tool_turn(2, "Bash", command="gh pr merge 288 --squash"),
+        _turn(3, text="merged"),
+    ]
+    client, _ = _client([{"facts": [_fact_payload(anchor=2, quote="a quote I made up")]}])
+    result = extract_chunk(chunk=Chunk(1, 3), turns=turns, llm_client=client, model="m")
+
+    assert "gh pr merge 288 --squash" in result.facts[0].quote
+    assert "a quote I made up" not in result.facts[0].quote
+    item_props = fact_tool_schema()["input_schema"]["properties"]["facts"]["items"]["properties"]
+    assert "quote" not in item_props
+
+
+def test_zero_facts_is_a_terminal_empty_answer_never_retried():
+    client, messages = _client([{"facts": []}])
+    result = extract_chunk(chunk=Chunk(1, 12), turns=_turns(), llm_client=client, model="m")
+
+    assert result.status is ExtractStatus.EMPTY
+    assert len(messages.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# One corrective retry per lint
+# ---------------------------------------------------------------------------
+
+
+def test_anchor_lint_earns_exactly_one_corrective_retry():
+    client, messages = _client(
+        [{"facts": [_fact_payload(anchor=99)]}, {"facts": [_fact_payload(anchor=3)]}]
+    )
+    result = extract_chunk(chunk=Chunk(1, 12), turns=_turns(), llm_client=client, model="m")
+
+    assert result.status is ExtractStatus.EXTRACTED
+    assert len(messages.calls) == EXTRACT_MAX_ATTEMPTS == 2
+    retry_prompt = _prompt_text(messages.calls[1])
+    assert "1-12" in retry_prompt
+    assert "99" in retry_prompt
+
+
+def test_kind_lint_earns_exactly_one_corrective_retry():
+    client, messages = _client(
+        [{"facts": [_fact_payload(kind="milestone")]}, {"facts": [_fact_payload(kind="done")]}]
+    )
+    result = extract_chunk(chunk=Chunk(1, 12), turns=_turns(), llm_client=client, model="m")
+
+    assert result.status is ExtractStatus.EXTRACTED
+    assert len(messages.calls) == 2
+    retry_prompt = _prompt_text(messages.calls[1])
+    assert "milestone" in retry_prompt
+    assert "progress" in retry_prompt
+
+
+def test_decision_without_why_earns_exactly_one_corrective_retry():
+    client, messages = _client(
+        [
+            {"facts": [_fact_payload(kind="decision", why="")]},
+            {"facts": [_fact_payload(kind="decision", why="Backward-only knowledge.")]},
+        ]
+    )
+    result = extract_chunk(chunk=Chunk(1, 12), turns=_turns(), llm_client=client, model="m")
+
+    assert result.status is ExtractStatus.EXTRACTED
+    assert len(messages.calls) == 2
+    assert "why" in _prompt_text(messages.calls[1]).lower()
+    assert result.facts[0].why == "Backward-only knowledge."
+
+
+def test_a_second_lint_miss_fails_the_chunk_without_a_third_call():
+    client, messages = _client(
+        [{"facts": [_fact_payload(anchor=99)]}, {"facts": [_fact_payload(anchor=98)]}]
+    )
+    result = extract_chunk(chunk=Chunk(1, 12), turns=_turns(), llm_client=client, model="m")
+
+    assert result.status is ExtractStatus.FAILED
+    assert len(messages.calls) == EXTRACT_MAX_ATTEMPTS
+    assert result.facts == []
+
+
+def test_an_llm_failure_never_raises_out_of_extraction():
+    client, messages = _client([None, None])
+    result = extract_chunk(chunk=Chunk(1, 12), turns=_turns(), llm_client=client, model="m")
+
+    assert result.status is ExtractStatus.FAILED
+    assert len(messages.calls) == EXTRACT_MAX_ATTEMPTS
+
+
+# ---------------------------------------------------------------------------
+# The publish gate stays in the path
+# ---------------------------------------------------------------------------
+
+
+class _WithholdingGate:
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def evaluate(self, chapter_text: str) -> GateResult:
+        self.seen.append(chapter_text)
+        return GateResult.withheld("secret", "the text carries an API key")
+
+
+def test_a_withheld_extraction_carries_its_rendered_text_for_quarantine():
+    gate = _WithholdingGate()
+    client, messages = _client([{"facts": [_fact_payload()]}, {"facts": [_fact_payload()]}])
+    result = extract_chunk(
+        chunk=Chunk(1, 12), turns=_turns(), llm_client=client, model="m", gate=gate
+    )
+
+    assert result.status is ExtractStatus.WITHHELD
+    assert result.withheld_category == "secret"
+    assert "Segmentation landed as an indices-only call." in result.withheld_text
+    assert len(messages.calls) == EXTRACT_MAX_ATTEMPTS
+    assert "the text carries an API key" in _prompt_text(messages.calls[1])
+
+
+# ---------------------------------------------------------------------------
+# Fact-table threading across chunks
+# ---------------------------------------------------------------------------
+
+
+def test_the_fact_table_from_earlier_chunks_reaches_the_next_call():
+    client, messages = _client(
+        [
+            {"facts": [_fact_payload(kind="progress", text="Chunker sketched.", anchor=2)]},
+            {"facts": [_fact_payload(kind="done", text="Chunker merged.", anchor=8)]},
+        ]
+    )
+    out = extract_session(
+        chunks=[Chunk(1, 6), Chunk(7, 12)],
+        turns=_turns(),
+        llm_client=client,
+        model="m",
+        headline=False,
+    )
+
+    first_prompt, second_prompt = (_prompt_text(c) for c in messages.calls[:2])
+    assert "Chunker sketched." not in first_prompt
+    assert "Chunker sketched." in second_prompt  # thread continuity, forward only
+    assert "segmentation" in second_prompt
+    assert [f.thread for f in out.facts] == ["segmentation", "segmentation"]
+    assert [f.kind for f in out.facts] == ["progress", "done"]
+
+
+def test_fact_table_content_never_surfaces_as_a_new_fact():
+    """Two guards: the anchor lint kills a re-anchored echo, dedup kills a copy."""
+    earlier = _fact_payload(kind="progress", text="Chunker sketched.", anchor=2)
+    # Chunk 2 echoes the table entry, re-anchored into its own range so it
+    # would slip past the anchor lint.
+    client, messages = _client(
+        [
+            {"facts": [earlier]},
+            {"facts": [_fact_payload(kind="progress", text="Chunker sketched.", anchor=8)]},
+        ]
+    )
+    out = extract_session(
+        chunks=[Chunk(1, 6), Chunk(7, 12)],
+        turns=_turns(),
+        llm_client=client,
+        model="m",
+        headline=False,
+    )
+
+    assert len(messages.calls) == 2  # the echo is dropped, not retried
+    assert [f.text for f in out.facts] == ["Chunker sketched."]
+    assert out.results[1].status is ExtractStatus.EMPTY
+
+    # ... and an echo that keeps its original anchor is structurally
+    # impossible: that anchor lies outside the chunk, so the lint rejects it.
+    assert fact_anchor_lint(
+        [Fact(kind="progress", text="Chunker sketched.", anchor_turn=2)], from_turn=7, to_turn=12
+    ) == [(0, 2)]
+
+
+def test_the_fact_table_renders_thread_kind_anchor_and_refs():
+    table = fact_table(
+        [
+            Fact(
+                kind="done",
+                text="Segmentation landed.",
+                anchor_turn=3,
+                thread="segmentation",
+                refs=[Ref("pr", "288")],
+            )
+        ]
+    )
+    assert "segmentation" in table
+    assert "done" in table
+    assert "@3" in table
+    assert "pr:288" in table
+
+
+# ---------------------------------------------------------------------------
+# The bounded headline call
+# ---------------------------------------------------------------------------
+
+
+def test_the_headline_is_one_bounded_call_after_the_final_chunk():
+    client, messages = _client(
+        [
+            {"facts": [_fact_payload()]},
+            {"headline": "Beat-aligned segmentation shipped in #288."},
+        ]
+    )
+    out = extract_session(
+        chunks=[Chunk(1, 12)],
+        turns=_turns(),
+        llm_client=client,
+        model="m",
+    )
+
+    assert out.headline == "Beat-aligned segmentation shipped in #288."
+    assert len(messages.calls) == 2
+    headline_prompt = _prompt_text(messages.calls[1])
+    assert "Segmentation landed as an indices-only call." in headline_prompt
+
+
+def test_a_headline_naming_an_absent_ref_earns_one_retry_then_is_dropped():
+    client, messages = _client(
+        [
+            {"facts": [_fact_payload()]},
+            {"headline": "Shipped in #999."},
+            {"headline": "Still shipped in #999."},
+        ]
+    )
+    out = extract_session(chunks=[Chunk(1, 12)], turns=_turns(), llm_client=client, model="m")
+
+    assert out.headline == ""  # dropped rather than published with a false ref
+    assert len(messages.calls) == 3  # 1 extraction + 2 headline attempts
+    assert "#999" in _prompt_text(messages.calls[2])
+    assert out.facts  # the facts survive a failed headline
+
+
+# ---------------------------------------------------------------------------
+# Prompt contract: the rules PRD 0008 fixes must reach the model
+# ---------------------------------------------------------------------------
+
+
+def test_the_extraction_prompt_carries_the_rules_the_prd_fixes():
+    client, messages = _client([{"facts": [_fact_payload()]}])
+    extract_chunk(chunk=Chunk(1, 12), turns=_turns(), llm_client=client, model="m")
+    prompt = _prompt_text(messages.calls[0]).lower()
+
+    assert "terminal" in prompt  # terminal-state rule
+    assert "month" in prompt  # the month test
+    assert "supervis" in prompt  # the supervision clause
+    for kind in ("progress", "done", "decision", "finding", "open"):
+        assert kind in prompt
+
+
+def test_an_orchestration_session_yields_progress_en_route_and_done_at_the_end():
+    """En-route edits are `progress`; only the terminal PR merge is `done`.
+
+    The stub replays what a rule-following model returns; what is asserted
+    here is that extraction preserves the kinds, threads them onto one key,
+    and code-attaches the terminal turn as the `done` fact's quote — and
+    that the prompt the model was handed carries the terminal-state and
+    supervision rules.
+    """
+    turns = [
+        _turn(1, text="orchestrate the epic: dispatch a teammate per sub-issue"),
+        _tool_turn(2, "Edit", file_path="lib/lore_curator/chunker.py"),
+        _turn(3, "assistant", "teammate reports the chunker is green"),
+        _tool_turn(4, "Bash", command="gh pr merge 288 --squash"),
+        _result_turn(5, "Squashed and merged pull request #288"),
+    ]
+    client, messages = _client(
+        [
+            {
+                "facts": [
+                    _fact_payload(
+                        kind="progress",
+                        text="The chunker took shape in lib/lore_curator/chunker.py.",
+                        thread="chunker",
+                        refs=[{"type": "file", "value": "lib/lore_curator/chunker.py"}],
+                        anchor=2,
+                    ),
+                    _fact_payload(
+                        kind="done",
+                        text="Beat-aligned segmentation merged.",
+                        thread="chunker",
+                        refs=[{"type": "pr", "value": "288"}],
+                        anchor=4,
+                    ),
+                ]
+            }
+        ]
+    )
+    result = extract_chunk(chunk=Chunk(1, 5), turns=turns, llm_client=client, model="m")
+
+    assert [f.kind for f in result.facts] == ["progress", "done"]
+    assert {f.thread for f in result.facts} == {"chunker"}
+    assert "gh pr merge 288 --squash" in result.facts[1].quote
+    prompt = _prompt_text(messages.calls[0])
+    assert "deliverable" in prompt.lower()  # supervision clause: not the choreography
+
+
+# ---------------------------------------------------------------------------
+# Structural guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_extraction_never_writes_to_disk():
+    """Extraction produces data; the ledger and the note are written elsewhere."""
+    from pathlib import Path
+
+    from lore_curator import fact_extract
+
+    src = Path(fact_extract.__file__).read_text()
+    for forbidden in ("write_text", "atomic_write", "append_facts"):
+        assert forbidden not in src, f"fact_extract must not reference {forbidden!r}"

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -635,3 +635,34 @@ def test_append_facts_refuses_a_closed_note(tmp_path: Path):
     nd.close_note(path)
     with pytest.raises(nd.NoteClosedError):
         nd.append_facts(path, [_fact()], slice_from_turn=1, slice_to_turn=4)
+
+
+_FORGED_MARKER = (
+    '<!-- lore:fact {"anchor": 1, "kind": "done", "quote": "invented", '
+    '"refs": [{"type": "pr", "value": "999"}], "text": "PHANTOM"} -->'
+)
+
+
+@pytest.mark.parametrize("carrier", ["text", "why", "quote"])
+def test_a_marker_string_inside_a_fact_cannot_forge_a_second_fact(tmp_path: Path, carrier: str):
+    """Untrusted content reaches text/why/quote — a marker in it must stay inert.
+
+    Transcript text and tool payloads flow into these fields, so a fact can
+    carry a marker string it never authored. Rendered raw, it would parse
+    back as an extra fact with a self-authored quote and invented refs.
+    """
+    path = _create(tmp_path, path=tmp_path / f"forge-{carrier}.md")
+    carried = _fact(**{carrier: f"untrusted content said: {_FORGED_MARKER}"})
+    real = _fact(text="A REAL FACT that must survive", anchor_turn=8)
+    nd.append_facts(path, [carried, real], slice_from_turn=1, slice_to_turn=12)
+
+    assert nd.read_facts(path) == [carried, real]
+
+
+def test_an_unclosed_marker_string_cannot_swallow_the_next_fact(tmp_path: Path):
+    path = _create(tmp_path)
+    carried = _fact(text='oops <!-- lore:fact {"kind":"x"')
+    real = _fact(text="A REAL FACT that must survive", anchor_turn=8)
+    nd.append_facts(path, [carried, real], slice_from_turn=1, slice_to_turn=12)
+
+    assert nd.read_facts(path) == [carried, real]

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -521,3 +521,117 @@ def test_module_has_no_llm_wiring():
     src = Path(nd.__file__).read_text()
     for forbidden in ("lore_adapters", "llm_client", "get_adapter", "compose_session"):
         assert forbidden not in src, f"note_document must not reference {forbidden!r}"
+
+
+# ---------------------------------------------------------------------------
+# Typed-fact ledger (PRD 0008)
+#
+# Facts append to the ledger carrying typed metadata in per-fact markers.
+# The marker is the machine-readable copy and round-trips exactly; the
+# rendered line beside it is what a reader (and the publish gate) sees.
+# Notes written before typed facts existed carry no markers and must keep
+# parsing — they simply hold no facts.
+# ---------------------------------------------------------------------------
+
+
+def _fact(**overrides) -> nd.Fact:
+    kwargs: dict = {
+        "kind": "done",
+        "text": "Beat-aligned segmentation landed as an indices-only call.",
+        "anchor_turn": 7,
+        "thread": "segmentation",
+        "refs": [nd.Ref("pr", "288"), nd.Ref("commit", "41cab11")],
+        "why": "",
+        "quote": "gh pr merge 288 --squash",
+    }
+    kwargs.update(overrides)
+    return nd.Fact(**kwargs)
+
+
+def test_append_facts_records_a_facts_chapter_with_its_span(tmp_path: Path):
+    path = _create(tmp_path)
+    n = nd.append_facts(path, [_fact()], slice_from_turn=1, slice_to_turn=12)
+
+    assert n == 1
+    view = nd.read_note(path)
+    entry = view.chapters[0]
+    assert entry["kind"] == "facts"
+    assert entry["from_turn"] == 1
+    assert entry["to_turn"] == 12
+    assert entry["count"] == 1
+
+
+def test_typed_metadata_round_trips_through_ledger_markers(tmp_path: Path):
+    path = _create(tmp_path)
+    facts = [
+        _fact(),
+        _fact(
+            kind="decision",
+            text="Extraction runs at session end, never per flush.",
+            anchor_turn=9,
+            thread="pipeline",
+            refs=[],
+            why="Which facts matter is only knowable backward, at the ending.",
+            quote="let's move all of it to the close path",
+        ),
+    ]
+    nd.append_facts(path, facts, slice_from_turn=1, slice_to_turn=12)
+
+    assert nd.read_facts(path) == facts
+
+
+def test_ledger_markers_survive_a_fact_that_closes_an_html_comment(tmp_path: Path):
+    """A fact quoting `-->` must not truncate its own marker."""
+    path = _create(tmp_path)
+    fact = _fact(text="The regex `<!--.*?-->` swallowed the next block.", quote="a --> b")
+    nd.append_facts(path, [fact], slice_from_turn=1, slice_to_turn=3)
+
+    assert nd.read_facts(path) == [fact]
+
+
+def test_pre_existing_untyped_notes_still_parse(tmp_path: Path):
+    """A note written before typed facts: chapters parse, facts are empty."""
+    path = _create(tmp_path)
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[nd.TopicBlock(lead="An older prose block.", anchor_turn=2)]),
+        slice_from_turn=1,
+        slice_to_turn=4,
+    )
+
+    view = nd.read_note(path)
+    assert [c["kind"] for c in view.chapters] == ["topic"]
+    assert nd.DISCLAIMER in view.body
+    assert nd.read_facts(path) == []
+
+
+def test_facts_and_prose_chapters_coexist_in_one_note(tmp_path: Path):
+    path = _create(tmp_path)
+    nd.append_chapter(
+        path,
+        nd.Chapter(blocks=[nd.TopicBlock(lead="An older prose block.", anchor_turn=2)]),
+        slice_from_turn=1,
+        slice_to_turn=4,
+    )
+    nd.append_facts(path, [_fact()], slice_from_turn=5, slice_to_turn=12)
+
+    view = nd.read_note(path)
+    assert [c["kind"] for c in view.chapters] == ["topic", "facts"]
+    assert [f.kind for f in nd.read_facts(path)] == ["done"]
+
+
+def test_rendered_fact_body_carries_text_quote_and_anchor(tmp_path: Path):
+    """What the publish gate scans is what the reader sees."""
+    rendered = nd.render_fact_body([_fact(why="Indices cannot carry a false claim.")])
+
+    assert "Beat-aligned segmentation landed as an indices-only call." in rendered
+    assert "Indices cannot carry a false claim." in rendered
+    assert '> "gh pr merge 288 --squash"' in rendered
+    assert "@7" in rendered
+
+
+def test_append_facts_refuses_a_closed_note(tmp_path: Path):
+    path = _create(tmp_path)
+    nd.close_note(path)
+    with pytest.raises(nd.NoteClosedError):
+        nd.append_facts(path, [_fact()], slice_from_turn=1, slice_to_turn=4)


### PR DESCRIPTION
Closes #284. Part of epic #282. Spec: `docs/prd/0008-typed-fact-session-notes.md`.

Builds on the segmenter from #283 and preserves its invariant: the model's output surface is
structured data only. Here that data is typed facts — never prose that later carries authority.

## What landed

**`lib/lore_curator/fact_extract.py` (new).** One first-generation LLM call per chunk emits typed
facts: `kind` (`progress` | `done` | `decision` | `finding` | `open`), an optional `thread` key,
structured `refs` (`pr`/`commit`/`file`/`tag`/`issue`), a short `text`, a `why` (mandatory for
decisions), and one `@turn` anchor. There is deliberately **no `quote` field in the tool schema** —
quotes are code-attached from the anchor turn, so a model cannot author the verbatim evidence for its
own claim. Three deterministic lints (anchor-in-chunk, kind-in-enum, decision-without-why) plus the
injected publish gate each earn exactly one corrective retry, mirroring `compose_chapter`'s
`CHAPTER_MAX_ATTEMPTS = 2` contract; a second miss fails the chunk into a coverage gap rather than
publishing unusable facts.

The extraction view keeps **tool payloads** (unlike the segmenter's collapsed view): a commit sha
lives in a Bash result and a PR number in a `gh` call, and nowhere else — without them, `done` facts
would carry no refs and #286 would have nothing to verify.

**`lib/lore_core/note_document.py`.** The ledger gains typed metadata: `Fact` / `Ref` / `FACT_KINDS` /
`REF_TYPES`, `append_facts` (a `facts` chapter, append-only like every other), `render_fact_body`
(what the publish gate scans), and `parse_facts` / `read_facts`.

## The three decisions worth reviewing

**Fact schema.** `Fact(kind, text, anchor_turn, thread, refs: list[Ref], why, quote)` — flat, with
`Ref(type, value)` frozen. Nothing in it phrases authority; #285/#286 own that, keyed on what code
could verify.

**Typed metadata on the ledger, old notes still parsing.** Each fact renders an HTML-comment marker
holding its machine-readable JSON copy, followed by the human-readable line. Parsing is
**marker-driven**, so a note written before typed facts existed carries no markers, yields no facts,
and keeps parsing untouched — no schema-version bump needed, and prose chapters and fact chapters
coexist in one note (tested). Markers use sorted keys and drop empty fields, so a re-render of the
same ledger is byte-stable (#285 will want that). A fact whose text contains `-->` would close its own
comment early, so that sequence is written as its JSON escape and `json.loads` restores it verbatim —
tested.

**Keeping the fact table out of the facts.** Call *n* receives the compact table from calls 1..n-1 for
thread continuity and dedup only. Two guards make that structural rather than a matter of prompt
obedience: (1) the **anchor lint** rejects any fact anchored outside the chunk — which every table
entry is, since it came from earlier turns; (2) a **text dedup** drops an echo that was re-anchored
into the chunk to slip past guard 1. Prompt wording is the third line of defense, not the first.

The headline is the one cross-chunk synthesis, and it is fenced: the table is its only source, a
deterministic lint rejects any `#N`, commit-shaped hex, backticked span, or path-shaped token absent
from the table, and a headline that still over-reaches after its one retry is **dropped** — a note
with no headline beats a headline with a ref that does not exist.

## Red → green evidence

Tests first, implementation second. Red (the whole suite could not even collect):

```
tests/test_fact_extract.py:19: in <module>
    from lore_core.note_document import Fact, Ref
E   ImportError: cannot import name 'Fact' from 'lore_core.note_document'
ERROR tests/test_fact_extract.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

Green, after `note_document.py` then `fact_extract.py`:

```
tests/test_note_document.py .....................................  35 passed
tests/test_fact_extract.py  .......................               23 passed
```

Full suite: `4 failed, 2764 passed, 16 skipped` — the 4 failures are the known pre-existing ANSI
width assertions (`test_cli_scopes`, `test_core_llm_wiring` ×2, `test_install_dispatcher`),
untouched by this branch.

Because two guarantees here are mine rather than the issue's literal wording, I mutation-checked that
their tests actually bite:

```
### MUTATION 1: remove the fact-table dedup filter
FAILED test_fact_table_content_never_surfaces_as_a_new_fact
  - assert ['Chunker ske...er sketched.'] == ['Chunker sketched.']
### MUTATION 2: headline lint result ignored
FAILED test_a_headline_naming_an_absent_ref_earns_one_retry_then_is_dropped
  - assert 'Shipped in #999.' == ''
```

`ruff check` and `ruff format --check` are clean on all four changed files.

## Acceptance criteria

- [x] Replay fixtures yield typed facts with kinds, threads, refs, anchors; quotes are code-attached verbatim
- [x] Anchor lint, kind-enum lint, and decision-without-why lint each earn exactly one corrective retry
- [x] Typed metadata round-trips through ledger markers; pre-existing (untyped) notes still parse
- [x] Thread keys stay continuous across chunks via the fact table; table content never surfaces as a new fact
- [x] Headline lint rejects threads/refs not present in the fact table
- [x] An orchestration-style fixture yields `progress` for en-route edits and `done` only at terminal states

## Scope

Extraction only. The deterministic renderer (#285) and ref verification / epistemic stamping (#286)
build on this; `chapter_flush.py` is deliberately untouched, so nothing is wired into the close path
yet — same lane discipline #283 kept.

Two ceilings are marked with `ponytail:` comments rather than pre-solved: the extraction view is
clipped per-turn only (the chunk size band already caps turn count), and a second lint miss fails the
whole chunk instead of salvaging the clean facts within it.
