### PR TITLE
Route the writing skills through file-issue (#309)

### DIFF
--- a/lore-workflow/skills/implement-issue/SKILL.md
+++ b/lore-workflow/skills/implement-issue/SKILL.md
@@ -89,8 +89,10 @@ leave those alone.
 Run **one review pass** with `code-review` at the **mid tier** by default — this is
 the small track, so the review is lighter than the epic chain's strong-tier
 crosscheck; escalate a genuinely architectural change to a stronger tier by
-judgement. Address the findings, keep the PR green, then open it linking the issue
-it closes and report back.
+judgement. Address the findings and keep the PR green. Write the PR body through
+[`file-issue`](../file-issue/SKILL.md) in PR-body mode — the register's prose
+rules, no issue skeleton — then open the PR from that file, linking the issue it
+closes, and report back.
 
 **Merging stays with the user.** They are present on this track, so the skill opens
 the PR and stops there — it does not self-merge. **Never merge on red.**

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -176,6 +176,11 @@ intended:
 - [ ] the docs commit landed with the epic PR — or, on fallback, the standalone docs PR opened and merged on
       green
 
+**Follow-ups.** Work that surfaces during the run and does not belong to this epic — a deferred fix, the
+remainder of a blocked feature — is filed through [`file-issue`](../file-issue/SKILL.md), never written
+inline. The machine-read text above stays exempt from it: the roadmap table, the board comment, and the
+verdict block are parsed, not read.
+
 Report.
 
 ## Teammate brief (fill, pass to each agent)

--- a/lore-workflow/skills/seed-epic/SKILL.md
+++ b/lore-workflow/skills/seed-epic/SKILL.md
@@ -49,8 +49,10 @@ Draft each body with the template below. Lead with intent; make the **findings**
 that is the handover value. Pointers are starting points, not gospel (they may go stale).
 
 ### 4. Publish
-Create each seed as a GitHub issue (`gh`), labeled `epic-seed` (create the label if missing).
-Link the originating epic and merged PRs. Do not modify the finished epic.
+File each seed through [`file-issue`](../file-issue/SKILL.md) in caller-template mode, handing
+it the seed template below — the funnel keeps that structure exactly and applies the register's
+writing rules inside it. Label each seed `epic-seed` (create the label if missing), link the
+originating epic and merged PRs, and do not modify the finished epic.
 
 Finish by printing each seed reference and the command for the fresh session:
 `/lore-workflow:orient <owner/repo#seed>`.

--- a/lore-workflow/skills/to-epic/SKILL.md
+++ b/lore-workflow/skills/to-epic/SKILL.md
@@ -85,9 +85,9 @@ Order matters so every cross-reference resolves:
    carries `epic:` (filled with the epic URL once it exists — step 4 closes this loop) and
    `repos:` (every involved repo). Fill the PRD body sections with the synthesized PRD. Commit
    it to the repo on the branch the docs PR will carry.
-2. **Create sub-issues** in dependency order so refs resolve, each in its target repo using the
-   sub-issue template (optionally labeled `epic:<n>` for grouping). Each sub-issue **links back
-   to the epic**.
+2. **Create sub-issues** in dependency order so refs resolve, each in its target repo through
+   [`file-issue`](../file-issue/SKILL.md) in caller-template mode, handing it the sub-issue
+   template below (optionally labeled `epic:<n>` for grouping).
 3. **Create the epic tracker issue**, labeled `epic` (create the label if missing). The body
    **links the PRD file** and carries a one-paragraph summary + the roadmap table + a task list
    of the sub-issues — **no PRD content is duplicated in the epic body** (link only).
@@ -103,11 +103,10 @@ Order matters so every cross-reference resolves:
 `/lore-workflow:orchestrate-epic` consumes, so it must be well-formed before the epic goes live. Run the
 deterministic, dependency-free `lore workflow validate-roadmap` on the composed epic body —
 e.g. `gh issue view <epic> --json body -q .body | lore workflow validate-roadmap -`, or point
-it at the drafted body file (`lore workflow validate-roadmap <path>`). It checks
-the required columns (`# | Feature | Issue | Repo | Type | Blocked by`), fully-qualified
-`owner/repo#n` Issue refs, blocked-by edges that resolve to rows in the table, and an acyclic
-dependency DAG. **Publish only a roadmap it accepts** — fix what it reports and re-run until
-it passes.
+it at the drafted body file (`lore workflow validate-roadmap <path>`). It checks the required
+columns (`# | Feature | Issue | Repo | Type | Blocked by`), fully-qualified `owner/repo#n`
+Issue refs, blocked-by edges that resolve to rows in the table, and an acyclic DAG.
+**Publish only a roadmap it accepts** — fix what it reports and re-run until it passes.
 
 Use fully-qualified refs (`owner/repo#n`) for every cross-repo link. Do not modify unrelated
 parent issues.
@@ -159,8 +158,7 @@ What this epic deliberately does not cover.
 ## Epic body template
 
 The epic is a **tracker, not a spec**: it **links** the PRD (no PRD content duplicated here)
-and carries the roadmap DAG. The **roadmap table stays in the epic body** — it is what
-`/lore-workflow:orchestrate-epic` reads.
+and carries the roadmap DAG — the table **stays in the epic body**, where `/lore-workflow:orchestrate-epic` reads it.
 
 <epic-body-template>
 ## Summary
@@ -186,6 +184,12 @@ below keeps the literal token, which is what the roadmap validator and `/lore-wo
 
 ## Sub-issue template
 
+An epic-linkage header, then the register's own section skeleton. File it through
+[`file-issue`](../file-issue/SKILL.md) in caller-template mode — the funnel resolves the
+register and applies its writing rules inside this structure, so none of those rules are
+repeated here. Keep "Required behaviour" to the slice's end-to-end behavior — not a
+layer-by-layer implementation — and path-free (same prototype exception as above).
+
 <sub-issue-template>
 ## Epic
 owner/repo#<epic>
@@ -193,27 +197,23 @@ owner/repo#<epic>
 ## Repo
 The repo this slice is implemented in.
 
-## What to build
-End-to-end behavior of this vertical slice — not layer-by-layer implementation. No file paths
-or code snippets (same prototype exception as above).
-
-## Acceptance criteria
-- [ ] Criterion 1
-- [ ] Criterion 2
+## Type
+AFK (runs autonomously, no human input) or HITL (human-in-the-loop: needs a human decision).
 
 ## Blocked by
 owner/repo#<n>, or "None — can start immediately".
 
-## Type
-AFK (runs autonomously, no human input) or HITL (human-in-the-loop: needs a human decision).
+## Context
+## Current behaviour
+## Required behaviour
+## Acceptance criteria
+## Out of scope
+## References
 
-## Pointers (starting points, may be stale)
-Non-authoritative starting points so a teammate reuses the discovery already done
-during shaping instead of re-exploring the repo from scratch. Everything here may
-have gone stale since the epic was formed — verify before trusting, and widen from
-here rather than treat it as the whole picture. The PRD stays path-free; these
-pointers live only in this disposable sub-issue (closed on merge), where staleness
-is a non-issue.
+Pointers (starting points, may be stale):
+Non-authoritative starting points, so a teammate reuses the discovery already done during
+shaping instead of re-exploring the repo. Verify before trusting and widen from here. The
+PRD stays path-free; these pointers live only in this disposable sub-issue, closed on merge.
 - **Dev notes** — modules/files to start from and interfaces to build against.
 - **Architecture excerpts** — the conventions and shared touchpoints this slice sits within.
 - **Test criteria** — tests that are prior art for what a good test looks like here.

--- a/tests/test_workflow_issue_register_wiring.py
+++ b/tests/test_workflow_issue_register_wiring.py
@@ -1,0 +1,127 @@
+"""The writing skills file through the `file-issue` funnel (sub-issue #309).
+
+PRD 0009 says to test external behaviour, not skill wording, so nothing here
+asserts prose. What is asserted is the machine-consumed part:
+
+- the four filing skills point at the funnel instead of prescribing filing,
+- `to-epic`'s sub-issue template carries the register's own section skeleton,
+- and an epic body composed from that template's linkage fields still passes
+  the roadmap validator, which is what `orchestrate-epic` reads.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from lore_core.style import default_style_path
+from lore_workflow import roadmap_validator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = REPO_ROOT / "lore-workflow" / "skills"
+
+# Every skill that writes issue or PR text. `file-issue` itself is the funnel.
+FILING_SKILLS = ("to-epic", "seed-epic", "orchestrate-epic", "implement-issue")
+
+# Linkage fields the roadmap table's columns are built from. Losing one of
+# these from the sub-issue template leaves `to-epic` without the data the
+# validator requires.
+ROADMAP_FIELDS = ("Repo", "Type", "Blocked by")
+
+_SECTION = re.compile(r"^## (.+)$", re.M)
+
+
+def _skill_text(name: str) -> str:
+    return (SKILLS_ROOT / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _block(text: str, tag: str) -> str:
+    match = re.search(rf"<{tag}>\n(.*?)\n</{tag}>", text, re.DOTALL)
+    assert match, f"missing <{tag}> block"
+    return match.group(1)
+
+
+def _sections(text: str) -> list[str]:
+    return _SECTION.findall(text)
+
+
+def _register_skeleton() -> list[str]:
+    """The section list the resolved register requires, read from the register
+    itself rather than restated here — an override changes both together."""
+    register = default_style_path("issue-register").read_text(encoding="utf-8")
+    match = re.search(r"## Required issue structure\n+```\n(.*?)```", register, re.DOTALL)
+    assert match, "the register lost its 'Required issue structure' block"
+    return _sections(match.group(1))
+
+
+def _field(body: str, heading: str) -> str:
+    """First non-empty line under ``## <heading>``."""
+    match = re.search(rf"^## {re.escape(heading)}$\n+(.+)$", body, re.M)
+    assert match, f"rendered sub-issue has no '## {heading}' section"
+    return match.group(1).strip()
+
+
+def _render_sub_issue(values: dict[str, str]) -> str:
+    """Render a sub-issue from the template's own section list, so a section
+    dropped from the template is a section missing from the render."""
+    sections = _sections(_block(_skill_text("to-epic"), "sub-issue-template"))
+    return "\n\n".join(
+        f"## {name}\n{values.get(name, 'Filled by the drafting session.')}" for name in sections
+    )
+
+
+@pytest.mark.parametrize("skill", FILING_SKILLS)
+def test_filing_skills_point_at_the_funnel(skill: str) -> None:
+    assert "../file-issue/SKILL.md" in _skill_text(skill), (
+        f"{skill}/SKILL.md must route its filing through the file-issue funnel"
+    )
+
+
+def test_sub_issue_template_carries_the_register_skeleton() -> None:
+    template = _block(_skill_text("to-epic"), "sub-issue-template")
+    present = _sections(template)
+    missing = [s for s in _register_skeleton() if s not in present]
+    assert not missing, f"sub-issue template is missing register sections: {missing}"
+
+
+def test_sub_issue_template_keeps_the_epic_linkage_header() -> None:
+    present = _sections(_block(_skill_text("to-epic"), "sub-issue-template"))
+    missing = [s for s in ("Epic", *ROADMAP_FIELDS) if s not in present]
+    assert not missing, f"sub-issue template is missing linkage sections: {missing}"
+
+
+def test_epic_body_composed_from_the_template_passes_the_validator() -> None:
+    """The acceptance criterion: compose the roadmap table out of what the new
+    sub-issue template carries, and the validator accepts it."""
+    subs = [
+        _render_sub_issue(
+            {
+                "Epic": "ccatobs/widget#11",
+                "Repo": "widget",
+                "Type": "AFK",
+                "Blocked by": blocked,
+            }
+        )
+        for blocked in ("None — can start immediately.", "#12", "#12, #13")
+    ]
+    rows = []
+    for number, sub in enumerate(subs, start=12):
+        blocked = _field(sub, "Blocked by")
+        rows.append(
+            f"| {number - 11} | Feature {number - 11} | ccatobs/widget#{number} "
+            f"| {_field(sub, 'Repo')} | {_field(sub, 'Type')} "
+            f"| {'—' if blocked.startswith('None') else blocked} |"
+        )
+    epic_body = "\n".join(
+        [
+            "## Roadmap",
+            "",
+            "| # | Feature | Issue | Repo | Type | Blocked by |",
+            "|---|---------|-------|------|------|------------|",
+            *rows,
+        ]
+    )
+    result = roadmap_validator.validate_roadmap(epic_body)
+    assert result.ok, f"composed epic body must validate; problems={result.problems}"
+    assert len(result.rows) == 3


### PR DESCRIPTION
Closes buchbend/lore#309. Slice 5 of epic buchbend/lore#310, on top of the merged funnel from #308.

## What changed

The four writing skills stop prescribing filing and point at the `file-issue` funnel:

- **to-epic** files sub-issues through the funnel in caller-template mode.
- **seed-epic** files seeds through the funnel in caller-template mode. The seed template keeps its own structure.
- **orchestrate-epic** files run follow-ups through the funnel.
- **implement-issue** writes the PR body through the funnel in PR-body mode.

The sub-issue template in `to-epic` becomes an epic-linkage header plus the register skeleton:

```
## Epic / ## Repo / ## Type / ## Blocked by
## Context / ## Current behaviour / ## Required behaviour
## Acceptance criteria / ## Out of scope / ## References
Pointers (starting points, may be stale):
```

The linkage header stays because `to-epic` builds the roadmap table columns from those four fields. `## What to build` gives way to the register's Context, Current behaviour and Required behaviour split. The shape matches the sub-issues of this epic, which were written by hand in the same form.

No skill restates the writing rules. Each names the mode and hands the structure to the funnel, which resolves the register.

## What did not change

The machine-read text in `orchestrate-epic` stays exempt and untouched: the roadmap table, the board comment that `lore workflow parse-board` reads, and the reviewer verdict block. The new follow-up paragraph names those three as exempt.

## Tests

`tests/test_workflow_issue_register_wiring.py` tests external structure, not skill wording. It reads the section skeleton out of the resolved register rather than restating the section names. A wiki override therefore moves the register and the test together.

Red before the change:

```
FAILED tests/test_workflow_issue_register_wiring.py::test_filing_skills_point_at_the_funnel[to-epic]
FAILED tests/test_workflow_issue_register_wiring.py::test_filing_skills_point_at_the_funnel[seed-epic]
FAILED tests/test_workflow_issue_register_wiring.py::test_filing_skills_point_at_the_funnel[orchestrate-epic]
FAILED tests/test_workflow_issue_register_wiring.py::test_filing_skills_point_at_the_funnel[implement-issue]
FAILED tests/test_workflow_issue_register_wiring.py::test_sub_issue_template_carries_the_register_skeleton
E       AssertionError: sub-issue template is missing register sections: ['Context', 'Current behaviour', 'Required behaviour', 'Out of scope', 'References']
5 failed, 2 passed in 0.20s
```

Green after:

```
7 passed in 0.16s
```

Two of the seven tests passed before the change and are regression guards, not red-to-green evidence:

- `test_sub_issue_template_keeps_the_epic_linkage_header` fails if a later edit drops `## Repo`, `## Type` or `## Blocked by`, which are the roadmap table columns.
- `test_epic_body_composed_from_the_template_passes_the_validator` renders three sub-issues from the shipped template, composes a roadmap table out of their linkage fields, and asserts `validate_roadmap` accepts it. `validate-roadmap` parses the epic body, not sub-issue bodies, so this test covers the coupling between the two templates rather than the sub-issue text.

Full suite: 2836 passed, 3 failed. The three failures are the known environment failures on the base: `tests/test_core_llm_wiring.py` twice and `tests/test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`.

`ruff check` and `ruff format --check` are clean on the added file.

## Dogfooding

This PR body went through the funnel in PR-body mode and was linted with Vale 3.17.0 against `lore style vale-config`.

## Out of scope

The epic body template still carries its one-paragraph summary inline. The acceptance criteria cover sub-issues, seeds, follow-ups and PR bodies, and the epic body is mostly the exempt roadmap table.
