### PR TITLE
Lighten the epic workflow cycle: DAG-derived compact band, slice collapse, batched crosscheck, capped orient brief, docs pre-land

### DIFF
--- a/docs/adr/0005-docs-land-with-the-epic.md
+++ b/docs/adr/0005-docs-land-with-the-epic.md
@@ -1,0 +1,53 @@
+# ADR 0005: Docs land with the epic, not after it
+
+- Status: Accepted
+- Date: 2026-08-03
+- Context: workflow-lightening review session, 2026-08-03 (with the wider
+  lightening pass: DAG-derived effort band, linear-chain slice collapse,
+  batched crosscheck)
+
+## Context
+
+`document-epic` ran as `orchestrate-epic`'s *final* stage: after the epic PR
+merged, it opened a separate docs PR that auto-merged on green, with human
+review post-hoc. That made documentation a structural afterthought — the epic
+was "done" before its docs existed, the whole-epic reviewer never saw them,
+and every epic produced a second PR trailing the first.
+
+## Decision
+
+`orchestrate-epic` invokes `document-epic` in a **pre-land mode**, after the
+last feature merges into `epic/<n>` and before the epic PR opens. In this
+mode the documenter commits the Diátaxis doc updates **directly onto the epic
+branch** — no separate docs PR. Consequences by construction:
+
+1. The epic PR carries code and docs as one reviewable unit; the whole-epic
+   review checks docs-vs-behavior mismatches alongside cross-feature
+   consistency.
+2. The epic's own CI gates the docs; there is no second merge to track.
+3. **Docs never block a green epic.** If the docs stage escalates or cannot
+   go green after one fix pass, the orchestrator drops the docs commit, lands
+   the epic, and runs standalone `document-epic` post-land — the prior
+   behavior, kept as fallback and as the catch-up path for already-merged
+   epics.
+
+The hard rule is unchanged: `document-epic` never touches `docs/prd/` or
+`docs/adr/` in either mode.
+
+## Consequences / Trade-offs
+
+- **Positive.** Docs are part of the deliverable, reviewed and gated with the
+  code they describe; one PR per epic instead of two.
+- **Negative.** Landing waits on the docs stage (bounded by the one-fix-pass
+  fallback), and a docs defect can now fail epic CI — mitigated by the same
+  fallback.
+
+## Alternatives considered
+
+- **Keep the post-land docs PR (prior design).** Rejected: it is the
+  afterthought this ADR removes — unreviewed by the epic reviewer, trailing
+  the merge.
+- **Docs per feature PR (each teammate documents its slice).** Rejected:
+  N teammates writing into the same docs tree invites conflicts, and slice-
+  local docs miss the cross-feature view; one documenter over the cumulative
+  diff is cheaper and more coherent.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -34,7 +34,7 @@ seed-epic → orient → grilling → to-epic → orchestrate-epic → document-
 | `grilling` | A relentless, one-question-at-a-time interview that stress-tests a plan. Default mode ("grill me") checks whether `domain-modeling` is needed at the end; "grill with docs" mode runs it alongside the interview from the start, sharpening terminology and updating `CONTEXT.md`/ADRs inline. |
 | `to-epic` | The human checkpoint. Turns a shaped plan into an **epic tracker** issue (linking a PRD under `docs/prd/`) plus one sub-issue per feature, emitting the canonical roadmap DAG `orchestrate-epic` consumes. |
 | `orchestrate-epic` | Fully autonomous: fans out one test-first teammate per feature, crosschecks every pull request, integrates onto an `epic/<n>` branch in dependency order, and lands one final pull request to the detected target branch. |
-| `document-epic` | Runs as `orchestrate-epic`'s **final automatic stage** (see below), not a manual step. Updates the Diátaxis docs to match the landed epic. |
+| `document-epic` | Runs as `orchestrate-epic`'s **automatic pre-land stage** (see below), not a manual step. Commits the Diátaxis docs onto the epic branch so they ship in the epic PR; standalone it catches up an already-merged epic via a docs PR. |
 | `tdd` | The red→green→refactor loop every implementation teammate follows. |
 
 `code-review` is a **built-in** Claude Code command, not a bundled skill —
