### PR TITLE
Ref verification + epistemic stamping: code-owned phrasing keyed on verifiable refs (#286)

### DIFF
--- a/docs/adr/0004-authority-phrasing-is-code-stamped.md
+++ b/docs/adr/0004-authority-phrasing-is-code-stamped.md
@@ -1,0 +1,109 @@
+# ADR 0004: Authority phrasing is code-stamped from verifiable refs
+
+- Status: Accepted
+- Date: 2026-07-12
+- Context: epic [#282](https://github.com/buchbend/lore/issues/282),
+  PRD [0008](../prd/0008-typed-fact-session-notes.md), sub-issue
+  [#286](https://github.com/buchbend/lore/issues/286)
+
+## Context
+
+Session notes are read by later sessions. A machine-extracted line like
+"Decision: the ledger is the source of truth" is pulled into a future context
+window and read as settled — even when the extraction over-read a musing. The
+future session restates it, the curator abstracts it into a decision note, and a
+claim that was never made acquires sources. Circular context poisoning: the
+system's own output becomes its evidence.
+
+The genre disclaimer at the top of a note is the only defense today, and under
+context pressure a wrapper loses to line-level phrasing. What a reader — human
+or model — ingests is the sentence, not the header above it.
+
+ADR 0003 made the note body a deterministic render of the ledger, which fixes
+*layout, ordering and suppression* but not this: a model-authored sentence
+rendered deterministically is still a model-authored sentence. The remaining
+question is who writes the words that carry epistemic weight.
+
+Typed-fact extraction gives each fact structured `refs` (`pr` / `commit` /
+`file` / `tag` / `issue`) — pointers to things that exist outside the note and
+can be checked without asking a model.
+
+## Decision
+
+**Code, never the model, authors the phrasing that carries authority.** The
+extraction model contributes a fact's `text` and its `why`. Every word around
+them — what the line claims about the world, and how strongly — is chosen by a
+template the renderer owns, keyed on `(kind, verification)`.
+
+`verification` is computed, not asserted (`lore_core.ref_verify`):
+
+- **Commits, tags and files are verified exactly** — against the session's own
+  deterministic frontmatter facts (what capture recorded) and then against local
+  git and the filesystem.
+- **PRs and issues are verified best-effort** through `gh`.
+- A fact's verdict is the weakest of its refs; a fact with no refs is its own
+  fourth column.
+
+Three verdicts, and the asymmetry between them is the decision:
+
+- `verified` — a check ran and succeeded. The line states itself plainly and
+  shows its pointer with a check mark.
+- `missing` — a check ran and came back empty. The line is **demoted**:
+  "Claimed in session, ref not found: …". A hallucinated ref costs authority
+  rather than buying it.
+- `unchecked` — nothing could be checked (offline, no `gh`, no repo, a value
+  that is not a sha or a number). The pointer is stamped `(unchecked)`.
+
+**Positive evidence only.** Verification promotes on success and on nothing
+else. A `gh` call that fails means GitHub was unreachable, not that the PR is
+fake, so it yields `unchecked` — never `verified`, never `missing`. A ref the
+verifier said nothing about at all renders `(unchecked)`. Offline operation
+therefore degrades a note's phrasing and never fails its render.
+
+**A `decision` with no refs is not a decision.** It renders under **Open** as
+"Agreed in discussion, recorded nowhere: `<text>` — `<why>`". The most
+poison-prone claim in the system becomes, by construction, a line that
+advertises its own weakness and invites checking.
+
+No LLM runs in the verification or the stamping path.
+
+## Consequences / Trade-offs
+
+- **Positive — over-claiming is capped by code, not by prompt obedience.** A
+  weak local model that labels a musing a `decision` produces a hedged line, not
+  an authoritative one. The failure mode of the cheapest tier is bounded.
+- **Positive — trust is a checkable property.** Every authoritative line carries
+  the pointer that earned it, so a reader can verify it in one command instead
+  of trusting the note's voice.
+- **Positive — the incentive is aligned.** The only way for a fact to read
+  confidently is to point at something real, which is also the only way it is
+  useful a month later.
+- **Negative — notes read more hedged than before**, including for facts that
+  are true but unrecorded. This is the intended trade: a true claim with no
+  artifact behind it is exactly the claim a later session should not ingest as
+  settled.
+- **Negative — a note's phrasing is not stable over time.** A ref that verified
+  at close may not verify on a re-render (a branch deleted, a repo moved). The
+  ledger is unchanged by this; only the reading moves, which ADR 0003 already
+  permits.
+- **Negative — verification costs subprocesses at close.** Bounded by deduping
+  refs and by the fact that it runs once per session, at the ending.
+- **Constraint on every future note feature.** Anything that adds a rendered
+  line must state where its authority comes from. A feature that lets a model
+  phrase its own certainty reopens the hole this ADR closes.
+
+## Alternatives considered
+
+- **Prompt the model to hedge appropriately.** Rejected: it is the model's own
+  judgement of its own certainty, which is exactly what fails. It also cannot be
+  tested — there is no assertion to write against "sounds suitably tentative".
+- **Verify with an LLM (check the fact against its quote).** Rejected here: it
+  puts a model back in the authority path, and no LLM re-reads LLM prose as
+  source material in this pipeline (the Stille-Post rule). The ledger keeps the
+  quote beside the claim, so a fidelity checker remains possible later as a
+  separate, clearly-labelled tier.
+- **Drop unverifiable facts from the render.** Rejected: silence is worse than a
+  hedge. An unbacked observation is often the most valuable thing in a session,
+  and the note's job is to say what it is, not to hide it.
+- **Treat a failed `gh` lookup as evidence of absence.** Rejected: it makes an
+  offline laptop rewrite history, demoting every real PR in the note.

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -917,10 +917,11 @@ def _verdicts_for(
 ) -> dict[tuple[str, str], str]:
     """Verify every distinct ref in the ledger against the world, once.
 
-    The session's own frontmatter facts are the offline evidence; ``repo_root``
-    (the cwd the session ran in) opens the local git and filesystem checks, and
-    the recorded repo lets ``gh`` be asked about PRs and issues. None of it is
-    required: whatever cannot be checked renders ``(unchecked)``.
+    The session's own frontmatter facts are the offline evidence for commits and
+    files; ``repo_root`` (the cwd the session ran in) opens the local git and
+    filesystem checks, and the recorded repo lets ``gh`` be asked about PRs and
+    issues — the only oracle for those. None of it is required: whatever cannot
+    be checked renders ``(unchecked)``.
     """
     refs = {(r.type, r.value) for f in facts for r in f.refs}
     if not refs:
@@ -930,8 +931,6 @@ def _verdicts_for(
     return verify_refs(
         sorted(refs),
         commits=[str(c) for c in fm.get("commits") or []],
-        prs=[str(p) for p in fm.get("prs") or []],
-        issues=[str(i) for i in linkage.get("issues") or []],
         files=[str(f) for f in [*(fm.get("files_modified") or []), *(fm.get("files_read") or [])]],
         repo_root=repo_root,
         repo=str(linkage.get("repo") or ""),

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -16,6 +16,15 @@ the reading is written once at close and rewritten if a reopened session
 grows the ledger. No LLM runs in that path: section order, anchor sort,
 and thread suppression are code.
 
+So is every word that carries epistemic weight (see ``docs/adr/0004``).
+A fact's refs are verified against git, the filesystem and ``gh``
+(:mod:`lore_core.ref_verify`), and the phrasing template is chosen by code
+from ``(kind, verification)``: an artifact-backed fact states itself
+plainly and shows its pointer, an unverifiable one is stamped
+``(unchecked)``, a ref that does not exist demotes its line, and a fact
+with no refs at all is attributed to the session that said it. The model
+authors ``text`` and ``why``, never the words around them.
+
 *Marker chapters* record failed and withheld chapters in deterministic
 text — no LLM decides their wording.
 
@@ -50,6 +59,7 @@ import yaml
 
 from lore_core.io import atomic_write_text
 from lore_core.linkage import Linkage
+from lore_core.ref_verify import MISSING, UNCHECKED, VERIFIED, verify_refs
 from lore_core.schema import parse_frontmatter, strip_frontmatter
 
 __all__ = [
@@ -63,6 +73,7 @@ __all__ = [
     "Fact",
     "FACT_KINDS",
     "REF_TYPES",
+    "NO_REFS",
     "SessionFacts",
     "Linkage",
     "NoteView",
@@ -362,6 +373,10 @@ def _render_topic_chapter(n: int, chapter: Chapter, from_turn: int, to_turn: int
 
 def _render_marker_chapter(n: int, kind: str, reason: str, from_turn: int, to_turn: int) -> str:
     span = f"@{from_turn}–@{to_turn}"
+    # Every call site passes a code-owned literal today. Neutralized anyway:
+    # the day a reason carries an upstream error string (a tool payload, a
+    # model message), a raw comment opener here would forge a fact.
+    reason = _neutralize_marker(reason)
     if kind == MARKER_WITHHELD:
         text = (
             f"> **Withheld chapter.** A chapter covering turns {span} was"
@@ -431,10 +446,105 @@ def _suppressed(facts: list[Fact]) -> set[int]:
     }
 
 
-def _fact_line(fact: Fact) -> str:
-    line = _neutralize_marker(fact.text.strip())
-    if fact.why.strip():
-        line = f"{line} Why: {_neutralize_marker(fact.why.strip())}"
+# ---------------------------------------------------------------------------
+# Epistemic stamping (see docs/adr/0004)
+#
+# The phrasing templates are code's, keyed on (kind, verification). The model
+# contributes `text` and `why` and nothing else, so no phrasing it emits can
+# claim more authority than its refs support: a verified ref buys a plain
+# statement plus its pointer, an unverifiable one is stamped `(unchecked)`, a
+# ref that does not exist demotes the whole line, and a fact with no ref is
+# attributed to the session that said it.
+# ---------------------------------------------------------------------------
+
+# A fact with no refs at all. Not a verdict `ref_verify` can return — there was
+# nothing to verify — but the fourth column of the template matrix.
+NO_REFS = "no_refs"
+
+# Session-attributed, stative phrasing for a fact no artifact backs. A ref-less
+# `decision` is the most poison-prone claim in the system (a musing an
+# extraction over-read as settled), so its template says exactly that, and
+# `_section_for` routes it under Open rather than Decisions recorded.
+_NO_REF_LEADS = {
+    "done": "Reported done in session, recorded nowhere:",
+    "progress": "Reported in session:",
+    "decision": "Agreed in discussion, recorded nowhere:",
+    "finding": "Observed in session:",
+    "open": "Left open in session:",
+}
+
+# A ref that was checked and is not there. Positive evidence ran out, so the
+# claim is handed back to the session that made it.
+_MISSING_LEAD = "Claimed in session, ref not found:"
+
+_STAMPS = {VERIFIED: "✓", UNCHECKED: "(unchecked)", MISSING: "(not found)"}
+
+
+def _verdict_of(fact: Fact, verdicts: dict[tuple[str, str], str]) -> str:
+    """A fact's verification: its weakest ref, or ``NO_REFS`` when it has none.
+
+    A ref the verifier said nothing about counts as ``UNCHECKED``. Absence of a
+    verdict is not a pass — that default is what makes a forgotten or crashed
+    verification degrade phrasing instead of forging a check mark.
+    """
+    if not fact.refs:
+        return NO_REFS
+    seen = [verdicts.get((r.type, r.value), UNCHECKED) for r in fact.refs]
+    for verdict in (MISSING, UNCHECKED):
+        if verdict in seen:
+            return verdict
+    return VERIFIED
+
+
+def _lead(kind: str, verification: str) -> str:
+    """The code-owned opening words for a ``(kind, verification)`` cell.
+
+    Empty for a verified or unchecked fact: it states itself, and its pointer
+    (stamped per ref) carries the epistemic load.
+    """
+    if verification == MISSING:
+        return _MISSING_LEAD
+    if verification == NO_REFS:
+        return _NO_REF_LEADS.get(kind, _NO_REF_LEADS["progress"])
+    return ""
+
+
+def _ref_clause(refs: list[Ref], verdicts: dict[tuple[str, str], str]) -> str:
+    """The fact's pointers, each carrying its own verdict's stamp.
+
+    Ref values are model-authored and land in the body, so they are neutralized
+    like any other transcript-derived string, and folded to one line — a fact is
+    one line, and a value with a newline in it would not be.
+    """
+    out = []
+    for ref in refs:
+        value = _neutralize_marker(" ".join(ref.value.split()))
+        stamp = _STAMPS[verdicts.get((ref.type, ref.value), UNCHECKED)]
+        out.append(f"{ref.type} {value} {stamp}".strip())
+    return ", ".join(out)
+
+
+def _section_for(fact: Fact, verification: str) -> str | None:
+    """Where the fact reads. A decision no artifact records is not a decision."""
+    if fact.kind == "decision" and verification == NO_REFS:
+        return "Open"
+    return _SECTION_OF.get(fact.kind)
+
+
+def _fact_line(fact: Fact, verification: str, verdicts: dict[tuple[str, str], str]) -> str:
+    text = _neutralize_marker(fact.text.strip())
+    why = _neutralize_marker(fact.why.strip())
+    lead = _lead(fact.kind, verification)
+    line = f"{lead} {text}" if lead else text
+    if why:
+        # The ref-less decision reads as one sentence — the claim and the reason
+        # it was believed, with nothing between them that could look like a
+        # citation. Every other line keeps `why` as an aside before its refs.
+        sep = " — " if lead == _NO_REF_LEADS["decision"] else " Why: "
+        line = f"{line}{sep}{why}"
+    clause = _ref_clause(fact.refs, verdicts)
+    if clause:
+        line = f"{line} — {clause}"
     return f"- {line} @{int(fact.anchor_turn)}"
 
 
@@ -453,25 +563,34 @@ def render_note_body(
     *,
     headline: str = "",
     gaps: list[tuple[int, int, str]] | None = None,
+    verdicts: dict[tuple[str, str], str] | None = None,
 ) -> str:
     """Render the typed ledger to the note a reader reads. Pure and total.
 
     Sections in fixed order, items sorted by anchor, empty sections dropped,
     one anchor at each line's end. ``gaps`` are the ``(from, to, reason)``
     spans of failed chapters, which read as coverage gaps under Open. Every
-    string that lands in the body is neutralized: text, why, headline and
-    reason all carry content the session did not author.
+    string that lands in the body is neutralized: text, why, headline, reason
+    and ref values all carry content the session did not author.
 
-    The same ledger renders to the same bytes, always — that is what lets the
-    body be thrown away and rebuilt at every close.
+    ``verdicts`` maps a ``(type, value)`` ref to what
+    :func:`lore_core.ref_verify.verify_refs` could establish about it, and it
+    picks each line's phrasing template. Omitting it renders every ref
+    ``(unchecked)`` — the safe direction, and the one an offline or failed
+    verification takes.
+
+    The same ledger and verdicts render to the same bytes, always — that is what
+    lets the body be thrown away and rebuilt at every close.
     """
+    verdicts = verdicts or {}
     dropped = _suppressed(facts)
     sections: dict[str, list[tuple[int, int, str]]] = {name: [] for name, _ in _SECTIONS}
     for pos, fact in enumerate(facts):
-        section = _SECTION_OF.get(fact.kind)
+        verification = _verdict_of(fact, verdicts)
+        section = _section_for(fact, verification)
         if section is None or pos in dropped:
             continue  # an unknown kind stays in the ledger; the body skips it
-        sections[section].append((fact.anchor_turn, pos, _fact_line(fact)))
+        sections[section].append((fact.anchor_turn, pos, _fact_line(fact, verification, verdicts)))
     for i, (from_turn, to_turn, reason) in enumerate(gaps or []):
         sections["Open"].append((from_turn, len(facts) + i, _gap_line(from_turn, to_turn, reason)))
 
@@ -786,19 +905,52 @@ def append_marker_chapter(
     return n
 
 
+def _verdicts_for(
+    facts: list[Fact], fm: dict[str, Any], repo_root: Path | None
+) -> dict[tuple[str, str], str]:
+    """Verify every distinct ref in the ledger against the world, once.
+
+    The session's own frontmatter facts are the offline evidence; ``repo_root``
+    (the cwd the session ran in) opens the local git and filesystem checks, and
+    the recorded repo lets ``gh`` be asked about PRs and issues. None of it is
+    required: whatever cannot be checked renders ``(unchecked)``.
+    """
+    refs = {(r.type, r.value) for f in facts for r in f.refs}
+    if not refs:
+        return {}
+    linkage = fm.get("linkage")
+    linkage = linkage if isinstance(linkage, dict) else {}
+    return verify_refs(
+        sorted(refs),
+        commits=[str(c) for c in fm.get("commits") or []],
+        prs=[str(p) for p in fm.get("prs") or []],
+        issues=[str(i) for i in linkage.get("issues") or []],
+        files=[str(f) for f in [*(fm.get("files_modified") or []), *(fm.get("files_read") or [])]],
+        repo_root=repo_root,
+        repo=str(linkage.get("repo") or ""),
+    )
+
+
 def render_note(
     path: Path,
     *,
     headline: str | None = None,
     title: str | None = None,
     wiki_root: Path | None = None,
+    repo_root: Path | None = None,
 ) -> None:
-    """Rewrite the note's derived body from its ledger. No LLM, no I/O but this.
+    """Rewrite the note's derived body from its ledger. No LLM in this path.
 
     The file becomes disclaimer + rendered note + ledger. Append-only governs
     the LEDGER; the body above it is derived state, thrown away and recomputed
     here — so a reopened session's later facts re-render the whole note instead
     of stranding a stale reading of it above them (extends ADR 0001).
+
+    Each fact's refs are verified first (git, the filesystem, ``gh``) and the
+    verdicts choose the phrasing (ADR 0004). ``repo_root`` is the session's
+    working directory — without it nothing local is consulted, so nothing is
+    promoted. Verification never raises and never blocks the render: an offline
+    machine writes the same note with hedged lines.
 
     ``headline`` is recorded in frontmatter so a later re-render reproduces the
     same note without a model; passing ``None`` keeps the one already there.
@@ -814,10 +966,12 @@ def render_note(
         fm["title"] = title
 
     ledger = _ledger_of(body)
+    facts = parse_facts(ledger)
     rendered = render_note_body(
-        parse_facts(ledger),
+        facts,
         headline=str(fm.get("headline") or ""),
         gaps=_coverage_gaps(fm),
+        verdicts=_verdicts_for(facts, fm, repo_root),
     )
     parts = [DISCLAIMER]
     if rendered:

--- a/lib/lore_core/note_document.py
+++ b/lib/lore_core/note_document.py
@@ -480,16 +480,23 @@ _MISSING_LEAD = "Claimed in session, ref not found:"
 _STAMPS = {VERIFIED: "✓", UNCHECKED: "(unchecked)", MISSING: "(not found)"}
 
 
-def _verdict_of(fact: Fact, verdicts: dict[tuple[str, str], str]) -> str:
-    """A fact's verification: its weakest ref, or ``NO_REFS`` when it has none.
+def _verdict_for(ref: Ref, verdicts: dict[tuple[str, str], str]) -> str:
+    """The verdict on one ref — the single place the default is decided.
 
     A ref the verifier said nothing about counts as ``UNCHECKED``. Absence of a
-    verdict is not a pass — that default is what makes a forgotten or crashed
-    verification degrade phrasing instead of forging a check mark.
+    verdict is not a pass: that default is what makes a forgotten, skipped or
+    crashed verification degrade phrasing instead of forging a check mark. Both
+    the line's phrasing and its stamp read the verdict from here, so the two can
+    never disagree about what was actually established.
     """
+    return verdicts.get((ref.type, ref.value), UNCHECKED)
+
+
+def _verdict_of(fact: Fact, verdicts: dict[tuple[str, str], str]) -> str:
+    """A fact's verification: its weakest ref, or ``NO_REFS`` when it has none."""
     if not fact.refs:
         return NO_REFS
-    seen = [verdicts.get((r.type, r.value), UNCHECKED) for r in fact.refs]
+    seen = [_verdict_for(r, verdicts) for r in fact.refs]
     for verdict in (MISSING, UNCHECKED):
         if verdict in seen:
             return verdict
@@ -519,7 +526,7 @@ def _ref_clause(refs: list[Ref], verdicts: dict[tuple[str, str], str]) -> str:
     out = []
     for ref in refs:
         value = _neutralize_marker(" ".join(ref.value.split()))
-        stamp = _STAMPS[verdicts.get((ref.type, ref.value), UNCHECKED)]
+        stamp = _STAMPS[_verdict_for(ref, verdicts)]
         out.append(f"{ref.type} {value} {stamp}".strip())
     return ", ".join(out)
 

--- a/lib/lore_core/ref_verify.py
+++ b/lib/lore_core/ref_verify.py
@@ -119,23 +119,19 @@ def _verify_file(value: str, files: Sequence[str], repo_root: Path | None) -> st
         return UNCHECKED
 
 
-def _numbers(values: Sequence[str]) -> set[str]:
-    out = set()
-    for v in values:
-        match = _NUMBER_RE.match(str(v).strip())
-        if match:
-            out.add(match.group(1))
-    return out
+def _verify_number(kind: str, value: str, repo_root: Path | None, repo: str) -> str:
+    """PRs and issues: ``gh`` is the only oracle, best-effort.
 
+    There is no frontmatter fast-path here, unlike commits and files. The
+    session's recorded PR/issue numbers come from regexes over branch names and
+    commit messages — text agents write — so a commit saying "Closes #99999"
+    would launder a fabricated number into a check mark. Existence of a PR or an
+    issue is a question only GitHub can answer.
 
-def _verify_number(
-    kind: str,
-    value: str,
-    known: Sequence[str],
-    repo_root: Path | None,
-    repo: str,
-) -> str:
-    """PRs and issues: frontmatter first, then ``gh``, best-effort.
+    ``--json state`` is load-bearing: ``gh`` answers ``--json number`` from the
+    argument itself and exits 0 without contacting the API, which verifies every
+    number ever invented. The field asked for must be one only the API can
+    supply.
 
     ``gh`` failing means only that ``gh`` failed — an unreachable API, no auth,
     no network. That is never evidence the ref is fake, so a non-zero exit
@@ -144,12 +140,9 @@ def _verify_number(
     match = _NUMBER_RE.match(value.strip())
     if not match:
         return UNCHECKED
-    number = match.group(1)
-    if number in _numbers(known):
-        return VERIFIED
     if repo_root is None and not repo:
         return UNCHECKED
-    cmd = ["gh", kind, "view", number, "--json", "number"]
+    cmd = ["gh", kind, "view", match.group(1), "--json", "state"]
     if repo:
         cmd += ["--repo", repo]
     return VERIFIED if _run(cmd, cwd=repo_root) == 0 else UNCHECKED
@@ -159,19 +152,18 @@ def verify_refs(
     refs: Iterable[tuple[str, str]],
     *,
     commits: Sequence[str] = (),
-    prs: Sequence[str] = (),
-    issues: Sequence[str] = (),
     files: Sequence[str] = (),
     repo_root: Path | None = None,
     repo: str = "",
 ) -> dict[tuple[str, str], str]:
     """Verdict for every ``(type, value)`` ref, checking each distinct ref once.
 
-    ``commits`` / ``prs`` / ``issues`` / ``files`` are the session's own
-    deterministic frontmatter facts — the offline evidence, and the only source
-    consulted when there is no repo to ask. ``repo_root`` gates every git and
-    filesystem check (absent: nothing local is checked, so nothing is promoted);
-    ``repo`` (``owner/name``) is passed to ``gh``.
+    ``commits`` / ``files`` are the session's own deterministic frontmatter
+    facts — captured SHAs and tool-recorded paths, evidence code produced, not
+    prose a model wrote. PRs and issues have no such source and go to ``gh``.
+    ``repo_root`` gates every git and filesystem check (absent: nothing local is
+    checked, so nothing is promoted); ``repo`` (``owner/name``) is passed to
+    ``gh``.
     """
     verdicts: dict[tuple[str, str], str] = {}
     for ref in refs:
@@ -184,10 +176,8 @@ def verify_refs(
             verdict = _verify_tag(value, repo_root)
         elif kind == "file":
             verdict = _verify_file(value, files, repo_root)
-        elif kind == "pr":
-            verdict = _verify_number("pr", value, prs, repo_root, repo)
-        elif kind == "issue":
-            verdict = _verify_number("issue", value, issues, repo_root, repo)
+        elif kind in ("pr", "issue"):
+            verdict = _verify_number(kind, value, repo_root, repo)
         else:
             verdict = UNCHECKED  # a ref type code cannot check is never evidence
         verdicts[ref] = verdict

--- a/lib/lore_core/ref_verify.py
+++ b/lib/lore_core/ref_verify.py
@@ -1,0 +1,194 @@
+"""Deterministic verification of the refs a fact carries.
+
+A rendered note line earns authoritative phrasing only from a ref that code
+could check, so what counts as evidence is decided here — never by a model, and
+never by the absence of a failure.
+
+Three verdicts, and the asymmetry between them is the point:
+
+``VERIFIED``
+    A check ran and succeeded. Commits, tags and files are checked *exactly*:
+    against the session's own frontmatter facts (what capture already recorded)
+    and then against local git and the filesystem. PRs and issues are checked
+    best-effort through ``gh``.
+``MISSING``
+    A check ran and came back empty — the commit, tag or file does not exist.
+    The renderer demotes the line, so a hallucinated ref costs authority
+    instead of buying it.
+``UNCHECKED``
+    Nothing could be checked: offline, no ``gh``, no repo to ask, a value that
+    is not a sha / tag / number. Never a check mark. A failed ``gh`` call is
+    always this and never ``MISSING`` — GitHub being unreachable is not
+    evidence that a PR is fake (positive evidence only; see ``docs/adr/0004``).
+
+Nothing here raises: verification degrades the phrasing of a note, it never
+fails a render. And nothing here calls an LLM.
+
+Ref values are model-authored strings. They are matched against a strict
+pattern per type before they may become an argument to ``git`` or ``gh``, so a
+value like ``--upload-pack=…`` is an unverifiable ref, not an option.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+__all__ = ["VERIFIED", "UNCHECKED", "MISSING", "verify_refs"]
+
+VERIFIED = "verified"
+UNCHECKED = "unchecked"
+MISSING = "missing"
+
+_TIMEOUT_SECONDS = 10
+
+# Argument gates. A value that does not match is unverifiable by construction —
+# it never reaches a subprocess.
+_SHA_RE = re.compile(r"\A[0-9a-f]{7,40}\Z")
+_TAG_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._/+-]{0,99}\Z")
+_NUMBER_RE = re.compile(r"\A#?(\d{1,9})\Z")
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None) -> int | None:
+    """Run ``cmd`` and return its exit code, or ``None`` if it could not run.
+
+    ``None`` is the "no evidence either way" answer — a missing binary, a
+    timeout, a broken sandbox. Callers must never read it as a negative.
+    """
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
+        return None
+    return result.returncode
+
+
+def _sha_verified(value: str, commits: Sequence[str]) -> bool:
+    """Whether a captured commit sha and the ref's sha are the same commit."""
+    return any(c and (c.lower().startswith(value) or value.startswith(c.lower())) for c in commits)
+
+
+def _verify_commit(value: str, commits: Sequence[str], repo_root: Path | None) -> str:
+    value = value.strip().lower()
+    if not _SHA_RE.match(value):
+        return UNCHECKED
+    if _sha_verified(value, commits):
+        return VERIFIED
+    if repo_root is None:
+        return UNCHECKED
+    # `^{commit}` refuses a sha that resolves to a blob or a tree: a fact that
+    # points at "a commit" must point at one.
+    code = _run(["git", "cat-file", "-e", f"{value}^{{commit}}"], cwd=repo_root)
+    if code is None:
+        return UNCHECKED
+    return VERIFIED if code == 0 else MISSING
+
+
+def _verify_tag(value: str, repo_root: Path | None) -> str:
+    value = value.strip()
+    if not _TAG_RE.match(value) or repo_root is None:
+        return UNCHECKED
+    code = _run(["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{value}"], cwd=repo_root)
+    if code is None:
+        return UNCHECKED
+    return VERIFIED if code == 0 else MISSING
+
+
+def _verify_file(value: str, files: Sequence[str], repo_root: Path | None) -> str:
+    value = value.strip()
+    if not value:
+        return UNCHECKED
+    if value in files:
+        return VERIFIED  # capture recorded touching it; it existed in this session
+    path = Path(value)
+    if not path.is_absolute():
+        if repo_root is None:
+            return UNCHECKED
+        path = repo_root / path
+    try:
+        return VERIFIED if path.exists() else MISSING
+    except OSError:
+        return UNCHECKED
+
+
+def _numbers(values: Sequence[str]) -> set[str]:
+    out = set()
+    for v in values:
+        match = _NUMBER_RE.match(str(v).strip())
+        if match:
+            out.add(match.group(1))
+    return out
+
+
+def _verify_number(
+    kind: str,
+    value: str,
+    known: Sequence[str],
+    repo_root: Path | None,
+    repo: str,
+) -> str:
+    """PRs and issues: frontmatter first, then ``gh``, best-effort.
+
+    ``gh`` failing means only that ``gh`` failed — an unreachable API, no auth,
+    no network. That is never evidence the ref is fake, so a non-zero exit
+    demotes to ``UNCHECKED``, never to ``MISSING``.
+    """
+    match = _NUMBER_RE.match(value.strip())
+    if not match:
+        return UNCHECKED
+    number = match.group(1)
+    if number in _numbers(known):
+        return VERIFIED
+    if repo_root is None and not repo:
+        return UNCHECKED
+    cmd = ["gh", kind, "view", number, "--json", "number"]
+    if repo:
+        cmd += ["--repo", repo]
+    return VERIFIED if _run(cmd, cwd=repo_root) == 0 else UNCHECKED
+
+
+def verify_refs(
+    refs: Iterable[tuple[str, str]],
+    *,
+    commits: Sequence[str] = (),
+    prs: Sequence[str] = (),
+    issues: Sequence[str] = (),
+    files: Sequence[str] = (),
+    repo_root: Path | None = None,
+    repo: str = "",
+) -> dict[tuple[str, str], str]:
+    """Verdict for every ``(type, value)`` ref, checking each distinct ref once.
+
+    ``commits`` / ``prs`` / ``issues`` / ``files`` are the session's own
+    deterministic frontmatter facts — the offline evidence, and the only source
+    consulted when there is no repo to ask. ``repo_root`` gates every git and
+    filesystem check (absent: nothing local is checked, so nothing is promoted);
+    ``repo`` (``owner/name``) is passed to ``gh``.
+    """
+    verdicts: dict[tuple[str, str], str] = {}
+    for ref in refs:
+        if ref in verdicts:
+            continue
+        kind, value = ref[0], ref[1]
+        if kind == "commit":
+            verdict = _verify_commit(value, commits, repo_root)
+        elif kind == "tag":
+            verdict = _verify_tag(value, repo_root)
+        elif kind == "file":
+            verdict = _verify_file(value, files, repo_root)
+        elif kind == "pr":
+            verdict = _verify_number("pr", value, prs, repo_root, repo)
+        elif kind == "issue":
+            verdict = _verify_number("issue", value, issues, repo_root, repo)
+        else:
+            verdict = UNCHECKED  # a ref type code cannot check is never evidence
+        verdicts[ref] = verdict
+    return verdicts

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -634,6 +634,8 @@ def _apply_extracted(
     it could not be extracted at all — the last of which the render reads back
     as a coverage gap. The body is then rewritten from the whole ledger, so a
     reopened session re-renders instead of stacking a second reading on top.
+    The render verifies each fact's refs and stamps the phrasing accordingly —
+    the last step of the pipeline, and the first one with no model in it.
     """
     # Read before writing: an unnamed note is one this flush gets to name.
     names_the_note = _flushed_to(ctx.note_path) < 0
@@ -694,6 +696,10 @@ def _apply_extracted(
         headline=headline,
         title=_scope_title(ctx.sidecar.scope, headline) if names_the_note else None,
         wiki_root=ctx.wiki_root,
+        # The session's own working directory is the repo its facts point at, so
+        # it is where their refs are checked. Without it the render still writes,
+        # with every ref unchecked (ADR 0004).
+        repo_root=Path(ctx.sidecar.cwd) if ctx.sidecar.cwd else None,
     )
     if names_the_note and headline:
         note_path = _rename_to_topic_slug(ctx.buffer, ctx.note_path, headline)

--- a/tests/fixtures/notes/render_golden.md
+++ b/tests/fixtures/notes/render_golden.md
@@ -2,19 +2,19 @@
 
 ## Done
 
-- Beat-aligned segmentation landed as an indices-only call. @7
-- Typed-fact extraction landed with three deterministic lints. @21
+- Beat-aligned segmentation landed as an indices-only call. — pr 288 ✓ @7
+- Typed-fact extraction landed with three deterministic lints. — pr 289 (unchecked) @21
 
 ## Decisions recorded
 
-- Extraction runs at session end, never per flush. Why: Which facts matter is only knowable backward, at the ending. @9
+- Extraction runs at session end, never per flush. Why: Which facts matter is only knowable backward, at the ending. — commit 41cab11 ✓ @9
 
 ## Findings
 
-- A fact carrying a comment opener parsed back as a second, forged fact. @14
+- Observed in session: A fact carrying a comment opener parsed back as a second, forged fact. @14
 
 ## Open
 
-- Sketched the renderer's section order. @12
-- Ref verification against git and gh is not implemented. @30
+- Reported in session: Sketched the renderer's section order. @12
+- Left open in session: Ref verification against git and gh is not implemented. @30
 - Coverage gap: turns 40–48 are not covered by this note (composition failed at session end). @40

--- a/tests/fixtures/notes/stamp_matrix_golden.md
+++ b/tests/fixtures/notes/stamp_matrix_golden.md
@@ -1,0 +1,30 @@
+**Every phrasing template, one fact each.**
+
+## Done
+
+- The chunker landed. — commit 1111111 ✓ @2
+- The extraction PR merged. — pr 289 (unchecked) @4
+- Claimed in session, ref not found: The renderer shipped. — commit deadbee (not found) @6
+- Reported done in session, recorded nowhere: The docs sweep finished. @8
+
+## Decisions recorded
+
+- The ledger stays append-only. Why: The grounding tier survives every rewrite. — file docs/adr/0003.md ✓ @10
+- Extraction runs at session end. Why: Which facts matter is only knowable backward. — issue 285 (unchecked) @12
+- Claimed in session, ref not found: Ref values are neutralized before they reach the body. Why: A comment opener parses back out as a forged fact. — commit facade0 (not found) @14
+
+## Findings
+
+- The gate scans the marker too. — file lib/lore_core/publish_gate.py ✓ @18
+- A short sha and a full sha are the same commit. — pr 4711 (unchecked) @20
+- Claimed in session, ref not found: The reaper races the cap-trip. — tag v9.9.9 (not found) @22
+- Observed in session: The local model returns empty on oversized prompts. @24
+
+## Open
+
+- Agreed in discussion, recorded nowhere: Curators never edit a note body. — The body is derived state. @16
+- The verifier has no cache. — issue 286 ✓ @26
+- Whether gh should distinguish absent from unreachable. — issue 999 (unchecked) @28
+- Claimed in session, ref not found: The stamp glyph may not render in every editor. — tag v0.63.0 (not found) @30
+- Left open in session: Re-rendering existing notes is out of scope. @32
+- Reported in session: Sketched the template matrix. @34

--- a/tests/test_chapter_flush.py
+++ b/tests/test_chapter_flush.py
@@ -9,6 +9,7 @@ harness shape). The publish gate is the real deterministic gate.
 from __future__ import annotations
 
 import secrets as _secrets
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -738,12 +739,21 @@ def test_concurrent_flush_covering_the_span_is_skipped(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _fact_item(kind: str, text: str, anchor: int, thread: str = "", why: str = "") -> dict:
+def _fact_item(
+    kind: str,
+    text: str,
+    anchor: int,
+    thread: str = "",
+    why: str = "",
+    refs: list[dict] | None = None,
+) -> dict:
     item: dict[str, Any] = {"kind": kind, "text": text, "anchor": anchor}
     if thread:
         item["thread"] = thread
     if why:
         item["why"] = why
+    if refs:
+        item["refs"] = refs
     return item
 
 
@@ -784,11 +794,12 @@ def test_session_end_extracts_typed_facts_and_renders_the_note(tmp_path):
     assert view.chapters[0]["from_turn"] == 0 and view.chapters[0]["to_turn"] == 12
     # The body is the render: headline, sections, ledger below.
     assert "**The flush race is fixed.**" in view.body
-    assert "- The flush race is fixed. @4" in view.body
-    assert "- The reaper races the cap-trip. @6" in view.body
+    # No refs on these facts, so code stamps them as session talk (never as fact).
+    assert "- Reported done in session, recorded nowhere: The flush race is fixed. @4" in view.body
+    assert "- Observed in session: The reaper races the cap-trip. @6" in view.body
     assert view.body.index("## Done") < view.body.index("## Ledger")
     # Suppression is render-time only: absent from the note, whole in the ledger.
-    assert "- Patched the buffer lock. @2" not in view.body
+    assert "Reported in session: Patched the buffer lock." not in view.body
     assert [f.text for f in nd.read_facts(outcome.note_path)] == [
         "Patched the buffer lock.",
         "The flush race is fixed.",
@@ -939,7 +950,64 @@ def test_reopened_session_re_renders_the_note_over_the_grown_ledger(tmp_path):
     view = nd.read_note(note_path)
     assert [c["kind"] for c in view.chapters] == ["facts", "facts"]
     assert view.body.count("## Done") == 1  # one rendered reading, not two
-    assert "- The lock landed. @4" in view.body
-    assert "- The renderer landed. @15" in view.body
+    assert "recorded nowhere: The lock landed. @4" in view.body
+    assert "recorded nowhere: The renderer landed. @15" in view.body
     assert "**The lock and the renderer landed.**" in view.body
     assert view.closed is True
+
+
+def test_the_close_path_verifies_refs_against_the_repo_the_session_ran_in(tmp_path):
+    """A real commit earns its check mark; an invented one demotes its line."""
+    lore_root = _lore_root(tmp_path)
+    wiki_root = lore_root / "wiki" / "private"
+    subprocess.run(["git", "init", "-q"], cwd=lore_root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=lore_root, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=lore_root, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "seed"], cwd=lore_root, check=True
+    )
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=lore_root, capture_output=True, text=True, check=True
+    ).stdout.strip()[:7]
+
+    all_turns = _turns(0, 12)
+    buf = _append(lore_root, all_turns)  # the session's cwd is this repo
+    client = _Client(
+        [
+            {"boundaries": []},
+            {
+                "facts": [
+                    _fact_item(
+                        "done",
+                        "The seed landed.",
+                        2,
+                        refs=[{"type": "commit", "value": head}],
+                    ),
+                    _fact_item(
+                        "done",
+                        "The phantom landed.",
+                        4,
+                        refs=[{"type": "commit", "value": "deadbeefdeadbeef"}],
+                    ),
+                ]
+            },
+            {"headline": "The seed landed."},
+        ]
+    )
+
+    outcome = synth_and_close(
+        buf.sidecar_path,
+        lore_root=lore_root,
+        wiki_root=wiki_root,
+        llm_client=client,
+        model="m",
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+        auto_commit=False,
+    )
+
+    body = nd.read_note(outcome.note_path).body
+    assert f"- The seed landed. — commit {head} ✓ @2" in body
+    assert (
+        "- Claimed in session, ref not found: The phantom landed."
+        " — commit deadbeefdeadbeef (not found) @4" in body
+    )

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -13,10 +13,13 @@ continuation block, disclaimer, marker chapter.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
 from lore_core import note_document as nd
+from lore_core import ref_verify as rv
+from lore_core.linkage import Linkage
 from lore_core.schema import parse_frontmatter, strip_frontmatter
 
 # ---------------------------------------------------------------------------
@@ -708,6 +711,7 @@ def _ledger_fixture() -> list[nd.Fact]:
             text="Extraction runs at session end, never per flush.",
             anchor_turn=9,
             thread="pipeline",
+            refs=[nd.Ref("commit", "41cab11")],
             why="Which facts matter is only knowable backward, at the ending.",
         ),
         nd.Fact(
@@ -732,11 +736,16 @@ def _ledger_fixture() -> list[nd.Fact]:
 
 
 def test_render_note_body_matches_the_golden_render(tmp_path: Path):
-    """Headline, section order, anchor sort, coverage gap — byte for byte."""
+    """Headline, section order, anchor sort, coverage gap, stamps — byte for byte."""
     rendered = nd.render_note_body(
         _ledger_fixture(),
         headline=_HEADLINE,
         gaps=[(40, 48, "composition failed at session end")],
+        verdicts={
+            ("pr", "288"): rv.VERIFIED,
+            ("pr", "289"): rv.UNCHECKED,
+            ("commit", "41cab11"): rv.VERIFIED,
+        },
     )
 
     assert rendered == _GOLDEN.read_text(encoding="utf-8").rstrip("\n")
@@ -761,9 +770,9 @@ def test_progress_is_suppressed_by_a_later_terminal_fact_in_its_thread():
     ]
     rendered = nd.render_note_body(facts)
 
-    assert "- The renderer PR merged. @9" in rendered
+    assert "The renderer PR merged. @9" in rendered
     assert "Opened the PR." not in rendered  # superseded by its thread's ending
-    assert "- Sketched the ADR. @5" in rendered  # its thread never ended
+    assert "Sketched the ADR. @5" in rendered  # its thread never ended
 
 
 def test_a_terminal_fact_earlier_in_the_thread_does_not_suppress_later_progress():
@@ -773,7 +782,7 @@ def test_a_terminal_fact_earlier_in_the_thread_does_not_suppress_later_progress(
     ]
     rendered = nd.render_note_body(facts)
 
-    assert "- Reopened the work. @9" in rendered
+    assert "Reopened the work. @9" in rendered
 
 
 def test_a_terminal_fact_in_another_thread_does_not_suppress_progress():
@@ -782,7 +791,7 @@ def test_a_terminal_fact_in_another_thread_does_not_suppress_progress():
         nd.Fact(kind="done", text="The renderer PR merged.", anchor_turn=9, thread="renderer"),
     ]
 
-    assert "- Sketched the ADR. @3" in nd.render_note_body(facts)
+    assert "Sketched the ADR. @3" in nd.render_note_body(facts)
 
 
 def test_suppressed_progress_stays_in_the_ledger(tmp_path: Path):
@@ -796,7 +805,8 @@ def test_suppressed_progress_stays_in_the_ledger(tmp_path: Path):
     nd.render_note(path)
 
     body = nd.read_note(path).body
-    assert "- Opened the PR. @3" not in body  # suppressed from the render
+    # The rendered form of that fact, had it survived — absent from the reading.
+    assert "Reported in session: Opened the PR." not in body
     assert nd.read_facts(path) == facts  # still whole in the ledger
 
 
@@ -904,8 +914,8 @@ def test_reopen_re_renders_the_body_over_the_grown_ledger(tmp_path: Path):
     assert view.closed is True
     assert [c["kind"] for c in view.chapters] == ["facts", "facts"]
     assert view.body.count("## Done") == 1  # one rendered section, not two
-    assert "- The lock landed. @2" in view.body
-    assert "- The renderer landed. @9" in view.body
+    assert "The lock landed. @2" in view.body
+    assert "The renderer landed. @9" in view.body
     assert view.body.count("**The lock landed.**") == 1  # the stale headline is gone
     assert [f.text for f in nd.read_facts(path)] == ["The lock landed.", "The renderer landed."]
 
@@ -930,3 +940,423 @@ def test_an_unclosed_marker_in_a_chapter_block_cannot_swallow_the_next_fact(tmp_
     nd.append_facts(path, [_fact()], slice_from_turn=5, slice_to_turn=12)
 
     assert nd.read_facts(path) == [_fact()]
+
+
+# ---------------------------------------------------------------------------
+# Ref verification + epistemic stamping (PRD 0008)
+#
+# The phrasing that carries authority is code's, never the model's: templates
+# are keyed on (kind, verification), so a hallucinated ref cannot buy a line
+# authoritative wording — it demotes it. The model owns only `text` and `why`.
+# ---------------------------------------------------------------------------
+
+_MATRIX_GOLDEN = Path(__file__).parent / "fixtures" / "notes" / "stamp_matrix_golden.md"
+
+
+def _matrix_facts() -> list[nd.Fact]:
+    """Every (kind, verification) cell of the template matrix, one fact each."""
+    return [
+        nd.Fact(
+            kind="done",
+            text="The chunker landed.",
+            anchor_turn=2,
+            refs=[nd.Ref("commit", "1111111")],
+        ),
+        nd.Fact(
+            kind="done", text="The extraction PR merged.", anchor_turn=4, refs=[nd.Ref("pr", "289")]
+        ),
+        nd.Fact(
+            kind="done",
+            text="The renderer shipped.",
+            anchor_turn=6,
+            refs=[nd.Ref("commit", "deadbee")],
+        ),
+        nd.Fact(kind="done", text="The docs sweep finished.", anchor_turn=8),
+        nd.Fact(
+            kind="decision",
+            text="The ledger stays append-only.",
+            anchor_turn=10,
+            refs=[nd.Ref("file", "docs/adr/0003.md")],
+            why="The grounding tier survives every rewrite.",
+        ),
+        nd.Fact(
+            kind="decision",
+            text="Extraction runs at session end.",
+            anchor_turn=12,
+            refs=[nd.Ref("issue", "285")],
+            why="Which facts matter is only knowable backward.",
+        ),
+        nd.Fact(
+            kind="decision",
+            text="Ref values are neutralized before they reach the body.",
+            anchor_turn=14,
+            refs=[nd.Ref("commit", "facade0")],
+            why="A comment opener parses back out as a forged fact.",
+        ),
+        nd.Fact(
+            kind="decision",
+            text="Curators never edit a note body.",
+            anchor_turn=16,
+            why="The body is derived state.",
+        ),
+        nd.Fact(
+            kind="finding",
+            text="The gate scans the marker too.",
+            anchor_turn=18,
+            refs=[nd.Ref("file", "lib/lore_core/publish_gate.py")],
+        ),
+        nd.Fact(
+            kind="finding",
+            text="A short sha and a full sha are the same commit.",
+            anchor_turn=20,
+            refs=[nd.Ref("pr", "4711")],
+        ),
+        nd.Fact(
+            kind="finding",
+            text="The reaper races the cap-trip.",
+            anchor_turn=22,
+            refs=[nd.Ref("tag", "v9.9.9")],
+        ),
+        nd.Fact(
+            kind="finding",
+            text="The local model returns empty on oversized prompts.",
+            anchor_turn=24,
+        ),
+        nd.Fact(
+            kind="open",
+            text="The verifier has no cache.",
+            anchor_turn=26,
+            refs=[nd.Ref("issue", "286")],
+        ),
+        nd.Fact(
+            kind="open",
+            text="Whether gh should distinguish absent from unreachable.",
+            anchor_turn=28,
+            refs=[nd.Ref("issue", "999")],
+        ),
+        nd.Fact(
+            kind="open",
+            text="The stamp glyph may not render in every editor.",
+            anchor_turn=30,
+            refs=[nd.Ref("tag", "v0.63.0")],
+        ),
+        nd.Fact(
+            kind="open",
+            text="Re-rendering existing notes is out of scope.",
+            anchor_turn=32,
+        ),
+        nd.Fact(kind="progress", text="Sketched the template matrix.", anchor_turn=34),
+    ]
+
+
+_MATRIX_VERDICTS = {
+    ("commit", "1111111"): rv.VERIFIED,
+    ("pr", "289"): rv.UNCHECKED,
+    ("commit", "deadbee"): rv.MISSING,
+    ("file", "docs/adr/0003.md"): rv.VERIFIED,
+    ("issue", "285"): rv.UNCHECKED,
+    ("commit", "facade0"): rv.MISSING,
+    ("file", "lib/lore_core/publish_gate.py"): rv.VERIFIED,
+    ("pr", "4711"): rv.UNCHECKED,
+    ("tag", "v9.9.9"): rv.MISSING,
+    ("issue", "286"): rv.VERIFIED,
+    ("issue", "999"): rv.UNCHECKED,
+    ("tag", "v0.63.0"): rv.MISSING,
+}
+
+
+def test_the_template_matrix_renders_exactly():
+    """Verified / unchecked / not-found / no-ref, across every kind."""
+    rendered = nd.render_note_body(
+        _matrix_facts(),
+        headline="Every phrasing template, one fact each.",
+        verdicts=_MATRIX_VERDICTS,
+    )
+
+    assert rendered == _MATRIX_GOLDEN.read_text(encoding="utf-8").rstrip("\n")
+
+
+def test_a_verified_ref_earns_a_plain_statement_with_its_pointer():
+    facts = [
+        nd.Fact(kind="done", text="The lock landed.", anchor_turn=4, refs=[nd.Ref("pr", "12")])
+    ]
+
+    rendered = nd.render_note_body(facts, verdicts={("pr", "12"): rv.VERIFIED})
+
+    assert "- The lock landed. — pr 12 ✓ @4" in rendered
+
+
+def test_a_nonexistent_ref_demotes_the_line_instead_of_stamping_it():
+    """The whole point: a hallucinated ref buys hedged phrasing, not authority."""
+    facts = [
+        nd.Fact(
+            kind="done", text="The lock landed.", anchor_turn=4, refs=[nd.Ref("commit", "deadbee")]
+        )
+    ]
+
+    rendered = nd.render_note_body(facts, verdicts={("commit", "deadbee"): rv.MISSING})
+
+    assert (
+        "- Claimed in session, ref not found: The lock landed."
+        " — commit deadbee (not found) @4" in rendered
+    )
+    assert "✓" not in rendered
+
+
+def test_an_unverifiable_ref_is_stamped_unchecked_and_never_gets_a_check_mark():
+    facts = [
+        nd.Fact(kind="done", text="The lock landed.", anchor_turn=4, refs=[nd.Ref("pr", "12")])
+    ]
+
+    rendered = nd.render_note_body(facts, verdicts={("pr", "12"): rv.UNCHECKED})
+
+    assert "- The lock landed. — pr 12 (unchecked) @4" in rendered
+    assert "✓" not in rendered
+
+
+def test_a_ref_with_no_verdict_at_all_is_unchecked_never_verified():
+    """Positive evidence only: silence from the verifier is not a pass."""
+    facts = [
+        nd.Fact(kind="done", text="The lock landed.", anchor_turn=4, refs=[nd.Ref("pr", "12")])
+    ]
+
+    rendered = nd.render_note_body(facts)
+
+    assert "(unchecked)" in rendered
+    assert "✓" not in rendered
+
+
+def test_the_worst_verdict_among_a_facts_refs_decides_its_phrasing():
+    facts = [
+        nd.Fact(
+            kind="done",
+            text="The lock landed.",
+            anchor_turn=4,
+            refs=[nd.Ref("pr", "12"), nd.Ref("commit", "deadbee")],
+        )
+    ]
+
+    rendered = nd.render_note_body(
+        facts, verdicts={("pr", "12"): rv.VERIFIED, ("commit", "deadbee"): rv.MISSING}
+    )
+
+    assert rendered.endswith(
+        "- Claimed in session, ref not found: The lock landed."
+        " — pr 12 ✓, commit deadbee (not found) @4"
+    )
+
+
+def test_a_ref_less_decision_routes_to_open_as_recorded_nowhere():
+    """The most poison-prone claim in the system advertises its own weakness."""
+    facts = [
+        nd.Fact(
+            kind="decision",
+            text="Extraction runs at session end.",
+            anchor_turn=9,
+            why="Which facts matter is only knowable backward.",
+        )
+    ]
+
+    rendered = nd.render_note_body(facts)
+
+    assert "## Decisions recorded" not in rendered
+    assert "## Open" in rendered
+    assert (
+        "- Agreed in discussion, recorded nowhere: Extraction runs at session end."
+        " — Which facts matter is only knowable backward. @9" in rendered
+    )
+
+
+def test_a_decision_with_a_verified_ref_stays_in_decisions_recorded():
+    facts = [
+        nd.Fact(
+            kind="decision",
+            text="The ledger stays append-only.",
+            anchor_turn=9,
+            refs=[nd.Ref("file", "docs/adr/0003.md")],
+            why="The grounding tier survives every rewrite.",
+        )
+    ]
+
+    rendered = nd.render_note_body(facts, verdicts={("file", "docs/adr/0003.md"): rv.VERIFIED})
+
+    assert "## Decisions recorded" in rendered
+    assert "Agreed in discussion, recorded nowhere" not in rendered
+
+
+def test_a_ref_less_fact_is_attributed_to_the_session(tmp_path: Path):
+    facts = [
+        nd.Fact(kind="done", text="The docs sweep finished.", anchor_turn=2),
+        nd.Fact(kind="finding", text="The reaper races the cap-trip.", anchor_turn=4),
+    ]
+
+    rendered = nd.render_note_body(facts)
+
+    assert "- Reported done in session, recorded nowhere: The docs sweep finished. @2" in rendered
+    assert "- Observed in session: The reaper races the cap-trip. @4" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Verification through the note lifecycle (git is real, `gh` is faked)
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    out = subprocess.run(["git", *args], cwd=str(repo), capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    (root / "seed.py").write_text("x = 1\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "first")
+    return root
+
+
+def test_render_verifies_a_commit_against_the_repo_it_was_captured_in(tmp_path: Path, repo: Path):
+    head = _git(repo, "rev-parse", "HEAD")[:7]
+    path = _create(tmp_path)
+    nd.append_facts(
+        path,
+        [
+            nd.Fact(
+                kind="done", text="The seed landed.", anchor_turn=2, refs=[nd.Ref("commit", head)]
+            ),
+            nd.Fact(
+                kind="done",
+                text="The invention landed.",
+                anchor_turn=4,
+                refs=[nd.Ref("commit", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")],
+            ),
+        ],
+        slice_from_turn=0,
+        slice_to_turn=6,
+    )
+
+    nd.render_note(path, repo_root=repo)
+
+    body = nd.read_note(path).body
+    assert f"- The seed landed. — commit {head} ✓ @2" in body
+    assert "- Claimed in session, ref not found: The invention landed." in body
+
+
+def test_render_verifies_a_commit_against_the_frontmatter_session_facts(tmp_path: Path):
+    """The offline source of truth: what capture already recorded, no git needed."""
+    sha = "41cab11f0e5a3b2c9d8e7f6a5b4c3d2e1f0a9b8c"
+    path = _create(tmp_path, facts=nd.SessionFacts(commits=[sha]))
+    nd.append_facts(
+        path,
+        [
+            nd.Fact(
+                kind="done",
+                text="Segmentation landed.",
+                anchor_turn=2,
+                refs=[nd.Ref("commit", "41cab11")],
+            )
+        ],
+        slice_from_turn=0,
+        slice_to_turn=4,
+    )
+
+    nd.render_note(path)
+
+    assert "- Segmentation landed. — commit 41cab11 ✓ @2" in nd.read_note(path).body
+
+
+def test_an_offline_render_never_fails_and_never_awards_a_check_mark(
+    tmp_path: Path, repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """No network, no gh, no git: the note still renders, hedged throughout."""
+    monkeypatch.setattr(rv, "_run", lambda cmd, *, cwd=None: None)
+    path = _create(tmp_path, linkage=Linkage(repo="buchbend/lore"))
+    nd.append_facts(
+        path,
+        [
+            nd.Fact(kind="done", text="The PR merged.", anchor_turn=2, refs=[nd.Ref("pr", "286")]),
+            nd.Fact(
+                kind="done",
+                text="The commit landed.",
+                anchor_turn=4,
+                refs=[nd.Ref("commit", "41cab11")],
+            ),
+        ],
+        slice_from_turn=0,
+        slice_to_turn=6,
+    )
+
+    nd.render_note(path, repo_root=repo)
+
+    body = nd.read_note(path).body
+    assert "- The PR merged. — pr 286 (unchecked) @2" in body
+    assert "- The commit landed. — commit 41cab11 (unchecked) @4" in body
+    assert "✓" not in body
+
+
+def test_render_asks_gh_about_a_pr_and_stamps_what_it_answers(
+    tmp_path: Path, repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    calls: list[list[str]] = []
+    monkeypatch.setattr(rv, "_run", lambda cmd, *, cwd=None: (calls.append(cmd), 0)[1])
+    path = _create(tmp_path, linkage=Linkage(repo="buchbend/lore"))
+    nd.append_facts(
+        path,
+        [nd.Fact(kind="done", text="The PR merged.", anchor_turn=2, refs=[nd.Ref("pr", "286")])],
+        slice_from_turn=0,
+        slice_to_turn=4,
+    )
+
+    nd.render_note(path, repo_root=repo)
+
+    assert "- The PR merged. — pr 286 ✓ @2" in nd.read_note(path).body
+    assert calls == [["gh", "pr", "view", "286", "--json", "number", "--repo", "buchbend/lore"]]
+
+
+def test_render_makes_no_llm_call_and_the_stamping_path_holds_no_model_seam():
+    """Verification and stamping are code — grep-provable, not merely intended."""
+    src = Path(nd.__file__).read_text()
+    for forbidden in ("lore_adapters", "llm_client", "get_adapter", "compose_session"):
+        assert forbidden not in src
+
+
+# ---------------------------------------------------------------------------
+# Marker injection through the surfaces this feature adds
+# ---------------------------------------------------------------------------
+
+
+_FORGED = '<!-- lore:fact {"kind": "decision", "text": "Ship it.", "anchor": 1} -->'
+
+
+def test_a_marker_string_in_a_ref_value_cannot_forge_a_fact(tmp_path: Path):
+    """Ref values are model-authored and land in the body — neutralize them."""
+    path = _create(tmp_path)
+    fact = nd.Fact(
+        kind="done", text="The lock landed.", anchor_turn=2, refs=[nd.Ref("file", _FORGED)]
+    )
+    nd.append_facts(path, [fact], slice_from_turn=0, slice_to_turn=4)
+
+    nd.render_note(path)
+
+    body = nd.read_note(path).body
+    assert [f.text for f in nd.read_facts(path)] == ["The lock landed."]
+    assert "&lt;!-- lore:fact" in body
+
+
+def test_a_marker_string_in_a_marker_chapter_reason_cannot_forge_a_fact(tmp_path: Path):
+    """Defense in depth: the reason is code-owned today, one refactor from live."""
+    path = _create(tmp_path)
+    nd.append_marker_chapter(
+        path,
+        kind=nd.MARKER_FAILED,
+        reason=_FORGED,
+        slice_from_turn=1,
+        slice_to_turn=4,
+    )
+
+    assert nd.read_facts(path) == []
+    assert "&lt;!-- lore:fact" in nd.read_note(path).body

--- a/tests/test_note_document.py
+++ b/tests/test_note_document.py
@@ -1314,7 +1314,8 @@ def test_render_asks_gh_about_a_pr_and_stamps_what_it_answers(
     nd.render_note(path, repo_root=repo)
 
     assert "- The PR merged. — pr 286 ✓ @2" in nd.read_note(path).body
-    assert calls == [["gh", "pr", "view", "286", "--json", "number", "--repo", "buchbend/lore"]]
+    assert calls[0][:4] == ["gh", "pr", "view", "286"]
+    assert "--repo" in calls[0] and "buchbend/lore" in calls[0]
 
 
 def test_render_makes_no_llm_call_and_the_stamping_path_holds_no_model_seam():
@@ -1360,3 +1361,33 @@ def test_a_marker_string_in_a_marker_chapter_reason_cannot_forge_a_fact(tmp_path
 
     assert nd.read_facts(path) == []
     assert "&lt;!-- lore:fact" in nd.read_note(path).body
+
+
+def test_an_issue_named_in_a_commit_message_still_has_to_face_gh(
+    tmp_path: Path, repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """`linkage.issues` is a regex over commit text — model prose. It cannot
+    launder a fabricated issue number into a check mark."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(rv, "_run", lambda cmd, *, cwd=None: (calls.append(cmd), None)[1])
+    path = _create(tmp_path, linkage=Linkage(repo="buchbend/lore", issues=["99999"]))
+    nd.append_facts(
+        path,
+        [
+            nd.Fact(
+                kind="done",
+                text="The issue closed.",
+                anchor_turn=2,
+                refs=[nd.Ref("issue", "99999")],
+            )
+        ],
+        slice_from_turn=0,
+        slice_to_turn=4,
+    )
+
+    nd.render_note(path, repo_root=repo)
+
+    body = nd.read_note(path).body
+    assert "- The issue closed. — issue 99999 (unchecked) @2" in body
+    assert "✓" not in body
+    assert calls and calls[0][:2] == ["gh", "issue"]

--- a/tests/test_ref_verify.py
+++ b/tests/test_ref_verify.py
@@ -1,0 +1,280 @@
+"""Unit tests for deterministic ref verification.
+
+A fact's refs are the only thing that can earn a rendered line authoritative
+phrasing, so what counts as evidence is the whole subject here. The rule is
+positive-evidence-only: ``VERIFIED`` requires a check that ran and succeeded,
+``MISSING`` a check that ran and came back empty, and ``UNCHECKED`` covers
+everything else — offline, no ``gh``, no repo, an unparseable value. Absence of
+failure is never promoted.
+
+No network: the ``gh`` seam is faked in every test that reaches it, and git
+runs against a throwaway repo under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from lore_core import ref_verify
+from lore_core.ref_verify import MISSING, UNCHECKED, VERIFIED, verify_refs
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    out = subprocess.run(["git", *args], cwd=str(repo), capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A throwaway git repo with one commit, one tag, one tracked file."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    (root / "lib").mkdir()
+    (root / "lib" / "thing.py").write_text("x = 1\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "first")
+    _git(root, "tag", "v1.2.0")
+    return root
+
+
+@pytest.fixture
+def head(repo: Path) -> str:
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _fake_gh(monkeypatch: pytest.MonkeyPatch, returncode: int | None) -> list[list[str]]:
+    """Intercept `gh` calls (git still runs for real). Returns the call log."""
+    calls: list[list[str]] = []
+    real = ref_verify._run
+
+    def fake(cmd: list[str], *, cwd=None):
+        if cmd and cmd[0] == "gh":
+            calls.append(cmd)
+            return returncode
+        return real(cmd, cwd=cwd)
+
+    monkeypatch.setattr(ref_verify, "_run", fake)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# commits — frontmatter facts, then local git
+# ---------------------------------------------------------------------------
+
+
+def test_a_commit_in_the_session_facts_is_verified_without_touching_git():
+    sha = "41cab11f0e5a3b2c9d8e7f6a5b4c3d2e1f0a9b8c"
+    verdicts = verify_refs([("commit", "41cab11")], commits=[sha])
+
+    assert verdicts[("commit", "41cab11")] == VERIFIED
+
+
+def test_a_commit_that_exists_in_the_local_repo_is_verified(repo: Path, head: str):
+    verdicts = verify_refs([("commit", head[:7])], repo_root=repo)
+
+    assert verdicts[("commit", head[:7])] == VERIFIED
+
+
+def test_a_commit_that_does_not_exist_demotes_to_missing(repo: Path):
+    dead = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    verdicts = verify_refs([("commit", dead)], repo_root=repo)
+
+    assert verdicts[("commit", dead)] == MISSING
+
+
+def test_a_commit_with_no_repo_to_check_against_is_unchecked_never_verified():
+    verdicts = verify_refs([("commit", "41cab11")])
+
+    assert verdicts[("commit", "41cab11")] == UNCHECKED
+
+
+def test_a_commit_value_that_is_not_a_sha_is_unchecked_and_never_reaches_git(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Ref values are model-authored: they never become git arguments."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(ref_verify, "_run", lambda cmd, *, cwd=None: calls.append(cmd) or 0)
+
+    verdicts = verify_refs([("commit", "--upload-pack=touch /tmp/pwned")], repo_root=repo)
+
+    assert verdicts[("commit", "--upload-pack=touch /tmp/pwned")] == UNCHECKED
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# tags — local git only
+# ---------------------------------------------------------------------------
+
+
+def test_an_existing_tag_is_verified(repo: Path):
+    assert verify_refs([("tag", "v1.2.0")], repo_root=repo)[("tag", "v1.2.0")] == VERIFIED
+
+
+def test_a_nonexistent_tag_demotes_to_missing(repo: Path):
+    assert verify_refs([("tag", "v9.9.9")], repo_root=repo)[("tag", "v9.9.9")] == MISSING
+
+
+def test_a_tag_with_no_repo_is_unchecked():
+    assert verify_refs([("tag", "v1.2.0")])[("tag", "v1.2.0")] == UNCHECKED
+
+
+def test_a_tag_value_that_could_be_an_option_never_reaches_git(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    calls: list[list[str]] = []
+    monkeypatch.setattr(ref_verify, "_run", lambda cmd, *, cwd=None: calls.append(cmd) or 0)
+
+    verdicts = verify_refs([("tag", "--exec=whoami")], repo_root=repo)
+
+    assert verdicts[("tag", "--exec=whoami")] == UNCHECKED
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# files — frontmatter facts, then the filesystem
+# ---------------------------------------------------------------------------
+
+
+def test_a_file_in_the_session_facts_is_verified_without_the_filesystem():
+    verdicts = verify_refs([("file", "lib/gone.py")], files=["lib/gone.py"])
+
+    assert verdicts[("file", "lib/gone.py")] == VERIFIED
+
+
+def test_a_file_that_exists_in_the_repo_is_verified(repo: Path):
+    verdicts = verify_refs([("file", "lib/thing.py")], repo_root=repo)
+
+    assert verdicts[("file", "lib/thing.py")] == VERIFIED
+
+
+def test_a_file_that_does_not_exist_demotes_to_missing(repo: Path):
+    verdicts = verify_refs([("file", "lib/invented.py")], repo_root=repo)
+
+    assert verdicts[("file", "lib/invented.py")] == MISSING
+
+
+def test_a_relative_file_with_no_repo_root_is_unchecked():
+    assert verify_refs([("file", "lib/thing.py")])[("file", "lib/thing.py")] == UNCHECKED
+
+
+# ---------------------------------------------------------------------------
+# PRs and issues — best-effort via gh, never promoted on failure
+# ---------------------------------------------------------------------------
+
+
+def test_a_pr_gh_can_resolve_is_verified(repo: Path, monkeypatch: pytest.MonkeyPatch):
+    calls = _fake_gh(monkeypatch, 0)
+
+    verdicts = verify_refs([("pr", "#286")], repo_root=repo, repo="buchbend/lore")
+
+    assert verdicts[("pr", "#286")] == VERIFIED
+    assert calls == [["gh", "pr", "view", "286", "--json", "number", "--repo", "buchbend/lore"]]
+
+
+def test_a_pr_gh_cannot_resolve_is_unchecked_not_verified(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _fake_gh(monkeypatch, 1)
+
+    assert verify_refs([("pr", "4711")], repo_root=repo, repo="o/r")[("pr", "4711")] == UNCHECKED
+
+
+def test_an_offline_pr_check_is_unchecked_and_never_raises(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """No network, no `gh` binary, a timeout — all the same: no evidence."""
+    _fake_gh(monkeypatch, None)
+
+    assert verify_refs([("pr", "286")], repo_root=repo, repo="o/r")[("pr", "286")] == UNCHECKED
+
+
+def test_an_issue_gh_can_resolve_is_verified(repo: Path, monkeypatch: pytest.MonkeyPatch):
+    calls = _fake_gh(monkeypatch, 0)
+
+    verdicts = verify_refs([("issue", "286")], repo_root=repo, repo="o/r")
+
+    assert verdicts[("issue", "286")] == VERIFIED
+    assert calls[0][:3] == ["gh", "issue", "view"]
+
+
+def test_a_pr_in_the_session_facts_is_verified_without_calling_gh(monkeypatch: pytest.MonkeyPatch):
+    calls = _fake_gh(monkeypatch, 1)
+
+    assert verify_refs([("pr", "#286")], prs=["286"])[("pr", "#286")] == VERIFIED
+    assert calls == []
+
+
+def test_a_pr_with_nowhere_to_ask_is_unchecked_and_calls_nothing(monkeypatch: pytest.MonkeyPatch):
+    calls = _fake_gh(monkeypatch, 0)
+
+    assert verify_refs([("pr", "286")])[("pr", "286")] == UNCHECKED
+    assert calls == []
+
+
+def test_a_pr_value_that_is_not_a_number_is_unchecked(repo: Path, monkeypatch: pytest.MonkeyPatch):
+    calls = _fake_gh(monkeypatch, 0)
+
+    verdicts = verify_refs([("pr", "the ledger PR")], repo_root=repo, repo="o/r")
+
+    assert verdicts == {("pr", "the ledger PR"): UNCHECKED}
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Structural guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_a_broken_toolchain_never_raises_and_never_verifies(
+    repo: Path, head: str, monkeypatch: pytest.MonkeyPatch
+):
+    """Every subprocess blows up: the render still gets a verdict for each ref."""
+
+    def boom(*args, **kwargs):
+        raise OSError("no such tool")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+
+    verdicts = verify_refs(
+        [("commit", head), ("tag", "v1.2.0"), ("pr", "286")],
+        repo_root=repo,
+        repo="o/r",
+    )
+
+    assert set(verdicts.values()) == {UNCHECKED}
+
+
+def test_an_unknown_ref_type_is_unchecked(repo: Path):
+    assert verify_refs([("blog", "x")], repo_root=repo)[("blog", "x")] == UNCHECKED
+
+
+def test_a_repeated_ref_is_checked_once(repo: Path, head: str, monkeypatch: pytest.MonkeyPatch):
+    calls: list[list[str]] = []
+    real = ref_verify._run
+
+    def counting(cmd, *, cwd=None):
+        calls.append(cmd)
+        return real(cmd, cwd=cwd)
+
+    monkeypatch.setattr(ref_verify, "_run", counting)
+
+    verdicts = verify_refs([("commit", head), ("commit", head)], repo_root=repo)
+
+    assert verdicts == {("commit", head): VERIFIED}
+    assert len(calls) == 1
+
+
+def test_module_has_no_llm_wiring():
+    """Verification is code, all the way down — no model may touch a verdict."""
+    src = Path(ref_verify.__file__).read_text()
+    for forbidden in ("lore_adapters", "llm_client", "get_adapter", "compose", "prompt"):
+        assert forbidden not in src, f"ref_verify must not reference {forbidden!r}"

--- a/tests/test_ref_verify.py
+++ b/tests/test_ref_verify.py
@@ -177,7 +177,8 @@ def test_a_pr_gh_can_resolve_is_verified(repo: Path, monkeypatch: pytest.MonkeyP
     verdicts = verify_refs([("pr", "#286")], repo_root=repo, repo="buchbend/lore")
 
     assert verdicts[("pr", "#286")] == VERIFIED
-    assert calls == [["gh", "pr", "view", "286", "--json", "number", "--repo", "buchbend/lore"]]
+    assert calls[0][:4] == ["gh", "pr", "view", "286"]
+    assert "--repo" in calls[0] and "buchbend/lore" in calls[0]
 
 
 def test_a_pr_gh_cannot_resolve_is_unchecked_not_verified(
@@ -206,11 +207,31 @@ def test_an_issue_gh_can_resolve_is_verified(repo: Path, monkeypatch: pytest.Mon
     assert calls[0][:3] == ["gh", "issue", "view"]
 
 
-def test_a_pr_in_the_session_facts_is_verified_without_calling_gh(monkeypatch: pytest.MonkeyPatch):
-    calls = _fake_gh(monkeypatch, 1)
+def test_the_gh_query_never_asks_for_a_field_gh_can_answer_by_itself(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """`gh pr view <N> --json number` echoes N back and exits 0 without ever
+    reaching the API — it verifies every number, including invented ones. Any
+    field gh can answer offline is a forged check mark, so none may be asked
+    for."""
+    calls = _fake_gh(monkeypatch, 0)
 
-    assert verify_refs([("pr", "#286")], prs=["286"])[("pr", "#286")] == VERIFIED
-    assert calls == []
+    verify_refs([("pr", "99999")], repo_root=repo, repo="o/r")
+
+    fields = calls[0][calls[0].index("--json") + 1].split(",")
+    assert "number" not in fields
+
+
+def test_a_pr_number_is_only_ever_verified_by_gh(repo: Path, monkeypatch: pytest.MonkeyPatch):
+    """No frontmatter fast-path: `linkage.prs`/`issues` are regexes over commit
+    messages and branch names — text agents write. A commit saying "Closes
+    #99999" is not evidence #99999 exists."""
+    calls = _fake_gh(monkeypatch, None)  # gh cannot answer
+
+    verdicts = verify_refs([("pr", "99999"), ("issue", "99999")], repo_root=repo, repo="o/r")
+
+    assert set(verdicts.values()) == {UNCHECKED}
+    assert len(calls) == 2  # both went to the one oracle that can say
 
 
 def test_a_pr_with_nowhere_to_ask_is_unchecked_and_calls_nothing(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_reopen_continue.py
+++ b/tests/test_reopen_continue.py
@@ -325,8 +325,8 @@ def test_resumed_session_reattaches_and_appends_to_same_note(tmp_path):
     assert chapters[1]["from_turn"] == 13 and chapters[1]["to_turn"] == 20
     # One rendered reading over the whole ledger, rewritten by the second close.
     assert view.body.count("## Done") == 1
-    assert "- The publish gate landed. @4" in view.body
-    assert "- The essence rewrite landed. @15" in view.body
+    assert "The publish gate landed. @4" in view.body
+    assert "The essence rewrite landed. @15" in view.body
     assert view.closed is True
 
 

--- a/tests/test_startup_sweep.py
+++ b/tests/test_startup_sweep.py
@@ -162,7 +162,7 @@ def test_sweep_extracts_and_closes_dead_session(tmp_path):
     view = nd.read_note(note_path)
     assert view.closed is True
     assert len([c for c in view.chapters if c.get("kind") == "facts"]) == 1
-    assert "- The crash is fixed. @2" in view.body
+    assert "The crash is fixed. @2" in view.body
     assert not buf.sidecar_path.exists()  # moved to _done/
     assert (tmp_path / ".lore" / "buffers" / "_done" / f"{buf.stem}.state.json").exists()
 


### PR DESCRIPTION
Closes #286. Layers onto #285's deterministic renderer: the render now **verifies each fact's refs and chooses the phrasing from what code could establish** — the feature the epic exists to make possible.

## The guarantee

The extraction model authors a fact's `text` and `why`. Code authors every word around them. Phrasing templates are keyed on `(kind, verification)`, so a hallucinated ref cannot buy a line authoritative wording — it **demotes** it.

## Template matrix

`tests/fixtures/notes/stamp_matrix_golden.md` renders every cell (verified / unchecked / not-found / no-ref × all five kinds), byte for byte:

```
- The chunker landed. — commit 1111111 ✓ @2
- The extraction PR merged. — pr 289 (unchecked) @4
- Claimed in session, ref not found: The renderer shipped. — commit deadbee (not found) @6
- Reported done in session, recorded nowhere: The docs sweep finished. @8
...
## Open
- Agreed in discussion, recorded nowhere: Curators never edit a note body. — The body is derived state. @16
```

A verified ref states itself plainly and shows its pointer. An unverifiable one is stamped `(unchecked)`. A ref that was checked and is not there hands the claim back to the session that made it. A fact with no refs is session-attributed and stative. A **`decision` with no refs is not a decision**: it routes into **Open** as `Agreed in discussion, recorded nowhere: <text> — <why>` — the most poison-prone claim in the system, advertising its own weakness by construction.

A fact's verdict is the weakest of its refs, so one bad ref demotes the line even when the others check out.

## How offline degrades without promoting

`lib/lore_core/ref_verify.py` is positive-evidence-only. Commits, tags and files are checked **exactly** — against the session's frontmatter facts (what capture already recorded) and then local git / the filesystem. PRs and issues are best-effort via `gh`.

- A check that **ran and came back empty** → `missing` → the line demotes.
- A check that **could not run** → `unchecked` → hedged, never a check mark. Offline, no `gh`, no repo, a value that is not a sha or a number: all the same answer.
- A failed `gh` call is **never** `missing`. An unreachable API is not evidence that a PR is fake — that would make an offline laptop rewrite history, demoting every real PR in the note.
- `repo_root` (the session's own cwd, wired through `chapter_flush`) gates every local check. Without it nothing is consulted, so nothing is promoted.
- Nothing in the path raises. Verification degrades a note's phrasing; it never fails its render.

## Neutralizing model-authored ref values

`Ref.value` is model-authored and lands in the body, so `_ref_clause` routes it through `_neutralize_marker` like every other transcript-derived string — a literal `<!-- lore:fact …` in a ref value would otherwise parse back out as a forged fact with attacker-chosen `kind`/`refs`. Values are also folded to one line (a fact is one line).

Two more edges closed: a value that is not a sha / tag / number **never becomes a `git` or `gh` argument** (so `--upload-pack=…` is an unverifiable ref, not an option), and `_render_marker_chapter` now neutralizes its `reason` — code-owned at all three call sites today, one refactor from live (the advisory carried over from #285).

**No LLM call in the verification or stamping path** — grep-asserted in both modules' tests.

## ADR

`docs/adr/0004-authority-phrasing-is-code-stamped.md` — authority phrasing is code-stamped from verifiable refs, never model-authored. It states the constraint on every future note feature: anything that adds a rendered line must say where its authority comes from.

## TDD evidence

Red first — the tests were written against a module that did not exist:

```
tests/test_note_document.py:21: in <module>
    from lore_core import ref_verify as rv
E   ImportError: cannot import name 'ref_verify' from 'lore_core'
2 errors in 0.94s
```

Green:

```
tests/test_ref_verify.py tests/test_note_document.py tests/test_chapter_flush.py
117 passed in 2.49s

full suite: 4 failed, 2827 passed, 16 skipped
(the 4 are the known pre-existing ANSI/terminal-width failures:
 test_cli_scopes, test_core_llm_wiring ×2, test_install_dispatcher)
```

`ruff check` + `ruff format --check` clean on the diff.

## Mutation checks

Every guarantee was mutated and confirmed to fail a test:

| Mutation | Result |
|---|---|
| A nonexistent commit ref verifies as real | **3 tests fail** (verify, render, close path) |
| The offline `gh` path emits a check mark | **3 tests fail** |
| The "recorded nowhere" routing is stripped | **2 tests fail** (matrix golden + routing) |
| A ref with no verdict defaults to verified | **1 test fails** — *see below* |
| Ref values are not neutralized | **1 test fails** (forged-fact regression) |
| The marker-chapter reason is not neutralized | **1 test fails** |

The fourth mutation **initially survived**, and it was right to. The default `unchecked` verdict was written twice — once for the line's phrasing, once for its stamp — so flipping one left the other honest and no test could see the disagreement. That default *is* the positive-evidence guarantee, so the second commit gives it one home (`_verdict_for`), read by both. The mutation now fails.

## Note for review

The stamping changes what a ref-less fact reads like, so #285's golden and a handful of assertions in `test_chapter_flush` / `test_reopen_continue` / `test_startup_sweep` move with it (a `done` with no artifact ref now reads "Reported done in session, recorded nowhere: …"). That churn is the feature — those were exactly the lines that used to assert world-state on the model's authority. Assertions about lifecycle (suppression, reopen, sweep) were rewritten to assert lifecycle rather than wording, and the negative suppression assertions were tightened so they cannot pass vacuously under the new phrasing.
