### PR TITLE
fix(curator): unstarve reaper scan window, sweep stale uncertain buffers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore",
   "description": "LLM-optimized knowledge graph for AI-coding teams \u2014 session notes, auto-extracted knowledge, pluggable briefings, magic context injection at session start.",
-  "version": "0.63.1",
+  "version": "0.63.2",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   closed-but-unarchived sidecars) at the head of the sort permanently
   starved the stale backlog — 76 abandoned buffers and their zero-chapter
   stub notes piled up in the vault. Capped passes now scan stalest-first
-  (by sidecar mtime), and the reaper archives closed-but-unarchived
-  sidecars to `_done/` so they stop eating scan slots.
+  (by sidecar mtime), and closed-but-unarchived sidecars no longer
+  consume scan slots: the reaper archives them to `_done/` on sight, and
+  when the archive collides (duplicate buffer for an already-archived
+  transcript/date) it logs a warning and moves on instead of letting the
+  stray clog the window on every pass.
 - **Startup sweep was a no-op on Linux.** `sweep_dead_sessions` skipped
   every uncertain-liveness buffer, but on Linux a dead session's owner
   pid is always a long-exited hook subprocess, so *every* dead buffer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (0.x means anything can change between minor versions until 1.0).
 
+## [0.63.2] - 2026-07-15
+
+### Fixed
+
+- **Reaper scan-window starvation.** A capped `reap_once` pass scanned
+  buffers in name order, so a handful of live sessions (and
+  closed-but-unarchived sidecars) at the head of the sort permanently
+  starved the stale backlog — 76 abandoned buffers and their zero-chapter
+  stub notes piled up in the vault. Capped passes now scan stalest-first
+  (by sidecar mtime), and the reaper archives closed-but-unarchived
+  sidecars to `_done/` so they stop eating scan slots.
+- **Startup sweep was a no-op on Linux.** `sweep_dead_sessions` skipped
+  every uncertain-liveness buffer, but on Linux a dead session's owner
+  pid is always a long-exited hook subprocess, so *every* dead buffer
+  judged as uncertain and the sweep never closed anything. Uncertain
+  buffers now fall back on the reaper's staleness threshold: fresh
+  heartbeat → skipped, stale → swept as dead.
+
 ## [0.63.1] - 2026-07-13
 
 ### Removed

