### PR TITLE
feat: ship the default Vale style + doctor check (#307)

### DIFF
--- a/lib/lore_cli/doctor_cmd.py
+++ b/lib/lore_cli/doctor_cmd.py
@@ -13,6 +13,8 @@ Checks:
   5. MCP server module imports (`lore mcp` would start it)
   6. lore_search index responds (FtsBackend.stats() succeeds)
   7. Current cwd's `## Lore` block parses (if attached; else skipped)
+  8. Vale is on PATH (advisory — absence degrades the issue register lint
+     to instruction-only, per ADR 0006, and never fails this run)
 
 `--fix` additionally repairs: rebuilds scopes.json from attachments.json,
 re-stamps drifted offer fingerprints, and migrates attachment path
@@ -25,6 +27,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from collections.abc import Callable
@@ -365,6 +368,15 @@ def _check_search_backend(cwd: str) -> Check:
     except Exception as e:
         return False, f"FTS backend failed: {e}"
     return True, f"FTS index: {stats.get('total_notes', '?')} notes"
+
+
+def _check_vale(cwd: str) -> Check:
+    """Vale is PATH-detected, not bundled — absence degrades the issue
+    register lint to instruction-only and never blocks (ADR 0006)."""
+    path = shutil.which("vale")
+    if path is None:
+        return False, "vale not on PATH — issue register lint is instruction-only until installed"
+    return True, f"vale found at {path}"
 
 
 def _check_attach(cwd: str) -> Check:
@@ -913,6 +925,7 @@ _CHECKS: list[tuple[str, Callable[[str], Check], bool]] = [
     ("cursor mcp", _check_cursor_mcp_command_resolves, False),
     ("cursor hooks", _check_cursor_hooks_config, False),
     ("attach", _check_attach, False),
+    ("vale", _check_vale, False),
 ]
 
 

--- a/lib/lore_cli/style_cmd.py
+++ b/lib/lore_cli/style_cmd.py
@@ -1,7 +1,9 @@
-"""`lore style show <name>` — print the style document that applies here.
+"""`lore style` — resolve the prose style documents agents write against.
 
     lore style show issue-register
     lore style show issue-register --wiki ccat
+    lore style vale-config
+    lore style vale-config --wiki ccat
 
 Without ``--wiki`` the wiki comes from the scope attached to the cwd. An
 unattached cwd resolves to the packaged default, so the command always
@@ -18,7 +20,11 @@ from pathlib import Path
 import typer
 from lore_core.config import get_wiki_root
 from lore_core.scope_resolver import resolve_scope
-from lore_core.style import UnknownStyle, resolve_style_path
+from lore_core.style import (
+    UnknownStyle,
+    resolve_style_path,
+    resolve_vale_config_path,
+)
 from rich.console import Console
 
 from lore_cli._argv_compat import argv_main
@@ -59,6 +65,24 @@ def show(
     # Plain write, not console.print: the text is markdown a linter and an
     # agent read back verbatim, and Rich would reflow it and eat `[...]`.
     sys.stdout.write(path.read_text())
+
+
+@app.command("vale-config")
+def vale_config(
+    wiki: str = typer.Option(
+        None, "--wiki", "-w", help="Wiki whose override wins (default: from cwd)."
+    ),
+) -> None:
+    """Print the resolved Vale config path.
+
+    `<wiki>/style/vale/vale.ini` wins, else the packaged default. Meant for
+    command substitution: `vale --config $(lore style vale-config) <file>`.
+    """
+    path = resolve_vale_config_path(wiki_dir=_wiki_dir(wiki))
+    # Plain write, not console.print: a path can contain `[...]`-shaped
+    # segments and Rich's markup parser would eat them (same hazard as
+    # `show`'s plain stdout write).
+    sys.stdout.write(str(path) + "\n")
 
 
 main = argv_main(app)

--- a/lib/lore_core/style.py
+++ b/lib/lore_core/style.py
@@ -9,6 +9,10 @@ the wiki and editing it. There is no per-repo layer.
 The defaults live outside `templates/` on purpose: `lore init` copies the whole
 templates tree into the vault, and a copy of the register sitting at
 `<lore_root>/templates/` would look editable while the resolver ignores it.
+
+The Vale config that lints the issue register resolves the same way, one
+directory over: `<wiki>/style/vale/vale.ini` wins, else the packaged
+`styles/vale/vale.ini`. See `default_vale_config_path`/`resolve_vale_config_path`.
 """
 
 from __future__ import annotations
@@ -49,3 +53,31 @@ def resolve_style_path(name: str, wiki_dir: Path | None = None) -> Path:
         if override.is_file():
             return override
     return default_style_path(name)
+
+
+def default_vale_config_path() -> Path:
+    """Return the packaged default Vale config (``styles/vale/vale.ini``).
+
+    Raises FileNotFoundError if packaging broke, same contract as
+    ``default_style_path``.
+    """
+    path = Path(__file__).resolve().parent / "styles" / "vale" / "vale.ini"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Could not locate the packaged Vale config at {path}. Reinstall Lore."
+        )
+    return path
+
+
+def resolve_vale_config_path(wiki_dir: Path | None = None) -> Path:
+    """Return the Vale config that wins for ``wiki_dir``: the wiki's own
+    ``style/vale/vale.ini`` if present, else the packaged default.
+
+    Same whole-file resolution as ``resolve_style_path`` — a Vale config and
+    its ``StylesPath`` rule directory are one unit, not merged.
+    """
+    if wiki_dir is not None:
+        override = wiki_dir / "style" / "vale" / "vale.ini"
+        if override.is_file():
+            return override
+    return default_vale_config_path()

--- a/lib/lore_core/styles/vale/IssueRegister/BackReference.yml
+++ b/lib/lore_core/styles/vale/IssueRegister/BackReference.yml
@@ -1,0 +1,10 @@
+# Rule 12 heuristic: flags "This/That/It" at a sentence's start followed
+# directly by a verb — the shape where the pronoun stands in for a whole
+# preceding clause rather than a repeated noun ("This file ..." is fine;
+# "This is a problem ..." is not).
+extends: existence
+message: "Rule 12 (clause back-reference): 'This/That/It' here refers to a whole clause; repeat the noun."
+level: warning
+scope: sentence
+raw:
+  - '^(This|That|It)\s+(is|was|are|were|means|meant|shows|showed|matters|mattered|works|worked|allows|allowed|creates|created|makes|made|becomes|became|remains|remained|seems|seemed|requires|required|helps|helped)\b'

--- a/lib/lore_core/styles/vale/IssueRegister/ParticipialOpener.yml
+++ b/lib/lore_core/styles/vale/IssueRegister/ParticipialOpener.yml
@@ -1,0 +1,10 @@
+# Rule 9 heuristic: flags a sentence that opens with a capitalized "-ing"
+# word (the common participial-clause-opener shape, e.g. "Having parsed the
+# header, ..."). Catches the common forms and misses the rest, per the
+# register's honest checkability claim.
+extends: existence
+message: "Rule 9 (participial opener): do not open a sentence with a participle; write two sentences."
+level: warning
+scope: sentence
+raw:
+  - '^[A-Z]\w*ing\b'

--- a/lib/lore_core/styles/vale/IssueRegister/SentenceLength.yml
+++ b/lib/lore_core/styles/vale/IssueRegister/SentenceLength.yml
@@ -1,0 +1,9 @@
+# Rule 6: max 20 words for an instruction, 25 for a description. Vale scores
+# per sentence, not per line, and cannot tell instruction from description,
+# so this flags any sentence past the more lenient 25-word ceiling.
+extends: existence
+message: "Rule 6 (sentence length): split this sentence, it runs past 25 words."
+level: error
+scope: sentence
+raw:
+  - '(?:\S+\s+){25,}\S+'

--- a/lib/lore_core/styles/vale/IssueRegister/Vocabulary.yml
+++ b/lib/lore_core/styles/vale/IssueRegister/Vocabulary.yml
@@ -1,0 +1,23 @@
+# Rule 3: use the shorter common word. List mirrors the "Banned:" list in
+# ../../issue-register.md — keep the two in sync by hand when either changes.
+extends: existence
+message: "Rule 3 (banned vocabulary): use a shorter common word instead of '%s'."
+ignorecase: true
+level: error
+tokens:
+  - leverage
+  - utilise
+  - robust
+  - seamless
+  - holistic
+  - comprehensive
+  - streamline
+  - delve
+  - underscore
+  - intricate
+  - crucial
+  - pivotal
+  - landscape
+  - journey
+  - unlock
+  - elevate

--- a/lib/lore_core/styles/vale/vale.ini
+++ b/lib/lore_core/styles/vale/vale.ini
@@ -1,0 +1,9 @@
+# Packaged default Vale config for the issue register (docs/adr/0006-...).
+# StylesPath is relative to this file, so `vale --config <this-path> <file>`
+# works from any cwd and needs nothing inside the user's repo. The rule
+# files live in IssueRegister/, sibling to this ini.
+StylesPath = .
+MinAlertLevel = suggestion
+
+[*.md]
+BasedOnStyles = IssueRegister

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ where = ["lib"]
 
 [tool.setuptools.package-data]
 "lore_cli" = ["integrations.d/*.toml"]
-"lore_core" = ["styles/*.md"]
+"lore_core" = ["styles/*.md", "styles/vale/*.ini", "styles/vale/IssueRegister/*.yml"]
 "lore_core.templates" = ["*.md", "integration-rules/*.md"]
 
 [tool.ruff]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -274,3 +274,23 @@ def test_check_spine_writable_reports_degrade_marker(tmp_path, monkeypatch):
     ok, msg = doctor_cmd._check_spine_writable(str(tmp_path))
     assert ok is False
     assert "spine write failed" in msg.lower()
+
+
+def test_check_vale_reports_absence_without_failing(monkeypatch):
+    """AC: `lore doctor` reports Vale's absence but never fails the run —
+    the check is registered advisory (fails_run=False)."""
+    monkeypatch.setattr(doctor_cmd.shutil, "which", lambda name: None)
+    ok, msg = doctor_cmd._check_vale(".")
+    assert ok is False
+    assert "vale" in msg.lower()
+    assert "not on path" in msg.lower()
+
+    entry = next(c for c in doctor_cmd._CHECKS if c[0] == "vale")
+    assert entry[2] is False, "vale check must not fail the overall doctor run"
+
+
+def test_check_vale_reports_presence(monkeypatch):
+    monkeypatch.setattr(doctor_cmd.shutil, "which", lambda name: "/usr/local/bin/vale")
+    ok, msg = doctor_cmd._check_vale(".")
+    assert ok is True
+    assert "/usr/local/bin/vale" in msg

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -1,0 +1,107 @@
+"""Tests for the packaged Vale style: resolution, `lore style vale-config`,
+and the real-binary integration.
+
+Vale is PATH-detected and not bundled with Lore (ADR 0006). The integration
+tests below run the actual binary against a fixture with one banned word and
+one 30-word sentence, and skip when Vale is absent — see PRD 0009's testing
+decisions.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from lore_cli.__main__ import app
+from lore_core.style import default_vale_config_path, resolve_vale_config_path
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+VALE_MISSING = shutil.which("vale") is None
+
+
+@pytest.fixture()
+def lore_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    (tmp_path / "wiki" / "notes").mkdir(parents=True)
+    return tmp_path
+
+
+# --- resolution ----------------------------------------------------------
+
+
+def test_default_vale_config_path_is_a_packaged_ini() -> None:
+    path = default_vale_config_path()
+    assert path.is_file()
+    assert path.name == "vale.ini"
+
+
+def test_resolve_falls_back_to_packaged_default(tmp_path: Path) -> None:
+    assert resolve_vale_config_path(wiki_dir=tmp_path) == default_vale_config_path()
+
+
+def test_wiki_vale_override_wins(tmp_path: Path) -> None:
+    override = tmp_path / "style" / "vale" / "vale.ini"
+    override.parent.mkdir(parents=True)
+    override.write_text("StylesPath = .\n")
+    assert resolve_vale_config_path(wiki_dir=tmp_path) == override
+
+
+def test_resolve_with_no_wiki_dir_returns_packaged_default() -> None:
+    assert resolve_vale_config_path(wiki_dir=None) == default_vale_config_path()
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def test_vale_config_cli_prints_the_packaged_default_path(lore_root: Path) -> None:
+    result = runner.invoke(app, ["style", "vale-config"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == str(default_vale_config_path())
+
+
+def test_vale_config_cli_prints_the_wiki_override_path(lore_root: Path) -> None:
+    override = lore_root / "wiki" / "notes" / "style" / "vale" / "vale.ini"
+    override.parent.mkdir(parents=True)
+    override.write_text("StylesPath = .\n")
+    result = runner.invoke(app, ["style", "vale-config", "--wiki", "notes"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == str(override)
+
+
+def test_vale_config_cli_falls_back_when_wiki_has_no_override(lore_root: Path) -> None:
+    result = runner.invoke(app, ["style", "vale-config", "--wiki", "notes"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == str(default_vale_config_path())
+
+
+# --- real-binary integration (skipped when Vale is not on PATH) -----------
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_vale_flags_a_banned_word(tmp_path: Path) -> None:
+    fixture = tmp_path / "issue.md"
+    fixture.write_text("# Title\n\nWe should leverage the existing system.\n")
+    result = subprocess.run(
+        ["vale", "--config", str(default_vale_config_path()), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert "leverage" in result.stdout.lower()
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_vale_flags_a_sentence_over_25_words(tmp_path: Path) -> None:
+    fixture = tmp_path / "issue.md"
+    long_sentence = " ".join(["word"] * 30) + ".\n"
+    fixture.write_text(f"# Title\n\n{long_sentence}")
+    result = subprocess.run(
+        ["vale", "--config", str(default_vale_config_path()), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert "sentence" in result.stdout.lower()
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary

Slice 3 of epic #310 — closes #307.

- `lib/lore_core/styles/vale/` — packaged default Vale config + style. `vale.ini` sets `StylesPath = .` (relative to the ini file itself, not the invoking cwd), so `vale --config <path> <file>` needs nothing inside a user repo. Four rule files under `IssueRegister/`:
  - `Vocabulary.yml` — rule 3, the 16-word banned list from the register, verbatim.
  - `SentenceLength.yml` — rule 6, flags any sentence past 25 words (Vale can't distinguish instruction vs. description context, so this uses the more lenient ceiling).
  - `ParticipialOpener.yml` — rule 9 heuristic (sentence opens with a capitalized `-ing` word).
  - `BackReference.yml` — rule 12 heuristic (`This/That/It` at sentence-start directly followed by a verb).
- `lore_core/style.py` — `default_vale_config_path()` / `resolve_vale_config_path(wiki_dir)`, same whole-file resolution shape as `resolve_style_path`, one directory over (`<wiki>/style/vale/vale.ini` wins, else packaged default).
- `lore_cli/style_cmd.py` — new `lore style vale-config [--wiki]` command, plain `sys.stdout.write` (not `console.print`) for the same reflow/`[...]`-eating reason `show` already avoids it.
- `lore_cli/doctor_cmd.py` — new advisory `_check_vale` (PATH-detected via `shutil.which`), registered `fails_run=False` so absence is reported (✗) but never fails the run.
- `pyproject.toml` — two new `package-data` globs for `lore_core`; confirmed present in a built wheel (`python -m pip wheel --no-deps -w ... .` then `zipfile -l`).

## Decisions

- **`StylesPath = .`, not `StylesPath = IssueRegister`.** The obvious-looking `StylesPath = IssueRegister` fails at runtime (`style 'IssueRegister' does not exist on StylesPath`) — `StylesPath` must point at the *parent* of the style directory, not the style directory itself. Verified against the real binary before committing.
- **Single 25-word ceiling for rule 6**, not two (20 for instruction / 25 for description). Vale scores per sentence, with no way to tell which register category a given sentence belongs to, so the linter uses the register's more lenient bound; the tighter 20-word bound for instructions stays a human/register-reading concern.
- **Vocabulary list is a hand-kept duplicate** of the register's "Banned:" list, not derived from the markdown at resolve time. A generator would be new machinery for a 16-word list that changes together with the register text in the same PR; a comment in `Vocabulary.yml` points at the source to keep them in sync.

## Vale on PATH in this environment

`vale` was **not** on PATH by default (`which vale` → not found). I downloaded the real `v3.17.0` Linux binary from GitHub releases into a scratch dir to verify the rules against real Vale output before writing them into the repo, and again to run the two `pytest.mark.skipif`-gated integration tests with it on PATH. Every rule (banned word, 30-word sentence, participial opener, this/that/it back-reference) fires correctly against fixtures, and a clean/compliant fixture produces 0 alerts (no false positives). Without Vale on PATH (the default state here), the two integration tests skip as designed — this is the PRD 0009 contract, not a gap.

## Red → green

`tests/test_vale_style.py` didn't exist; `tests/test_doctor.py`'s two new vale tests referenced `doctor_cmd._check_vale`, which didn't exist. First run:

```
ERROR tests/test_vale_style.py - ImportError: cannot import name 'default_vale_config_path' from 'lore_core.style'
FAILED tests/test_doctor.py::test_check_vale_reports_absence_without_failing - AttributeError: module 'lore_cli.doctor_cmd' has no attribute 'shutil'
FAILED tests/test_doctor.py::test_check_vale_reports_presence - AttributeError: module 'lore_cli.doctor_cmd' has no attribute 'shutil'
```

After implementation, `tests/test_vale_style.py` + the two `test_doctor.py` additions:

```
9 passed, 2 skipped  (vale absent from PATH — the 2 real-binary tests skip)
```

With the scratch Vale binary added to PATH:

```
9 passed  (all 9, including the 2 real-binary integration tests)
```

## Full suite

`python -m pytest -q` (whole repo, worktree `lib/` pinned via `PYTHONPATH` — the shared venv's `.pth` otherwise resolves `lore_core` to the main checkout, not this worktree):

```
2849 passed, 1 skipped, 1 warning, 11 subtests passed
4 failed (all pre-existing on epic/310, confirmed via git stash — unrelated to this change):
  - test_core_llm_wiring.py::test_core_wires_subprocess_backend_when_claude_on_path
  - test_core_llm_wiring.py::test_core_wires_sdk_backend_when_only_api_key_set
  - test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success
  - test_workflow_docs_drift.py::test_lore_workflow_skill_references_resolve_to_shipped_skills
    (the known #308 file-issue-skill-not-shipped-yet failure called out in my brief)
```

`ruff check .` / `ruff format --check .`: diffed against baseline (`git stash`) — the only findings in files I touched are pre-existing (identical line-shifted output in `doctor_cmd.py` and `test_doctor.py`, both untouched by my diff except for appends). My own new code is 100% clean on both.

## Test plan

- [x] `python -m pytest -q tests/test_vale_style.py tests/test_doctor.py -k vale` — 9 passed, 2 skipped (vale absent)
- [x] Same, with a scratch Vale v3.17.0 binary on PATH — 9 passed, 0 skipped
- [x] `python -m pytest -q` (full suite) — only pre-existing failures remain
- [x] `ruff check .` / `ruff format --check .` — no new findings
- [x] Built a wheel, listed contents — all 5 Vale files present under `lore_core/styles/vale/`