### PR TITLE
docs: how-to and explanation for the issue register (#310)

### DIFF
--- a/docs/explanation/why-the-issue-register.md
+++ b/docs/explanation/why-the-issue-register.md
@@ -1,0 +1,89 @@
+# Why the issue register is a document, not config
+
+The **issue register** fixes the prose style for issue text, PR descriptions,
+and ADR context sections. Lore ships one default. A team replaces it with one
+file in its wiki. This page explains three choices. Why the register is a prose
+document rather than a settings block. Why a team's copy wins whole rather than
+merging. Why the lint runs when the text is written, not when it is committed.
+
+The decisions here are recorded in
+[ADR 0006](../adr/0006-issue-register-whole-file-override-generation-time-lint.md).
+
+## The problem it solves
+
+Agent-written issues read polished and cost readers real effort. An
+international team converges on a shared subset of English. Agents pull toward
+a wider vocabulary, denser sentences, and context that existed only in the
+session that wrote the issue.
+
+A review of four agent-written issues found the concrete failures. No shared
+section structure. No acceptance criteria. Sentences over 30 words. Epic
+context assumed instead of stated. Vocabulary was not the failure — the
+banned-word list scored zero hits.
+
+The failure that matters is structural. A confident sentence written over a
+missing fact survives review far too easily.
+
+## Why a document
+
+The rules are prose because they are read by a language model and by people,
+and because most of them cannot be expressed as settings. "Name where every
+observation came from" and "do not fill a gap with a plausible guess" are
+judgement, not flags. A settings block would capture the banned-word list and
+the sentence cap, which are the least valuable rules, and drop the rest.
+
+Shipping a document also means the register can carry a worked example. The
+default register shows one issue before and after. An example teaches a style
+faster than a rule list does.
+
+## Why whole-file override
+
+A team's copy replaces the default entirely. Nothing merges.
+
+Merging a rules essay is ill-defined. Two documents that both describe how to
+open a sentence do not combine into one coherent instruction. They combine into
+a contradiction the reader has to resolve. Whole-file resolution also leaves no
+cascade to debug — one lookup answers "which register applies here", and the
+answer is a path you can open.
+
+The cost is that customizing means copying the default and editing it, and a
+team that does so stops inheriting later improvements to the default. That
+trade is deliberate: a register that silently changes under a team is worse
+than one they own.
+
+There is no per-repo layer for the same reason. The register belongs to a
+team, and a team's wiki is where its shared conventions already live.
+
+## Why lint at generation time
+
+Vale runs when an agent drafts the text, not when a commit lands.
+
+A lint that runs in CI catches the problem after the issue is filed. By then a
+fix means editing a body that people have already read. A lint that runs at
+generation time catches it while the draft is still a temp file. The agent
+rewrites and reruns before anything is posted.
+
+This also keeps the lint honest about what it can check. Only two rules are
+mechanically decidable: banned words and sentence length. Two more are
+regex heuristics that over-fire — a rule against participial openers also flags
+a heading like `## Testing decisions`. The rest are review-only. Vale reports
+the heuristics as warnings and exits 0, so an over-fire never blocks a correct
+sentence, and the fix loop cannot spin on one.
+
+Vale is not bundled. It is a single binary, detected on `PATH`. When it is
+absent the register still applies as instructions and nothing blocks. Lore
+degrades to the weaker enforcement rather than failing.
+
+## What the register does not do
+
+It does not fix terminology. One term with one meaning is a glossary problem,
+and the glossary is a separate artifact.
+
+It does not decide what is worth filing. The `file-issue` skill owns how to
+write and file; the caller decides what to capture. A funnel that second-
+guessed the caller's judgement would turn every capture into a negotiation.
+
+## Related
+
+- [Customize the issue register](../how-to/customize-the-issue-register.md)
+- [Why the PRD lives in the repo](why-prd-in-repo.md)

--- a/docs/how-to/customize-the-issue-register.md
+++ b/docs/how-to/customize-the-issue-register.md
@@ -1,0 +1,85 @@
+# Customize the issue register
+
+**Goal:** replace the issue register, the prose style agents write issue and PR
+text against, with your team's own — and, if you lint, replace the Vale rules
+that check it.
+
+Lore ships a default register as package data. A wiki overrides it with one
+file. Resolution is whole-file: your file wins entirely, or the packaged
+default does. There is no merge and no per-repo layer.
+
+## Before you start
+
+- `lore` installed and the repo `lore attach`ed to a wiki.
+- Vale on `PATH`, only if you want the lint step. `lore doctor` reports whether
+  Vale is present. Its absence never blocks; the register still applies as
+  instructions.
+
+## Steps
+
+1. **Read the register that applies today.**
+
+   ```
+   lore style show issue-register
+   ```
+
+   Without an override the command prints the packaged default. The command
+   always prints something, so an agent always has a style to follow.
+
+2. **Copy it into your wiki and edit it.**
+
+   ```
+   lore style show issue-register > "$LORE_ROOT/wiki/<name>/style/issue-register.md"
+   ```
+
+   Create the `style/` directory first if it does not exist. Edit the copy.
+   Re-run `lore style show issue-register` from a repo attached to that wiki
+   and confirm your text comes back.
+
+3. **Override the Vale rules, if you lint.**
+
+   The Vale config resolves the same way:
+
+   ```
+   lore style vale-config
+   ```
+
+   Copy the whole packaged `styles/vale/` directory, not the `vale.ini` alone:
+
+   ```
+   cp -r "$(dirname "$(lore style vale-config)")" "$LORE_ROOT/wiki/<name>/style/vale"
+   ```
+
+   The ini sets `StylesPath = .`, so Vale looks for the rule directory next to
+   the ini it loaded. An ini copied without its `IssueRegister/` directory
+   fails with exit code 2 and `style 'IssueRegister' does not exist on
+   StylesPath`.
+
+4. **Check the rules fire.**
+
+   ```
+   vale --config "$(lore style vale-config)" <file>.md
+   ```
+
+   Exit code 1 means error-level findings. Exit code 0 with printed output
+   means warning-level heuristics, which are advisory. Exit code 2 means the
+   invocation itself is broken.
+
+   Give the file a `.md` extension. The packaged config scopes its rules to
+   `[*.md]`, so a `.txt` or extensionless file reports `0 files` and exits 0
+   without checking anything.
+
+## Notes
+
+- The banned-word list lives in the register text and in the Vale style. A
+  test asserts the two agree, so edit both together.
+- Overriding the register replaces the whole document, including its section
+  skeleton and EARS patterns. Start from the packaged copy rather than a blank
+  file unless you intend to drop those.
+- Wikis are portable. The override travels with the wiki repo, so a team that
+  takes its wiki elsewhere keeps its register.
+
+## Related
+
+- [Write a good fast-path issue](write-a-fast-path-issue.md)
+- [Why the issue register is a document, not config](../explanation/why-the-issue-register.md)


### PR DESCRIPTION
Documentation catch-up for epic #310 (the issue register), merged as `987e2b6`.

## Edit plan

The cumulative epic diff was classified with `lore_workflow.diataxis`. Only the
paths below warranted a docs edit.

| Path | Quadrant | Action |
|---|---|---|
| `docs/how-to/customize-the-issue-register.md` | how-to | **new** — override the register and the Vale style per wiki |
| `docs/explanation/why-the-issue-register.md` | explanation | **new** — document-not-config, whole-file override, generation-time lint (cites ADR 0006) |
| `docs/how-to/write-a-fast-path-issue.md` | how-to | already updated in #320 — no further edit |
| `lib/lore_core/style.py`, `lib/lore_cli/style_cmd.py`, `lib/lore_cli/doctor_cmd.py` | reference | **no edit needed** — every new public symbol already carries a complete docstring, and this repo has no Sphinx tree; `docs/architecture/cli-contract.md` documents CLI *shape*, not an enumeration of verbs |

Everything else classified as skip: package manifests, `CHANGELOG.md`, `CONTEXT.md`
and `docs/conventions.md` (both already updated by the epic itself), the packaged
register and Vale assets, and the skill files.

No `docs/prd/**` or `docs/adr/**` path is in this diff.

## Why these two

The how-to fills a real gap. Overriding the Vale style was documented only in a
module docstring and `--help`, and doing it the obvious way is broken: copying
`vale.ini` without its `IssueRegister/` directory exits 2 with `style
'IssueRegister' does not exist on StylesPath`, because the ini sets
`StylesPath = .`. The recipe copies the directory whole and says why. It also
carries the `[*.md]` scoping trap — a `.txt` draft reports `0 files` and exits 0
without checking anything.

The explanation records the three decisions from ADR 0006 that a reader will
otherwise have to reverse-engineer: why the register is prose rather than
config, why a team's copy wins whole instead of merging, and why the lint runs
at generation time rather than in CI.

## Dogfooding

Both new docs were linted with the register's own Vale style
(`vale --config "$(lore style vale-config)"`): **0 errors**. Four sentence-length
errors were fixed. The remaining findings are all warning-level heuristics — the
documented rule 9 over-fire on gerund subjects ("Overriding the register…",
"Merging a rules essay…") — left standing rather than mangling correct prose.

Links verified to resolve. `test_workflow_docs_drift.py` and
`test_style_register.py` pass.

Epic #310 · slices #305 #306 #307 #308 #309 · epic PR #319 · cross-feature fixes #320
