### PR TITLE
Close the issue register's cross-feature gaps

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -315,6 +315,11 @@ Terms used in the workflow layer and orchestration:
   a team overrides it whole-file with `<wiki>/style/issue-register.md`.
   `lore style show issue-register` resolves the two. The register fixes
   style, not terminology — terminology stays with the glossary.
+  Overriding the lint means copying `styles/vale/` whole — the ini plus
+  its `IssueRegister/` rule directory — into `<wiki>/style/vale/`. Vale
+  resolves `StylesPath` next to the ini, so an override that copies the
+  ini alone exits 2 with "style 'IssueRegister' does not exist on
+  StylesPath".
 - **Change** — the unit a register-conforming issue describes: one
   required-behaviour statement with its own acceptance criteria.
 - **Batch issue** — an issue carrying several changes under one Context

--- a/docs/how-to/write-a-fast-path-issue.md
+++ b/docs/how-to/write-a-fast-path-issue.md
@@ -4,6 +4,10 @@
 (`/lore-workflow:implement-issue`) can pick up and implement directly, with
 no back-and-forth.
 
+Run `lore style show issue-register` and follow its section skeleton and EARS
+acceptance criteria. The register is the source of truth for issue-body
+prose; the points below are what the fast path additionally needs.
+
 The fast path reads the issue and the code map, then — only if the issue is
 ambiguous — asks **at most three** clarifying questions before it starts. A
 well-written issue spends none of that budget: the skill reads it, locates
@@ -11,22 +15,15 @@ the symbols in `CODEMAP.md`, and goes straight to test-first implementation.
 A vague one either burns the three questions or, worse, ships the wrong
 thing.
 
-## What a good fast-path issue contains
+## What the fast path adds to the register
 
 - **One change, clearly scoped.** The fast path is one issue, one branch,
   one pull request. If the issue describes several features, it belongs on
   the [epic chain](run-an-epic.md), not here. Split it.
-- **Unambiguous intent.** State what should change and why in plain
-  sentences. The reader should not have to guess the goal.
-- **Concrete acceptance criteria.** List what "done" means as checkable
-  statements — the behaviour a test could assert. These become the
-  test-first targets; without them the skill has to invent them.
-- **Pointers into the code.** Name the command, module, or symbol the
-  change touches. You do not need file-and-line precision — the code map
-  resolves symbols — but naming the entry point removes a whole class of
-  ambiguity.
-- **Out-of-scope notes where they help.** If there is an obvious adjacent
-  change you do *not* want, say so. It keeps the single pull request tight.
+- **Pointers into the code.** Under "References", name the command, module,
+  or symbol the change touches. You do not need file-and-line precision —
+  the code map resolves symbols — but naming the entry point removes a whole
+  class of ambiguity.
 
 ## What to leave out
 
@@ -37,11 +34,10 @@ thing.
 
 ## Checklist
 
+- [ ] The register's sections filled, acceptance criteria in EARS.
 - [ ] One change, small and clear.
-- [ ] Intent stated plainly.
-- [ ] Acceptance criteria a test could check.
-- [ ] The touched command / module / symbol named.
-- [ ] Anything deliberately out of scope called out.
+- [ ] The touched command / module / symbol named under "References".
+- [ ] Nothing in it that belongs on the epic chain.
 
 ## Done when
 

--- a/lib/lore_core/styles/issue-register.md
+++ b/lib/lore_core/styles/issue-register.md
@@ -203,7 +203,8 @@ Paste this into the agent instruction file so that generated issues arrive in th
 ## Issue writing
 
 When you write or edit an issue, a PR description, or an ADR context section,
-follow lore/style/issue-register.md. In short:
+follow the issue register (`lore style show issue-register`, or the copy your team
+pasted below). In short:
 
 - Use the required section structure. Keep empty sections.
 - One term, one meaning. Take terms from the glossary. Do not invent domain

--- a/lore-workflow/skills/brief/SKILL.md
+++ b/lore-workflow/skills/brief/SKILL.md
@@ -66,8 +66,8 @@ Reuse the existing gates verbatim — no new document types:
 
 On confirmation, pick one:
 
-- **(a) File an issue and run the fast track** — `gh issue create` capturing the agreed
-  brief (intent + acceptance criteria), then invoke
+- **(a) File an issue and run the fast track** — file the agreed brief (intent +
+  acceptance criteria) through [`file-issue`](../file-issue/SKILL.md), then invoke
   [`/lore-workflow:implement-issue`](../implement-issue/SKILL.md) on it. Default for
   anything that benefits from a durable tracker entry.
 - **(b) Implement directly with [`/lore-workflow:tdd`](../tdd/SKILL.md)** — when even an

