### PR TITLE
docs: align Diataxis docs with typed-fact session notes (#282)

### DIFF
--- a/CONTEXT-FORMAT.md
+++ b/CONTEXT-FORMAT.md
@@ -1,57 +1,116 @@
-# Session note format v2 — title and body shape
+# Session note format — title and body shape
 
-Refines the note-essence voice from `CONTEXT.md`'s "The session note"
-section: same vocabulary (chapter, topic block, lead, disclaimer), two
-rendering changes that make a note's *display* title and its *skim
-layer* easier to read at a glance. Grounded in
-`lore_core/note_document.py` and `lore_curator/stub_note.py`.
+The exact shape a session note takes on disk. `CONTEXT.md` owns the
+vocabulary (buffer, flush, chapter, fact, ledger, disclaimer) and the write
+path; this file is the rendering. Grounded in `lore_core/note_document.py`
+and `lore_curator/stub_note.py`.
+
+A note is written **once, at session close** — the whole file below appears
+in one step. Nothing is rendered while the session runs.
 
 ## Title: `scope: name`
 
 A note's frontmatter `title` is a placeholder at creation
-(`stub_note._placeholder_title`, e.g. `proj:x session — 2026-07-10`) —
-the first heartbeat fires before any chapter exists, so there's no
-topic to name yet. Once the first chapter composes, the title is
-replaced with `<scope>: <name>`:
+(`stub_note._placeholder_title`, e.g. `proj:x session — 2026-07-10`) — the
+first heartbeat fires before there is any content to name.
 
-- **scope first** — the linkage scope (repo/project slug, e.g.
-  `proj:x` or `ccat:data-center`) so a list of notes sorts and scans
-  by *where*, not by an arbitrary date stamp.
-- **name second** — a compiled human-readable name taken from the
-  first chapter's opening lead (`stub_note._topic_title`, reusing
-  `_lead_for_rename`'s same source text as the filename slug — title
-  and filename always name the same topic).
+At close, one bounded LLM call writes the session's **headline** from the
+extracted fact table, and the headline names the note:
+`render_note(title=_scope_title(scope, headline))` replaces the placeholder
+with `<scope>: <name>`.
+
+- **scope first** — the linkage scope (repo/project slug, e.g. `proj:x` or
+  `ccat:data-center`) so a list of notes sorts and scans by *where*, not by
+  an arbitrary date stamp.
+- **name second** — the headline, minus its trailing period.
 
 Example: `proj:x: Traced the flush race`.
 
-The rename happens once, on chapter 1 only
-(`note_document.append_chapter`'s `title` kwarg is a no-op past the
-first chapter) — later chapters extend the note but never rename it,
-matching the existing filename-rename behavior
-(`chapter_flush._rename_to_topic_slug`).
+The same headline slugs the filename (`chapter_flush._rename_to_topic_slug`),
+so title and filename always name the same topic. An empty headline leaves
+both at their placeholder.
 
-## Body: inline lead
-
-Each topic block's bold lead sentence opens the same paragraph as its
-body prose — not a standalone bold line sitting above a blank-line
-gap:
+## Body: disclaimer, reading, ledger
 
 ```
-**Chose an append-only note model.** We decided the note file is
-append-only until close.
+> **Lab-notebook session note — not authoritative.** …          ← DISCLAIMER
+
+**Traced the flush race.**                                       ← headline
+
+## Done
+- The chunker landed. — commit 1111111 ✓ @2
+- The extraction PR merged. — pr 289 (unchecked) @4
+
+## Decisions recorded
+- The ledger stays append-only. Why: The grounding tier survives every
+  rewrite. — file docs/adr/0003.md ✓ @10
+
+## Findings
+- The gate scans the marker too. — file lib/lore_core/publish_gate.py ✓ @18
+- Observed in session: The local model returns empty on oversized prompts. @24
+
+## Open
+- Agreed in discussion, recorded nowhere: Curators never edit a note body.
+  — The body is derived state. @16
+- Coverage gap: turns 40–71 are not covered by this note (extraction failed
+  at session end). @40
+
+## Ledger                                                        ← LEDGER_HEADING
+<!-- lore:chapter 1 @0-39 -->
+<!-- lore:fact {"anchor": 2, "kind": "done", …} -->
+**The chunker landed.**
+> "…verbatim quote from turn 2…"
+@2
+…
 ```
 
-not:
+Everything above `## Ledger` is **derived state** — a pure function of the
+ledger below it, recomputed in full at every close (ADR 0003). The ledger is
+append-only. The same ledger renders to the same bytes, always.
+
+### The four sections
+
+Fixed order, which is the reading order: **Done**, **Decisions recorded**,
+**Findings**, **Open**. Items sort by anchor. Empty sections are dropped
+entirely.
+
+- A `progress` fact reads under **Open** — it is unfinished work at the
+  session's ending — *unless* its thread later reached a terminal (`done`)
+  fact, in which case the render suppresses it. Suppression is a decision of
+  the reading only; the fact stays whole in the ledger.
+- A `decision` with no refs is not a decision: it routes to **Open** as
+  *"Agreed in discussion, recorded nowhere: … — <why>"*.
+- Every chapter that is not a `facts` chapter — a failed marker, a withheld
+  marker, or a prose chapter from a legacy note — renders as a one-line
+  **coverage gap** under Open, so a partial reading never presents itself as
+  complete.
+
+### A rendered line
 
 ```
-**Chose an append-only note model.**
-
-We decided the note file is append-only until close.
+- [lead] <text> [Why: <why>] [— <type> <value> <stamp>, …] @<anchor>
 ```
 