--- a/lib/lore_curator/chapter_flush.py
+++ b/lib/lore_curator/chapter_flush.py
@@ -940,11 +940,16 @@ def sweep_dead_sessions(
       the rest are left for the next sweep (they drain over successive
       starts) so one startup is always bounded.
 
-    Live owners are left alone; uncertain liveness (no ``/proc`` / macOS /
-    network fs) is left to the reaper's staleness path rather than swept.
+    Live owners are left alone. Uncertain liveness (no ``/proc`` / macOS /
+    network fs / same-host pid gone) falls back on the reaper's staleness
+    threshold: a fresh heartbeat is skipped, a stale one is swept as dead.
+    On Linux a dead session's owner pid is a long-exited hook subprocess,
+    so every dead buffer judges as uncertain — skipping all of them made
+    the sweep a no-op.
     """
-    from lore_curator.reaper import is_owner_alive
+    from lore_curator.reaper import _is_stale, _now_utc, _staleness_threshold, is_owner_alive
 
+    now = _now_utc()
     report = SweepReport()
     dead: list[tuple[str, Any, Any]] = []
     for buf in iter_all(lore_root):
@@ -956,7 +961,9 @@ def sweep_dead_sessions(
         if verdict is True:
             report.alive_skipped += 1
             continue
-        if verdict is None:
+        if verdict is None and not _is_stale(
+            sidecar, threshold_s=_staleness_threshold(buf, default_s=1800), now=now
+        ):
             report.uncertain_skipped += 1
             continue
         dead.append((sidecar.local_date or "", buf, sidecar))

--- a/lib/lore_curator/reaper.py
+++ b/lib/lore_curator/reaper.py
@@ -39,7 +39,6 @@ Concurrency:
 
 from __future__ import annotations
 
-import contextlib
 import os
 import socket
 from dataclasses import dataclass, field
@@ -210,7 +209,6 @@ def reap_once(
     for buf in sorted(iter_all(lore_root), key=_sidecar_mtime):
         if max_per_pass is not None and report.scanned >= max_per_pass:
             break
-        report.scanned += 1
         try:
             verdict, reason = _judge(
                 buf,
@@ -219,20 +217,34 @@ def reap_once(
                 logger=logger,
             )
         except Exception as exc:  # noqa: BLE001 - never let one buffer abort the pass
+            report.scanned += 1
             report.skipped.append((buf.stem, f"judge-error: {type(exc).__name__}: {exc}"))
             continue
 
-        if verdict == "alive":
-            report.alive += 1
-            continue
         if verdict == "closed":
             # A closed-but-unarchived sidecar (flush died between the state
-            # transition and the _done/ move) would occupy a scan slot on
-            # every pass — finish the archival here.
+            # transition and the _done/ move) would otherwise occupy a scan
+            # slot on every pass — and it sorts stalest, so it would clog the
+            # whole window. Finish the archival here, without consuming a
+            # slot: judging it is one flock + JSON read, no spawn.
             report.already_done += 1
-            with contextlib.suppress(Exception), buf.with_lock(blocking=False) as held:
-                if held:
-                    buf.close()
+            try:
+                with buf.with_lock(blocking=False) as held:
+                    if held:
+                        buf.close()
+            except Exception as exc:  # noqa: BLE001 - e.g. a _done/ archive collision
+                if logger is not None:
+                    logger.emit(
+                        "warning",
+                        reason="done-archive-collision",
+                        stem=buf.stem,
+                        detail=str(exc),
+                    )
+            continue
+
+        report.scanned += 1
+        if verdict == "alive":
+            report.alive += 1
             continue
         if verdict == "skip":
             report.skipped.append((buf.stem, reason))

--- a/lib/lore_curator/reaper.py
+++ b/lib/lore_curator/reaper.py
@@ -36,8 +36,10 @@ Concurrency:
 - Spawn role is ``a-flush`` (distinct from ``a``) so reaper-driven
   spawns don't stampede the regular curator-A spawn lock.
 """
+
 from __future__ import annotations
 
+import contextlib
 import os
 import socket
 from dataclasses import dataclass, field
@@ -194,13 +196,27 @@ def reap_once(
     host = socket.gethostname()
     report = ReaperReport()
 
-    for buf in iter_all(lore_root):
+    def _sidecar_mtime(b: Buffer) -> float:
+        # Sidecar mtime tracks the last heartbeat write; a vanished file
+        # sorts first and is handled as "no-sidecar" by the judge.
+        try:
+            return b.sidecar_path.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    # Stalest-first: a capped pass must reach the abandoned backlog even
+    # when live sessions would otherwise occupy every scan slot (name
+    # order starved buffers deeper in the list indefinitely).
+    for buf in sorted(iter_all(lore_root), key=_sidecar_mtime):
         if max_per_pass is not None and report.scanned >= max_per_pass:
             break
         report.scanned += 1
         try:
             verdict, reason = _judge(
-                buf, host=host, now=now, logger=logger,
+                buf,
+                host=host,
+                now=now,
+                logger=logger,
             )
         except Exception as exc:  # noqa: BLE001 - never let one buffer abort the pass
             report.skipped.append((buf.stem, f"judge-error: {type(exc).__name__}: {exc}"))
@@ -210,7 +226,13 @@ def reap_once(
             report.alive += 1
             continue
         if verdict == "closed":
+            # A closed-but-unarchived sidecar (flush died between the state
+            # transition and the _done/ move) would occupy a scan slot on
+            # every pass — finish the archival here.
             report.already_done += 1
+            with contextlib.suppress(Exception), buf.with_lock(blocking=False) as held:
+                if held:
+                    buf.close()
             continue
         if verdict == "skip":
             report.skipped.append((buf.stem, reason))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lore"
-version = "0.63.1"
+version = "0.63.2"
 description = "LLM-optimized knowledge graph for AI-coding teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_reaper_force_flush.py
+++ b/tests/test_reaper_force_flush.py
@@ -304,3 +304,47 @@ def test_closed_buffer_is_archived_to_done(lore_root, monkeypatch):
     assert not buf.sidecar_path.exists()
     done = lore_root / ".lore" / "buffers" / "_done" / buf.sidecar_path.name
     assert done.exists()
+
+
+def test_unarchivable_closed_buffer_does_not_clog_capped_pass(lore_root, monkeypatch):
+    """Livelock regression: a closed sidecar whose _done/ archive already
+    exists (duplicate buffer for an archived (transcript_id, local_date))
+    can't be moved -- and it sorts stalest, so if it consumed a scan slot
+    every capped pass would re-scan it and never reach the reapable
+    backlog. Closed verdicts must not consume slots."""
+    import shutil
+    import socket
+
+    closed_buf, _ = _seed(lore_root, transcript_id="dup")
+    with closed_buf.with_lock():
+        closed_buf.transition("ready")
+        closed_buf.transition("flushing")
+        closed_buf.transition("closed")
+    done = lore_root / ".lore" / "buffers" / "_done"
+    done.mkdir(exist_ok=True)
+    shutil.copy(closed_buf.sidecar_path, done / closed_buf.sidecar_path.name)  # collision
+    ancient = (datetime.now(UTC) - timedelta(days=9)).timestamp()
+    os.utime(closed_buf.sidecar_path, (ancient, ancient))
+
+    stale_buf, _ = _seed(lore_root, transcript_id="stale")
+    stale = (datetime.now(UTC) - timedelta(hours=3)).isoformat().replace("+00:00", "Z")
+    with stale_buf.with_lock():
+        stale_buf.patch(
+            owner=OwnerInfo(pid=2**31 - 1, host=socket.gethostname(), start_ts=0.0),
+            last_heartbeat=stale,
+            last_appended_at=stale,
+        )
+    old = (datetime.now(UTC) - timedelta(hours=3)).timestamp()
+    os.utime(stale_buf.sidecar_path, (old, old))
+
+    spawned: list = []
+    monkeypatch.setattr(
+        "lore_curator.reaper.spawn_detached_flush",
+        lambda buffer_path, lore_root: spawned.append(buffer_path) or True,
+    )
+    report = reap_once(lore_root, max_per_pass=1)
+    assert report.already_done == 1
+    assert report.force_flushed == 1
+    assert spawned == [stale_buf.sidecar_path]
+    # The colliding sidecar stays in place (never clobber _done history).
+    assert closed_buf.sidecar_path.exists()

--- a/tests/test_reaper_force_flush.py
+++ b/tests/test_reaper_force_flush.py
@@ -1,4 +1,5 @@
 """Tests for lore_curator.reaper — liveness reaper."""
+
 from __future__ import annotations
 
 import os
@@ -31,9 +32,7 @@ def lore_root(tmp_path: Path) -> Path:
 
 @pytest.fixture(autouse=True)
 def patch_collectors(monkeypatch):
-    monkeypatch.setattr(
-        "lore_curator.session_activity.collect_commits_by_sha", lambda *a, **kw: []
-    )
+    monkeypatch.setattr("lore_curator.session_activity.collect_commits_by_sha", lambda *a, **kw: [])
     monkeypatch.setattr(
         "lore_curator.session_activity.collect_issues_in_window", lambda *a, **kw: ([], [])
     )
@@ -47,10 +46,16 @@ def patch_collectors(monkeypatch):
 def _seed(lore_root: Path, **append_kw) -> tuple:
     """Seed one buffer; return (buffer, sidecar)."""
     outcome = append_chunk(
-        lore_root=lore_root, chunk_turns=_make_turns(2), local_date="2026-05-01",
+        lore_root=lore_root,
+        chunk_turns=_make_turns(2),
+        local_date="2026-05-01",
         transcript_id=append_kw.pop("transcript_id", "abc"),
-        integration="claude-code", wiki="private", scope="proj:x",
-        cwd=lore_root, wiki_root=lore_root / "wiki" / "private", cfg=WikiConfig(),
+        integration="claude-code",
+        wiki="private",
+        scope="proj:x",
+        cwd=lore_root,
+        wiki_root=lore_root / "wiki" / "private",
+        cfg=WikiConfig(),
         **append_kw,
     )
     return outcome.buffer, outcome.buffer.read_sidecar()
@@ -64,13 +69,16 @@ def _seed(lore_root: Path, **append_kw) -> tuple:
 def test_owner_alive_local_pid_returns_true_or_none():
     """Real-process check on the test runner's pid -- should be True or None
     (None when /proc isn't readable, e.g. macOS)."""
-    sidecar = Sidecar(owner=OwnerInfo(
-        pid=os.getpid(),
-        host="x",
-        start_ts=0.0,
-    ))
+    sidecar = Sidecar(
+        owner=OwnerInfo(
+            pid=os.getpid(),
+            host="x",
+            start_ts=0.0,
+        )
+    )
     # Force host match.
     import socket
+
     sidecar.owner.host = socket.gethostname()
     verdict = is_owner_alive(sidecar)
     assert verdict in (True, None)  # depends on /proc availability
@@ -247,3 +255,52 @@ def test_max_per_pass_bounds_scan(lore_root, monkeypatch):
         _seed(lore_root, transcript_id=tid)
     report = reap_once(lore_root, max_per_pass=2)
     assert report.scanned == 2
+
+
+def test_capped_pass_scans_stalest_first(lore_root, monkeypatch):
+    """Regression for scan-window starvation: with more buffers than
+    max_per_pass, the stale buffer must win a scan slot even when fresh
+    buffers sort ahead of it by name -- otherwise a handful of live
+    sessions at the head of the name order starves the backlog forever."""
+    for tid in ("aaa", "abb", "acc"):
+        _seed(lore_root, transcript_id=tid)  # fresh, name-sorted first
+
+    import socket
+
+    stale_buf, _ = _seed(lore_root, transcript_id="zzz-stale")
+    stale = (datetime.now(UTC) - timedelta(hours=3)).isoformat().replace("+00:00", "Z")
+    with stale_buf.with_lock():
+        stale_buf.patch(
+            owner=OwnerInfo(pid=2**31 - 1, host=socket.gethostname(), start_ts=0.0),
+            last_heartbeat=stale,
+            last_appended_at=stale,
+        )
+    old = (datetime.now(UTC) - timedelta(hours=3)).timestamp()
+    os.utime(stale_buf.sidecar_path, (old, old))
+
+    spawned: list = []
+    monkeypatch.setattr(
+        "lore_curator.reaper.spawn_detached_flush",
+        lambda buffer_path, lore_root: spawned.append(buffer_path) or True,
+    )
+    report = reap_once(lore_root, max_per_pass=2)
+    assert report.scanned == 2
+    assert report.force_flushed == 1
+    assert spawned == [stale_buf.sidecar_path]
+
+
+def test_closed_buffer_is_archived_to_done(lore_root, monkeypatch):
+    """A closed-but-unarchived sidecar (flush died between transition and
+    archive) must not occupy scan slots forever -- the reaper moves it to
+    _done/ when it sees one."""
+    buf, _ = _seed(lore_root)
+    with buf.with_lock():
+        buf.transition("ready")
+        buf.transition("flushing")
+        buf.transition("closed")
+
+    report = reap_once(lore_root)
+    assert report.already_done == 1
+    assert not buf.sidecar_path.exists()
+    done = lore_root / ".lore" / "buffers" / "_done" / buf.sidecar_path.name
+    assert done.exists()

--- a/tests/test_startup_sweep.py
+++ b/tests/test_startup_sweep.py
@@ -268,6 +268,36 @@ def test_sweep_skips_uncertain_owner(tmp_path):
     assert buf.sidecar_path.exists()
 
 
+def test_sweep_closes_uncertain_owner_with_stale_heartbeat(tmp_path):
+    """Same-host dead sessions always judge as uncertain (the owner pid is a
+    short-lived hook subprocess), so 'skip all uncertain' made the sweep a
+    no-op on Linux. Uncertain + heartbeat past the staleness threshold must
+    sweep like a dead owner."""
+    from datetime import UTC, datetime, timedelta
+
+    lore_root = _lore_root(tmp_path)
+    all_turns = _turns(0, 12)  # above the trivial-session gate
+    buf = _seed(lore_root, all_turns, tid="stale-uncertain", owner=_uncertain_owner())
+    stale = (datetime.now(UTC) - timedelta(hours=3)).isoformat().replace("+00:00", "Z")
+    with buf.with_lock():
+        buf.patch(last_heartbeat=stale, last_appended_at=stale)
+
+    report = sweep_dead_sessions(
+        lore_root,
+        llm_client=_Client(
+            [
+                {"boundaries": []},
+                {"facts": [{"kind": "done", "text": "The crash is fixed.", "anchor": 2}]},
+                {"headline": "The crash is fixed."},
+            ]
+        ),
+        adapter_lookup=_lookup(_Adapter(all_turns)),
+    )
+    assert report.uncertain_skipped == 0
+    assert report.swept == 1
+    assert not buf.sidecar_path.exists()  # archived to _done
+
+
 def test_startup_sweep_is_contended_when_global_lock_held(tmp_path):
     lore_root = _lore_root(tmp_path)
     all_turns = _turns(0, 2)


### PR DESCRIPTION
## Problem

56 zero-chapter stub notes piled up in the ccat wiki and 76 buffers sat stuck in `accumulating` (oldest 9 days past the 30-min staleness window, `flush_attempts: 0`). The delete-empty-notes gate in `chapter_flush` never fired because nothing ever flushed these buffers:

1. **Reaper starvation** — the inline `reap_once` (cap 5) scanned buffers in name order; live sessions and closed-but-unarchived sidecars permanently occupied the head slots, so the stale backlog was never reached. Today's spine log shows every pass scanning exactly the same 5.
2. **Sweep no-op** — `sweep_dead_sessions` skipped all uncertain-liveness buffers, but on Linux a dead session's owner pid is a long-exited hook subprocess, so *every* dead buffer judges uncertain. Zero `sweep-stale-closed` events in the entire spine history.

## Fix

- Capped reaper passes scan **stalest-first** (sidecar mtime); closed-but-unarchived sidecars are archived to `_done/` on sight.
- Sweep applies the reaper's staleness fallback to uncertain buffers: fresh heartbeat → skip, stale → sweep as dead.

## Testing

- New: `test_capped_pass_scans_stalest_first`, `test_closed_buffer_is_archived_to_done`, `test_sweep_closes_uncertain_owner_with_stale_heartbeat` (red before, green after).
- Full suite: 2794 passed; the 4 failures (`test_core_llm_wiring`, `test_install_dispatcher`) reproduce identically against untouched main — pre-existing/environmental.

Version bumped to 0.63.2 (plugin-relevant curator code).