--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -127,9 +127,10 @@ Report every URL you created back to the caller.
 ## Callers
 
 [`to-epic`](../to-epic/SKILL.md), [`seed-epic`](../seed-epic/SKILL.md),
-[`orchestrate-epic`](../orchestrate-epic/SKILL.md) follow-ups, and
-[`implement-issue`](../implement-issue/SKILL.md) file through this skill instead of
-writing issue bodies inline.
+[`brief`](../brief/SKILL.md), [`implement-issue`](../implement-issue/SKILL.md), and
+[`orchestrate-epic`](../orchestrate-epic/SKILL.md) — both its follow-ups and the PR
+bodies its teammates open — file through this skill instead of writing issue or PR
+bodies inline.
 
 Machine-readable text stays exempt: roadmap tables, board comments, and reviewer
 verdicts are parsed, not read, so the register does not apply to them.

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -198,8 +198,9 @@ Report.
 > Sibling-write hazard: parallel teammates in separate worktrees under one session can share an isolation
 > pointer, so in-place editor writes (Edit/Write) from one can clobber another. Apply file changes via shell
 > (heredoc or scripted edits) at absolute paths instead.
-> Deliver: push, open the PR linking #<n>, report the PR number, red→green evidence, and a one-paragraph
-> summary of changes and any decisions you made.
+> Deliver: push, write the PR body through `/lore-workflow:file-issue` in PR-body mode, open the PR from
+> that file linking #<n>, report the PR number, red→green evidence, and a one-paragraph summary of
+> changes and any decisions you made.
 
 ## Stop conditions (escalate, pause that branch only)
 A feature flagged HITL; a teammate failing crosscheck after 2 fix rounds; an ambiguous spec needing a

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -9,13 +9,19 @@ decisions.
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 from lore_cli.__main__ import app
-from lore_core.style import default_vale_config_path, resolve_vale_config_path
+from lore_core.style import (
+    default_style_path,
+    default_vale_config_path,
+    resolve_vale_config_path,
+)
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -76,6 +82,40 @@ def test_vale_config_cli_falls_back_when_wiki_has_no_override(lore_root: Path) -
     result = runner.invoke(app, ["style", "vale-config", "--wiki", "notes"])
     assert result.exit_code == 0, result.output
     assert result.output.strip() == str(default_vale_config_path())
+
+
+# --- banned-word list stays single-sourced --------------------------------
+
+
+def _listed_after(marker: str, text: str) -> list[str]:
+    """The comma-separated words a `<marker>: a, b, c.` run names, unwrapped
+    across line breaks."""
+    match = re.search(rf"{re.escape(marker)}(.*?)\.", text, re.DOTALL)
+    assert match, f"the register lost its '{marker}' list"
+    return [w.strip() for w in match.group(1).split(",")]
+
+
+def _register_text() -> str:
+    return default_style_path("issue-register").read_text(encoding="utf-8")
+
+
+def _vocabulary_tokens() -> list[str]:
+    path = default_vale_config_path().parent / "IssueRegister" / "Vocabulary.yml"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))["tokens"]
+
+
+def test_vocabulary_rule_matches_the_register_banned_list() -> None:
+    """Rule 3's words, the Vale tokens that enforce them, and the paste block's
+    copy are three hand-synced lists — drift between them means the linter and
+    the register disagree about what is banned."""
+    banned = _listed_after("Banned:", _register_text())
+    assert _vocabulary_tokens() == banned
+
+
+def test_paste_block_repeats_the_register_banned_list() -> None:
+    text = _register_text()
+    paste = text.split("## Block for CLAUDE.md and AGENTS.md", 1)[1]
+    assert _listed_after("Do not use:", paste) == _listed_after("Banned:", text)
 
 
 # --- real-binary integration (skipped when Vale is not on PATH) -----------

--- a/tests/test_workflow_issue_register_wiring.py
+++ b/tests/test_workflow_issue_register_wiring.py
@@ -3,7 +3,7 @@
 PRD 0009 says to test external behaviour, not skill wording, so nothing here
 asserts prose. What is asserted is the machine-consumed part:
 
