### PR TITLE
feat(lore-workflow): brief + consolidate-docs skills

### DIFF
--- a/lore-workflow/.claude-plugin/plugin.json
+++ b/lore-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore-workflow",
   "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams. Depends on lore.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/lore-workflow/README.md
+++ b/lore-workflow/README.md
@@ -25,6 +25,8 @@ delegation conventions shared across skills live in
 | `to-epic` | Turn a plan/PRD into a PRD file plus an epic tracker issue with a roadmap DAG. |
 | `orchestrate-epic` | Supervise parallel TDD implementation of an epic — plan, dispatch, crosscheck, land. |
 | `implement-issue` | Fast path for one well-understood GitHub issue, outside the epic chain. |
+| `brief` | Middle rung — pack-only orientation + one reflected brief, then handoff to `implement-issue` or `tdd`. |
+| `consolidate-docs` | Sweep a wild-grown docs tree — plan-approved merge/move/delete back into Diátaxis shape. |
 | `tdd` | Test-driven red-green-refactor loop. |
 | `debug` | Systematic root-cause debugging with a hard circuit breaker. |
 | `document-epic` | After an epic merges, update Diátaxis docs to match the implemented state. |

--- a/lore-workflow/skills/brief/SKILL.md
+++ b/lore-workflow/skills/brief/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: lore-workflow:brief
+description: Middle-weight rung between implement-issue and the epic chain — pack-only
+  orientation, one reflected brief with recommended answers, document gates, then handoff
+  to implement-issue or tdd. Use when the task is clear-ish in the user's head but not
+  written down, medium-sized, and needs alignment without a full grilling. Triggers on
+  "brief me", "brief this", or "/lore-workflow:brief".
+---
+
+# Brief
+
+You are briefing: compress `orient` + `grilling` into **one bounded exchange**, then hand
+off. The task is clear-ish in the user's head but not written down — too big to skip
+alignment, too small for the epic chain's fan-out and interview.
+
+Routing rule (which rung a task belongs on):
+
+- **Written & clear issue** → `/lore-workflow:implement-issue`.
+- **In the user's head, single change** → this skill.
+- **Multi-feature or unsettled** → the chain (`/lore-workflow:orient` → `grilling` → `to-epic`).
+
+## Process
+
+### 1. Pack-only orientation — no fan-out, ever
+
+Pull `lore_context_pack` once and `lore_codemap` (or `lore codemap`) once. That is the whole
+intake. **Never spawn Explore subagents** — if the pack comes back thin for some facet, say
+so in the brief instead of searching wider. The context pack was built precisely so a
+deterministic pull replaces the fan-out on known ground; the fan-out weight is what this
+rung exists to avoid.
+
+### 2. One reflected brief, questions embedded
+
+Present a single message:
+
+- **What I understand you want** — restated in the project's domain language.
+- **Constraints that bear on it** — relevant ADRs, prior sessions, code landscape from the
+  pack. Name explicitly any facet where the pack was thin.
+- **Provisional scope** — in / out.
+- **Questions (max 3–5), each with your recommended answer pre-filled.**
+
+The user replies once — "yes to your recs except #3" — and that *is* the alignment. No
+one-question-at-a-time loop. Ask a second round only if an answer genuinely forks the
+design; this is explicitly **not a grilling**.
+
+### 3. Escalate if it turns out to be chain-weight
+
+If while briefing you discover the work is really multi-feature or the shape is unsettled,
+stop and say so: "this is chain-weight — run `/lore-workflow:orient`". The brief you already
+wrote seeds orient's step 1; nothing is wasted.
+
+### 4. Document gate, not document ritual
+
+Reuse the existing gates verbatim — no new document types:
+
+- **ADR** — apply `domain-modeling`'s three criteria (hard to reverse / surprising without
+  context / a real trade-off) to the decision the brief lands on. All three hold → draft the
+  ADR at `docs/adr/NNNN-kebab.md` as part of the downstream work. Any one missing → skip
+  silently, no placeholder. (See [`domain-modeling`](../domain-modeling/SKILL.md).)
+- **Glossary / CONTEXT.md** — touch only if the brief actually coined a *new* domain term.
+- **No PRD, no epic tracker.** Those belong to the chain.
+- **No brief file.** Lore's auto session capture already records the exchange; a persisted
+  brief would duplicate what session notes do.
+
+### 5. Handoff
+
+On confirmation, pick one:
+
+- **(a) File an issue and run the fast track** — `gh issue create` capturing the agreed
+  brief (intent + acceptance criteria), then invoke
+  [`/lore-workflow:implement-issue`](../implement-issue/SKILL.md) on it. Default for
+  anything that benefits from a durable tracker entry.
+- **(b) Implement directly with [`/lore-workflow:tdd`](../tdd/SKILL.md)** — when even an
+  issue is ceremony. The workflow invariants still apply: strict TDD, ruff clean, never
+  merge on red, ADR gate (above) and the Diátaxis docs pass from
+  [`implement-issue`](../implement-issue/SKILL.md) step 5, one branch, one PR, merging
+  stays with the user.
+
+Either way the consistent-documents guarantee survives, because the ADR and Diátaxis gates
+run downstream on the implementing track.

