### PR TITLE
feat(lore-workflow): add the file-issue funnel skill (#308)

### DIFF
--- a/lore-workflow/README.md
+++ b/lore-workflow/README.md
@@ -31,3 +31,4 @@ delegation conventions shared across skills live in
 | `debug` | Systematic root-cause debugging with a hard circuit breaker. |
 | `document-epic` | After an epic merges, update Diátaxis docs to match the implemented state. |
 | `seed-epic` | End a session by turning follow-up context into an epic-seed tracker issue. |
+| `file-issue` | The filing funnel — resolve the issue register, draft, Vale-lint, then post the issue or PR body. |

--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -33,12 +33,18 @@ Add `--wiki <name>` when the target repo belongs to a wiki other than the cwd's.
 
 ## 2. Draft to a file whose name ends in `.md`
 
-```bash
-draft="$(mktemp -d)/issue.md"
+Write the body to this exact path:
+
+```
+${TMPDIR:-/tmp}/lore-file-issue.md
 ```
 
-The extension is load-bearing. The Vale config scopes its rules to `[*.md]`. A draft
-saved as `.txt`, or with no extension, lints zero files and exits 0 — step 3 would
+**Repeat that path literally in steps 3 and 4. Never hold it in a shell variable** —
+each step may run as its own shell, and a variable set in step 2 is gone by step 3.
+Vale would then get an empty argument and lint nothing.
+
+The `.md` extension is load-bearing. The Vale config scopes its rules to `[*.md]`, so a
+draft saved as `.txt`, or with no extension, lints zero files and exits 0 — step 3 would
 report a clean draft without having read one line of it.
 
 Pick the mode from what the caller handed you:
@@ -77,15 +83,20 @@ whether Vale is on PATH.)
 With Vale present:
 
 ```bash
-vale --config "$(lore style vale-config)" "$draft"
+vale --config "$(lore style vale-config)" "${TMPDIR:-/tmp}/lore-file-issue.md"
 ```
 
 Read the result by exit code, not by whether anything printed:
 
-- **Non-zero exit** — at least one `error`-level finding: banned vocabulary, or a
-  sentence past the length ceiling. Rewrite those, then run again until the exit code
-  is 0.
+- **Exit 1** — at least one `error`-level finding: banned vocabulary, or a sentence past
+  the length ceiling. Rewrite those, then run again until the exit code is 0.
 - **Exit 0 with findings printed** — `warning`-level heuristics only. Advisory.
+- **Exit 2** — the invocation itself is broken, not the prose. Vale exits 2 on an empty
+  path argument and on a `--config` path it cannot resolve. **Stop and report.** Editing
+  prose here rewrites a draft that was never read.
+
+Vale reports "0 files" as success, so a lint that read nothing still looks clean. Confirm
+the output names your draft file before you trust a clean result.
 
 The heuristics over-fire by design, and the register says as much. The participle rule
 matches any capitalised `-ing` word opening a sentence, so a heading like
@@ -100,11 +111,12 @@ back.
 
 ```bash
 gh issue create --repo <owner>/<repo> --title "<imperative title, max 12 words>" \
-  --body-file "$draft"
+  --body-file "${TMPDIR:-/tmp}/lore-file-issue.md"
 ```
 
 Use `--body-file`, never a retyped `--body` string — the bytes Vale checked must be the
-bytes that get posted. For a PR body, `gh pr create --body-file "$draft"`.
+bytes that get posted. For a PR body, swap in
+`gh pr create --body-file "${TMPDIR:-/tmp}/lore-file-issue.md"`.
 
 In batch mode the caller chooses the granularity it asked for: one issue holding the
 numbered blocks, or one issue per block. Do not silently split or merge what you were

--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: lore-workflow:file-issue
+description: The one funnel for writing and filing issue text — resolve the team's issue
+  register, draft in its skeleton (single change, batch, a caller's template, or a PR
+  body), lint with Vale when Vale is installed, then post with gh. Use whenever you are
+  about to write or edit a GitHub issue, a sub-issue, or a PR description. Triggers on
+  "file an issue", "file these as issues", or "/lore-workflow:file-issue".
+---
+
+# File Issue
+
+The single funnel for writing and filing issue text. Every workflow skill that files an
+issue or a PR body routes through here, and the user can invoke it directly.
+
+**The caller decides *what* to capture. This skill owns *how* to write and file it.**
+Never re-litigate the caller's judgement about whether something deserves an issue.
+
+## Hard rule: run in-context
+
+Do every step in the calling session. **Never spawn a subagent** — not to draft, not to
+lint, not to post. One subagent per issue is the cost this funnel exists to avoid.
+
+## 1. Resolve the register
+
+```bash
+lore style show issue-register
+```
+
+Read the output. It carries the required section skeleton, the EARS patterns for
+acceptance criteria, and the prose rules. **Never write from memory of the rules** — a
+team overrides the register inside its wiki, so the resolved text is the only authority.
+Add `--wiki <name>` when the target repo belongs to a wiki other than the cwd's.
+
+## 2. Draft to a file whose name ends in `.md`
+
+```bash
+draft="$(mktemp -d)/issue.md"
+```
+
+The extension is load-bearing. The Vale config scopes its rules to `[*.md]`. A draft
+saved as `.txt`, or with no extension, lints zero files and exits 0 — step 3 would
+report a clean draft without having read one line of it.
+
+Pick the mode from what the caller handed you:
+
+| Mode | Use when | Shape |
+|---|---|---|
+| **Single change** | there is one change to capture | The register's full section skeleton. One statement under "Required behaviour", with its own EARS criteria. |
+| **Batch** | several changes share one Context, land in one PR, and have no ordering between them | Keep the skeleton. Give each change its own numbered subheading under "Required behaviour", then repeat the same numbered subheadings under "Acceptance criteria". **Every numbered change carries its own criteria** — never one pooled list. |
+| **Caller template** | the caller supplied a structure (a sub-issue header, an epic-seed shape) | Keep the caller's structure exactly. Add no section, drop no section, reorder nothing. Apply the prose rules and EARS *inside* the supplied structure. |
+| **PR body** | writing the body for `gh pr create` | Prose rules only. No register skeleton. |
+
+Before drafting a batch, check the register's "Batch issues" section for the split rule.
+A change that needs its own Context, or that must land before another change, is a
+separate issue rather than a numbered block.
+
+### When a fact is missing
+
+Write the section heading and `TODO:` followed by the specific question. **Never fill
+the gap with a plausible guess.** A confident sentence written over a missing fact is
+the failure the register exists to stop, and it survives review far too easily.
+
+## 3. Lint — only when Vale is installed
+
+Check for Vale first, as its own command. Keep the two commands separate — chaining
+them with `&&` makes a missing Vale exit non-zero, which is indistinguishable from the
+"findings" exit below, and sends you into a fix loop over a lint that never ran.
+
+```bash
+command -v vale
+```
+
+Empty output means Vale is absent. **Post the draft unlinted** and say so in one line
+when you report back. The linter never blocks filing. (`lore doctor` also reports
+whether Vale is on PATH.)
+
+With Vale present:
+
+```bash
+vale --config "$(lore style vale-config)" "$draft"
+```
+
+Read the result by exit code, not by whether anything printed:
+
+- **Non-zero exit** — at least one `error`-level finding: banned vocabulary, or a
+  sentence past the length ceiling. Rewrite those, then run again until the exit code
+  is 0.
+- **Exit 0 with findings printed** — `warning`-level heuristics only. Advisory.
+
+The heuristics over-fire by design, and the register says as much. The participle rule
+matches any capitalised `-ing` word opening a sentence, so a heading like
+`## Testing decisions`, or a sentence opening with `Nothing`, trips it. **Do not mangle
+correct prose to silence a warning.** Leave the sentence and move on.
+
+Cap the fix loop at three passes. A finding that survives three rewrites is a rule
+fighting a correct sentence. Post the draft anyway and name the finding when you report
+back.
+
+## 4. Post the exact file you linted
+
+```bash
+gh issue create --repo <owner>/<repo> --title "<imperative title, max 12 words>" \
+  --body-file "$draft"
+```
+
+Use `--body-file`, never a retyped `--body` string — the bytes Vale checked must be the
+bytes that get posted. For a PR body, `gh pr create --body-file "$draft"`.
+
+In batch mode the caller chooses the granularity it asked for: one issue holding the
+numbered blocks, or one issue per block. Do not silently split or merge what you were
+given.
+
+Report every URL you created back to the caller.
+
+## Callers
+
+[`to-epic`](../to-epic/SKILL.md), [`seed-epic`](../seed-epic/SKILL.md),
+[`orchestrate-epic`](../orchestrate-epic/SKILL.md) follow-ups, and
+[`implement-issue`](../implement-issue/SKILL.md) file through this skill instead of
+writing issue bodies inline.
+
+Machine-readable text stays exempt: roadmap tables, board comments, and reviewer
+verdicts are parsed, not read, so the register does not apply to them.

--- a/tests/test_workflow_plugin_structural.py
+++ b/tests/test_workflow_plugin_structural.py
@@ -39,6 +39,7 @@ EXPECTED_SKILL_NAMES = {
     "debug",
     "document-epic",
     "domain-modeling",
+    "file-issue",
     "grilling",
     "implement-issue",
     "orchestrate-epic",


### PR DESCRIPTION
Closes #308. Part of epic #310. Base is `epic/310`.

## What this adds

`lore-workflow:file-issue` — the one funnel for writing and filing issue
text. The skill resolves the register with `lore style show
issue-register`, drafts into its skeleton, lints with Vale when Vale is
installed, then posts with `gh`.

The skill runs in the calling session and never spawns a subagent.

Four modes:

| Mode | Shape |
|---|---|
| Single change | The register's full section skeleton, one EARS criteria set. |
| Batch | One numbered subheading per change under "Required behaviour", the same subheadings repeated under "Acceptance criteria". Each change carries its own criteria. |
| Caller template | Keep the caller's structure exactly. Apply the prose rules inside it. |
| PR body | Prose rules only, no skeleton. |

## Red to green

`tests/test_workflow_docs_drift.py` failed on `epic/310` before this
branch, because PRD 0009 cites a skill that did not ship:

```
FAILED tests/test_workflow_docs_drift.py::test_lore_workflow_skill_references_resolve_to_shipped_skills
E       AssertionError: Doc/skill drift:
E           docs/prd/0009-issue-register.md: cites lore-workflow:file-issue, no such skill
```

I added `file-issue` to `EXPECTED_SKILL_NAMES` in
`tests/test_workflow_plugin_structural.py` as a second failing check:

```
FAILED tests/test_workflow_plugin_structural.py::test_every_expected_skill_ships
E       AssertionError: skill set mismatch — missing: {'file-issue'}
```

Both pass now, together with the README skill-table check:

```
tests/test_workflow_plugin_structural.py tests/test_workflow_docs_drift.py
tests/test_skill_cli_drift.py: 59 passed, 1 skipped
```

Full suite: 2829 passed, 3 failed. The three failures are the known
environment failures on the base commit, in `tests/test_core_llm_wiring.py`
and `tests/test_install_dispatcher.py`.

## Two findings verified against the real Vale binary

I downloaded Vale 3.17.0 into a scratch directory and ran it, rather than
reasoning about the config.

The packaged config scopes its rules to `[*.md]`. A draft written to a
`.txt` file, or to a file with no extension, reports zero alerts and exits
0. The lint reads nothing and looks clean:

```
draft.md   -> 3 alerts, rc=1
draft.txt  -> 0 alerts, rc=0
draft      -> 0 alerts, rc=0
```

The skill therefore requires the `.md` extension and states the reason.

Vale's exit code tracks error-level findings only. A file whose only
findings are the rule 9 and rule 12 heuristics prints those findings and
still exits 0. The fix loop keys on the exit code, so the documented
over-fires stay advisory:

```
banned word + heuristic -> rc=1
heuristic only          -> rc=0
```

My first draft of the lint step chained the checks as `command -v vale
>/dev/null && vale ...`. A missing Vale then exits 1, which the reader
cannot tell apart from "errors found". The skill now runs the two commands
separately and says why.

## Ruff

`ruff check .` reports 554 findings on this tree. The base commit reports
the same 554. The files in this diff are clean.

## Out of scope

Rerouting the callers. `to-epic`, `seed-epic`, `orchestrate-epic` and
`implement-issue` keep filing as they do today; slice 5 (#309) reroutes
them. No version bump, per the epic's release plan.
