### PR TITLE
fix(install): refresh lore-workflow@lore plugin cache on upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,8 +136,13 @@ if [ "$HAS_PLUGIN" -eq 1 ]; then
     say "Refreshing Claude plugin cache (integrations already configured)..."
     if command -v claude >/dev/null 2>&1; then
         claude plugin update lore@lore || warn "claude plugin update failed; run it manually"
+        # lore-workflow versions independently; without its own refresh the
+        # installed skills silently stay on the old version.
+        if grep -q '"lore-workflow@lore"' "$PLUGIN_INDEX"; then
+            claude plugin update lore-workflow@lore || warn "claude plugin update lore-workflow@lore failed; run it manually"
+        fi
     else
-        warn "claude CLI not found; run: claude plugin update lore@lore"
+        warn "claude CLI not found; run: claude plugin update lore@lore (and lore-workflow@lore if installed)"
     fi
     say "Done. Restart Claude Code to load the refreshed plugin."
 else

--- a/tests/test_install_sh_hardening.py
+++ b/tests/test_install_sh_hardening.py
@@ -29,3 +29,12 @@ def test_install_sh_fails_when_lore_not_on_path():
 
 def test_install_sh_first_install_chains_into_lore_init():
     assert "exec lore init" in INSTALL_SH.read_text()
+
+
+def test_install_sh_upgrade_refreshes_both_plugin_caches():
+    text = INSTALL_SH.read_text()
+    assert "claude plugin update lore@lore" in text
+    assert "claude plugin update lore-workflow@lore" in text, (
+        "the upgrade path must refresh lore-workflow@lore too — otherwise its "
+        "skills cache silently stays on the old version (#311)"
+    )


### PR DESCRIPTION
Fixes #311.

`install.sh`'s upgrade path refreshed only `lore@lore` (`install.sh:138`), so the independently-versioned `lore-workflow` plugin kept serving stale cached skills after every `lore update` — observed live after the 0.64.0 release, where `lore-workflow` stayed on 0.2.0 despite 0.3.0 shipping the new epic-cycle skills.

- Refresh `lore-workflow@lore` too, guarded on the plugin index listing it (same pattern as the existing `lore@lore` check).
- Extend the no-`claude`-CLI warning to name both plugins.
- Structural test added red→green in `tests/test_install_sh_hardening.py` (asserts both `claude plugin update` calls are present).

No release bump needed: `lore update` fetches `install.sh` fresh from `main` for installed users (source checkouts use their local copy).