--- a/lore-workflow/skills/consolidate-docs/SKILL.md
+++ b/lore-workflow/skills/consolidate-docs/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: lore-workflow:consolidate-docs
+description: Pass over an existing documentation tree that has grown wild and consolidate
+  it — inventory, classify into Diátaxis quadrants, find duplication/contradiction/orphans,
+  propose a consolidation plan, and apply it as one docs PR only after the user approves the
+  plan. NEVER touches docs/prd or docs/adr. Use when docs have wild growth, overlap, or no
+  clear structure. Triggers on "consolidate docs", "docs cleanup", "/lore-workflow:consolidate-docs".
+---
+
+# Consolidate Docs
+
+You are the **consolidator**: a documentation tree has grown wild — overlapping pages,
+prose that restates the API, orphans nothing links to — and it needs to converge back into
+a coherent Diátaxis shape. Unlike `document-epic` (which extends docs after one epic's
+delta), this skill sweeps the **whole existing tree** and reduces it.
+
+**Input:** a docs root (a repo's `docs/`, or a path the user names).
+**Mode:** plan-first — the consolidation plan is reviewed by the user **before** any file
+is moved, merged, or deleted. Deleting human-written docs is not a call this skill makes
+alone.
+
+## Hard rule — never edit the canonical record
+
+Same rule as `document-epic`: **NEVER modify anything under `docs/prd/` or `docs/adr/`.**
+Read them for context; never write, move, rename, or delete them. `is_excluded(path)` from
+`lore_workflow.diataxis` flags these paths — trust it and re-check your final diff.
+
+## Loop
+
+### 1. Inventory
+
+Walk the docs root and build one table: every doc file with its path, title, headings, and
+inbound links (grep the tree for references to it — toctrees, relative links, wikilinks).
+Note which files no toctree/index reaches (**orphans**) and which links point at files that
+no longer exist (**dangles**).
+
+### 2. Classify
+
+Run every path through `classify(path, ...)` / `classify_changeset` from
+`lore_workflow.diataxis` to get each doc's quadrant (tutorial / how-to / reference /
+explanation) or "skip"/"excluded". Where the directory layout gives no signal, judge the
+quadrant from the content: is it teaching (tutorial), a recipe (how-to), describing the API
+(reference), or explaining why (explanation)? A doc that mixes quadrants is itself a
+finding — Diátaxis pages serve one need each.
+
+### 3. Find the wild growth
+
+For each quadrant, look for:
+
+- **Duplication** — two pages covering the same task/concept; propose merging into the
+  better-located one, with the survivor absorbing anything unique from the loser.
+- **Contradiction** — pages that disagree with each other or with the implemented behavior;
+  verify against the code before proposing which side wins.
+- **Prose-restated reference** — hand-written pages paraphrasing the API; propose replacing
+  with docstrings + autosummary/toctree wiring, the repo's reference convention.
+- **Mixed-quadrant pages** — propose the split (or the dominant-quadrant home).
+- **Orphans and dangles** — propose wiring in, merging, or deleting; a dangle is fixed at
+  the link, an orphan needs a decision.
+- **Stale content** — flag only on **named positive evidence**: a contradiction with the
+  code, a reference to a removed feature, a broken link. Age alone never flags a doc.
+
+### 4. Propose the plan
+
+Present one consolidation plan: per action — `merge A into B`, `move`, `split`, `delete`,
+`rewire link`, `convert to docstring reference` — with a one-line reason each. Group by
+quadrant, deletions listed last and most explicitly. **Wait for the user's approval**; they
+may strike individual actions. Do not proceed on silence.
+
+### 5. Apply as one docs PR
+
+On approval, execute the surviving actions on a branch off the repo's integration branch.
+Preserve content when merging — the survivor absorbs, the loser is deleted only after its
+unique content has a home. Fix every link/toctree the moves break; a consolidation that
+leaves new dangles has failed its own step 3. Re-confirm no `docs/prd`/`docs/adr` path is
+in the diff. Open one PR summarizing plan → applied actions. **Merging stays with the
+user** — unlike `document-epic`, this PR touches human-written pages and does not
+auto-merge.
+
+## Relationship to document-epic
+
+`document-epic` is incremental (one epic's delta, autonomous, auto-merge on green);
+`consolidate-docs` is a periodic sweep (whole tree, plan-approved, human-merged). Run this
+when growth has outpaced structure; run `document-epic` after every epic so it stays rare.

--- a/lore-workflow/skills/implement-issue/SKILL.md
+++ b/lore-workflow/skills/implement-issue/SKILL.md
@@ -25,7 +25,9 @@ Reach for this when the user hands you a single GitHub issue they wrote and the
 change is small and clear enough that spinning up the full epic chain would be
 pure overhead. If the work is really several features, or the shape is still
 unsettled, it belongs on the chain (`orient` → `grilling` → `to-epic`),
-not here.
+not here. If the task is clear-ish but only in the user's head — no written
+issue yet — [`/lore-workflow:brief`](../brief/SKILL.md) is the rung in
+between: it aligns in one exchange and can hand back to this skill.
 
 ## Flow
 

--- a/lore-workflow/skills/orient/SKILL.md
+++ b/lore-workflow/skills/orient/SKILL.md
@@ -69,3 +69,7 @@ On confirmation, carry the shared understanding into the grilling step — defau
 against.
 
 Chain: `/lore-workflow:orient` → `/lore-workflow:grilling` → `/lore-workflow:to-epic` → `/lore-workflow:orchestrate-epic`.
+
+Lighter rungs exist beside the chain: a single change that is clear-ish but unwritten
+takes `/lore-workflow:brief`; a written, clear issue takes `/lore-workflow:implement-issue`.
+Reserve this chain for multi-feature or unsettled work.

--- a/tests/test_workflow_plugin_structural.py
+++ b/tests/test_workflow_plugin_structural.py
@@ -33,7 +33,9 @@ KEBAB_CASE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
 # Every ported skill must carry the plugin's slash-command prefix.
 EXPECTED_SKILL_NAMES = {
+    "brief",
     "ccat-workflow-init",
+    "consolidate-docs",
     "debug",
     "document-epic",
     "domain-modeling",


### PR DESCRIPTION
## What

Two new lore-workflow skills plus routing wiring, from the middle-ground design discussed in session:

- **`brief`** — the missing rung between `implement-issue` (issue exists, written & clear) and the epic chain (multi-feature / unsettled): task is clear-ish in the user's head but unwritten. Pack-only orientation (`lore_context_pack` + `lore_codemap`, **no Explore fan-out ever**), one reflected brief with max 3–5 questions each carrying a recommended answer, then handoff to `implement-issue` (files the issue) or straight to `tdd`. Reuses the existing ADR three-criteria gate and Diátaxis pass downstream — no new document types, no persisted brief file (session capture records it).
- **`consolidate-docs`** — periodic sweep for wild-grown docs trees: inventory + inbound-link map, quadrant classification via `lore_workflow.diataxis`, findings (duplication, contradiction, prose-restated reference, mixed-quadrant pages, orphans/dangles, positive-evidence staleness only), then a **user-approved** consolidation plan applied as one **human-merged** docs PR. Same `docs/prd`/`docs/adr` hard exclusion as `document-epic`.

## Also

- Routing rule cross-referenced in `orient` and `implement-issue` so the three rungs self-route.
- README skill table updated.
- `lore-workflow` plugin version 0.1.0 → 0.2.0 (installed plugin caches only re-fetch on a version change).