-A reader reads the bold sentence and bails, or keeps reading the same
-paragraph for the rest of the topic — no forced stop between claim and
-support. The skim layer (bold leads read top-to-bottom, CONTEXT.md)
-is unchanged: leads are still bold, still self-sufficient, still first
-in their paragraph. Quote and `@N` anchor still follow as their own
-lines. See `note_document._render_block`.
+The `text` and the `why` are the model's. **Every other word is code's**
+(ADR 0004), chosen by a template keyed on `(kind, verification)`:
+
+| Verification | Lead | Ref stamp |
+| :--- | :--- | :--- |
+| verified | *(none — the line states itself)* | `✓` |
+| unchecked | *(none)* | `(unchecked)` |
+| missing | `Claimed in session, ref not found:` | `(not found)` |
+| no refs | `Reported done in session, recorded nowhere:` / `Reported in session:` / `Agreed in discussion, recorded nowhere:` / `Observed in session:` / `Left open in session:` (by kind) | — |
+
+## The ledger
+
+One chapter per extracted chunk, opened by an HTML-comment delimiter carrying
+its turn span. Each fact is stored twice: as a machine-readable
+`<!-- lore:fact {…} -->` marker (the copy `render_note` reads back) and as
+human-readable text — the bold statement, its code-attached verbatim quote
+from the anchor turn, and the `@N` anchor. Drill-down chain: rendered line →
+fact in the ledger → quote → archived transcript turn.
+
+Notes written before typed facts carry **prose chapters** of bold-lead topic
+blocks instead of fact markers. They still parse and still render; contributing
+no facts, their spans appear as coverage gaps in any note that mixes them with
+facts. They are not migrated (fix-forward).

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ threads live in a chat window that disappears. PRs capture the diff;
 nothing captures *why*. Lore closes the loop:
 
 ```
-Session with AI  →  (auto at SessionEnd / PreCompact / cap-trip)
-                 →  transcript captured into a per-session buffer
-                 →  one chapter composed per flush, gated for PII/
-                    secrets/directive phrasing before it's appended
+Session with AI  →  transcript captured into a per-session buffer
+                 →  (at SessionEnd, once) the whole session is segmented,
+                    extracted into typed facts, gated for PII/secrets/
+                    directive phrasing, and rendered by code
                  →  one lab-notebook session note per session,
                     readable via MCP pull at next SessionStart
 ```
@@ -188,8 +188,9 @@ network egress to PyPI / the marketplace.
 
 Session notes auto-extract from Claude Code transcripts; explicit
 capture commands are no longer needed. Each session's turns accumulate
-in a buffer and are composed into chapters of a single, per-session
-lab-notebook note (see `CONTEXT.md` for the full model). Anything else
+in a buffer, and at session end the whole session is extracted into a
+single, per-session lab-notebook note — nothing is written while the
+session runs (see `CONTEXT.md` for the full model). Anything else
 in a wiki — concepts, decisions, projects, reference notes — is
 written directly, by hand or via `/lore:inbox`; there is no automatic
 daily abstraction pass.
@@ -244,13 +245,16 @@ Interactive — asks for wiki + scope, writes the managed block to
 
 Once attached with a wiki present:
 
-- **Claude Code SessionEnd / PreCompact hooks**, plus ordinary tool
-  activity, drive a per-session buffer-and-flush heartbeat — no cron.
-  A flush composes one chapter (one LLM call) from the buffered slice
-  and appends it to the session's note, behind the publish gate. No
-  LLM runs inline in the hook itself; the flush is detached.
+- **Claude Code hooks**, plus ordinary tool activity, drive a per-session
+  buffer heartbeat — no cron. **SessionEnd is the only flush:** the whole
+  session is segmented into chunks, each chunk extracted into typed facts,
+  and the note body rendered from them by code, behind the publish gate.
+  Mid-session events (a pre-compact, the buffer tripping its cap) only
+  bookkeep — the buffer keeps accumulating and no model is called, because
+  which turns mattered is knowable only from the ending. No LLM runs inline
+  in the hook itself; the flush is detached.
 - **SessionStart** also sweeps any session whose owning process is
-  provably dead (crash, closed laptop lid) — its note gets one compose
+  provably dead (crash, closed laptop lid) — its note gets one extraction
   attempt and closes, under a global singleton lock. All detached —
   SessionStart never blocks.
 - **Banner at SessionStart** is deliberately minimal: a status line, an
@@ -292,9 +296,10 @@ curator:
   threshold_pending_turns: 30   # spawn the heartbeat when ≥ N buffered turns
   max_pending_age_s: 600        # OR the oldest pending entry is this old
   a_noteworthy_tier: middle     # middle (default) | simple (cheap, higher false-neg)
-  synthesis_buffer_cap_turns: 120   # flush a chapter at this many turns...
+  synthesis_buffer_cap_turns: 120   # record a cap-trip at this many turns...
   synthesis_buffer_cap_chars: 240000 # ...or this many transcript chars
-  synthesis_model_tier: middle  # which `models.*` tier composes chapters
+                                     # (bookkeeping — the buffer keeps growing)
+  synthesis_model_tier: middle  # `models.*` tier for segmentation + extraction
 models:
   simple: claude-haiku-4-5
   middle: claude-sonnet-4-6
@@ -414,7 +419,7 @@ curator:
     base_url: https://chat.kiconnect.nrw/api/v1   # your gateway root
     # api_key_env: LORE_OPENAI_API_KEY            # optional override
     model_simple: gpt-4o-mini                     # cheap tier
