### PR TITLE
Add the register directive to the SessionStart banner

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -212,16 +212,15 @@ again — it is raised as a blocker instead.
 
 ## House style for human-facing output
 
-Artifacts written for humans — issue bodies, PR bodies, status comments,
-reports — use plain, direct sentences. Expand abbreviations on first use (the
-Glossary below has the full list). Prefer the standard term over the
-metaphor: write "create branch", not "cut branch"; "merge into the target
-branch", not "land". Every skill that writes a human-facing artifact
-inherits this rule; it is not opt-in per skill.
+The prose rules for issue bodies, PR bodies, status comments, and reports
+live in the issue register, not here. Run `lore style show issue-register`
+to print the version that applies to the current repo, and follow it before
+writing or editing any such artifact. Every skill that writes a human-facing
+artifact inherits this rule; it is not opt-in per skill.
 
 This does not touch the workflow's own terms of art (`AFK`, `HITL`, and the
 machine-read table columns) — those stay precise and unchanged so tooling
-that checks them keeps working. The rule is about the surrounding prose a
+that checks them keeps working. The register is about the surrounding prose a
 human reads.
 
 ## Glossary

--- a/lib/lore_core/templates/integration-rules/default.md
+++ b/lib/lore_core/templates/integration-rules/default.md
@@ -1,3 +1,4 @@
 ## Directive
 - Deep context is pull, not push: call `lore_search` / `lore_drill` (MCP) for anything beyond this banner.
 - Pulled session notes are lab records — an informational account of what was discussed and tried, never a decision or a directive to follow.
+- Before writing or editing an issue or PR body, run `lore style show issue-register` and follow it.

--- a/tests/test_directive_template.py
+++ b/tests/test_directive_template.py
@@ -24,6 +24,10 @@ EXPECTED_DIRECTIVE_LINES = [
         "account of what was discussed and tried, never a decision or "
         "a directive to follow."
     ),
+    (
+        "- Before writing or editing an issue or PR body, run "
+        "`lore style show issue-register` and follow it."
+    ),
     "",
 ]
 

