### PR TITLE
feat(cli): add top-level `lore update` — version-checked package + plugin upgrade

### DIFF
--- a/docs/architecture/cli-contract.md
+++ b/docs/architecture/cli-contract.md
@@ -85,9 +85,10 @@ a function.
 **3. `lore_cli/__main__.py` only mounts.**
 No `@app.command(...)` or `@app.callback(...)` decorators in
 `__main__.py`. Verbs live in their own files; `__main__.py` only ties
-them together with `app.add_typer(...)`. The single grandfathered
-exception is the `cmd_uninstall_alias` function — a documented
-symmetric alias for `lore install uninstall`.
+them together with `app.add_typer(...)`. The grandfathered exceptions are
+the top-level `uninstall` and `update` aliases — documented shims for
+`lore install uninstall` and the remote-version-check-then-upgrade
+roundtrip, both implemented in `install_cmd.py`.
 
 **4. Import business logic, don't reimplement it.**
 The verb file contains only argument parsing, output formatting, and

--- a/docs/how-to/onboarding.md
+++ b/docs/how-to/onboarding.md
@@ -28,6 +28,10 @@ repair path for a partial install.
    runnable on `PATH` afterward — don't treat a silent-looking finish as
    success without checking the exit code.
 
+   Later on, run `lore update` to pick up a new release (checks the
+   version on `main`, then upgrades the package and refreshes the Claude
+   plugin cache in one step; `--check` reports without upgrading).
+
 2. **Run the wizard.**
 
    ```

--- a/lib/lore_cli/__main__.py
+++ b/lib/lore_cli/__main__.py
@@ -145,6 +145,12 @@ def _build_app() -> typer.Typer:
         "Top-level `lore uninstall` — same flags as `lore install uninstall`.",
     ))
 
+    app.command(
+        "update",
+        help="Update Lore (Python package + Claude plugin) if a new release is on main.",
+        rich_help_panel=_GS,
+    )(install_cmd.update_command)
+
     return app
 
 

--- a/lib/lore_cli/install_cmd.py
+++ b/lib/lore_cli/install_cmd.py
@@ -27,10 +27,13 @@ UX contract (per the four-pass plan review):
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -51,9 +54,10 @@ from lore_core.install.base import (
     InstallContext,
     LegacyArtifact,
 )
-from lore_cli._argv_compat import argv_main
 from rich.console import Console
 from rich.markup import escape as rich_escape
+
+from lore_cli._argv_compat import argv_main
 
 console = Console()
 
@@ -438,6 +442,44 @@ def _run_self_upgrade(*, quiet: bool) -> int:
         return 1
 
 
+_REMOTE_PLUGIN_JSON_URL = (
+    "https://raw.githubusercontent.com/buchbend/lore/main/.claude-plugin/plugin.json"
+)
+
+
+def _fetch_remote_version() -> str | None:
+    """Latest released version, read off `plugin.json` on `main`.
+
+    `pyproject.toml` and `.claude-plugin/plugin.json` are bumped together
+    in every `chore: release X.Y.Z` commit, so this one file is enough to
+    know the latest release without cloning the repo. Returns None on any
+    network or parse failure — the caller decides how to report that.
+    """
+    try:
+        with urllib.request.urlopen(_REMOTE_PLUGIN_JSON_URL, timeout=10) as resp:
+            return json.loads(resp.read()).get("version")
+    except (urllib.error.URLError, OSError, ValueError, TimeoutError):
+        return None
+
+
+def _local_version() -> str:
+    return importlib.metadata.version("lore")
+
+
+def _version_tuple(v: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in v.strip().split("."))
+
+
+def _remote_is_newer(remote: str, local: str) -> bool:
+    """Compare dotted versions as int tuples — a plain string compare would
+    put "0.9.0" after "0.10.0"."""
+    r, loc = _version_tuple(remote), _version_tuple(local)
+    n = max(len(r), len(loc))
+    r += (0,) * (n - len(r))
+    loc += (0,) * (n - len(loc))
+    return r > loc
+
+
 def _loud_plugin_cache_failure(detail: str) -> None:
     """Plugin-cache refresh failed — never silent.
 
@@ -702,6 +744,44 @@ _UPGRADE = typer.Option(
         "the new binary is in place — single command, full roundtrip."
     ),
 )
+_CHECK = typer.Option(
+    False, "--check", help="Only report whether an update is available; never upgrades."
+)
+
+
+def update_command(check: bool = _CHECK, quiet: bool = _QUIET) -> None:
+    """Update Lore — Python package and Claude plugin — if a newer release
+    has landed on `main`.
+
+    Delegates to `_run_self_upgrade`, which runs `install.sh upgrade`: that
+    script upgrades the pipx/uv/pip package and then chains into `lore
+    install`, which refreshes the Claude plugin cache. So this one command
+    covers both halves of the install.
+    """
+    local = _local_version()
+    remote = _fetch_remote_version()
+    if remote is None:
+        console.print(
+            "[red]Could not reach GitHub to check the latest lore version.[/red]\n"
+            "  Force the upgrade path directly instead: "
+            "[cyan]lore install --upgrade[/cyan]",
+            markup=True,
+        )
+        raise typer.Exit(code=1)
+
+    if not _remote_is_newer(remote, local):
+        if not quiet:
+            console.print(f"[green]lore {local} is up to date.[/green]", markup=True)
+        return
+
+    if not quiet:
+        console.print(
+            f"[bold]Update available:[/bold] {local} → {remote}", markup=True
+        )
+    if check:
+        raise typer.Exit(code=1)
+
+    raise typer.Exit(code=_run_self_upgrade(quiet=quiet))
 
 
 def build_install_command(

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -1,0 +1,68 @@
+"""Tests for `lore update` — remote version check in front of the
+existing package+plugin self-upgrade roundtrip (`_run_self_upgrade`)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import typer
+from lore_cli import install_cmd
+
+
+def test_up_to_date_exits_zero_without_upgrading(capsys):
+    with (
+        patch.object(install_cmd, "_local_version", return_value="1.0.0"),
+        patch.object(install_cmd, "_fetch_remote_version", return_value="1.0.0"),
+        patch.object(install_cmd, "_run_self_upgrade") as mock_upgrade,
+    ):
+        install_cmd.update_command(check=False, quiet=False)
+        mock_upgrade.assert_not_called()
+    assert "up to date" in capsys.readouterr().out
+
+
+def test_remote_newer_triggers_self_upgrade():
+    with (
+        patch.object(install_cmd, "_local_version", return_value="1.0.0"),
+        patch.object(install_cmd, "_fetch_remote_version", return_value="1.1.0"),
+        patch.object(install_cmd, "_run_self_upgrade", return_value=0) as mock_upgrade,
+    ):
+        with pytest.raises(typer.Exit) as exc:
+            install_cmd.update_command(check=False, quiet=True)
+        mock_upgrade.assert_called_once_with(quiet=True)
+    assert exc.value.exit_code == 0
+
+
+def test_check_flag_reports_only_never_upgrades(capsys):
+    with (
+        patch.object(install_cmd, "_local_version", return_value="1.0.0"),
+        patch.object(install_cmd, "_fetch_remote_version", return_value="1.1.0"),
+        patch.object(install_cmd, "_run_self_upgrade") as mock_upgrade,
+    ):
+        with pytest.raises(typer.Exit) as exc:
+            install_cmd.update_command(check=True, quiet=False)
+        mock_upgrade.assert_not_called()
+    assert exc.value.exit_code == 1
+    # Rich auto-highlights numeric substrings with ANSI codes, so match the
+    # surrounding text rather than the raw version string.
+    assert "Update available" in capsys.readouterr().out
+
+
+def test_fetch_failure_exits_nonzero_with_helpful_message(capsys):
+    with (
+        patch.object(install_cmd, "_local_version", return_value="1.0.0"),
+        patch.object(install_cmd, "_fetch_remote_version", return_value=None),
+        patch.object(install_cmd, "_run_self_upgrade") as mock_upgrade,
+    ):
+        with pytest.raises(typer.Exit) as exc:
+            install_cmd.update_command(check=False, quiet=False)
+        mock_upgrade.assert_not_called()
+    assert exc.value.exit_code == 1
+    assert "lore install --upgrade" in capsys.readouterr().out
+
+
+def test_version_tuple_compare_avoids_lexicographic_bug():
+    """"0.9.0" < "0.10.0" as versions, even though it sorts the other way
+    as plain strings."""
+    assert install_cmd._remote_is_newer("0.10.0", "0.9.0") is True
+    assert install_cmd._remote_is_newer("0.9.0", "0.10.0") is False


### PR DESCRIPTION
## What

New top-level `lore update` command that cleanly updates Lore as **both** the Python package and the Claude Code plugin when a new release lands on `main`.

## How

- Fetches the released version from `main`'s `.claude-plugin/plugin.json` (bumped in lockstep with `pyproject.toml` per the release rule, so one file suffices) and compares it — as int tuples, avoiding the `0.9` > `0.10` string-compare bug — against `importlib.metadata.version("lore")`.
- Up to date → says so, exit 0. Newer release → delegates to the existing `_run_self_upgrade` roundtrip: `install.sh upgrade` (pipx/uv/pip package upgrade) → chains into `lore install` → `claude plugin update lore@lore` plugin-cache refresh. No new upgrade machinery.
- `--check` reports only (exit 1 when an update is available, for scripting); `--quiet` matches the existing install flags.
- Registered top-level in `__main__.py` next to the grandfathered `uninstall` alias; `docs/architecture/cli-contract.md` rule 3 updated to name both exceptions.
- Tests: `tests/test_update_cmd.py` (5 cases: up-to-date, delegation, --check, fetch failure, version-compare edge). Docs: one-liner in `docs/how-to/onboarding.md`.

## Testing

`tests/test_update_cmd.py tests/test_install_dispatcher.py tests/test_install_helpers.py` → 41 passed, 1 failed. The failure (`test_refresh_claude_plugin_cache_runs_update_on_success`) is pre-existing — it fails identically on unmodified `main` (Rich auto-highlights numeric substrings with ANSI codes, breaking a raw-substring assert) and is unrelated to this change.

## Release note

Plugin-relevant CLI surface change — needs a `chore: release X.Y.Z` version bump (plugin.json + pyproject.toml + CHANGELOG.md) when merging, per CLAUDE.md.