-- the four filing skills point at the funnel instead of prescribing filing,
+- the filing skills point at the funnel instead of prescribing filing,
 - `to-epic`'s sub-issue template carries the register's own section skeleton,
 - and an epic body composed from that template's linkage fields still passes
   the roadmap validator, which is what `orchestrate-epic` reads.
@@ -22,7 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_ROOT = REPO_ROOT / "lore-workflow" / "skills"
 
 # Every skill that writes issue or PR text. `file-issue` itself is the funnel.
-FILING_SKILLS = ("to-epic", "seed-epic", "orchestrate-epic", "implement-issue")
+FILING_SKILLS = ("to-epic", "seed-epic", "orchestrate-epic", "implement-issue", "brief")
 
 # Linkage fields the roadmap table's columns are built from. Losing one of
 # these from the sub-issue template leaves `to-epic` without the data the


### PR DESCRIPTION
Applies the five findings from the whole-epic cross-feature review on #319. Epic #310.

## What changed

**1. The funnel claim is now true.** `file-issue` states that every workflow skill filing an issue or a PR body routes through it. Two callers still filed inline. `brief` step 5(a) is one, and it is the default branch of the most common medium-weight path. The teammate brief in `orchestrate-epic` is the other; it had teammates open PRs with an inline body. Both now route through the funnel. `brief` joins `FILING_SKILLS` in `tests/test_workflow_issue_register_wiring.py`; `orchestrate-epic` was already in that list. `file-issue`'s `## Callers` section lists the five callers and names both `orchestrate-epic` call sites.

`orchestrate-epic`'s machine-read formats are byte-identical: the roadmap table, the `lore-orchestrate-epic:status` board comment and its columns, and the reviewer verdict block.

**2. The fast-path how-to no longer teaches a competing shape.** `docs/how-to/write-a-fast-path-issue.md` opens with `lore style show issue-register` and keeps only what the fast path adds to the register: one change, and code pointers under "References". Three list items restated register rules and are gone: unambiguous intent, concrete acceptance criteria, and optional out-of-scope notes. The last one contradicted the register, which requires the section.

**3. The paste block cites the resolver.** The register said "follow lore/style/issue-register.md". No such path exists in the shipped model. The block now names `lore style show issue-register` and the pasted copy.

**4. The banned-word list has a guard.** The 16 words live in register rule 3, the register's paste block, and `Vocabulary.yml`. Two tests in `tests/test_vale_style.py` parse all three lists and compare them. The test hardcodes no word, so it adds no fourth copy.

**5. The Vale override is documented.** `CONTEXT.md`'s Register entry states that overriding the lint means copying `styles/vale/` whole, and names the exit code and message an ini-only override produces.

## Evidence

Test run pins `PYTHONPATH` at this worktree's `lib`.

- Full suite: 2839 passed, 18 skipped, 3 failed. Base was 2836 passed with the same 3 failures: `tests/test_core_llm_wiring.py` twice and `tests/test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`. The 3 new passes are the `brief` parameter and the two list-sync tests.
- Red first on finding 1: `test_filing_skills_point_at_the_funnel[brief]` failed with "brief/SKILL.md must route its filing through the file-issue funnel", then passed after the edit.
- The finding 4 guards match today, so drift was injected to prove they bite. A token added to `Vocabulary.yml`, and one word dropped from rule 3, failed both tests. Both files were restored.
- Finding 5 was reproduced with Vale 3.17.0. An override holding only `vale.ini` exits 2 with "style 'IssueRegister' does not exist on StylesPath". The same override with `IssueRegister/` copied alongside exits 1 and reports the planted banned word.
- With Vale on PATH, the 2 skipped integration tests in `tests/test_vale_style.py` run: 11 passed.
- The edited register lints to the same 22 errors and 3 warnings as the base register. The register trips its own rules where it quotes the banned words and the bad example.
- `ruff check` and `ruff format --check` are clean on both changed test files.

## Judgement calls

- The teammate brief in `orchestrate-epic` uses `/lore-workflow:file-issue`, not the relative `../file-issue/SKILL.md` link the other callers use. That block is pasted to an agent in another worktree, where a relative link resolves to nothing. The block already refers to `/lore-workflow:tdd` and `/lore-workflow:debug` in the same form.
- The paste block's copy of the banned words is asserted as well as `Vocabulary.yml`. The assertion is the same parse. A paste block that disagrees with rule 3 misleads every foreign agent reading the block.