@@ -128,19 +128,23 @@ comments). The plain-text view times out on large trackers.
 
 ## `document-epic`'s auto stage
 
-`document-epic` is **not a manual step**. It runs as `orchestrate-epic`'s
-final automatic subagent stage, **after the epic PR lands**:
+`document-epic` is **not a manual step**. It runs as an `orchestrate-epic`
+subagent stage **before the epic PR lands** (ADR 0005):
 
-1. The epic's feature PRs are integrated and the epic branch lands on the
-   target branch.
-2. `orchestrate-epic` dispatches `document-epic` as its last subagent.
-3. `document-epic` generates the Diátaxis docs for the change, **opens a
-   docs PR**, and **auto-merges it on green CI**.
-4. A human **reviews post-hoc** — the docs land autonomously; review happens
-   without blocking the merge.
+1. The epic's feature PRs are integrated into `epic/<n>` and its CI is green.
+2. `orchestrate-epic` dispatches `document-epic` in **pre-land mode**: it
+   generates the Diátaxis docs for the cumulative diff and **commits them
+   onto the epic branch** — no separate docs PR.
+3. The docs ship inside the epic PR: the whole-epic review sees them and the
+   epic's CI gates them. Docs stop being an afterthought that trails the
+   merge.
+4. Fallback: if the docs stage escalates or cannot go green, the epic lands
+   without it and standalone `document-epic` runs post-land — its own docs
+   PR, auto-merged on green, human review post-hoc. Docs never block a green
+   epic.
 
-This keeps documentation in lock-step with shipped code without adding a
-manual gate to the autonomous loop.
+Standalone invocation (pointing it at an already-merged epic) remains the
+catch-up path and keeps the old behavior: docs PR, auto-merge on green.
 
 ### Diátaxis handoff
 

--- a/docs/how-to/run-an-epic.md
+++ b/docs/how-to/run-an-epic.md
@@ -31,12 +31,17 @@ small, clear change, use the [fast path](use-the-fast-path.md) instead.
    `/lore-workflow:orchestrate-epic`. It validates the roadmap
    (`lore workflow validate-roadmap`), creates the `epic/<issue>` integration
    branch from the detected target branch (`develop` if present, else
-   `main`), fans out one test-first teammate per feature, crosschecks every
-   pull request, integrates the features in dependency order, and opens the
-   final pull request to the target branch.
-4. **Let the docs catch up.** After the epic merges, `orchestrate-epic`
-   automatically runs `/lore-workflow:document-epic`, which opens a docs PR
-   and auto-merges it on green. You review post-hoc.
+   `main`), implements the features test-first (one teammate per feature when
+   they run in parallel; one sequential teammate when the roadmap is a
+   straight chain), crosschecks every pull request, integrates the features
+   in dependency order, and opens the final pull request to the target
+   branch.
+4. **Docs ship with the epic.** Before that final pull request,
+   `orchestrate-epic` automatically runs `/lore-workflow:document-epic`,
+   which commits the Diátaxis doc updates onto the epic branch — the docs
+   land inside the epic PR, not as a trailing afterthought. Only if the docs
+   stage fails does it fall back to the old post-merge docs PR
+   (auto-merged on green, reviewed post-hoc).
 
 ## Notes
 
@@ -55,6 +60,7 @@ small, clear change, use the [fast path](use-the-fast-path.md) instead.
 
 ## Done when
 
-- The final epic pull request is merged to the target branch.
+- The final epic pull request — docs included — is merged to the target
+  branch.
 - Every sub-issue is closed and every roadmap checkbox is ticked.
-- The docs PR has merged on green.
+- On docs fallback only: the standalone docs PR has merged on green.

--- a/lore-workflow/skills/document-epic/SKILL.md
+++ b/lore-workflow/skills/document-epic/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: lore-workflow:document-epic
-description: After an epic merges, update a repo's Diátaxis documentation (tutorials, how-to,
-  reference, explanation) to reflect the implemented state, then open a docs PR that
-  auto-merges on green. NEVER touches docs/prd or docs/adr. Use after an epic lands and its
-  user-facing docs need to catch up. Standalone and cross-repo aware.
+description: Update a repo's Diátaxis documentation (tutorials, how-to, reference,
+  explanation) to match an epic's implemented state. Pre-land (invoked by orchestrate-epic)
+  it commits docs onto the epic branch so they ship in the epic PR; standalone (an already
+  merged epic) it opens a docs PR that auto-merges on green. NEVER touches docs/prd or
+  docs/adr. Cross-repo aware.
 ---
 
 # Document Epic
 