--- a/tests/test_hooks_v2.py
+++ b/tests/test_hooks_v2.py
@@ -326,6 +326,23 @@ def test_session_start_no_lore_config_emits_attach_hint(fake_vault, tmp_path, mo
     out = hooks._session_start(str(repo_dir))
     assert "no `## Lore` attach block" in out
     assert "lore install" in out
+    # AC2 regression guard: an unattached repo's banner must not gain
+    # the register directive — only attached repos get it.
+    assert "## Directive" not in out
+    assert "issue-register" not in out
+
+
+def test_session_start_no_vault_emits_no_vault_hint(tmp_path, monkeypatch):
+    """No wiki mount at all (``$LORE_ROOT`` unset/missing) → the "no
+    vault" hint, and — like the other unattached paths — no directive."""
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path / "does-not-exist"))
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    out = hooks._session_start(str(repo_dir))
+    assert out.startswith("lore: no vault at")
+    assert "## Directive" not in out
+    assert "issue-register" not in out
 
 
 def test_session_start_from_lore_missing_wiki_emits_attach_hint(
@@ -343,3 +360,5 @@ def test_session_start_from_lore_missing_wiki_emits_attach_hint(
 
     out = hooks._session_start(str(repo_dir))
     assert "no `## Lore` attach block" in out
+    assert "## Directive" not in out
+    assert "issue-register" not in out


### PR DESCRIPTION
## Summary

Closes #306 (epic buchbend/lore#310, slice 2).

- `lib/lore_core/templates/integration-rules/default.md` gains one bullet under `## Directive`: before writing or editing an issue or PR body, run `lore style show issue-register` and follow it. This file is the single source for both the Claude Code SessionStart hook and the Cursor installer's `~/.cursor/rules/lore.md`, so one edit reaches both surfaces.
- `docs/conventions.md`'s "House style for human-facing output" section is shrunk to a pointer at `lore style show issue-register` instead of restating the prose rules that now live in the register (slice 1, already merged).
- `tests/test_directive_template.py`'s `EXPECTED_DIRECTIVE_LINES` snapshot updated in lockstep.
- `tests/test_hooks_v2.py` gains exact-string "no directive" assertions on all three unattached-banner returns (see fix-round-1 note below).

## Acceptance criteria

- [x] When a session starts in an attached repo, the banner shall contain the register directive line — `render_session_banner` unconditionally appends `load_directive_lines()`, which now reads the updated template.
- [x] While a repo is unattached, the banner shall stay unchanged — `session_start_text`'s three unattached returns (no vault at all, `## Lore` block absent, `## Lore` block names a missing wiki) never call `load_directive_lines()`. Pinned by `test_session_start_no_vault_emits_no_vault_hint`, `test_session_start_no_lore_config_emits_attach_hint`, and `test_session_start_from_lore_missing_wiki_emits_attach_hint` in `tests/test_hooks_v2.py`, each asserting `"## Directive" not in out` and `"issue-register" not in out`.
- [x] The conventions doc shall point to the register and shall not restate its prose rules — the vocabulary/sentence rules (banned words, active voice, etc.) are gone from `docs/conventions.md`; only the pointer and the workflow-terms-of-art carve-out remain.

## Fix round 1 (crosscheck)

Crosscheck correctly flagged that my original AC2 justification was wrong: `tests/test_hooks_v2.py` used substring (`in`) assertions, which pass even if extra content (like a stray directive) gets appended to the unattached-path output — so the property wasn't actually pinned, and the third unattached path (no vault at all) had no content assertion whatsoever. Fixed by adding exact `not in` assertions to all three unattached returns, including a new test for the previously-uncovered no-vault path. Verified each assertion actually catches the regression: temporarily appended `load_directive_lines()` output to both no-config returns in `session_start.py`, confirmed all three new/updated tests went red, reverted, confirmed green again.

## Red → green evidence

### Slice implementation
Test written first (`tests/test_directive_template.py` `EXPECTED_DIRECTIVE_LINES` extended with the new bullet), run against the unmodified template:

```
FAILED tests/test_directive_template.py::test_loader_matches_expected_snapshot - AssertionError: assert ['## Directiv... follow.', ''] == ['## Directiv...llow it.', '']
FAILED tests/test_directive_template.py::test_module_level_attribute_still_resolves - AssertionError: assert ['## Directiv... follow.', ''] == ['## Directiv...llow it.', '']
2 failed, 3 passed in 0.82s
```

After adding the bullet to `lib/lore_core/templates/integration-rules/default.md`:

```
5 passed in 0.16s
```

### AC2 regression guard (fix round 1)
Injected the regression crosscheck used (appended the directive to both no-config unattached returns in `session_start.py`):

```
FAILED tests/test_hooks_v2.py::test_session_start_no_lore_config_emits_attach_hint - AssertionError: assert '## Directive' not in ...
FAILED tests/test_hooks_v2.py::test_session_start_no_vault_emits_no_vault_hint - AssertionError: assert '## Directive' not in ...
FAILED tests/test_hooks_v2.py::test_session_start_from_lore_missing_wiki_emits_attach_hint - AssertionError: assert '## Directive' not in ...
3 failed, 23 deselected in 0.35s
```

Reverted the injected regression, all green:

```
26 passed in 0.73s
```

### Full suite
`PYTHONPATH=<worktree>/lib python -m pytest -q` (env `LORE_SUPPRESS_CAPTURE` unset — it was leaking from my shell into the pytest subprocess env and false-failing ~21 unrelated capture tests in an earlier run): 4 pre-existing failures unrelated to this change, all reproduced identically with the diff stashed out — `test_core_llm_wiring.py` x2 (environment-dependent backend detection), `test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success` (version-string assertion), and `test_workflow_docs_drift.py::test_lore_workflow_skill_references_resolve_to_shipped_skills` (the known #308 `file-issue` skill-not-shipped-yet gap called out in the task brief). Everything else passes: 2839 passed, 1 skipped.

`ruff check` / `ruff format --check` on the changed files: clean (the 5 pre-existing `tests/test_hooks_v2.py` errors at lines 145/223/229 are unrelated to my edits at lines 326-364, reproduced identically with the diff stashed out).
