### PR TITLE
fix(redaction): Google API keys ending in -, / or + were published unredacted

### DIFF
--- a/lib/lore_core/redaction.py
+++ b/lib/lore_core/redaction.py
@@ -49,10 +49,17 @@ class _PatternSpec:
 # Patterns are intentionally conservative: false-positives only cost a
 # redaction marker; false-negatives can leak secrets. Order matters for
 # overlap dedup below — earlier matches win.
+#
+# A trailing `\b` is only safe when the preceding character class is
+# word-only. Where the class admits `-`, `/` or `+`, a key ending in one of
+# them has no word/non-word transition to close on: with an exact count the
+# match fails outright and the secret is emitted verbatim; with an open-ended
+# count the regex backtracks and leaves the tail unredacted. Those patterns
+# close on a negative lookahead over their own alphabet instead.
 _PATTERNS: tuple[_PatternSpec, ...] = (
     _PatternSpec(
         kind="sk-api-key",
-        pattern=re.compile(r"\bsk-(?:ant-)?[A-Za-z0-9_-]{20,}\b"),
+        pattern=re.compile(r"\bsk-(?:ant-)?[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"),
     ),
     _PatternSpec(
         kind="ghp-token",
@@ -60,7 +67,7 @@ _PATTERNS: tuple[_PatternSpec, ...] = (
     ),
     _PatternSpec(
         kind="aiza-key",
-        pattern=re.compile(r"\bAIza[0-9A-Za-z_\-/+]{35}\b"),
+        pattern=re.compile(r"\bAIza[0-9A-Za-z_\-/+]{35}(?![0-9A-Za-z_\-/+])"),
     ),
     _PatternSpec(
         kind="aws-access-key",
@@ -75,7 +82,8 @@ _PATTERNS: tuple[_PatternSpec, ...] = (
     _PatternSpec(
         kind="jwt",
         pattern=re.compile(
-            r"\b[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"
+            r"\b[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"
+            r"(?![A-Za-z0-9_-])"
         ),
         predicate=lambda v: len(v) > 60,
     ),

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import secrets
+import string
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,14 @@ class TestSkApiKeys:
         assert hits[0].kind == "sk-api-key"
         assert "[REDACTED:sk-api-key]" in redacted
 
+    def test_redaction_catches_sk_key_ending_in_dash(self):
+        """A trailing dash is part of the key, not left dangling after it."""
+        token = "a" * 29 + "-"
+        text = f"key: sk-{token} ok"
+        redacted, hits = redact(text)
+        assert len(hits) == 1
+        assert redacted == "key: [REDACTED:sk-api-key] ok"
+
 
 class TestGithubToken:
     """GitHub personal access tokens."""
@@ -52,17 +61,27 @@ class TestGithubToken:
 class TestGoogleApiKey:
     """Google API keys (AIza...)."""
 
-    def test_redaction_catches_aiza_key(self):
-        """Google API key pattern AIza<35 more> replaced."""
-        # AIza followed by 35 alphanumeric chars (per spec: [0-9A-Za-z_-])
-        import string
-        charset = string.ascii_letters + string.digits + "_-"
-        suffix = "".join(secrets.choice(charset) for _ in range(35))
+    # Real keys draw from [A-Za-z0-9_-]; the pattern also admits / and +. The
+    # tail character decides whether a trailing \b can close the match, so the
+    # boundary cases are enumerated rather than sampled.
+    @pytest.mark.parametrize("tail", ["A", "9", "_", "-", "/", "+"])
+    def test_redaction_catches_aiza_key(self, tail):
+        """Google API key pattern AIza<35 more> replaced, whatever the tail."""
+        suffix = "a" * 34 + tail
         text = f"API key AIza{suffix} here"
         redacted, hits = redact(text)
         assert len(hits) == 1
         assert hits[0].kind == "aiza-key"
         assert "[REDACTED:aiza-key]" in redacted
+        assert suffix not in redacted
+
+    def test_redaction_catches_random_aiza_key(self):
+        """A key over the real Google alphabet is redacted whole."""
+        charset = string.ascii_letters + string.digits + "_-"
+        suffix = "".join(secrets.choice(charset) for _ in range(35))
+        text = f"API key AIza{suffix} here"
+        redacted, hits = redact(text)
+        assert len(hits) == 1
         assert suffix not in redacted
 
 


### PR DESCRIPTION
Closes #290, #281, #240, #198 — all four are the same bug seen from different angles.

## The bug

`lib/lore_core/redaction.py` closed the `aiza-key` pattern on `\b`:

```python
re.compile(r"\bAIza[0-9A-Za-z_\-/+]{35}\b")
```

The character class admits `-`, `/` and `+`, which are non-word characters. A key ending in one of them has no word/non-word transition for the `\b` to close on, and because `{35}` is an exact count the regex cannot backtrack to a shorter match — so **the pattern does not fire and the key is written into the note body verbatim**. Real Google keys draw from `[A-Za-z0-9_-]`, so ~1 in 64 (1.6%) end in `-` and leaked.

Redaction is what scrubs a captured transcript *before* it becomes a durable session note in a git-committed wiki, and `publish_gate.has_secret()` reuses these same patterns as its blocking pre-LLM scanner. A miss here is a secret pushed to a remote.

## The fix

Close on a negative lookahead over the pattern's own alphabet instead of on Python's word-character rule.

Audited the siblings for the same shape:

| pattern | class | before | now |
|---|---|---|---|
| `aiza-key` | admits `-/+`, exact `{35}` | **leaked whole key** | lookahead |
| `sk-api-key` | admits `-`, open `{20,}` | backtracked, left tail unredacted | lookahead |
| `jwt` | admits `-`, open `{10,}` | backtracked, left tail unredacted | lookahead |
| `ghp-token` | word-only | safe | unchanged |
| `aws-access-key` | word-only | safe | unchanged |
| `high-entropy-credential` | no trailing anchor | safe | unchanged |

## Not flaky, correct

`test_redaction_catches_aiza_key` built its suffix with `secrets.choice` over an alphabet containing `-`, so it detected this real bug ~1.6% of runs and was filed twice as a flaky test (#240, #198). It was never flaky — it was an intermittently-correct test. Boundary tails are now enumerated (`A 9 _ - / +`), so the regression is pinned instead of sampled; a random-alphabet case stays alongside it.

## Verification

- `tests/test_redaction.py`: 32 passed.
- Full suite: 2734 passed. The 4 failures on this branch (`test_cli_scopes`, `test_core_llm_wiring` ×2, `test_install_dispatcher`) are pre-existing ANSI/terminal-width assertion failures — they fail identically against unmodified `lib/` on `main`.
- No real `AIza…` key exists anywhere in git history or in the vault; scanned both.