-You are the **documenter**: a merged epic changed what the software does, and the
-user-facing docs must catch up. You update the **Diátaxis four** to match the implemented
-state, then open a docs PR and let it auto-merge on green — a human reviews post-hoc. You do
-not change behavior; you describe it.
+You are the **documenter**: an epic changed what the software does, and the user-facing docs
+must match. You update the **Diátaxis four** to the implemented state. You do not change
+behavior; you describe it.
 
-**Input:** a merged epic (issue number or URL), possibly spanning repos.
+**Input:** an epic (issue number or URL), possibly spanning repos — either **pre-land** (its
+`epic/<n>` branch exists, all features merged into it; this is how `orchestrate-epic` invokes
+you, per ADR 0005) or **standalone** (the epic already merged; docs catching up post-hoc).
 **Mode:** autonomous — run the loop without asking. Stop only to report completion or to
 escalate a hard blocker (see Stop conditions).
 
@@ -46,11 +48,12 @@ Every documentation edit you make belongs to exactly one quadrant
 
 ## Loop
 
-**Map the deltas.** Read the merged epic with `gh ... --json` (see the repo's own
+**Map the deltas.** Read the epic with `gh ... --json` (see the repo's own
 conventions doc, if any).
-From it gather three sources of truth: the **merged PRD** (intent), the **sub-issue PRs**
+From it gather three sources of truth: the **PRD** (intent), the **sub-issue PRs**
 (per-feature acceptance notes that reveal which behaviors are user-facing), and the
-**cumulative epic diff** (every path the epic touched, with its change kind). Build one list
+**cumulative epic diff** — pre-land that is `<target_branch>...epic/<n>`; standalone it is
+the merged range (every path the epic touched, with its change kind). Build one list
 of changed paths, each tagged with its change kind and — for source files — whether it
 touches the **public API** (a non-underscore symbol exported from the package). This list is
 the input to classification.
@@ -73,13 +76,18 @@ autosummary/toctree entries — never substitute prose for a docstring. Keep edi
 what the epic changed; do not rewrite untouched docs. Re-confirm no `docs/prd`/`docs/adr`
 path is in your diff.
 
-**Open the docs PR.** Branch off the repo's integration branch, commit the doc edits, and
-open a PR that summarizes the documented deltas and links the epic and its sub-issues. **Auto-
-merge it on green CI** — documentation lands without blocking on human review; a human reviews
-post-hoc. Never auto-merge on red.
+**Deliver.**
+- *Pre-land* (invoked from `orchestrate-epic`): commit the doc edits **directly onto the
+  epic branch** — no separate PR. The epic PR carries them, the whole-epic review sees them,
+  and the epic's own CI gates them. Report the commit SHA and the edit plan.
+- *Standalone* (epic already merged): branch off the repo's integration branch, commit, and
+  open a PR that summarizes the documented deltas and links the epic and its sub-issues.
+  **Auto-merge it on green CI** — documentation lands without blocking on human review; a
+  human reviews post-hoc. Never auto-merge on red.
 
 **Cross-repo.** An epic may span repos. Repeat the loop per affected repo, each against its
-own docs layout and its own integration branch. One docs PR per repo.
+own docs layout and its own epic/integration branch. One delivery per repo (pre-land commit
+or standalone docs PR).
 
 ## Dry-run
 

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -57,11 +57,12 @@ No board comment found → fresh run; proceed to the gate.
 
 **Roadmap gate + effort band.** Run `lore workflow validate-roadmap --json` →
 `{ok, rows, repos, edges, problems}`. `ok: false` → refuse to start: report `problems` and stop, never
-dispatching against a malformed or cyclic roadmap. Otherwise pick the band from the counts, not by eye:
-**compact** iff `rows ≤ 2` and `repos == 1` and every `Type` is AFK with no HITL flags; **standard** otherwise
-(full batched loop, concurrency cap N). Record the band in your epic note. Then build the feature DAG, split
-into dependency-ordered batches (features in a batch are independent), and cut and push `epic/<issue>` from
-the up-to-date `target_branch`.
+dispatching against a malformed or cyclic roadmap. Otherwise build the feature DAG from `edges` and split it
+into dependency-ordered batches (features in a batch are independent). Pick the band from the numbers, not by
+eye: **compact** iff `repos == 1`, every `Type` is AFK, and either the DAG offers no real parallelism — every
+batch holds exactly one feature, i.e. a straight chain of any length — or `rows ≤ 3`; **standard** otherwise
+(full batched loop, concurrency cap N). Fan-out only pays when features actually run side by side. Record the
+band in your epic note, then cut and push `epic/<issue>` from the up-to-date `target_branch`.
 
 **Emit the board.** One comment on the epic issue, edited in place at a few deliberate points (batch start,
 each merge, each blocker, completion) — never a second comment. It MUST carry, verbatim, the marker and
@@ -100,13 +101,15 @@ the same feature is not respawned — mark it blocked and escalate.
 
 _Compact mode._ Skip the fan-out: one worktree, one teammate, briefed to implement every feature of the band
 sequentially — still one branch and one PR per feature, still strict TDD, still each PR crosschecked below.
-Optionally batch the review: one strong-tier reviewer over the band's PRs in a single pass.
+The crosscheck batches exactly as in standard mode: one strong-tier reviewer over the band's PRs in one pass.
 
-**Crosscheck (delegated).** When a teammate reports its PR you do **not** read the diff — delegating the read
-keeps your context free as the epic grows. Spawn one reviewer subagent per PR at the **strong-tier**
-(`lore tier resolve strong`; no delegation inherits the session model). It reads the diff and the linked
-sub-issue and returns exactly this verdict, one line per check, posting the same text as the PR comment; you
-consume only the verdict and record its outcome in your epic note:
+**Crosscheck (delegated, batched).** When teammates report their PRs you do **not** read the diffs —
+delegating the read keeps your context free as the epic grows. Spawn **one reviewer subagent per batch** at
+the **strong-tier** (`lore tier resolve strong`; no delegation inherits the session model): it reads each of
+the batch's PR diffs and linked sub-issues and returns one verdict block per PR, posting each as that PR's
+comment; you consume only the verdicts and record their outcomes in your epic note. A batch of one degenerates
+to a per-PR review; if one PR's diff is too large to share a reviewer, split that reviewer out and note the
+deviation in your epic note. Per PR the verdict is exactly:
 ```
 PR #<n>
 reviewer tier: strong
@@ -119,7 +122,7 @@ verdict: PASS | FAIL
 fixes (only on FAIL): 1. <precise fix>  2. <precise fix>  …
 ```
 Post with `gh pr comment <n> --body …`. On **PASS**, advance to Merge. On **FAIL**, `SendMessage` the teammate
-the numbered fix list and re-review once it reports back — **max 2 fix rounds**. A round that doesn't move the
+the numbered fix list and re-review (that PR alone) once it reports back — **max 2 fix rounds**. A round that doesn't move the
 verdict → send the `/lore-workflow:debug` method (reproduce, isolate root cause, heed its circuit breaker),
 not a vaguer "try again". Still FAIL after the second → mark the feature blocked and escalate. The Dispatch
 tier is advisory; a reviewer tier deviation is allowed but recorded in your epic note (full contract:
@@ -139,13 +142,22 @@ dispatching dependents. Where the repo carries migrations, verify a single migra
 heads`) — squash-merges can silently fork the migration DAG. A failed invariant blocks the batch: fix forward
 or escalate.
 
-**Land.** All features merged and epic-branch CI green → open one PR `epic/<issue> → <target_branch>` linking
-every sub-issue.
+**Document (delegated, pre-land).** Docs ship with the epic, not after it (ADR 0005). Once all features are
+merged and epic-branch CI is green, invoke `document-epic` in its **pre-land mode**: it classifies the
+cumulative diff (`<target_branch>...epic/<issue>`) into the Diátaxis four and commits the doc updates directly
+onto `epic/<issue>` — no separate docs PR. If it escalates, or its edits cannot go green after one fix pass,
+fall back: drop the docs commit, land the epic without it, and run standalone `document-epic` post-land (its
+own auto-merging docs PR) — docs never block a green epic.
+
+**Land.** Features merged, docs committed, epic-branch CI green → open one PR
+`epic/<issue> → <target_branch>` linking every sub-issue.
 
 **Whole-epic review (delegated).** Before merging that PR, spawn one strong-tier reviewer over the cumulative
-diff (`<target_branch>...epic/<issue>`). Not a per-feature re-review — scope it to cross-feature consistency
-(inconsistent naming, duplicated helpers, conflicting edits to shared files), the class that only surfaces
-once every diff lands together. Reuse the reviewer verdict shape with this cross-feature checklist; post it on
+diff (`<target_branch>...epic/<issue>`). Skip this stage entirely when the epic has ≤ 2 features — the
+crosscheck just read those same diffs; go straight to the deploy-gate check and merge. Not a per-feature
+re-review — scope it to cross-feature consistency (inconsistent naming, duplicated helpers, conflicting edits
+to shared files), the class that only surfaces once every diff lands together, plus docs-vs-behavior
+mismatches now that the diff carries the docs commit. Reuse the reviewer verdict shape with this cross-feature checklist; post it on
 the epic PR. It gates the merge like a crosscheck: **PASS** → merge; **FAIL** → route the fix list to the
 teammate(s) owning the affected files, re-review once, max 2 rounds, then mark the epic blocked and escalate
 rather than merge. The epic→target merge follows the deploy-gate policy: if `epic-policy` returned
@@ -155,16 +167,14 @@ epic issue done with the merge SHA.
 **Cleanup.** Delete every merged feature branch (local and remote) and remove its worktree. Leave nothing
 behind but the epic branch's own history.
 
-**Document.** Invoke `document-epic` as the final automatic stage: it classifies changed paths into the
-Diátaxis four, opens a docs PR, and auto-merges on green CI (never on red).
-
 **Land checklist.** Before reporting completion, emit and satisfy this — each item verified true, not merely
 intended:
 - [ ] every roadmap checkbox ticked and every sub-issue closed
 - [ ] the epic PR merged, its merge SHA recorded on the epic issue
 - [ ] the board finalized to the end state (no stale queued/running rows)
 - [ ] every merged feature's branch and worktree gone, local and remote
-- [ ] the docs PR opened, and merged once its CI is green
+- [ ] the docs commit landed with the epic PR — or, on fallback, the standalone docs PR opened and merged on
+      green
 
 Report.
 

--- a/lore-workflow/skills/orient/SKILL.md
+++ b/lore-workflow/skills/orient/SKILL.md
@@ -51,12 +51,18 @@ Scale the fan-out to the ask: a small change may need a single Explore pass (or 
 pack already covers it); a broad feature warrants all facets.
 
 ### 3. Reflect back
-Present a tight brief in the conversation:
-- **What I understand you want** — restated in the project's domain language.
-- **Relevant landscape** — the code + docs/ADR constraints and prior art that bear on it.
+Present a tight brief in the conversation — **one screen, ~300 words, hard cap**. Order it so
+what the user must react to comes first:
 - **What we're actually deciding** — the crux, and the real choices ahead.
 - **Open questions & assumptions** — the unknowns, and the assumptions you're running on.
+- **What I understand you want** — one short paragraph, in the project's domain language.
+- **Relevant landscape** — at most five bullets, each a fact that constrains a decision (an
+  ADR that forbids an option, a module that already does half the work). Everything else you
+  learned stays in your context; close with "ask for the long version" instead of printing it.
 - **Tentative scope** — in / out, marked provisional.
+
+The cap governs the printed brief, never the homework behind it — explore fully, report
+selectively.
 
 ### 4. Loop
 Ask whether this matches. If the user corrects or adds input, re-orient with a *targeted*

--- a/lore-workflow/skills/to-epic/SKILL.md
+++ b/lore-workflow/skills/to-epic/SKILL.md
@@ -24,19 +24,14 @@ Tracker: the project's GitHub issues, via `gh` (use `--json` for reads — see t
 conventions doc, if any). This set is self-contained: it defines its own epic/sub-issue
 conventions below and does not rely on an external label vocabulary.
 
-The PRD-in-docs / gh-epic-as-tracker model is implemented by this skill. The deterministic
-file mechanics — create the PRD at `docs/prd/NNNN-kebab.md` with front-matter that links the
-epic and lists the involved repos, and wire it idempotently into `docs/prd/index.md`'s toctree
-— live in `lore`'s `lore workflow create-prd` subcommand, so they are reproducible and tested
-independently of this skill:
+The deterministic file mechanics — create the PRD at `docs/prd/NNNN-kebab.md` with
+front-matter linking the epic and repos, wired idempotently into `docs/prd/index.md`'s
+toctree — live in `lore workflow create-prd` (prints the PRD path):
 
 ```
 lore workflow create-prd --slug <kebab> --title "<Title>" --epic-url <url> \
     --repo owner/repo [--repo owner/repo-b ...] [--target <repo-root>]
 ```
-
-It prints the PRD path and wires the toctree; there is no Python helper bundled with this
-skill any more.
 
 ## Process
 
@@ -60,19 +55,27 @@ isolation. This PRD is the **source of truth** and becomes the **file** at
 `docs/prd/NNNN-kebab.md`, **not** the epic body. The epic body links it and carries only the
 one-paragraph summary + roadmap (see Publish).
 
-### 4. Draft the roadmap (vertical slices)
-Break the work into **tracer-bullet** features — each a thin slice cutting end-to-end through
-all layers, sized as one teammate / one branch / one PR. Prefer many thin slices over few
-thick ones. For each feature capture: title, target repo, type (AFK / HITL — prefer AFK),
-blocked-by, and acceptance criteria as checkboxes. HITL slices need a human decision or
-design review; `/lore-workflow:orchestrate-epic` escalates rather than auto-implements them, so resolve
+### 4. Draft the roadmap (fewest slices that earn their overhead)
+Break the work into **tracer-bullet** features — each a slice cutting end-to-end through all
+layers, sized as one teammate / one branch / one PR. Every row costs fixed downstream
+overhead in `/lore-workflow:orchestrate-epic` (teammate spawn, crosscheck, merge, sibling
+rebases), so cut the fewest slices that earn a split. A split earns its cost only for
+**real parallelism** (independent files/repos genuinely running side by side), **a HITL
+boundary** (isolate the human decision so the AFK remainder runs unattended), or **risk
+isolation** (quarantine the uncertain piece from the safe work). Everything else merges —
+hard rule: **a strictly linear blocked-by chain collapses into one slice**; the orchestrator
+serializes it anyway, so extra rows buy only overhead. Conceptual separation and layer
+boundaries never justify a split. Target 2–4 slices (1 is fine; more than 6 smells like two
+epics). For each feature capture: title, target repo, type (AFK / HITL — prefer AFK),
+blocked-by, and acceptance criteria as checkboxes. HITL slices need a human decision;
+`/lore-workflow:orchestrate-epic` escalates rather than auto-implements them, so resolve
 what you can into AFK during planning.
 
 ### 5. Quiz the user (the checkpoint)
 Present the breakdown as a numbered list (Title · Repo · Type · Blocked by · criteria) **and
 the parallel batches it implies** (topological grouping of the DAG). Ask: right granularity?
-dependencies correct? repos correct? AFK/HITL correct? merge or split any slice? Iterate to
-approval — `/lore-workflow:orchestrate-epic` will not ask again.
+dependencies correct? repos correct? AFK/HITL correct? merge or split any slice? — when in
+doubt, merge. Iterate to approval — `/lore-workflow:orchestrate-epic` will not ask again.
 
 ### 6. Publish
 Order matters so every cross-reference resolves:
@@ -89,9 +92,8 @@ Order matters so every cross-reference resolves:
    **links the PRD file** and carries a one-paragraph summary + the roadmap table + a task list
    of the sub-issues — **no PRD content is duplicated in the epic body** (link only).
 4. **Close the cross-reference loop.** Set the PRD front-matter `epic:` to the epic issue URL,
-   and (if an ADR records this decision) cross-link PRD ↔ ADR. The result is **bidirectional
-   cross-references** PRD ↔ epic ↔ ADR ↔ sub-issue: a PRD links its epic (and ADR); the epic
-   links the PRD and its sub-issues; each sub-issue links back to the epic.
+   and (if an ADR records this decision) cross-link PRD ↔ ADR — **bidirectional
+   cross-references** PRD ↔ epic ↔ ADR ↔ sub-issue throughout.
 5. **Close the consumed seed.** If this epic was formed from an epic-seed issue (labeled
    `epic-seed`, produced by `/lore-workflow:seed-epic`), close that seed issue with a comment linking the
    newly formed epic (`gh issue close <seed> --comment "Formed into epic <owner/repo#epic>"`).
@@ -104,8 +106,7 @@ e.g. `gh issue view <epic> --json body -q .body | lore workflow validate-roadmap
 it at the drafted body file (`lore workflow validate-roadmap <path>`). It checks
 the required columns (`# | Feature | Issue | Repo | Type | Blocked by`), fully-qualified
 `owner/repo#n` Issue refs, blocked-by edges that resolve to rows in the table, and an acyclic
-dependency DAG. **Publish only a roadmap it accepts:** a table it rejects is malformed and
-would break the orchestrator, so fix the columns, refs, or edges it reports and re-run until
+dependency DAG. **Publish only a roadmap it accepts** — fix what it reports and re-run until
 it passes.
 
 Use fully-qualified refs (`owner/repo#n`) for every cross-repo link. Do not modify unrelated


### PR DESCRIPTION
## Why

The orient → grilling → to-epic → orchestrate-epic cycle works but is heavy: the orient report is long to read, and orchestrate-epic burns tokens and turnaround mostly because to-epic splits work into too many issues — each row pays a fixed overhead (teammate spawn, strong-tier review, merge, sibling rebases) even when the DAG gives no parallelism back. Docs were also a structural afterthought, trailing the epic merge in a second PR.

## What changed

- **orient** — reflect-back hard-capped (~300 words, one screen), reordered so *what we're deciding* and *open questions* come first; landscape limited to at most five decision-constraining facts, long version on request. Homework unchanged — only the printed brief shrinks.
- **to-epic** — slicing doctrine inverted: from "prefer many thin slices" to *fewest slices that earn their overhead*. A split is justified only by real parallelism, a HITL boundary, or risk isolation. Hard rule: a strictly linear blocked-by chain collapses into one slice (the orchestrator serializes it anyway). Target 2–4 slices; the checkpoint quiz defaults to merging.
- **orchestrate-epic** — compact band now derived from the DAG instead of `rows ≤ 2`: single repo, all AFK, and either no batch wider than one feature (a straight chain, any length) or ≤ 3 rows. Crosscheck batched: one strong-tier reviewer per batch, one verdict block per PR. Whole-epic review skipped for ≤ 2-feature epics.
- **document-epic / ADR 0005** — docs ship *with* the epic: pre-land mode commits the Diátaxis updates onto the epic branch before the epic PR opens, so the whole-epic review and epic CI gate them. Fallback (docs stage escalates / can't go green): land without docs, run the old post-land docs PR. Standalone mode unchanged for catching up merged epics.
- **docs** — `conventions.md` auto-stage section and `how-to/run-an-epic.md` updated to match; new `docs/adr/0005-docs-land-with-the-epic.md`.

## Verification

- `tests/test_workflow_plugin_structural.py` + `tests/test_workflow_docs_drift.py`: all pass (to-epic trimmed back under its 220-line budget).
- Full suite: 2798 passed; the 3 failures (`test_core_llm_wiring`, `test_install_dispatcher`) fail identically on `main` — pre-existing, unrelated.

## On merge

This ships plugin-relevant behavior — needs the usual `chore: release X.Y.Z` bump (plugin.json + pyproject + CHANGELOG) after landing.