-    model_middle: gpt-4o                          # default tier (chapter compose at synthesis_model_tier: middle)
+    model_middle: gpt-4o                          # default tier (extraction at synthesis_model_tier: middle)
     model_high:   gpt-4o                          # heaviest tier (synthesis_model_tier: high)
 ```
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -87,7 +87,7 @@ a detached flush needs to run.
    (unless one is already threaded in).
 2. The trace_id crosses the process boundary as `LORE_TRACE_ID` in the
    detached `lore curator flush` subprocess's environment — the *one*
-   place it's handed off (`chapter_flush.py:1097`).
+   place it's handed off (`chapter_flush.py:spawn_detached_flush`).
 3. `lore_cli/curator_cmd.py` reads `LORE_TRACE_ID` and stamps it onto
    every `source="curator"` run event the flush emits (`run-start`,
    `noteworthy`, `session-note`, `run-end`, …).

--- a/docs/architecture/session-note-lifecycle.md
+++ b/docs/architecture/session-note-lifecycle.md
@@ -1,57 +1,92 @@
 # Session-note lifecycle — one session, one note
 
-**Audience:** contributors who open a note whose frontmatter says
-`note_status: closed`, watch it gain another chapter an hour later, and
-wonder how a "closed" note is still being written to — or who need to
-know why a resumed session no longer leaves two half-duplicated notes
-behind.
+**Audience:** contributors who watch a long session run for hours without a
+note appearing anywhere, or who open a note whose frontmatter says
+`note_status: closed`, see it change an hour later, and wonder how a "closed"
+note is still being written to.
 
-The session note is the deterministic core's one-record-per-session
-artifact: a fixed disclaimer followed by chronological chapters, one per
-flush. `CONTEXT.md` is the vocabulary (buffer, flush, chapter, block,
-anchor, marker); this document explains the **lifecycle** that vocabulary
-moves through — `create → append → close → reopen` — and the guarantee
-that lifecycle exists to keep: **one session produces exactly one note.**
+The session note is the deterministic core's one-record-per-session artifact:
+a fixed disclaimer, a rendered reading of the session, and below it the
+append-only ledger the reading was computed from. `CONTEXT.md` is the
+vocabulary (buffer, flush, chapter, fact, anchor, marker); this document
+explains the **lifecycle** that vocabulary moves through — `create → close →
+segment → extract → render → seal` — and the guarantee it exists to keep:
+**one session produces exactly one note.**
 
 ---
 
-## The promise, and how it used to break
+## One flush, and it is the ending
 
-A session note should be a faithful, skimmable, navigable record of what
-*one* session figured out. Two failure classes broke that promise even
-after the note *voice* was fixed:
+The note file is created at the session's first heartbeat — disclaimer,
+frontmatter, no content. After that, **nothing is written to it while the
+session runs.** Turns accumulate in the buffer and that is all.
 
-- **One session, several notes.** A session closed early (a false
-  liveness reap) or resumed after a `/compact`, an editor restart, or an
-  idle-then-return would mint a *second* note file that re-narrated the
-  first from an empty note-so-far. The vault accumulated sibling notes
-  that each told part of the story and repeated the rest.
-- **Notes reporting work the session never did.** Material the user
-  pasted only as a formatting exemplar or a reference was read by the
-  composer and reported as the session's own findings — with every block
-  collapsing onto the single turn that held the pasted blob, so the
-  anchors were useless for navigation.
+Which of a session's turns mattered is only knowable *backward*, from its
+ending: at the moment a slice happens, "PR #524 opened" genuinely is its
+substance, and only the ending reveals that twenty such lines collapse into
+"all five features merged". So the whole session is read at once, at the close,
+and the note appears once, complete. The reasoning behind that is
+[why a session note is written only at the end](../explanation/why-notes-are-written-at-session-end.md);
+this page is the mechanics.
 
-The lifecycle below closes both. The full problem statement and the
-per-decision rationale live in
-[PRD 0002](../prd/0002-useful-session-notes.md); the immutability
-trade-off is recorded in
-[ADR 0001](../adr/0001-session-note-reopen-relaxes-close-immutability.md).
+**`capture_routing.CLOSE_TRIGGERS` is the single authority** for which trigger
+flushes, and it holds exactly one entry: `session-end`. Everything else
+bookkeeps.
+
+| Event | What happens |
+|---|---|
+| Buffer trips its cap (`synthesis_buffer_cap_turns` / `_chars`) | A `cap-tripped` event is recorded on the buffer. It keeps accumulating. No chapter, no model call. |
+| Pre-compact | Forwarded to `request_flush_for_my_buffers`, which drops it — not in `CLOSE_TRIGGERS`. The buffer keeps accumulating. |
+| Session end | The buffer's `flush_requested` is stamped and the close path runs. |
+| Reaper / startup sweep | The same close path, for a session whose owner died without one. |
+
+Session end's **unconditional drain** is preserved: a buffer that tripped its
+cap and kept growing still drains the whole session at close, cap or no cap.
+The cap is now a bookkeeping marker — it says the buffer got large, and
+nothing else acts on it.
+
+The close path is `lore_curator/chapter_flush.py::synth_and_close`:
+
+```
+segment_session   (cheap model — returns turn INDICES only)
+  → extract_session (one call per chunk — typed facts; plus one headline)
+  → publish gate
+  → append_facts | withheld marker + quarantine | failed marker
+  → render_note   (pure code — verify refs, stamp phrasing, lay out the body)
+  → close_note
+```
+
+Every LLM call a note costs is in the first two steps. The segmenter
+(`lore_curator/chunker.py`) reads a collapsed view of the session and returns a
+list of integers — its entire output surface, so its errors degrade to
+suboptimal windows and never to false facts. The extractor
+(`lore_curator/fact_extract.py`) reads the raw turns of one chunk at a time and
+emits typed facts: a `kind` (`progress` | `done` | `decision` | `finding` |
+`open`), a `thread` key, structured `refs`, a short `text`, a `why` (mandatory
+for a decision), and one `@turn` anchor.
+
+Nothing downstream is generative. **The ledger is append-only; the body above it
+is a derived render** — thrown away and recomputed in full from the ledger at
+every close ([ADR 0003](../adr/0003-note-body-is-a-derived-render-of-the-ledger.md)).
+Section order, anchor sort, thread suppression and every word that carries
+epistemic weight are code
+([ADR 0004](../adr/0004-authority-phrasing-is-code-stamped.md)). The same ledger
+renders to the same bytes, always.
 
 ---
 
 ## Keeping one session to one note
 
-Two mechanisms cooperate: a session is not closed while it is merely
-quiet, and if it *is* closed and then resumes, it reattaches to its own
-note instead of starting a new one.
+Two mechanisms cooperate: a session is not closed while it is merely quiet, and
+if it *is* closed and then resumes, it reattaches to its own note instead of
+starting a new one.
 
 ### 1. Liveness — "pid gone, same host" is uncertain, not dead
 
-The buffer records an owner `pid`, re-stamped every heartbeat to the
-current hook subprocess — which exits within milliseconds. So "the owner
-pid is gone" is the **normal steady state of a live session**, not a
-death signal. `lore_curator/reaper.py::is_owner_alive` returns:
+The buffer records an owner `pid`, re-stamped every heartbeat to the current
+hook subprocess — which exits within milliseconds. So "the owner pid is gone" is
+the **normal steady state of a live session**, not a death signal.
+`lore_curator/reaper.py::is_owner_alive` returns:
 
 | Owner state | Verdict | Consequence |
 |---|---|---|
@@ -59,157 +94,164 @@ death signal. `lore_curator/reaper.py::is_owner_alive` returns:
 | Owner `host` differs from this host | `False` (dead) | reap immediately |
 | Same host, pid gone / start-ts mismatch / no `/proc` access | `None` (uncertain) | fall back on the staleness threshold |
 
-The critical case is the last row. A same-host pid-gone owner is
-**uncertain**, so the reaper and the SessionStart sweep defer to
-`liveness_stale_threshold_s` (default 30 min, doubled on macOS) instead
-of closing instantly. A genuinely dead session still closes — just via
-staleness, a little later — so no buffer leaks. Only an *unambiguously*
-dead owner (a different host) is reaped on sight. This alone stops most
-of the duplicate-note churn, because the live session that was being
-reaped mid-flight now survives.
+The critical case is the last row. A same-host pid-gone owner is **uncertain**,
+so the reaper and the SessionStart sweep defer to `liveness_stale_threshold_s`
+(default 30 min, doubled on macOS) instead of closing instantly. A genuinely
+dead session still closes — just via staleness, a little later — so no buffer
+leaks. Only an *unambiguously* dead owner (a different host) is reaped on sight.
 
-### 2. Reopen + continue — a resume reattaches to its own note
+### 2. Reopen + re-render — a resume reattaches to its own note
 
-Staleness still closes a session that goes genuinely idle and later
-comes back. When it comes back, the next heartbeat finds no live buffer
-(it was archived to `_done/`) and would, historically, mint a fresh
-sidecar with an empty note pointer and thus a **second** file.
+Staleness still closes a session that goes genuinely idle and later comes back.
+When it comes back, the next heartbeat finds no live buffer (it was archived to
+`_done/`) and would, historically, mint a fresh sidecar with an empty note
+pointer and thus a **second** file.
 
-Instead, at the `existing is None` branch of
-`buffer_append.py::append_chunk`, the code first calls
-`buffer.reopen_from_done()`: it looks in `_done/` for an archived buffer
-of the **same stem** (`<transcript_id>__<local_date>`) and, if found,
-*moves* it back to the live directory and continues appending chapters
-to the same note. The archived note is reopened with
-`lore_core/note_document.py::reopen_note`, and note-so-far is seeded from
-the existing body so the next compose does not repeat earlier content.
-The drain emits `buffer-reopened` rather than a second `note-filed`.
+Instead, at the `existing is None` branch of `buffer_append.py::append_chunk`,
+the code first calls `buffer.reopen_from_done()`: it looks in `_done/` for an
+archived buffer of the **same stem** (`<transcript_id>__<local_date>`) and, if
+found, *moves* it back to the live directory. The archived note is reopened with
+`lore_core/note_document.py::reopen_note`, and the second close appends the new
+facts to the ledger and **re-renders the whole body over it** — a reading of the
+whole session, not a second reading stacked under the first. The drain emits
+`buffer-reopened` rather than a second `note-filed`.
 
 If the prior note was discarded (a trivial/empty session whose file was
-deleted), the restored pointer dangles; the restore detects the missing
-file, clears the pointer, and lets a fresh note be created — it never
-crashes trying to reopen a deleted file.
+deleted), the restored pointer dangles; the restore detects the missing file,
+clears the pointer, and lets a fresh note be created — it never crashes trying
+to reopen a deleted file.
 
-**This deliberately relaxes one invariant.** Before this epic, `close`
-was terminal: a note with `note_status: closed` was immutable and
-`append_chapter` raised `NoteClosedError`. `reopen_note` flips that
-status back to `open` so a resumed session can append. The carve-out is
-narrow and its trade-offs are the subject of
+**This deliberately relaxes one invariant.** Before, `close` was terminal: a
+note with `note_status: closed` was immutable and any append raised
+`NoteClosedError`. `reopen_note` flips that status back to `open` so a resumed
+session can add to it. The carve-out is narrow and its trade-offs are the
+subject of
 [ADR 0001](../adr/0001-session-note-reopen-relaxes-close-immutability.md):
 
-- Only a session's **own** continuing heartbeat, keyed on the identical
-  stem, ever reopens its own note. No cross-session or curator writer can.
+- Only a session's **own** continuing heartbeat, keyed on the identical stem,
+  ever reopens its own note. No cross-session or curator writer can.
 - Immutability still holds for every derived/curated artifact (concepts,
   decisions, threads).
-- Reopen only ever *appends* — earlier chapters are never edited, so the
-  append-only-within-a-session contract is intact. What changes is that
-  `note_status: closed` is no longer a guarantee of *permanence* for a
-  session note; the same file may gain chapters if its session resumes.
+- The **ledger** is only ever appended to — a fact is never edited or deleted
+  once written, and keeps its quote and its anchor. The **body** is the part
+  that is rewritten, which ADR 0003 states outright.
 
 ---
 
 ## Recording only what the session worked on
 
-One session, one note is worthless if that one note reports the wrong
-work. Two extraction-side checks keep the record faithful. Both live in
-`lore_curator/fact_extract.py` and both are written explicitly because
-the extraction model is a ~120B open model, weak at implicit pragmatics.
+One session, one note is worthless if that one note reports the wrong work. The
+extraction prompt (`lore_curator/fact_extract.py::_build_prompt`) carries four
+rules explicitly, because the extraction model is a small open model, weak at
+implicit pragmatics:
 
-### Quoted and reference material is not the session's work
+- **The month test.** A fact earns its place only if it would change what a
+  colleague does or believes a month from now. Few facts, or none, is the normal
+  answer for a chunk.
+- **The terminal-state rule.** `done` means a terminal state and nothing else: a
+  commit landed, a PR merged, a suite verified green. Work en route — an edit
+  made, a draft opened, a review requested — is `progress`, however much it felt
+  like a milestone at the time.
+- **The supervision clause.** When the session supervises other agents, the
+  subject is the *deliverable*, not the choreography. Dispatching a teammate or
+  posting a status comment is not a fact; what the teammate delivered, and
+  whether it landed, is.
+- **Quoted and reference material is not the session's work.** Content the user
+  pastes as an exemplar, a reference, or a comparison — a formatting sample, an
+  older note of their own — describes *that material*, not this session. Its
+  claims, tools and paths are never reported as the session's facts. The
+  exception: when working on that material *was* the task.
 
-`_build_prompt` carries an explicit clause: content the user pastes or
-quotes as an **exemplar, reference, or comparison** — signalled by
-framing ("this is a form I'd like", "for example", "an older version
-of"), by a fenced code block, or by a block that carries its **own**
-`@N`-anchored bold leads (the shape of an earlier note) — is *about* that
-pasted material and does **not** describe what this session did. Its
-claims, tools, paths, and config are never reported as the session's
-findings. The one exception: when working on that material *was* the
-topic (the user asked to review, fix, or reason about it), that work is
-the session's work and is recorded. The chapter tool schema's `body`
-description reinforces the same rule.
+Three deterministic lints police the result, and each earns **exactly one**
+corrective retry before the chunk degrades: an anchor outside the chunk, a
+`kind` outside the enum, a `decision` with no `why`. The anchor lint is also
+what makes the Stille-Post rule structural rather than hopeful — each extraction
+call sees the compact fact table of the calls before it, for thread continuity
+and dedup only, and any fact lifted from that table is anchored outside the
+chunk and rejected. No model in this pipeline reads model prose as source
+material.
 
-### Same-anchor soft lint — nudge honest anchors
-
-`chapter_same_anchor_lint` flags a chapter with **more than two** blocks
-all citing one turn — the tell of several "findings" derived from a
-single pasted passage. Two blocks sharing a turn is common and
-unremarkable; more than two is usually a collapse that makes the anchors
-useless for navigation. On a hit, the compose loop issues **exactly one**
-corrective retry (`_same_anchor_feedback`: "confirm these are distinct
-findings … re-anchor each block to the turn where its own topic actually
-started"). It is a **soft** signal: it never hard-rejects and never
-fabricates anchor diversity — after the single nudge the chapter
-publishes regardless of whether the anchors changed. This sits beside the
-existing hard `chapter_anchor_lint` (which rejects out-of-range anchors),
-reusing the same retry plumbing.
+Quotes are **code-attached** from the anchor turn. The extraction tool schema
+has no quote field, so the model cannot author the verbatim evidence for its own
+claim.
 
 ---
 
 ## Naming the file after its topic
 
-The note file is created — and first named — at the first heartbeat,
-before any chapter exists, so its initial slug is an incidental guess (a
-commit subject, a touched file's basename, or a bare timestamp). Once the
-first chapter composes, its opening lead names the session's actual
-topic, and `chapter_flush.py::_rename_to_topic_slug` renames the file to
-match (only on chapter 1). A chapter with no usable lead, or a lead that
-slugs to nothing or to the bare fallback `session`, leaves the filename
-untouched rather than risk an empty slug; same-minute collisions still
-get a numeric suffix. Stub notes that never compose a chapter keep their
-fallback name.
+The note file is created — and first named — at the first heartbeat, before any
+content exists, so its initial slug is an incidental guess (a commit subject, a
+touched file's basename, or a bare timestamp). At close, one bounded call writes
+the session's **headline** from the fact table (the only cross-chunk synthesis
+in the pipeline; a lint rejects a headline naming a ref or thread the table does
+not contain, and a headline that cannot pass it is dropped rather than
+published). The headline names both the frontmatter `title`
+(`stub_note._scope_title` → `<scope>: <headline>`) and the filename
+(`chapter_flush._rename_to_topic_slug`) — so title and filename always name the
+same topic. An empty headline, or one that slugs to nothing or to the bare
+fallback `session`, leaves the filename untouched rather than risk an empty
+slug; same-minute collisions get a numeric suffix.
 
 ---
 
 ## How failures surface
 
-A flush can fail in two different places, and each surfaces differently.
+A close can fail in two different places, and each surfaces differently.
 
-**Inside compose — a marker chapter in the note itself.** This is the
-give-up semantics from "Writing a note" above: mid-session failure is
-silent while a retry chance remains, but a buffer that grows to 2x the
-cap with a prior failed attempt gets a deterministic **failed marker**
-chapter, and a publish-gate withhold gets a **withheld marker** chapter
-(the full composed text goes to the private quarantine sidecar instead).
-Either way the note stays open and readable — the marker chapter *is*
-the failure record, right where a reader would look for the missing
-content.
+**Inside the pipeline — a marker chapter, and a coverage gap in the reading.**
+A chunk the model cannot extract becomes a deterministic **failed marker** for
+its span; a chunk the publish gate withholds becomes a **withheld marker** (the
+full text goes to the private quarantine sidecar instead). Both are ledger
+chapters, so both are chapters the rendered body cannot speak for — and every
+non-`facts` chapter renders as a one-line **coverage gap** under Open: *"Coverage
+gap: turns 40–71 are not covered by this note."* One bad chunk never costs the
+rest of the session, and a partial note can never present itself as complete.
+The same is true of a legacy prose chapter, which still parses but contributes
+no facts.
 
-**Outside compose — a dead-lettered flush on the spine.** Everything
-between "a hook decides a flush is needed" and "compose starts" —
-spawn failures, buffer-sidecar read errors, chapter-append I/O errors —
-used to fail silently. The flush lifecycle state machine
-(`lore_core/flush_store.py`, issue #189) makes this queryable instead: a
-flush that exhausts its bounded retries (3 attempts, exponential
-backoff) becomes a `dead-lettered` record with a structured reason
-instead of vanishing. `lore trace dead` lists them; `lore status`'s
-alerts section surfaces a nonzero dead-letter count and names that same
-command. Every transition — including the ones that don't dead-letter —
-also lands on the event spine (`source="curator"`,
-`event="flush-<state>"`), so `lore trace <trace-id-or-session-id>`
-replays the whole path a specific flush took, marker chapter or not.
+There is no silent mid-session defer and no give-up bound any more; both were
+properties of the per-flush composer. A close either extracts, withholds, or
+fails — and the note ends closed either way.
 
-A hard failure of the spine *writer* itself (an `OSError` mid-`emit`) is
-the one thing that can't be a spine event — it touches
-`spine-failed.marker` instead, which `lore doctor` and `lore status`
-check for directly.
+**Outside the pipeline — a dead-lettered flush on the spine.** Everything
+between "a hook decides a flush is needed" and "extraction starts" — spawn
+failures, buffer-sidecar read errors, chapter-append I/O errors — used to fail
+silently. The flush lifecycle state machine (`lore_core/flush_store.py`) makes
+this queryable instead: a flush that exhausts its bounded retries (3 attempts,
+exponential backoff) becomes a `dead-lettered` record with a structured reason
+instead of vanishing. `lore trace dead` lists them; `lore status`'s alerts
+section surfaces a nonzero dead-letter count and names that same command. Every
+transition also lands on the event spine (`source="curator"`,
+`event="flush-<state>"`), so `lore trace <trace-id-or-session-id>` replays the
+whole path a specific flush took, marker chapter or not.
+
+A hard failure of the spine *writer* itself (an `OSError` mid-`emit`) is the one
+thing that can't be a spine event — it touches `spine-failed.marker` instead,
+which `lore doctor` and `lore status` check for directly.
 
 ---
 
 ## See also
 
-- `CONTEXT.md` — the note vocabulary (buffer, flush, chapter, block,
-  anchor, marker) and the buffer/flush/compose write path.
-- [`observability.md`](observability.md) — the event spine's full
-  envelope shape, producer list, trace_id lifecycle, and retention
-  policy behind the dead-letter/marker distinction above.
-- [ADR 0001](../adr/0001-session-note-reopen-relaxes-close-immutability.md)
-  — the close-immutability carve-out, its alternatives, and its
-  concurrency and trade-off analysis.
-- [PRD 0002](../prd/0002-useful-session-notes.md) — the problem
-  statement, the pilot transcript that exposed both failure classes, and
-  the per-decision rationale.
-- Source: `lore_curator/reaper.py` (liveness),
-  `lore_curator/buffer_append.py` + `lore_core/note_document.py`
-  (reopen + continue), `lore_curator/fact_extract.py` (extraction
-  fidelity), `lore_curator/chapter_flush.py` (topic slug).
+- [`why-notes-are-written-at-session-end.md`](../explanation/why-notes-are-written-at-session-end.md)
+  — why the pipeline runs backward from the ending, and why code owns the
+  phrasing.
+- `CONTEXT.md` — the note vocabulary (buffer, flush, chapter, fact, anchor,
+  marker) and the buffer/flush/render write path.
+- `CONTEXT-FORMAT.md` — the exact title and body shape a rendered note takes.
+- [`observability.md`](observability.md) — the event spine's full envelope
+  shape, producer list, trace_id lifecycle, and retention policy behind the
+  dead-letter/marker distinction above.
+- [ADR 0001](../adr/0001-session-note-reopen-relaxes-close-immutability.md) —
+  the close-immutability carve-out.
+- [ADR 0003](../adr/0003-note-body-is-a-derived-render-of-the-ledger.md) — the
+  body as derived state over an append-only ledger.
+- [ADR 0004](../adr/0004-authority-phrasing-is-code-stamped.md) — ref
+  verification and code-stamped phrasing.
+- [PRD 0008](../prd/0008-typed-fact-session-notes.md) — the problem statement
+  and per-decision rationale for typed-fact notes.
+- Source: `lore_curator/reaper.py` (liveness), `lore_curator/buffer_append.py`
+  (bookkeeping + reopen), `lore_curator/chunker.py` (segmentation),
+  `lore_curator/fact_extract.py` (extraction), `lore_curator/chapter_flush.py`
+  (the close path), `lore_core/note_document.py` +
+  `lore_core/ref_verify.py` (render, verify, stamp).

--- a/docs/explanation/why-notes-are-written-at-session-end.md
+++ b/docs/explanation/why-notes-are-written-at-session-end.md
@@ -1,0 +1,144 @@
+# Why a session note is written only at the end
+
+**Audience:** anyone who notices that nothing appears in the vault while a
+session runs, or who wonders why a note's lines read so carefully — "Agreed
+in discussion, recorded nowhere: …", "commit 3f9a2c1 ✓", "(unchecked)" —
+instead of plainly stating what happened.
+
+Both come from one decision: **the model never writes the words that carry
+authority, and it writes nothing at all until the session is over.** This page
+explains what that buys and what it costs.
+
+---
+
+## Composing forward recorded the working, not the work
+
+Notes used to be written *while the session ran*. Each flush turned the newest
+slice of transcript into a chapter of prose and appended it; the chapter was
+immutable from then on. The note grew as the session grew.
+
+That structure produced three defects no amount of prompt tuning could reach,
+because they are properties of *when* the writing happened, not of how well the
+model wrote.
+
+**Which facts matter is only knowable backward.** At the moment a slice is
+composed, "PR #524 opened" genuinely is the substance of that slice. Only the
+ending reveals that twenty such blocks collapse into a single line: "all five
+features merged". A model composing forward cannot know the future, so a long
+orchestration session yielded dozens of blocks — status comment posted,
+worktree prepared, teammate dispatched — of which perhaps five would matter to
+a reader a month later. Process narration drowned the substance.
+
+**Interim states froze into the record.** "Features #514–#516 remain in
+progress" is false by the end of the note that contains it. Append-only-until-
+close guaranteed that class of noise for any session long enough to change its
+own mind.
+
+**And the worst one: model prose became the next session's evidence.** A
+machine-extracted line like "Decision: the ledger is the source of truth" gets
+pulled into a later session's context window and read as settled — even when
+the extraction over-read a musing into a decision. That session restates it. A
+curator abstracts it into a decision note. A claim nobody ever made acquires
+sources. This is circular context poisoning: the system's own output becomes
+its own evidence, and each pass makes the claim look better attested than the
+last.
+
+The genre disclaimer at the top of a note was the only defense against that
+last one, and under context pressure a wrapper loses to line-level phrasing.
+What a reader ingests — human or model — is the sentence, not the header above
+it.
+
+---
+
+## The fix: read the session backward, and let code do the claiming
+
+Two changes, and they are inseparable.
+
+### All LLM work happens once, at the ending
+
+Nothing is written to the note while a session runs. Mid-session events — the
+buffer tripping its cap, a pre-compact — only bookkeep: the buffer keeps
+accumulating, no chapter is appended, no model is called. At session end the
+whole session is read in one pipeline (segmented into logical chunks, each
+chunk extracted into typed facts) and the note appears once, complete.
+
+Because the render sees the whole session at once, the ending can retire its
+own middle. A `progress` fact whose thread later reached a terminal state is
+simply not in the reading. It is still in the ledger below, with its quote and
+its anchor, so nothing is lost — but the note no longer lies about how it ends.
+
+### Code, not the model, authors epistemic weight
+
+The extraction model contributes two things: a fact's `text` and its `why`.
+Every word around them — what the line claims about the world, and how strongly
+— is chosen by a phrasing template the renderer owns, keyed on `(kind,
+verification)`.
+
+`verification` is *computed*, never asserted. Commits, tags and files are
+checked against the session's own captured facts and then against local git and
+the filesystem. Pull requests and issues are checked best-effort through `gh`.
+The verdict is one of three, and the asymmetry between them is the whole point:
+
+- **verified** — a check ran and succeeded. The line states itself plainly and
+  shows its pointer.
+- **missing** — a check ran and came back empty. The line is *demoted*:
+  "Claimed in session, ref not found: …". A hallucinated ref costs authority
+  rather than buying it.
+- **unchecked** — nothing could be checked (offline, no `gh`, no repository).
+  The pointer is stamped `(unchecked)`.
+
+The direction of the incentive flips. Under forward composition, a model that
+invented a plausible PR number got a confident-sounding line for free. Now the
+only way for a fact to read confidently is to point at something that actually
+exists — which is also the only way it is useful to anyone a month later.
+
+**Positive evidence only.** Verification promotes on success and on nothing
+else. A `gh` call that fails means GitHub was unreachable, not that the PR is
+fake, so it yields *unchecked* — never *verified*, and never *missing*.
+Otherwise an offline laptop would rewrite history, demoting every real ref in
+the note. Absence of a failure is never evidence.
+
+**A decision no artifact records is not a decision.** It renders under **Open**
+as "Agreed in discussion, recorded nowhere: `<text>` — `<why>`". The most
+poison-prone claim in the system becomes, by construction, a line that
+advertises its own weakness and invites checking.
+
+The quote beside each fact in the ledger is code-attached from the anchored
+turn — the extraction tool schema has no quote field at all, so the model
+cannot author the verbatim evidence for its own claim. And no model in this
+pipeline reads model prose as source material: facts come from the transcript,
+never from another model's summary of it.
+
+---
+
+## What this does not buy
+
+Determinism does not make content true. It makes false authority *unreachable*
+and every claim *cheap to check*. What remains on the model's side of the line:
+
+- **Fidelity** — whether a fact's text is faithful to the turn it was anchored
+  to. Mitigated by the verbatim quote sitting beside it in the ledger, and
+  bounded by the refs that back a `done` or a `decision`.
+- **Misclassification** — a musing labelled a `decision`. Worst case it lands
+  under Open as a hedged "recorded nowhere" line that invites checking. That is
+  the failure mode the cheapest model tier is *allowed* to have.
+- **Omission** — irreducible. The ledger and the archived transcript remain the
+  recovery path.
+
+It also costs something real: **notes read more hedged than they used to**,
+including for facts that are true but recorded nowhere. That is the intended
+trade. A true claim with no artifact behind it is exactly the claim a later
+session should not ingest as settled.
+
+---
+
+## See also
+
+- [ADR 0003](../adr/0003-note-body-is-a-derived-render-of-the-ledger.md) — why
+  the note body is derived state, thrown away and recomputed from the ledger.
+- [ADR 0004](../adr/0004-authority-phrasing-is-code-stamped.md) — the phrasing
+  templates, the three verdicts, and the alternatives that were rejected.
+- [`session-note-lifecycle.md`](../architecture/session-note-lifecycle.md) —
+  the mechanics: buffer, close, segment, extract, render, verify, publish gate.
+- [PRD 0008](../prd/0008-typed-fact-session-notes.md) — the full problem
+  statement and the per-decision rationale.

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -29,36 +29,95 @@ Escalate through three commands, each one level deeper:
    `$CLAUDE_PROJECT_DIR` and that the plugin hooks are actually installed
    (`lore install`).
 
-## "A note never appeared"
+## "No note appeared while my session was running"
+
+**Expected — nothing is written until the session ends.** A session's turns
+accumulate in a buffer; mid-session events (the buffer tripping its cap, a
+pre-compact) only bookkeep. Which of a session's turns mattered is knowable
+only backward, from its ending, so the whole session is read in one pass at
+close and the note appears once, complete. `capture_routing.CLOSE_TRIGGERS`
+is the single authority for which trigger flushes, and it holds exactly one
+entry: `session-end`.
+
+You will see a stub note file appear early (frontmatter, disclaimer, no
+content) — that is the placeholder the close path fills in. If the session
+has *ended* and the note is still empty or absent, that is the next entry.
+Background: [why notes are written at session
+end](../explanation/why-notes-are-written-at-session-end.md).
+
+## "A note never appeared" (after the session ended)
 
 1. **`lore status`** — the alerts section fires when there's a
    dead-lettered flush or a diverged wiki; it names the exact
    drill-down command, so start here rather than guessing.
-2. **Check the note itself for a marker chapter.** A mid-session failure
-   is silent while a retry chance remains (by design — see
-   [`session-note-lifecycle.md`, "How failures surface"](../architecture/session-note-lifecycle.md#how-failures-surface)),
-   but a give-up or a publish-gate withhold leaves a **marker chapter**
-   directly in the note. If the note exists and has a withheld-marker
-   chapter, the actual content is sitting in `lore quarantine list` (safe
-   category text only — a reviewer runs `lore quarantine show <id>` to
-   see the redacted text).
-3. **`lore trace dead`** — lists every dead-lettered flush (exhausted its
+2. **Check whether the session was discarded on purpose.** A trivial session
+   (a handful of turns, no files touched, no commits, no issues) is dropped
+   deterministically at close without spending a model call, and a session
+   whose extraction returned zero facts is dropped too — the extractor's
+   "nothing of substance" answer. Both delete the stub rather than close it
+   around an empty note. `lore trace <session-id>` shows `flush-trivial` or
+   `flush-empty` when this is what happened.
+3. **Check the note itself for a coverage gap or a marker chapter.** A chunk
+   the model could not extract becomes a **failed marker** in the ledger and a
+   one-line coverage gap in the reading; a chunk the publish gate withheld
+   becomes a **withheld marker**, and its actual content is sitting in `lore
+   quarantine list` (safe category text only — a reviewer runs `lore quarantine
+   show <id>` to see the redacted text). See
+   [`session-note-lifecycle.md`, "How failures surface"](../architecture/session-note-lifecycle.md#how-failures-surface).
+4. **`lore trace dead`** — lists every dead-lettered flush (exhausted its
    3 retries) with its reason. If the buffer you expected shows up here,
    that's your answer: `data.error`/the reason string names the cause
-   (spawn failure, compose failure, sidecar read error, chapter-append
+   (spawn failure, extraction failure, sidecar read error, chapter-append
    I/O error).
-4. **`lore trace last`** (or a specific trace_id / note path /
+5. **`lore trace last`** (or a specific trace_id / note path /
    `[[wikilink]]` once you have one) — the full chronological story of
    that flush: hook decision, spawn, LLM calls, gate outcome, note
    append, with durations and error codes at each step. `--plain` for a
    script-safe rendering, `--json` for the raw spine records.
 
+## "My note has a coverage gap line"
+
+A line like *"Coverage gap: turns 40–71 are not covered by this note"* means the
+rendered body cannot speak for that span of the session. Two causes:
+
+- **A chunk failed extraction** (or the publish gate withheld it). The span is
+  recorded in the ledger as a marker chapter with its reason, and the gap line
+  carries that reason in parentheses. One bad chunk never costs the rest of the
+  session — the other chunks still rendered.
+- **The ledger holds legacy prose.** A note written before typed facts (or a
+  session that reopened one) carries prose chapters, which contribute no facts.
+  Their spans are gaps by construction. Old notes are not migrated — this is
+  fix-forward.
+
+The gap line is deliberate, not a bug: a partial note that presented itself as
+complete would be worse than one that says where it stops. The transcript turns
+are still there; `@N` anchors point into the archived transcript.
+
+## "A ref in my note says `(unchecked)`"
+
+The ref could not be checked, which is not the same as being wrong. Commits,
+tags and files are verified against local git and the session's captured facts;
+pull requests and issues go to `gh`. When any of that is unavailable — you're
+offline, `gh` isn't installed or authenticated, the note was rendered outside
+the repository — the check cannot run, and the ref is stamped `(unchecked)`.
+
+**Positive evidence only:** a check that could not run never promotes a ref and
+never demotes it either. A failed `gh` call means GitHub was unreachable, not
+that the PR is fake, so it can never render `(not found)` — otherwise an offline
+laptop would rewrite history. Rendering never fails on this; it only hedges. See
+[ADR 0004](../adr/0004-authority-phrasing-is-code-stamped.md).
+
+`(not found)` is the other verdict, and it means the opposite: a check *did*
+run and came back empty. That ref does not exist, and its line is demoted to
+"Claimed in session, ref not found: …".
+
 ## "A flush looks stuck"
 
 `lore status`'s `flushes` line shows `queued` / `running` / `dead-lettered`
 counts. A flush sitting in `queued` or `running` for a long time is
-either genuinely still working (spawn → compose → gate → append can take
-tens of seconds) or waiting out its exponential backoff after a failed
+either genuinely still working (spawn → segment → extract → gate → render
+can take tens of seconds, one model call per chunk) or waiting out its
+exponential backoff after a failed
 attempt (base 60s, doubling, capped at 3600s — see
 `lore_core/flush_store.py`). `lore trace <selector>` shows which: a
 `flush-running` step with no `flush-published`/`flush-dead-lettered`


### PR DESCRIPTION
Documentation-only follow-up to epic #282 (typed-fact session notes, PRD 0008, released in 0.63.0). No code changes.

The docs still described the removed path: notes composed *forward*, one prose chapter per flush, with cap-trip and pre-compact as flush triggers. Reality since 0.63.0 is that **all LLM work happens at session end** — segment (turn indices only) → extract (typed facts, one call per chunk) → render + verify + stamp (pure code, no model) — and `capture_routing.CLOSE_TRIGGERS` is the single authority, holding only `session-end`.

## Path → Diátaxis quadrant

| Path | Quadrant | Change |
| :--- | :--- | :--- |
| `docs/architecture/session-note-lifecycle.md` | Explanation (architecture) | Rewritten to the shipped pipeline. Names `CLOSE_TRIGGERS`; states the ledger is append-only and the body a derived, byte-deterministic render (ADR 0003). Drops forward composition, `chapter_compose`, `synth_in_place`, in-place flush, silent-defer and the give-up bound. |
| `CONTEXT-FORMAT.md` | Reference | Title is now the session headline via `render_note(title=_scope_title(...))`, not a first-chapter lead. Body renders **Done / Decisions recorded / Findings / Open** with the `(kind, verification)` phrasing matrix. Legacy prose notes still parse and read as coverage gaps. |
| `docs/how-to/troubleshooting.md` | How-to | Adds the three symptoms users hit now: no note while the session runs (expected), a coverage-gap line, a `(unchecked)` ref. Fixes the stale give-up/marker entry and the `compose → gate → append` pipeline in "a flush looks stuck". |
| `docs/explanation/why-notes-are-written-at-session-end.md` | Explanation | **New.** Forward composition recorded the working, not the work; interim states froze into the record; worst, model-authored phrasing was ingested by the *next* session as authority — circular context poisoning. The defense: code, never the model, authors words that carry epistemic weight; a hallucinated ref demotes rather than promotes; positive evidence only. Cites ADR 0003 and ADR 0004. |
| `README.md` | — | Pipeline blurb, "what runs automatically", and the curator config comments: cap-trip is bookkeeping, not a flush; the model tier drives segmentation + extraction, not chapter composition. |
| `docs/architecture/observability.md` | — | One stale line-number citation into `chapter_flush.py` (the epic moved it); now names the function. |

`docs/prd/**` and `docs/adr/**` are untouched — read for context only.