### PR TITLE
Epic #310: the issue register — per-team style, Vale lint, file-issue funnel

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore",
   "description": "LLM-optimized knowledge graph for AI-coding teams \u2014 session notes, auto-extracted knowledge, pluggable briefings, magic context injection at session start.",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (0.x means anything can change between minor versions until 1.0).
 
+## [0.65.0] - 2026-08-03
+
+The issue register (#310, PRD 0009, ADR 0006): a default prose style for
+agent-written issue and PR text, overridable per team with one file in the
+wiki.
+
+### Added
+
+- **`lore style` command group** (#305, #307). `lore style show issue-register`
+  prints the resolved register; `lore style vale-config` prints the resolved
+  Vale config path. Resolution is whole-file per wiki —
+  `<wiki>/style/issue-register.md` (or `<wiki>/style/vale/vale.ini`) wins, else
+  the packaged default. No merge, no per-repo layer. An unknown style name
+  exits non-zero and names the known styles.
+- **Default issue register** shipped as package data at
+  `lore_core/styles/issue-register.md`: ASD-STE100-derived prose rules, EARS
+  acceptance-criteria patterns, a fixed section skeleton, and a "Batch issues"
+  section defining *change* and *batch issue* with the split rule.
+- **Default Vale style** shipped as package data (#307), covering banned words
+  and sentence length as errors, plus participial-opener and clause-back-
+  reference heuristics as warnings. Vale is PATH-detected and never bundled;
+  its absence degrades to instruction-only enforcement and never blocks.
+- **`lore doctor` reports Vale** presence on PATH without failing the run (#307).
+- **`lore-workflow:file-issue` skill** (#308) — the one funnel for writing and
+  filing issue text. Four modes (single change, batch, caller template, PR
+  body), a Vale lint loop when Vale is installed, and posting via
+  `gh --body-file` so the bytes linted are the bytes posted. Runs in-context and
+  never spawns a subagent.
+
+### Changed
+
+- **SessionStart banner** carries one register directive: resolve
+  `lore style show issue-register` before writing or editing an issue or PR body
+  (#306). Unattached repos are unaffected.
+- **`docs/conventions.md`** house-style section is now a pointer to the
+  register instead of restating its rules (#306).
+- **The writing skills route through the funnel** (#309): `to-epic` files
+  sub-issues, `seed-epic` files seeds in caller-template mode,
+  `implement-issue` writes PR bodies in PR-body mode, and `orchestrate-epic`
+  files run follow-ups through it. `to-epic`'s sub-issue template is now an
+  epic-linkage header plus the register skeleton. Machine-readable formats stay
+  exempt and unchanged: the roadmap table, the board comment, and the reviewer
+  verdict block.
+- `CONTEXT.md` defines *register*, *change*, and *batch issue* (#305).
+- `lore-workflow` plugin 0.3.0 → 0.4.0.
+
 ## [0.64.0] - 2026-08-03
 
 Epic-cycle lightening (#304, ADR 0005) plus two previously unreleased changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,17 @@ wiki.
   register instead of restating its rules (#306).
 - **The writing skills route through the funnel** (#309): `to-epic` files
   sub-issues, `seed-epic` files seeds in caller-template mode,
-  `implement-issue` writes PR bodies in PR-body mode, and `orchestrate-epic`
-  files run follow-ups through it. `to-epic`'s sub-issue template is now an
-  epic-linkage header plus the register skeleton. Machine-readable formats stay
-  exempt and unchanged: the roadmap table, the board comment, and the reviewer
-  verdict block.
+  `implement-issue` writes PR bodies in PR-body mode, `orchestrate-epic` files
+  run follow-ups through it and has its teammates write PR bodies through it,
+  and `brief` files its handoff issue through it. `to-epic`'s sub-issue
+  template is now an epic-linkage header plus the register skeleton.
+  Machine-readable formats stay exempt and unchanged: the roadmap table, the
+  board comment, and the reviewer verdict block.
+- **`docs/how-to/write-a-fast-path-issue.md`** now opens with the register
+  resolver and no longer restates its rules — one of its items contradicted the
+  register's "sections may be empty and stay in the file".
+- Guards against banned-word drift: the list in the Vale style and the one in
+  the register's paste block are both asserted against rule 3 of the register.
 - `CONTEXT.md` defines *register*, *change*, and *batch issue* (#305).
 - `lore-workflow` plugin 0.3.0 → 0.4.0.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -309,3 +309,15 @@ Terms used in the workflow layer and orchestration:
   session handover: the epic seed is filed in the issue tracker and is
   one-time context for a shaped body of work, not a carry-forward between
   sessions.
+- **Register** — the prose style an agent writes issue text, PR bodies and
+  ADR context sections in: sentence and vocabulary rules, EARS acceptance
+  criteria, and the required section skeleton. Lore ships one default;
+  a team overrides it whole-file with `<wiki>/style/issue-register.md`.
+  `lore style show issue-register` resolves the two. The register fixes
+  style, not terminology — terminology stays with the glossary.
+- **Change** — the unit a register-conforming issue describes: one
+  required-behaviour statement with its own acceptance criteria.
+- **Batch issue** — an issue carrying several changes under one Context
+  section, landing as one PR, with no ordering dependency between the
+  changes. A change that needs its own context, or that must land before
+  another, leaves the batch.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -315,6 +315,11 @@ Terms used in the workflow layer and orchestration:
   a team overrides it whole-file with `<wiki>/style/issue-register.md`.
   `lore style show issue-register` resolves the two. The register fixes
   style, not terminology — terminology stays with the glossary.
+  Overriding the lint means copying `styles/vale/` whole — the ini plus
+  its `IssueRegister/` rule directory — into `<wiki>/style/vale/`. Vale
+  resolves `StylesPath` next to the ini, so an override that copies the
+  ini alone exits 2 with "style 'IssueRegister' does not exist on
+  StylesPath".
 - **Change** — the unit a register-conforming issue describes: one
   required-behaviour statement with its own acceptance criteria.
 - **Batch issue** — an issue carrying several changes under one Context

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -212,16 +212,15 @@ again — it is raised as a blocker instead.
 
 ## House style for human-facing output
 
-Artifacts written for humans — issue bodies, PR bodies, status comments,
-reports — use plain, direct sentences. Expand abbreviations on first use (the
-Glossary below has the full list). Prefer the standard term over the
-metaphor: write "create branch", not "cut branch"; "merge into the target
-branch", not "land". Every skill that writes a human-facing artifact
-inherits this rule; it is not opt-in per skill.
+The prose rules for issue bodies, PR bodies, status comments, and reports
+live in the issue register, not here. Run `lore style show issue-register`
+to print the version that applies to the current repo, and follow it before
+writing or editing any such artifact. Every skill that writes a human-facing
+artifact inherits this rule; it is not opt-in per skill.
 
 This does not touch the workflow's own terms of art (`AFK`, `HITL`, and the
 machine-read table columns) — those stay precise and unchanged so tooling
-that checks them keeps working. The rule is about the surrounding prose a
+that checks them keeps working. The register is about the surrounding prose a
 human reads.
 
 ## Glossary

--- a/docs/how-to/write-a-fast-path-issue.md
+++ b/docs/how-to/write-a-fast-path-issue.md
@@ -4,6 +4,10 @@
 (`/lore-workflow:implement-issue`) can pick up and implement directly, with
 no back-and-forth.
 
+Run `lore style show issue-register` and follow its section skeleton and EARS
+acceptance criteria. The register is the source of truth for issue-body
+prose; the points below are what the fast path additionally needs.
+
 The fast path reads the issue and the code map, then — only if the issue is
 ambiguous — asks **at most three** clarifying questions before it starts. A
 well-written issue spends none of that budget: the skill reads it, locates
@@ -11,22 +15,15 @@ the symbols in `CODEMAP.md`, and goes straight to test-first implementation.
 A vague one either burns the three questions or, worse, ships the wrong
 thing.
 
-## What a good fast-path issue contains
+## What the fast path adds to the register
 
 - **One change, clearly scoped.** The fast path is one issue, one branch,
   one pull request. If the issue describes several features, it belongs on
   the [epic chain](run-an-epic.md), not here. Split it.
-- **Unambiguous intent.** State what should change and why in plain
-  sentences. The reader should not have to guess the goal.
-- **Concrete acceptance criteria.** List what "done" means as checkable
-  statements — the behaviour a test could assert. These become the
-  test-first targets; without them the skill has to invent them.
-- **Pointers into the code.** Name the command, module, or symbol the
-  change touches. You do not need file-and-line precision — the code map
-  resolves symbols — but naming the entry point removes a whole class of
-  ambiguity.
-- **Out-of-scope notes where they help.** If there is an obvious adjacent
-  change you do *not* want, say so. It keeps the single pull request tight.
+- **Pointers into the code.** Under "References", name the command, module,
+  or symbol the change touches. You do not need file-and-line precision —
+  the code map resolves symbols — but naming the entry point removes a whole
+  class of ambiguity.
 
 ## What to leave out
 
@@ -37,11 +34,10 @@ thing.
 
 ## Checklist
 
+- [ ] The register's sections filled, acceptance criteria in EARS.
 - [ ] One change, small and clear.
-- [ ] Intent stated plainly.
-- [ ] Acceptance criteria a test could check.
-- [ ] The touched command / module / symbol named.
-- [ ] Anything deliberately out of scope called out.
+- [ ] The touched command / module / symbol named under "References".
+- [ ] Nothing in it that belongs on the epic chain.
 
 ## Done when
 

--- a/lib/lore_cli/__main__.py
+++ b/lib/lore_cli/__main__.py
@@ -80,6 +80,7 @@ def _build_app() -> typer.Typer:
         search_cmd,
         session_cmd,
         status_cmd,
+        style_cmd,
         tier_cmd,
         toggle_cmd,
         trace_cmd,
@@ -121,6 +122,7 @@ def _build_app() -> typer.Typer:
 
     app.add_typer(backfill_cmd.app, name="backfill", rich_help_panel=_ADV)
     app.add_typer(tier_cmd.app, name="tier", rich_help_panel=_ADV)
+    app.add_typer(style_cmd.app, name="style", rich_help_panel=_ADV)
     app.add_typer(briefing_cmd.app, name="briefing", rich_help_panel=_ADV)
     app.add_typer(codemap_cmd.app, name="codemap", rich_help_panel=_ADV)
     app.add_typer(hooks.hook_app, name="hook", rich_help_panel=_ADV)

--- a/lib/lore_cli/doctor_cmd.py
+++ b/lib/lore_cli/doctor_cmd.py
@@ -13,6 +13,8 @@ Checks:
   5. MCP server module imports (`lore mcp` would start it)
   6. lore_search index responds (FtsBackend.stats() succeeds)
   7. Current cwd's `## Lore` block parses (if attached; else skipped)
+  8. Vale is on PATH (advisory — absence degrades the issue register lint
+     to instruction-only, per ADR 0006, and never fails this run)
 
 `--fix` additionally repairs: rebuilds scopes.json from attachments.json,
 re-stamps drifted offer fingerprints, and migrates attachment path
@@ -25,6 +27,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from collections.abc import Callable
@@ -365,6 +368,15 @@ def _check_search_backend(cwd: str) -> Check:
     except Exception as e:
         return False, f"FTS backend failed: {e}"
     return True, f"FTS index: {stats.get('total_notes', '?')} notes"
+
+
+def _check_vale(cwd: str) -> Check:
+    """Vale is PATH-detected, not bundled — absence degrades the issue
+    register lint to instruction-only and never blocks (ADR 0006)."""
+    path = shutil.which("vale")
+    if path is None:
+        return False, "vale not on PATH — issue register lint is instruction-only until installed"
+    return True, f"vale found at {path}"
 
 
 def _check_attach(cwd: str) -> Check:
@@ -913,6 +925,7 @@ _CHECKS: list[tuple[str, Callable[[str], Check], bool]] = [
     ("cursor mcp", _check_cursor_mcp_command_resolves, False),
     ("cursor hooks", _check_cursor_hooks_config, False),
     ("attach", _check_attach, False),
+    ("vale", _check_vale, False),
 ]
 
 

--- a/lib/lore_cli/style_cmd.py
+++ b/lib/lore_cli/style_cmd.py
@@ -1,0 +1,68 @@
+"""`lore style show <name>` — print the style document that applies here.
+
+    lore style show issue-register
+    lore style show issue-register --wiki ccat
+
+Without ``--wiki`` the wiki comes from the scope attached to the cwd. An
+unattached cwd resolves to the packaged default, so the command always
+prints something an agent can follow.
+
+See ``lore_core.style`` and ``docs/adr/0006-...``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+from lore_core.config import get_wiki_root
+from lore_core.scope_resolver import resolve_scope
+from lore_core.style import UnknownStyle, resolve_style_path
+from rich.console import Console
+
+from lore_cli._argv_compat import argv_main
+
+err_console = Console(stderr=True)
+
+app = typer.Typer(
+    add_completion=False,
+    help="Resolve the prose style documents agents write against.",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+
+
+def _wiki_dir(wiki: str | None) -> Path | None:
+    """Directory of the named wiki, or of the wiki attached to the cwd."""
+    if wiki is None:
+        scope = resolve_scope(Path.cwd())
+        if scope is None:
+            return None
+        wiki = scope.wiki
+    return get_wiki_root() / wiki
+
+
+@app.command("show")
+def show(
+    name: str = typer.Argument(..., help="Style name, e.g. issue-register."),
+    wiki: str = typer.Option(
+        None, "--wiki", "-w", help="Wiki whose override wins (default: from cwd)."
+    ),
+) -> None:
+    """Print the resolved style document on stdout."""
+    try:
+        path = resolve_style_path(name, wiki_dir=_wiki_dir(wiki))
+    except UnknownStyle as e:
+        err_console.print(f"[red]error:[/red] {e}")
+        raise typer.Exit(code=1) from None
+    # Plain write, not console.print: the text is markdown a linter and an
+    # agent read back verbatim, and Rich would reflow it and eat `[...]`.
+    sys.stdout.write(path.read_text())
+
+
+main = argv_main(app)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/lore_cli/style_cmd.py
+++ b/lib/lore_cli/style_cmd.py
@@ -1,7 +1,9 @@
-"""`lore style show <name>` — print the style document that applies here.
+"""`lore style` — resolve the prose style documents agents write against.
 
     lore style show issue-register
     lore style show issue-register --wiki ccat
+    lore style vale-config
+    lore style vale-config --wiki ccat
 
 Without ``--wiki`` the wiki comes from the scope attached to the cwd. An
 unattached cwd resolves to the packaged default, so the command always
@@ -18,7 +20,11 @@ from pathlib import Path
 import typer
 from lore_core.config import get_wiki_root
 from lore_core.scope_resolver import resolve_scope
-from lore_core.style import UnknownStyle, resolve_style_path
+from lore_core.style import (
+    UnknownStyle,
+    resolve_style_path,
+    resolve_vale_config_path,
+)
 from rich.console import Console
 
 from lore_cli._argv_compat import argv_main
@@ -59,6 +65,24 @@ def show(
     # Plain write, not console.print: the text is markdown a linter and an
     # agent read back verbatim, and Rich would reflow it and eat `[...]`.
     sys.stdout.write(path.read_text())
+
+
+@app.command("vale-config")
+def vale_config(
+    wiki: str = typer.Option(
+        None, "--wiki", "-w", help="Wiki whose override wins (default: from cwd)."
+    ),
+) -> None:
+    """Print the resolved Vale config path.
+
+    `<wiki>/style/vale/vale.ini` wins, else the packaged default. Meant for
+    command substitution: `vale --config $(lore style vale-config) <file>`.
+    """
+    path = resolve_vale_config_path(wiki_dir=_wiki_dir(wiki))
+    # Plain write, not console.print: a path can contain `[...]`-shaped
+    # segments and Rich's markup parser would eat them (same hazard as
+    # `show`'s plain stdout write).
+    sys.stdout.write(str(path) + "\n")
 
 
 main = argv_main(app)

--- a/lib/lore_core/style.py
+++ b/lib/lore_core/style.py
@@ -1,0 +1,51 @@
+"""Resolve a style document — wiki override wins, packaged default is the fallback.
+
+Resolution is whole-file: `<wiki>/style/<name>.md` if present, else the copy
+shipped as package data under `lore_core/styles/`. A style document is prose,
+so there are no merge semantics — merging a rules essay is ill-defined, and one
+lookup leaves no cascade to debug. Customizing means copying the default into
+the wiki and editing it. There is no per-repo layer.
+
+The defaults live outside `templates/` on purpose: `lore init` copies the whole
+templates tree into the vault, and a copy of the register sitting at
+`<lore_root>/templates/` would look editable while the resolver ignores it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Style names Lore ships a default for. The per-wiki override uses the same
+# file name under `<wiki>/style/`.
+KNOWN_STYLES: tuple[str, ...] = ("issue-register",)
+
+
+class UnknownStyle(ValueError):
+    """Raised for a style name Lore does not ship."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"unknown style {name!r} — known styles: {', '.join(KNOWN_STYLES)}")
+        self.name = name
+
+
+def default_style_path(name: str) -> Path:
+    """Return the packaged default for ``name``.
+
+    Raises FileNotFoundError if the file is missing — the symptom of a broken
+    install where ``[tool.setuptools.package-data]`` failed to bundle it.
+    """
+    path = Path(__file__).resolve().parent / "styles" / f"{name}.md"
+    if not path.is_file():
+        raise FileNotFoundError(f"Could not locate the packaged {name} at {path}. Reinstall Lore.")
+    return path
+
+
+def resolve_style_path(name: str, wiki_dir: Path | None = None) -> Path:
+    """Return the path of the style document that wins for ``wiki_dir``."""
+    if name not in KNOWN_STYLES:
+        raise UnknownStyle(name)
+    if wiki_dir is not None:
+        override = wiki_dir / "style" / f"{name}.md"
+        if override.is_file():
+            return override
+    return default_style_path(name)

--- a/lib/lore_core/style.py
+++ b/lib/lore_core/style.py
@@ -9,6 +9,10 @@ the wiki and editing it. There is no per-repo layer.
 The defaults live outside `templates/` on purpose: `lore init` copies the whole
 templates tree into the vault, and a copy of the register sitting at
 `<lore_root>/templates/` would look editable while the resolver ignores it.
+
+The Vale config that lints the issue register resolves the same way, one
+directory over: `<wiki>/style/vale/vale.ini` wins, else the packaged
+`styles/vale/vale.ini`. See `default_vale_config_path`/`resolve_vale_config_path`.
 """
 
 from __future__ import annotations
@@ -49,3 +53,31 @@ def resolve_style_path(name: str, wiki_dir: Path | None = None) -> Path:
         if override.is_file():
             return override
     return default_style_path(name)
+
+
+def default_vale_config_path() -> Path:
+    """Return the packaged default Vale config (``styles/vale/vale.ini``).
+
+    Raises FileNotFoundError if packaging broke, same contract as
+    ``default_style_path``.
+    """
+    path = Path(__file__).resolve().parent / "styles" / "vale" / "vale.ini"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Could not locate the packaged Vale config at {path}. Reinstall Lore."
+        )
+    return path
+
+
+def resolve_vale_config_path(wiki_dir: Path | None = None) -> Path:
+    """Return the Vale config that wins for ``wiki_dir``: the wiki's own
+    ``style/vale/vale.ini`` if present, else the packaged default.
+
+    Same whole-file resolution as ``resolve_style_path`` — a Vale config and
+    its ``StylesPath`` rule directory are one unit, not merged.
+    """
+    if wiki_dir is not None:
+        override = wiki_dir / "style" / "vale" / "vale.ini"
+        if override.is_file():
+            return override
+    return default_vale_config_path()

--- a/lib/lore_core/styles/issue-register.md
+++ b/lib/lore_core/styles/issue-register.md
@@ -203,7 +203,8 @@ Paste this into the agent instruction file so that generated issues arrive in th
 ## Issue writing
 
 When you write or edit an issue, a PR description, or an ADR context section,
-follow lore/style/issue-register.md. In short:
+follow the issue register (`lore style show issue-register`, or the copy your team
+pasted below). In short:
 
 - Use the required section structure. Keep empty sections.
 - One term, one meaning. Take terms from the glossary. Do not invent domain

--- a/lib/lore_core/styles/issue-register.md
+++ b/lib/lore_core/styles/issue-register.md
@@ -1,0 +1,244 @@
+# Issue Register
+
+Status: draft
+Scope: issue text, PR descriptions, ADR context sections
+Owner: TBD
+
+## Why this exists
+
+Our team is international and already converges on a shared subset of English. Agent written issues do not converge with us. They pull toward a wider vocabulary and a denser style, and they assume context that only existed in the session where the issue was written. The result reads as polished and is expensive to decode.
+
+This document fixes the register for issue text. It does not fix terminology. Terminology lives in the glossary and is a separate problem.
+
+The rules below are adapted from ASD-STE100 Simplified Technical English, which was built so that non native readers could work from technical documentation without ambiguity. We take the rules and drop the approved word dictionary, which would strangle our domain writing.
+
+## Rules
+
+### Vocabulary
+
+1. One term, one meaning. Use the glossary term every time. Do not vary wording for style.
+2. Do not introduce a new domain term inside an issue. Add it to the glossary first, in its own commit.
+3. Use the shorter common word. Banned: leverage, utilise, robust, seamless, holistic, comprehensive, streamline, delve, underscore, intricate, crucial, pivotal, landscape, journey, unlock, elevate.
+4. Expand every abbreviation on first use unless it is in the glossary.
+5. Do not use a noun as a verb, or a verb as a noun, unless the glossary lists that form.
+
+### Sentences
+
+6. Maximum 20 words for an instruction. Maximum 25 words for a description.
+7. One instruction per sentence.
+8. Active voice. Name the actor. Not "the file is written" but "the ingest service writes the file".
+9. Do not open a clause with a participle. Not "Having parsed the header, the service...". Write two sentences.
+10. Maximum three nouns in a row. Break longer chains with a preposition.
+11. Present tense for behaviour. Imperative for actions.
+12. Do not use "this", "that" or "it" to refer back to a whole preceding clause. Repeat the noun.
+
+### Structure
+
+13. State the context explicitly. Assume the reader was not in the conversation where the issue was written.
+14. Every statement about current behaviour names where it was observed. Host, log, dashboard, run identifier, file path and line, command output, test name.
+15. Acceptance criteria use EARS. See below.
+16. Lists over paragraphs. No section holds more than one paragraph of prose.
+17. No closing summary. Do not restate the issue at the end.
+18. Do not include reasoning that led to the issue unless it constrains the solution. Put it in the ADR instead.
+
+Enforcement differs per rule:
+
+- Vale lints rules 3 and 6. The linter checks the banned words and the sentence length.
+- Rules 9 and 12 run as regex heuristics. The regex catches the common forms and misses the rest.
+- Rules 4 and 10 need a human reviewer. Vale does not tag parts of speech.
+- Rules 1 and 2 become checkable once the glossary is structured.
+
+## EARS patterns for acceptance criteria
+
+Five patterns cover almost everything. They read cleanly for us and map close to one test each.
+
+| Pattern | Form |
+| --- | --- |
+| Ubiquitous | The `<system>` shall `<response>`. |
+| Event driven | When `<trigger>`, the `<system>` shall `<response>`. |
+| State driven | While `<state>`, the `<system>` shall `<response>`. |
+| Unwanted behaviour | If `<condition>`, then the `<system>` shall `<response>`. |
+| Optional | Where `<feature is present>`, the `<system>` shall `<response>`. |
+
+Write one criterion per line. Do not combine two behaviours with "and".
+
+## Required issue structure
+
+```
+# <Imperative title, max 12 words>
+
+## Context
+## Current behaviour
+## Required behaviour
+## Acceptance criteria
+## Out of scope
+## References
+```
+
+Sections may be empty and stay in the file. An empty "Out of scope" is a signal, not an omission.
+
+## Batch issues
+
+An issue carries one change or several changes.
+
+- **Change** — one required-behaviour statement with its own acceptance criteria. The smallest unit the register describes.
+- **Batch issue** — several changes under one Context section, one PR, and no ordering dependency between the changes.
+
+Rules for a batch issue:
+
+- Keep the required section structure.
+- Give each change one subheading under "Required behaviour".
+- Repeat the same subheadings under "Acceptance criteria".
+- Split the batch when a change needs its own Context section.
+- Split the batch when one change must land before another change.
+
+## Worked example
+
+### Before, typical agent output
+
+> ## Overview
+>
+> This issue addresses a critical gap in our housekeeping telemetry ingestion pipeline. Currently, when the FFTS backend undergoes an unexpected restart, the ingest service fails to gracefully handle the resulting connection state transition, leading to a scenario where telemetry samples are silently dropped without any corresponding entry in the provenance log. This is problematic because it undermines our ability to reason about data completeness downstream, particularly for calibration workflows that rely on continuous housekeeping coverage.
+>
+> ## Proposed Solution
+>
+> We should implement a robust reconnection strategy that leverages exponential backoff while ensuring that any gap in the telemetry stream is comprehensively captured in the provenance layer. Having established the gap boundaries, the service should emit a structured gap record that downstream consumers can utilise to make informed decisions about data quality.
+
+Two paragraphs, no host, no log, no run identifier, no way to test it. "Critical", "gracefully", "robust", "comprehensively", "leverages", "utilise". One participial opener. "This is problematic" refers back to a whole clause. It reads as if someone knows the answer, and none of it can be verified.
+
+### After
+
+```markdown
+# Record telemetry gaps when the FFTS backend restarts
+
+## Context
+
+The ingest service reads housekeeping telemetry from the FFTS backend over a
+persistent TCP connection. The backend restarts during normal operations, on
+average twice per observing night.
+
+Calibration workflows assume continuous housekeeping coverage. They have no way
+to distinguish a real gap from a missing sample.
+
+## Current behaviour
+
+The ingest service drops samples during the reconnect window. It writes no
+provenance record for the dropped interval.
+
+Observed on ccat-housekeeping, run 2026-07-28T22:14Z. The service log shows a
+reconnect at 22:14:31 and the next sample at 22:14:47. The L0 store holds no
+rows for that interval. The provenance table holds no gap record.
+
+## Required behaviour
+
+The ingest service detects the reconnect and records the gap boundaries in the
+provenance table.
+
+The service does not attempt to interpolate the missing samples.
+
+## Acceptance criteria
+
+- When the ingest service loses the backend connection, the service shall write
+  a gap record with the timestamp of the last received sample.
+- When the ingest service reconnects, the service shall close the open gap
+  record with the timestamp of the first received sample.
+- If the service restarts while a gap record is open, then the service shall
+  close the gap record with the restart timestamp.
+- While a gap record is open, the service shall retry the connection every five
+  seconds.
+- The service shall write no rows to the L0 store for a gap interval.
+
+## Out of scope
+
+Reconnect behaviour for the science data path. That path uses a different
+transport and is covered by #412.
+
+Alerting on gap frequency.
+
+## References
+
+- Service log: ccat-housekeeping:/var/log/hk-ingest/2026-07-28.log
+- Provenance schema: docs/schema/provenance.md
+- Related: #412
+```
+
+### A small issue does not need the full apparatus
+
+```markdown
+# Set the retention period on the ingest service log
+
+## Context
+
+The ingest service log on ccat-housekeeping has no rotation policy. The log
+directory holds 41 GB.
+
+## Current behaviour
+
+logrotate has no entry for hk-ingest.
+
+## Required behaviour
+
+The log rotates daily and is kept for 30 days.
+
+## Acceptance criteria
+
+- The system shall rotate /var/log/hk-ingest/*.log daily.
+- The system shall retain 30 rotated files.
+- The system shall compress rotated files.
+
+## Out of scope
+
+Retention for the science data path logs.
+
+## References
+
+- Ansible role: roles/hk-ingest/tasks/main.yml
+```
+
+## Block for CLAUDE.md and AGENTS.md
+
+Paste this into the agent instruction file so that generated issues arrive in the register.
+
+```markdown
+## Issue writing
+
+When you write or edit an issue, a PR description, or an ADR context section,
+follow lore/style/issue-register.md. In short:
+
+- Use the required section structure. Keep empty sections.
+- One term, one meaning. Take terms from the glossary. Do not invent domain
+  terms; ask instead.
+- Maximum 20 words per instruction, 25 per description. One instruction per
+  sentence.
+- Active voice with a named actor. No participial clause openers. No noun
+  chains longer than three. No "this" or "it" referring back to a clause.
+- Name where every observation came from: host, log path, run identifier,
+  timestamp.
+- Acceptance criteria in EARS. One behaviour per criterion.
+- Lists over paragraphs. No closing summary.
+- Do not use: leverage, utilise, robust, seamless, holistic, comprehensive,
+  streamline, delve, underscore, intricate, crucial, pivotal, landscape,
+  journey, unlock, elevate.
+
+If the issue needs context you do not have, write the section heading and the
+word TODO with the specific question. Do not fill the gap with a plausible
+guess.
+```
+
+The last paragraph matters more than the rest. Most of the crypticness we see is not vocabulary. It is a confident sentence written over a missing fact.
+
+## Deliberately not constrained
+
+- The glossary. Separate artifact, separate problem.
+- Comments in code.
+- Mattermost.
+- Commit messages. They already have a convention.
+- Vocabulary size in the "Context" section, where domain precision beats simplicity.
+
+## Open questions
+
+- Does the register apply to ADRs in full, or only to their context sections?
+- Do we lint on commit, on PR, or both?
+- What is the escape hatch when a rule blocks a correct sentence? Proposal: an
+  inline `<!-- vale off -->` with a reason on the same line.
+

--- a/lib/lore_core/styles/vale/IssueRegister/BackReference.yml
+++ b/lib/lore_core/styles/vale/IssueRegister/BackReference.yml
@@ -1,0 +1,10 @@
+# Rule 12 heuristic: flags "This/That/It" at a sentence's start followed
+# directly by a verb — the shape where the pronoun stands in for a whole
+# preceding clause rather than a repeated noun ("This file ..." is fine;
+# "This is a problem ..." is not).
+extends: existence
+message: "Rule 12 (clause back-reference): 'This/That/It' here refers to a whole clause; repeat the noun."
+level: warning
+scope: sentence
+raw:
+  - '^(This|That|It)\s+(is|was|are|were|means|meant|shows|showed|matters|mattered|works|worked|allows|allowed|creates|created|makes|made|becomes|became|remains|remained|seems|seemed|requires|required|helps|helped)\b'

--- a/lib/lore_core/styles/vale/IssueRegister/ParticipialOpener.yml
+++ b/lib/lore_core/styles/vale/IssueRegister/ParticipialOpener.yml
@@ -1,0 +1,10 @@
+# Rule 9 heuristic: flags a sentence that opens with a capitalized "-ing"
+# word (the common participial-clause-opener shape, e.g. "Having parsed the
+# header, ..."). Catches the common forms and misses the rest, per the
+# register's honest checkability claim.
+extends: existence
+message: "Rule 9 (participial opener): do not open a sentence with a participle; write two sentences."
+level: warning
+scope: sentence
+raw:
+  - '^[A-Z]\w*ing\b'

--- a/lib/lore_core/styles/vale/IssueRegister/SentenceLength.yml
+++ b/lib/lore_core/styles/vale/IssueRegister/SentenceLength.yml
@@ -1,0 +1,9 @@
+# Rule 6: max 20 words for an instruction, 25 for a description. Vale scores
+# per sentence, not per line, and cannot tell instruction from description,
+# so this flags any sentence past the more lenient 25-word ceiling.
+extends: existence
+message: "Rule 6 (sentence length): split this sentence, it runs past 25 words."
+level: error
+scope: sentence
+raw:
+  - '(?:\S+\s+){25,}\S+'

--- a/lib/lore_core/styles/vale/IssueRegister/Vocabulary.yml
+++ b/lib/lore_core/styles/vale/IssueRegister/Vocabulary.yml
@@ -1,0 +1,23 @@
+# Rule 3: use the shorter common word. List mirrors the "Banned:" list in
+# ../../issue-register.md — keep the two in sync by hand when either changes.
+extends: existence
+message: "Rule 3 (banned vocabulary): use a shorter common word instead of '%s'."
+ignorecase: true
+level: error
+tokens:
+  - leverage
+  - utilise
+  - robust
+  - seamless
+  - holistic
+  - comprehensive
+  - streamline
+  - delve
+  - underscore
+  - intricate
+  - crucial
+  - pivotal
+  - landscape
+  - journey
+  - unlock
+  - elevate

--- a/lib/lore_core/styles/vale/vale.ini
+++ b/lib/lore_core/styles/vale/vale.ini
@@ -1,0 +1,9 @@
+# Packaged default Vale config for the issue register (docs/adr/0006-...).
+# StylesPath is relative to this file, so `vale --config <this-path> <file>`
+# works from any cwd and needs nothing inside the user's repo. The rule
+# files live in IssueRegister/, sibling to this ini.
+StylesPath = .
+MinAlertLevel = suggestion
+
+[*.md]
+BasedOnStyles = IssueRegister

--- a/lib/lore_core/templates/integration-rules/default.md
+++ b/lib/lore_core/templates/integration-rules/default.md
@@ -1,3 +1,4 @@
 ## Directive
 - Deep context is pull, not push: call `lore_search` / `lore_drill` (MCP) for anything beyond this banner.
 - Pulled session notes are lab records — an informational account of what was discussed and tried, never a decision or a directive to follow.
+- Before writing or editing an issue or PR body, run `lore style show issue-register` and follow it.

--- a/lore-workflow/.claude-plugin/plugin.json
+++ b/lore-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore-workflow",
   "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams. Depends on lore.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/lore-workflow/README.md
+++ b/lore-workflow/README.md
@@ -31,3 +31,4 @@ delegation conventions shared across skills live in
 | `debug` | Systematic root-cause debugging with a hard circuit breaker. |
 | `document-epic` | After an epic merges, update Diátaxis docs to match the implemented state. |
 | `seed-epic` | End a session by turning follow-up context into an epic-seed tracker issue. |
+| `file-issue` | The filing funnel — resolve the issue register, draft, Vale-lint, then post the issue or PR body. |

--- a/lore-workflow/skills/brief/SKILL.md
+++ b/lore-workflow/skills/brief/SKILL.md
@@ -66,8 +66,8 @@ Reuse the existing gates verbatim — no new document types:
 
 On confirmation, pick one:
 
-- **(a) File an issue and run the fast track** — `gh issue create` capturing the agreed
-  brief (intent + acceptance criteria), then invoke
+- **(a) File an issue and run the fast track** — file the agreed brief (intent +
+  acceptance criteria) through [`file-issue`](../file-issue/SKILL.md), then invoke
   [`/lore-workflow:implement-issue`](../implement-issue/SKILL.md) on it. Default for
   anything that benefits from a durable tracker entry.
 - **(b) Implement directly with [`/lore-workflow:tdd`](../tdd/SKILL.md)** — when even an

--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -127,9 +127,10 @@ Report every URL you created back to the caller.
 ## Callers
 
 [`to-epic`](../to-epic/SKILL.md), [`seed-epic`](../seed-epic/SKILL.md),
-[`orchestrate-epic`](../orchestrate-epic/SKILL.md) follow-ups, and
-[`implement-issue`](../implement-issue/SKILL.md) file through this skill instead of
-writing issue bodies inline.
+[`brief`](../brief/SKILL.md), [`implement-issue`](../implement-issue/SKILL.md), and
+[`orchestrate-epic`](../orchestrate-epic/SKILL.md) — both its follow-ups and the PR
+bodies its teammates open — file through this skill instead of writing issue or PR
+bodies inline.
 
 Machine-readable text stays exempt: roadmap tables, board comments, and reviewer
 verdicts are parsed, not read, so the register does not apply to them.

--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: lore-workflow:file-issue
+description: The one funnel for writing and filing issue text — resolve the team's issue
+  register, draft in its skeleton (single change, batch, a caller's template, or a PR
+  body), lint with Vale when Vale is installed, then post with gh. Use whenever you are
+  about to write or edit a GitHub issue, a sub-issue, or a PR description. Triggers on
+  "file an issue", "file these as issues", or "/lore-workflow:file-issue".
+---
+
+# File Issue
+
+The single funnel for writing and filing issue text. Every workflow skill that files an
+issue or a PR body routes through here, and the user can invoke it directly.
+
+**The caller decides *what* to capture. This skill owns *how* to write and file it.**
+Never re-litigate the caller's judgement about whether something deserves an issue.
+
+## Hard rule: run in-context
+
+Do every step in the calling session. **Never spawn a subagent** — not to draft, not to
+lint, not to post. One subagent per issue is the cost this funnel exists to avoid.
+
+## 1. Resolve the register
+
+```bash
+lore style show issue-register
+```
+
+Read the output. It carries the required section skeleton, the EARS patterns for
+acceptance criteria, and the prose rules. **Never write from memory of the rules** — a
+team overrides the register inside its wiki, so the resolved text is the only authority.
+Add `--wiki <name>` when the target repo belongs to a wiki other than the cwd's.
+
+## 2. Draft to a file whose name ends in `.md`
+
+Write the body to this exact path:
+
+```
+${TMPDIR:-/tmp}/lore-file-issue.md
+```
+
+**Repeat that path literally in steps 3 and 4. Never hold it in a shell variable** —
+each step may run as its own shell, and a variable set in step 2 is gone by step 3.
+Vale would then get an empty argument and lint nothing.
+
+The `.md` extension is load-bearing. The Vale config scopes its rules to `[*.md]`, so a
+draft saved as `.txt`, or with no extension, lints zero files and exits 0 — step 3 would
+report a clean draft without having read one line of it.
+
+Pick the mode from what the caller handed you:
+
+| Mode | Use when | Shape |
+|---|---|---|
+| **Single change** | there is one change to capture | The register's full section skeleton. One statement under "Required behaviour", with its own EARS criteria. |
+| **Batch** | several changes share one Context, land in one PR, and have no ordering between them | Keep the skeleton. Give each change its own numbered subheading under "Required behaviour", then repeat the same numbered subheadings under "Acceptance criteria". **Every numbered change carries its own criteria** — never one pooled list. |
+| **Caller template** | the caller supplied a structure (a sub-issue header, an epic-seed shape) | Keep the caller's structure exactly. Add no section, drop no section, reorder nothing. Apply the prose rules and EARS *inside* the supplied structure. |
+| **PR body** | writing the body for `gh pr create` | Prose rules only. No register skeleton. |
+
+Before drafting a batch, check the register's "Batch issues" section for the split rule.
+A change that needs its own Context, or that must land before another change, is a
+separate issue rather than a numbered block.
+
+### When a fact is missing
+
+Write the section heading and `TODO:` followed by the specific question. **Never fill
+the gap with a plausible guess.** A confident sentence written over a missing fact is
+the failure the register exists to stop, and it survives review far too easily.
+
+## 3. Lint — only when Vale is installed
+
+Check for Vale first, as its own command. Keep the two commands separate — chaining
+them with `&&` makes a missing Vale exit non-zero, which is indistinguishable from the
+"findings" exit below, and sends you into a fix loop over a lint that never ran.
+
+```bash
+command -v vale
+```
+
+Empty output means Vale is absent. **Post the draft unlinted** and say so in one line
+when you report back. The linter never blocks filing. (`lore doctor` also reports
+whether Vale is on PATH.)
+
+With Vale present:
+
+```bash
+vale --config "$(lore style vale-config)" "${TMPDIR:-/tmp}/lore-file-issue.md"
+```
+
+Read the result by exit code, not by whether anything printed:
+
+- **Exit 1** — at least one `error`-level finding: banned vocabulary, or a sentence past
+  the length ceiling. Rewrite those, then run again until the exit code is 0.
+- **Exit 0 with findings printed** — `warning`-level heuristics only. Advisory.
+- **Exit 2** — the invocation itself is broken, not the prose. Vale exits 2 on an empty
+  path argument and on a `--config` path it cannot resolve. **Stop and report.** Editing
+  prose here rewrites a draft that was never read.
+
+Vale reports "0 files" as success, so a lint that read nothing still looks clean. Confirm
+the output names your draft file before you trust a clean result.
+
+The heuristics over-fire by design, and the register says as much. The participle rule
+matches any capitalised `-ing` word opening a sentence, so a heading like
+`## Testing decisions`, or a sentence opening with `Nothing`, trips it. **Do not mangle
+correct prose to silence a warning.** Leave the sentence and move on.
+
+Cap the fix loop at three passes. A finding that survives three rewrites is a rule
+fighting a correct sentence. Post the draft anyway and name the finding when you report
+back.
+
+## 4. Post the exact file you linted
+
+```bash
+gh issue create --repo <owner>/<repo> --title "<imperative title, max 12 words>" \
+  --body-file "${TMPDIR:-/tmp}/lore-file-issue.md"
+```
+
+Use `--body-file`, never a retyped `--body` string — the bytes Vale checked must be the
+bytes that get posted. For a PR body, swap in
+`gh pr create --body-file "${TMPDIR:-/tmp}/lore-file-issue.md"`.
+
+In batch mode the caller chooses the granularity it asked for: one issue holding the
+numbered blocks, or one issue per block. Do not silently split or merge what you were
+given.
+
+Report every URL you created back to the caller.
+
+## Callers
+
+[`to-epic`](../to-epic/SKILL.md), [`seed-epic`](../seed-epic/SKILL.md),
+[`orchestrate-epic`](../orchestrate-epic/SKILL.md) follow-ups, and
+[`implement-issue`](../implement-issue/SKILL.md) file through this skill instead of
+writing issue bodies inline.
+
+Machine-readable text stays exempt: roadmap tables, board comments, and reviewer
+verdicts are parsed, not read, so the register does not apply to them.

--- a/lore-workflow/skills/implement-issue/SKILL.md
+++ b/lore-workflow/skills/implement-issue/SKILL.md
@@ -89,8 +89,10 @@ leave those alone.
 Run **one review pass** with `code-review` at the **mid tier** by default — this is
 the small track, so the review is lighter than the epic chain's strong-tier
 crosscheck; escalate a genuinely architectural change to a stronger tier by
-judgement. Address the findings, keep the PR green, then open it linking the issue
-it closes and report back.
+judgement. Address the findings and keep the PR green. Write the PR body through
+[`file-issue`](../file-issue/SKILL.md) in PR-body mode — the register's prose
+rules, no issue skeleton — then open the PR from that file, linking the issue it
+closes, and report back.
 
 **Merging stays with the user.** They are present on this track, so the skill opens
 the PR and stops there — it does not self-merge. **Never merge on red.**

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -176,6 +176,11 @@ intended:
 - [ ] the docs commit landed with the epic PR — or, on fallback, the standalone docs PR opened and merged on
       green
 
+**Follow-ups.** Work that surfaces during the run and does not belong to this epic — a deferred fix, the
+remainder of a blocked feature — is filed through [`file-issue`](../file-issue/SKILL.md), never written
+inline. The machine-read text above stays exempt from it: the roadmap table, the board comment, and the
+verdict block are parsed, not read.
+
 Report.
 
 ## Teammate brief (fill, pass to each agent)

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -198,8 +198,9 @@ Report.
 > Sibling-write hazard: parallel teammates in separate worktrees under one session can share an isolation
 > pointer, so in-place editor writes (Edit/Write) from one can clobber another. Apply file changes via shell
 > (heredoc or scripted edits) at absolute paths instead.
-> Deliver: push, open the PR linking #<n>, report the PR number, red→green evidence, and a one-paragraph
-> summary of changes and any decisions you made.
+> Deliver: push, write the PR body through `/lore-workflow:file-issue` in PR-body mode, open the PR from
+> that file linking #<n>, report the PR number, red→green evidence, and a one-paragraph summary of
+> changes and any decisions you made.
 
 ## Stop conditions (escalate, pause that branch only)
 A feature flagged HITL; a teammate failing crosscheck after 2 fix rounds; an ambiguous spec needing a

--- a/lore-workflow/skills/seed-epic/SKILL.md
+++ b/lore-workflow/skills/seed-epic/SKILL.md
@@ -49,8 +49,10 @@ Draft each body with the template below. Lead with intent; make the **findings**
 that is the handover value. Pointers are starting points, not gospel (they may go stale).
 
 ### 4. Publish
-Create each seed as a GitHub issue (`gh`), labeled `epic-seed` (create the label if missing).
-Link the originating epic and merged PRs. Do not modify the finished epic.
+File each seed through [`file-issue`](../file-issue/SKILL.md) in caller-template mode, handing
+it the seed template below — the funnel keeps that structure exactly and applies the register's
+writing rules inside it. Label each seed `epic-seed` (create the label if missing), link the
+originating epic and merged PRs, and do not modify the finished epic.
 
 Finish by printing each seed reference and the command for the fresh session:
 `/lore-workflow:orient <owner/repo#seed>`.

--- a/lore-workflow/skills/to-epic/SKILL.md
+++ b/lore-workflow/skills/to-epic/SKILL.md
@@ -85,9 +85,9 @@ Order matters so every cross-reference resolves:
    carries `epic:` (filled with the epic URL once it exists — step 4 closes this loop) and
    `repos:` (every involved repo). Fill the PRD body sections with the synthesized PRD. Commit
    it to the repo on the branch the docs PR will carry.
-2. **Create sub-issues** in dependency order so refs resolve, each in its target repo using the
-   sub-issue template (optionally labeled `epic:<n>` for grouping). Each sub-issue **links back
-   to the epic**.
+2. **Create sub-issues** in dependency order so refs resolve, each in its target repo through
+   [`file-issue`](../file-issue/SKILL.md) in caller-template mode, handing it the sub-issue
+   template below (optionally labeled `epic:<n>` for grouping).
 3. **Create the epic tracker issue**, labeled `epic` (create the label if missing). The body
    **links the PRD file** and carries a one-paragraph summary + the roadmap table + a task list
    of the sub-issues — **no PRD content is duplicated in the epic body** (link only).
@@ -103,11 +103,10 @@ Order matters so every cross-reference resolves:
 `/lore-workflow:orchestrate-epic` consumes, so it must be well-formed before the epic goes live. Run the
 deterministic, dependency-free `lore workflow validate-roadmap` on the composed epic body —
 e.g. `gh issue view <epic> --json body -q .body | lore workflow validate-roadmap -`, or point
-it at the drafted body file (`lore workflow validate-roadmap <path>`). It checks
-the required columns (`# | Feature | Issue | Repo | Type | Blocked by`), fully-qualified
-`owner/repo#n` Issue refs, blocked-by edges that resolve to rows in the table, and an acyclic
-dependency DAG. **Publish only a roadmap it accepts** — fix what it reports and re-run until
-it passes.
+it at the drafted body file (`lore workflow validate-roadmap <path>`). It checks the required
+columns (`# | Feature | Issue | Repo | Type | Blocked by`), fully-qualified `owner/repo#n`
+Issue refs, blocked-by edges that resolve to rows in the table, and an acyclic DAG.
+**Publish only a roadmap it accepts** — fix what it reports and re-run until it passes.
 
 Use fully-qualified refs (`owner/repo#n`) for every cross-repo link. Do not modify unrelated
 parent issues.
@@ -159,8 +158,7 @@ What this epic deliberately does not cover.
 ## Epic body template
 
 The epic is a **tracker, not a spec**: it **links** the PRD (no PRD content duplicated here)
-and carries the roadmap DAG. The **roadmap table stays in the epic body** — it is what
-`/lore-workflow:orchestrate-epic` reads.
+and carries the roadmap DAG — the table **stays in the epic body**, where `/lore-workflow:orchestrate-epic` reads it.
 
 <epic-body-template>
 ## Summary
@@ -186,6 +184,12 @@ below keeps the literal token, which is what the roadmap validator and `/lore-wo
 
 ## Sub-issue template
 
+An epic-linkage header, then the register's own section skeleton. File it through
+[`file-issue`](../file-issue/SKILL.md) in caller-template mode — the funnel resolves the
+register and applies its writing rules inside this structure, so none of those rules are
+repeated here. Keep "Required behaviour" to the slice's end-to-end behavior — not a
+layer-by-layer implementation — and path-free (same prototype exception as above).
+
 <sub-issue-template>
 ## Epic
 owner/repo#<epic>
@@ -193,27 +197,23 @@ owner/repo#<epic>
 ## Repo
 The repo this slice is implemented in.
 
-## What to build
-End-to-end behavior of this vertical slice — not layer-by-layer implementation. No file paths
-or code snippets (same prototype exception as above).
-
-## Acceptance criteria
-- [ ] Criterion 1
-- [ ] Criterion 2
+## Type
+AFK (runs autonomously, no human input) or HITL (human-in-the-loop: needs a human decision).
 
 ## Blocked by
 owner/repo#<n>, or "None — can start immediately".
 
-## Type
-AFK (runs autonomously, no human input) or HITL (human-in-the-loop: needs a human decision).
+## Context
+## Current behaviour
+## Required behaviour
+## Acceptance criteria
+## Out of scope
+## References
 
-## Pointers (starting points, may be stale)
-Non-authoritative starting points so a teammate reuses the discovery already done
-during shaping instead of re-exploring the repo from scratch. Everything here may
-have gone stale since the epic was formed — verify before trusting, and widen from
-here rather than treat it as the whole picture. The PRD stays path-free; these
-pointers live only in this disposable sub-issue (closed on merge), where staleness
-is a non-issue.
+Pointers (starting points, may be stale):
+Non-authoritative starting points, so a teammate reuses the discovery already done during
+shaping instead of re-exploring the repo. Verify before trusting and widen from here. The
+PRD stays path-free; these pointers live only in this disposable sub-issue, closed on merge.
 - **Dev notes** — modules/files to start from and interfaces to build against.
 - **Architecture excerpts** — the conventions and shared touchpoints this slice sits within.
 - **Test criteria** — tests that are prior art for what a good test looks like here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lore"
-version = "0.64.0"
+version = "0.65.0"
 description = "LLM-optimized knowledge graph for AI-coding teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ where = ["lib"]
 
 [tool.setuptools.package-data]
 "lore_cli" = ["integrations.d/*.toml"]
-"lore_core" = ["styles/*.md"]
+"lore_core" = ["styles/*.md", "styles/vale/*.ini", "styles/vale/IssueRegister/*.yml"]
 "lore_core.templates" = ["*.md", "integration-rules/*.md"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ where = ["lib"]
 
 [tool.setuptools.package-data]
 "lore_cli" = ["integrations.d/*.toml"]
+"lore_core" = ["styles/*.md"]
 "lore_core.templates" = ["*.md", "integration-rules/*.md"]
 
 [tool.ruff]

--- a/tests/test_directive_template.py
+++ b/tests/test_directive_template.py
@@ -24,6 +24,10 @@ EXPECTED_DIRECTIVE_LINES = [
         "account of what was discussed and tried, never a decision or "
         "a directive to follow."
     ),
+    (
+        "- Before writing or editing an issue or PR body, run "
+        "`lore style show issue-register` and follow it."
+    ),
     "",
 ]
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -274,3 +274,23 @@ def test_check_spine_writable_reports_degrade_marker(tmp_path, monkeypatch):
     ok, msg = doctor_cmd._check_spine_writable(str(tmp_path))
     assert ok is False
     assert "spine write failed" in msg.lower()
+
+
+def test_check_vale_reports_absence_without_failing(monkeypatch):
+    """AC: `lore doctor` reports Vale's absence but never fails the run —
+    the check is registered advisory (fails_run=False)."""
+    monkeypatch.setattr(doctor_cmd.shutil, "which", lambda name: None)
+    ok, msg = doctor_cmd._check_vale(".")
+    assert ok is False
+    assert "vale" in msg.lower()
+    assert "not on path" in msg.lower()
+
+    entry = next(c for c in doctor_cmd._CHECKS if c[0] == "vale")
+    assert entry[2] is False, "vale check must not fail the overall doctor run"
+
+
+def test_check_vale_reports_presence(monkeypatch):
+    monkeypatch.setattr(doctor_cmd.shutil, "which", lambda name: "/usr/local/bin/vale")
+    ok, msg = doctor_cmd._check_vale(".")
+    assert ok is True
+    assert "/usr/local/bin/vale" in msg

--- a/tests/test_hooks_v2.py
+++ b/tests/test_hooks_v2.py
@@ -326,6 +326,23 @@ def test_session_start_no_lore_config_emits_attach_hint(fake_vault, tmp_path, mo
     out = hooks._session_start(str(repo_dir))
     assert "no `## Lore` attach block" in out
     assert "lore install" in out
+    # AC2 regression guard: an unattached repo's banner must not gain
+    # the register directive — only attached repos get it.
+    assert "## Directive" not in out
+    assert "issue-register" not in out
+
+
+def test_session_start_no_vault_emits_no_vault_hint(tmp_path, monkeypatch):
+    """No wiki mount at all (``$LORE_ROOT`` unset/missing) → the "no
+    vault" hint, and — like the other unattached paths — no directive."""
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path / "does-not-exist"))
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    out = hooks._session_start(str(repo_dir))
+    assert out.startswith("lore: no vault at")
+    assert "## Directive" not in out
+    assert "issue-register" not in out
 
 
 def test_session_start_from_lore_missing_wiki_emits_attach_hint(
@@ -343,3 +360,5 @@ def test_session_start_from_lore_missing_wiki_emits_attach_hint(
 
     out = hooks._session_start(str(repo_dir))
     assert "no `## Lore` attach block" in out
+    assert "## Directive" not in out
+    assert "issue-register" not in out

--- a/tests/test_style_register.py
+++ b/tests/test_style_register.py
@@ -1,0 +1,179 @@
+"""`lore style show <name>` — whole-file resolution and default-register content.
+
+Resolution is whole-file per wiki: `<wiki>/style/<name>.md` wins, else the
+packaged default. Content tests pin the three edits that separate the shipped
+register from its draft.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from lore_cli.__main__ import app
+from lore_core.style import KNOWN_STYLES, UnknownStyle, resolve_style_path
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def lore_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    (tmp_path / "wiki" / "notes").mkdir(parents=True)
+    return tmp_path
+
+
+def _default_text() -> str:
+    return resolve_style_path("issue-register").read_text()
+
+
+# --- resolution ---------------------------------------------------------
+
+
+def test_known_styles_lists_the_issue_register() -> None:
+    assert "issue-register" in KNOWN_STYLES
+
+
+def test_default_resolves_to_packaged_file(tmp_path: Path) -> None:
+    path = resolve_style_path("issue-register", wiki_dir=tmp_path)
+    assert path.is_file()
+    assert path.read_text().startswith("# Issue Register")
+
+
+def test_wiki_override_wins(tmp_path: Path) -> None:
+    override = tmp_path / "style" / "issue-register.md"
+    override.parent.mkdir(parents=True)
+    override.write_text("# Our register\n")
+    assert resolve_style_path("issue-register", wiki_dir=tmp_path) == override
+
+
+def test_packaged_default_lives_outside_the_templates_tree() -> None:
+    """`lore init` copytree's templates/ into the vault — a copy of the register
+    there would look editable while the resolver ignores it."""
+    from lore_core.templates import templates_dir
+
+    assert templates_dir() not in resolve_style_path("issue-register").parents
+
+
+def test_unknown_style_raises_and_names_the_known_ones() -> None:
+    with pytest.raises(UnknownStyle) as exc:
+        resolve_style_path("prose-register")
+    assert "issue-register" in str(exc.value)
+
+
+# --- CLI ----------------------------------------------------------------
+
+
+def test_show_prints_the_packaged_default(lore_root: Path) -> None:
+    result = runner.invoke(app, ["style", "show", "issue-register"])
+    assert result.exit_code == 0, result.output
+    assert "# Issue Register" in result.output
+    assert "## Batch issues" in result.output
+
+
+def test_show_prints_the_wiki_override(lore_root: Path) -> None:
+    override = lore_root / "wiki" / "notes" / "style" / "issue-register.md"
+    override.parent.mkdir(parents=True)
+    override.write_text("# Our own register\n")
+    result = runner.invoke(app, ["style", "show", "issue-register", "--wiki", "notes"])
+    assert result.exit_code == 0, result.output
+    assert "Our own register" in result.output
+    assert "## Batch issues" not in result.output
+
+
+def test_show_falls_back_to_default_when_the_wiki_has_no_override(lore_root: Path) -> None:
+    result = runner.invoke(app, ["style", "show", "issue-register", "--wiki", "notes"])
+    assert result.exit_code == 0, result.output
+    assert "# Issue Register" in result.output
+
+
+def test_show_uses_the_wiki_resolved_from_cwd(lore_root: Path, monkeypatch) -> None:
+    """No `--wiki`: the wiki comes from the attached scope of the cwd."""
+    from lore_core.types import Scope
+
+    override = lore_root / "wiki" / "notes" / "style" / "issue-register.md"
+    override.parent.mkdir(parents=True)
+    override.write_text("# Scope-resolved register\n")
+    monkeypatch.setattr(
+        "lore_cli.style_cmd.resolve_scope",
+        lambda cwd: Scope(
+            wiki="notes",
+            scope="notes:x",
+            backend="none",
+            claude_md_path=Path("/nowhere/CLAUDE.md"),
+        ),
+    )
+    result = runner.invoke(app, ["style", "show", "issue-register"])
+    assert result.exit_code == 0, result.output
+    assert "Scope-resolved register" in result.output
+
+
+def test_show_unknown_style_exits_nonzero_and_names_known_styles(lore_root: Path) -> None:
+    result = runner.invoke(app, ["style", "show", "prose-register"])
+    assert result.exit_code != 0
+    assert "issue-register" in result.output
+
+
+def test_show_prints_the_file_verbatim(lore_root: Path) -> None:
+    """No Rich markup interpretation, no reflow — a linter reads this text."""
+    override = lore_root / "wiki" / "notes" / "style" / "issue-register.md"
+    override.parent.mkdir(parents=True)
+    long_line = "- Banned: [leverage] " + "word " * 40
+    override.write_text(long_line + "\n")
+    result = runner.invoke(app, ["style", "show", "issue-register", "--wiki", "notes"])
+    assert result.exit_code == 0, result.output
+    assert long_line in result.output
+
+
+# --- default register content -------------------------------------------
+
+
+def test_register_defines_change_and_batch_issue() -> None:
+    text = _default_text()
+    assert "## Batch issues" in text
+    section = text.split("## Batch issues", 1)[1].split("\n## ", 1)[0]
+    assert "**Change**" in section
+    assert "**Batch issue**" in section
+    assert "acceptance criteria" in section
+    assert "one PR" in section
+
+
+def test_rule_14_accepts_code_flavored_provenance() -> None:
+    rule = next(line for line in _default_text().splitlines() if line.startswith("14. "))
+    for form in ("file path", "command output", "test name"):
+        assert form in rule, rule
+
+
+def test_checkability_claim_is_honest() -> None:
+    text = _default_text()
+    # The draft's over-claim must be gone.
+    assert "Rules 3, 4, 6, 9, 10 and 12 are mechanically checkable" not in text
+    claims = text.split("## EARS patterns", 1)[0]
+    linted = next(line for line in claims.splitlines() if "lints rules" in line)
+    assert re.search(r"rules 3 and 6", linted)
+    assert re.search(r"[Rr]ules 9 and 12 .*heuristic", claims)
+    assert re.search(r"[Rr]ules 4 and 10 .*review", claims)
+
+
+def test_register_keeps_the_paste_block_for_consumers_without_lore() -> None:
+    text = _default_text()
+    assert "## Block for CLAUDE.md and AGENTS.md" in text
+    assert "## Issue writing" in text
+
+
+def test_register_keeps_the_ears_patterns_and_section_skeleton() -> None:
+    text = _default_text()
+    assert "## EARS patterns for acceptance criteria" in text
+    assert "## Required issue structure" in text
+    for heading in ("## Context", "## Current behaviour", "## Acceptance criteria"):
+        assert heading in text
+
+
+def test_context_md_defines_the_new_terms() -> None:
+    text = (REPO_ROOT / "CONTEXT.md").read_text()
+    for term in ("**Register**", "**Change**", "**Batch issue**"):
+        assert term in text, term

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -1,0 +1,107 @@
+"""Tests for the packaged Vale style: resolution, `lore style vale-config`,
+and the real-binary integration.
+
+Vale is PATH-detected and not bundled with Lore (ADR 0006). The integration
+tests below run the actual binary against a fixture with one banned word and
+one 30-word sentence, and skip when Vale is absent — see PRD 0009's testing
+decisions.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from lore_cli.__main__ import app
+from lore_core.style import default_vale_config_path, resolve_vale_config_path
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+VALE_MISSING = shutil.which("vale") is None
+
+
+@pytest.fixture()
+def lore_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    (tmp_path / "wiki" / "notes").mkdir(parents=True)
+    return tmp_path
+
+
+# --- resolution ----------------------------------------------------------
+
+
+def test_default_vale_config_path_is_a_packaged_ini() -> None:
+    path = default_vale_config_path()
+    assert path.is_file()
+    assert path.name == "vale.ini"
+
+
+def test_resolve_falls_back_to_packaged_default(tmp_path: Path) -> None:
+    assert resolve_vale_config_path(wiki_dir=tmp_path) == default_vale_config_path()
+
+
+def test_wiki_vale_override_wins(tmp_path: Path) -> None:
+    override = tmp_path / "style" / "vale" / "vale.ini"
+    override.parent.mkdir(parents=True)
+    override.write_text("StylesPath = .\n")
+    assert resolve_vale_config_path(wiki_dir=tmp_path) == override
+
+
+def test_resolve_with_no_wiki_dir_returns_packaged_default() -> None:
+    assert resolve_vale_config_path(wiki_dir=None) == default_vale_config_path()
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def test_vale_config_cli_prints_the_packaged_default_path(lore_root: Path) -> None:
+    result = runner.invoke(app, ["style", "vale-config"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == str(default_vale_config_path())
+
+
+def test_vale_config_cli_prints_the_wiki_override_path(lore_root: Path) -> None:
+    override = lore_root / "wiki" / "notes" / "style" / "vale" / "vale.ini"
+    override.parent.mkdir(parents=True)
+    override.write_text("StylesPath = .\n")
+    result = runner.invoke(app, ["style", "vale-config", "--wiki", "notes"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == str(override)
+
+
+def test_vale_config_cli_falls_back_when_wiki_has_no_override(lore_root: Path) -> None:
+    result = runner.invoke(app, ["style", "vale-config", "--wiki", "notes"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == str(default_vale_config_path())
+
+
+# --- real-binary integration (skipped when Vale is not on PATH) -----------
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_vale_flags_a_banned_word(tmp_path: Path) -> None:
+    fixture = tmp_path / "issue.md"
+    fixture.write_text("# Title\n\nWe should leverage the existing system.\n")
+    result = subprocess.run(
+        ["vale", "--config", str(default_vale_config_path()), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert "leverage" in result.stdout.lower()
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_vale_flags_a_sentence_over_25_words(tmp_path: Path) -> None:
+    fixture = tmp_path / "issue.md"
+    long_sentence = " ".join(["word"] * 30) + ".\n"
+    fixture.write_text(f"# Title\n\n{long_sentence}")
+    result = subprocess.run(
+        ["vale", "--config", str(default_vale_config_path()), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert "sentence" in result.stdout.lower()
+    assert result.returncode != 0

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -9,13 +9,19 @@ decisions.
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 from lore_cli.__main__ import app
-from lore_core.style import default_vale_config_path, resolve_vale_config_path
+from lore_core.style import (
+    default_style_path,
+    default_vale_config_path,
+    resolve_vale_config_path,
+)
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -76,6 +82,40 @@ def test_vale_config_cli_falls_back_when_wiki_has_no_override(lore_root: Path) -
     result = runner.invoke(app, ["style", "vale-config", "--wiki", "notes"])
     assert result.exit_code == 0, result.output
     assert result.output.strip() == str(default_vale_config_path())
+
+
+# --- banned-word list stays single-sourced --------------------------------
+
+
+def _listed_after(marker: str, text: str) -> list[str]:
+    """The comma-separated words a `<marker>: a, b, c.` run names, unwrapped
+    across line breaks."""
+    match = re.search(rf"{re.escape(marker)}(.*?)\.", text, re.DOTALL)
+    assert match, f"the register lost its '{marker}' list"
+    return [w.strip() for w in match.group(1).split(",")]
+
+
+def _register_text() -> str:
+    return default_style_path("issue-register").read_text(encoding="utf-8")
+
+
+def _vocabulary_tokens() -> list[str]:
+    path = default_vale_config_path().parent / "IssueRegister" / "Vocabulary.yml"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))["tokens"]
+
+
+def test_vocabulary_rule_matches_the_register_banned_list() -> None:
+    """Rule 3's words, the Vale tokens that enforce them, and the paste block's
+    copy are three hand-synced lists — drift between them means the linter and
+    the register disagree about what is banned."""
+    banned = _listed_after("Banned:", _register_text())
+    assert _vocabulary_tokens() == banned
+
+
+def test_paste_block_repeats_the_register_banned_list() -> None:
+    text = _register_text()
+    paste = text.split("## Block for CLAUDE.md and AGENTS.md", 1)[1]
+    assert _listed_after("Do not use:", paste) == _listed_after("Banned:", text)
 
 
 # --- real-binary integration (skipped when Vale is not on PATH) -----------

--- a/tests/test_workflow_issue_register_wiring.py
+++ b/tests/test_workflow_issue_register_wiring.py
@@ -3,7 +3,7 @@
 PRD 0009 says to test external behaviour, not skill wording, so nothing here
 asserts prose. What is asserted is the machine-consumed part:
 
-- the four filing skills point at the funnel instead of prescribing filing,
+- the filing skills point at the funnel instead of prescribing filing,
 - `to-epic`'s sub-issue template carries the register's own section skeleton,
 - and an epic body composed from that template's linkage fields still passes
   the roadmap validator, which is what `orchestrate-epic` reads.
@@ -22,7 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_ROOT = REPO_ROOT / "lore-workflow" / "skills"
 
 # Every skill that writes issue or PR text. `file-issue` itself is the funnel.
-FILING_SKILLS = ("to-epic", "seed-epic", "orchestrate-epic", "implement-issue")
+FILING_SKILLS = ("to-epic", "seed-epic", "orchestrate-epic", "implement-issue", "brief")
 
 # Linkage fields the roadmap table's columns are built from. Losing one of
 # these from the sub-issue template leaves `to-epic` without the data the

--- a/tests/test_workflow_issue_register_wiring.py
+++ b/tests/test_workflow_issue_register_wiring.py
@@ -1,0 +1,127 @@
+"""The writing skills file through the `file-issue` funnel (sub-issue #309).
+
+PRD 0009 says to test external behaviour, not skill wording, so nothing here
+asserts prose. What is asserted is the machine-consumed part:
+
+- the four filing skills point at the funnel instead of prescribing filing,
+- `to-epic`'s sub-issue template carries the register's own section skeleton,
+- and an epic body composed from that template's linkage fields still passes
+  the roadmap validator, which is what `orchestrate-epic` reads.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from lore_core.style import default_style_path
+from lore_workflow import roadmap_validator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_ROOT = REPO_ROOT / "lore-workflow" / "skills"
+
+# Every skill that writes issue or PR text. `file-issue` itself is the funnel.
+FILING_SKILLS = ("to-epic", "seed-epic", "orchestrate-epic", "implement-issue")
+
+# Linkage fields the roadmap table's columns are built from. Losing one of
+# these from the sub-issue template leaves `to-epic` without the data the
+# validator requires.
+ROADMAP_FIELDS = ("Repo", "Type", "Blocked by")
+
+_SECTION = re.compile(r"^## (.+)$", re.M)
+
+
+def _skill_text(name: str) -> str:
+    return (SKILLS_ROOT / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _block(text: str, tag: str) -> str:
+    match = re.search(rf"<{tag}>\n(.*?)\n</{tag}>", text, re.DOTALL)
+    assert match, f"missing <{tag}> block"
+    return match.group(1)
+
+
+def _sections(text: str) -> list[str]:
+    return _SECTION.findall(text)
+
+
+def _register_skeleton() -> list[str]:
+    """The section list the resolved register requires, read from the register
+    itself rather than restated here — an override changes both together."""
+    register = default_style_path("issue-register").read_text(encoding="utf-8")
+    match = re.search(r"## Required issue structure\n+```\n(.*?)```", register, re.DOTALL)
+    assert match, "the register lost its 'Required issue structure' block"
+    return _sections(match.group(1))
+
+
+def _field(body: str, heading: str) -> str:
+    """First non-empty line under ``## <heading>``."""
+    match = re.search(rf"^## {re.escape(heading)}$\n+(.+)$", body, re.M)
+    assert match, f"rendered sub-issue has no '## {heading}' section"
+    return match.group(1).strip()
+
+
+def _render_sub_issue(values: dict[str, str]) -> str:
+    """Render a sub-issue from the template's own section list, so a section
+    dropped from the template is a section missing from the render."""
+    sections = _sections(_block(_skill_text("to-epic"), "sub-issue-template"))
+    return "\n\n".join(
+        f"## {name}\n{values.get(name, 'Filled by the drafting session.')}" for name in sections
+    )
+
+
+@pytest.mark.parametrize("skill", FILING_SKILLS)
+def test_filing_skills_point_at_the_funnel(skill: str) -> None:
+    assert "../file-issue/SKILL.md" in _skill_text(skill), (
+        f"{skill}/SKILL.md must route its filing through the file-issue funnel"
+    )
+
+
+def test_sub_issue_template_carries_the_register_skeleton() -> None:
+    template = _block(_skill_text("to-epic"), "sub-issue-template")
+    present = _sections(template)
+    missing = [s for s in _register_skeleton() if s not in present]
+    assert not missing, f"sub-issue template is missing register sections: {missing}"
+
+
+def test_sub_issue_template_keeps_the_epic_linkage_header() -> None:
+    present = _sections(_block(_skill_text("to-epic"), "sub-issue-template"))
+    missing = [s for s in ("Epic", *ROADMAP_FIELDS) if s not in present]
+    assert not missing, f"sub-issue template is missing linkage sections: {missing}"
+
+
+def test_epic_body_composed_from_the_template_passes_the_validator() -> None:
+    """The acceptance criterion: compose the roadmap table out of what the new
+    sub-issue template carries, and the validator accepts it."""
+    subs = [
+        _render_sub_issue(
+            {
+                "Epic": "ccatobs/widget#11",
+                "Repo": "widget",
+                "Type": "AFK",
+                "Blocked by": blocked,
+            }
+        )
+        for blocked in ("None — can start immediately.", "#12", "#12, #13")
+    ]
+    rows = []
+    for number, sub in enumerate(subs, start=12):
+        blocked = _field(sub, "Blocked by")
+        rows.append(
+            f"| {number - 11} | Feature {number - 11} | ccatobs/widget#{number} "
+            f"| {_field(sub, 'Repo')} | {_field(sub, 'Type')} "
+            f"| {'—' if blocked.startswith('None') else blocked} |"
+        )
+    epic_body = "\n".join(
+        [
+            "## Roadmap",
+            "",
+            "| # | Feature | Issue | Repo | Type | Blocked by |",
+            "|---|---------|-------|------|------|------------|",
+            *rows,
+        ]
+    )
+    result = roadmap_validator.validate_roadmap(epic_body)
+    assert result.ok, f"composed epic body must validate; problems={result.problems}"
+    assert len(result.rows) == 3

--- a/tests/test_workflow_plugin_structural.py
+++ b/tests/test_workflow_plugin_structural.py
@@ -39,6 +39,7 @@ EXPECTED_SKILL_NAMES = {
     "debug",
     "document-epic",
     "domain-modeling",
+    "file-issue",
     "grilling",
     "implement-issue",
     "orchestrate-epic",


### PR DESCRIPTION
Lands epic #310 — the issue register.

Lore ships a default prose register for agent-written issue and PR text. A team
overrides it with one file in its wiki. One command resolves it, the SessionStart
banner points at that command, Vale lints drafts at generation time, and one
`file-issue` skill funnels all lore-workflow filing.

**PRD:** `docs/prd/0009-issue-register.md` · **ADR:** `docs/adr/0006-issue-register-whole-file-override-generation-time-lint.md`

## Slices

| Feature | Issue | PR |
|---|---|---|
| Default register + `lore style show` resolution | #305 | #314 |
| SessionStart directive + conventions pointer | #306 | #315 |
| Default Vale style + doctor check | #307 | #316 |
| file-issue funnel skill | #308 | #317 |
| Route the writing skills through file-issue | #309 | #318 |

Closes #305, closes #306, closes #307, closes #308, closes #309, closes #310.

## State

Every feature PR passed a delegated strong-tier crosscheck before merging into
`epic/310`. Two needed a fix round: #315 (an acceptance criterion had no test —
the reviewer proved it by injecting the regression and watching the suite stay
green) and #317 (the lint loop could silently lint nothing).

CI is green on the epic branch. The `test_workflow_docs_drift` failure inherited
from `main` — the PRD cited `lore-workflow:file-issue` before the skill existed,
per the docs-pre-land pattern — cleared when #308 shipped that skill.

Includes `chore: release 0.65.0` (lore 0.64.0 → 0.65.0, lore-workflow 0.3.0 → 0.4.0).

## Known follow-up

`file-issue` drafts to a fixed path, `${TMPDIR:-/tmp}/lore-file-issue.md`. Two
sessions filing concurrently under the same TMPDIR would overwrite each other's
draft. A per-run suffix derived from the issue slug would restore isolation
without reintroducing the cross-shell variable that the fixed path removed.
