### PR TITLE
Replace cut and land with plain verbs in the workflow docs

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -34,7 +34,7 @@ seed-epic → orient → grilling → to-epic → orchestrate-epic → document-
 | `grilling` | A relentless, one-question-at-a-time interview that stress-tests a plan. Default mode ("grill me") checks whether `domain-modeling` is needed at the end; "grill with docs" mode runs it alongside the interview from the start, sharpening terminology and updating `CONTEXT.md`/ADRs inline. |
 | `to-epic` | The human checkpoint. Turns a shaped plan into an **epic tracker** issue (linking a PRD under `docs/prd/`) plus one sub-issue per feature, emitting the canonical roadmap DAG `orchestrate-epic` consumes. |
 | `orchestrate-epic` | Fully autonomous: fans out one test-first teammate per feature, crosschecks every pull request, integrates onto an `epic/<n>` branch in dependency order, and lands one final pull request to the detected target branch. |
-| `document-epic` | Runs as `orchestrate-epic`'s **automatic pre-land stage** (see below), not a manual step. Commits the Diátaxis docs onto the epic branch so they ship in the epic PR; standalone it catches up an already-merged epic via a docs PR. |
+| `document-epic` | Runs as `orchestrate-epic`'s **automatic pre-merge stage** (see below), not a manual step. Commits the Diátaxis docs onto the epic branch so they ship in the epic PR; standalone it catches up an already-merged epic via a docs PR. |
 | `tdd` | The red→green→refactor loop every implementation teammate follows. |
 
 `code-review` is a **built-in** Claude Code command, not a bundled skill —
@@ -132,14 +132,14 @@ comments). The plain-text view times out on large trackers.
 subagent stage **before the epic PR lands** (ADR 0005):
 
 1. The epic's feature PRs are integrated into `epic/<n>` and its CI is green.
-2. `orchestrate-epic` dispatches `document-epic` in **pre-land mode**: it
+2. `orchestrate-epic` dispatches `document-epic` in **pre-merge mode**: it
    generates the Diátaxis docs for the cumulative diff and **commits them
    onto the epic branch** — no separate docs PR.
 3. The docs ship inside the epic PR: the whole-epic review sees them and the
    epic's CI gates them. Docs stop being an afterthought that trails the
    merge.
 4. Fallback: if the docs stage escalates or cannot go green, the epic lands
-   without it and standalone `document-epic` runs post-land — its own docs
+   without it and standalone `document-epic` runs afterwards — its own docs
    PR, auto-merged on green, human review post-hoc. Docs never block a green
    epic.
 
@@ -241,8 +241,6 @@ first time.
   design review.
 - **crosscheck** — the strong-tier review a delegated reviewer performs on a
   teammate's PR before merge.
-- **land** — merge a pull request into its target branch.
-- **cut** (a branch) — create a new branch.
 - **fan out** — dispatch multiple teammate agents to work in parallel, one
   per feature.
 - **green / red** — a test suite that passes / fails; shorthand for the

--- a/docs/how-to/resume-a-broken-epic.md
+++ b/docs/how-to/resume-a-broken-epic.md
@@ -34,7 +34,7 @@ comment — precisely so a second run heals rather than duplicates.
    - a feature still queued or blocked is **redispatched** from where it
      left off;
    - the `epic/<issue>` branch, if it already exists, is **reused, never
-     re-cut**, so the resumed run never collides with half-merged state.
+     re-created**, so the resumed run never collides with half-merged state.
 4. **It continues in the same status comment.** It edits that one existing
    comment in place for every further update; a resumed run never opens a
    second status comment.

--- a/docs/how-to/run-an-epic.md
+++ b/docs/how-to/run-an-epic.md
@@ -39,7 +39,7 @@ small, clear change, use the [fast path](use-the-fast-path.md) instead.
 4. **Docs ship with the epic.** Before that final pull request,
    `orchestrate-epic` automatically runs `/lore-workflow:document-epic`,
    which commits the Diátaxis doc updates onto the epic branch — the docs
-   land inside the epic PR, not as a trailing afterthought. Only if the docs
+   merge inside the epic PR, not as a trailing afterthought. Only if the docs
    stage fails does it fall back to the old post-merge docs PR
    (auto-merged on green, reviewed post-hoc).
 

--- a/lore-workflow/skills/document-epic/SKILL.md
+++ b/lore-workflow/skills/document-epic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lore-workflow:document-epic
 description: Update a repo's Diátaxis documentation (tutorials, how-to, reference,
-  explanation) to match an epic's implemented state. Pre-land (invoked by orchestrate-epic)
+  explanation) to match an epic's implemented state. Pre-merge (invoked by orchestrate-epic)
   it commits docs onto the epic branch so they ship in the epic PR; standalone (an already
   merged epic) it opens a docs PR that auto-merges on green. NEVER touches docs/prd or
   docs/adr. Cross-repo aware.
@@ -13,7 +13,7 @@ You are the **documenter**: an epic changed what the software does, and the user
 must match. You update the **Diátaxis four** to the implemented state. You do not change
 behavior; you describe it.
 
-**Input:** an epic (issue number or URL), possibly spanning repos — either **pre-land** (its
+**Input:** an epic (issue number or URL), possibly spanning repos — either **pre-merge** (its
 `epic/<n>` branch exists, all features merged into it; this is how `orchestrate-epic` invokes
 you, per ADR 0005) or **standalone** (the epic already merged; docs catching up post-hoc).
 **Mode:** autonomous — run the loop without asking. Stop only to report completion or to
@@ -52,7 +52,7 @@ Every documentation edit you make belongs to exactly one quadrant
 conventions doc, if any).
 From it gather three sources of truth: the **PRD** (intent), the **sub-issue PRs**
 (per-feature acceptance notes that reveal which behaviors are user-facing), and the
-**cumulative epic diff** — pre-land that is `<target_branch>...epic/<n>`; standalone it is
+**cumulative epic diff** — pre-merge that is `<target_branch>...epic/<n>`; standalone it is
 the merged range (every path the epic touched, with its change kind). Build one list
 of changed paths, each tagged with its change kind and — for source files — whether it
 touches the **public API** (a non-underscore symbol exported from the package). This list is
@@ -77,16 +77,16 @@ what the epic changed; do not rewrite untouched docs. Re-confirm no `docs/prd`/`
 path is in your diff.
 
 **Deliver.**
-- *Pre-land* (invoked from `orchestrate-epic`): commit the doc edits **directly onto the
+- *Pre-merge* (invoked from `orchestrate-epic`): commit the doc edits **directly onto the
   epic branch** — no separate PR. The epic PR carries them, the whole-epic review sees them,
   and the epic's own CI gates them. Report the commit SHA and the edit plan.
 - *Standalone* (epic already merged): branch off the repo's integration branch, commit, and
   open a PR that summarizes the documented deltas and links the epic and its sub-issues.
-  **Auto-merge it on green CI** — documentation lands without blocking on human review; a
+  **Auto-merge it on green CI** — documentation merges without blocking on human review; a
   human reviews post-hoc. Never auto-merge on red.
 
 **Cross-repo.** An epic may span repos. Repeat the loop per affected repo, each against its
-own docs layout and its own epic/integration branch. One delivery per repo (pre-land commit
+own docs layout and its own epic/integration branch. One delivery per repo (pre-merge commit
 or standalone docs PR).
 
 ## Dry-run

--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -52,12 +52,12 @@ Pick the mode from what the caller handed you:
 | Mode | Use when | Shape |
 |---|---|---|
 | **Single change** | there is one change to capture | The register's full section skeleton. One statement under "Required behaviour", with its own EARS criteria. |
-| **Batch** | several changes share one Context, land in one PR, and have no ordering between them | Keep the skeleton. Give each change its own numbered subheading under "Required behaviour", then repeat the same numbered subheadings under "Acceptance criteria". **Every numbered change carries its own criteria** — never one pooled list. |
+| **Batch** | several changes share one Context, go into one PR, and have no ordering between them | Keep the skeleton. Give each change its own numbered subheading under "Required behaviour", then repeat the same numbered subheadings under "Acceptance criteria". **Every numbered change carries its own criteria** — never one pooled list. |
 | **Caller template** | the caller supplied a structure (a sub-issue header, an epic-seed shape) | Keep the caller's structure exactly. Add no section, drop no section, reorder nothing. Apply the prose rules and EARS *inside* the supplied structure. |
 | **PR body** | writing the body for `gh pr create` | Prose rules only. No register skeleton. |
 
 Before drafting a batch, check the register's "Batch issues" section for the split rule.
-A change that needs its own Context, or that must land before another change, is a
+A change that needs its own Context, or that must merge before another change, is a
 separate issue rather than a numbered block.
 
 ### When a fact is missing

--- a/lore-workflow/skills/implement-issue/SKILL.md
+++ b/lore-workflow/skills/implement-issue/SKILL.md
@@ -57,7 +57,7 @@ Create one branch, `feat/<issue>-slug`, off the **detected target branch** —
 `develop` if that branch exists on the remote, else the repo default (`main`);
 never assume it. Implement the change with [`/lore-workflow:tdd`](../tdd/SKILL.md): the strict
 red → green → refactor loop, one behavior at a time, tests before code. Everything
-lands in **one PR** on that branch.
+goes into **one PR** on that branch.
 
 ### 4. ADR gate
 

--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lore-workflow:orchestrate-epic
 description: Supervise parallel TDD implementation of an epic tracker issue across one or
-  more repos — plans, dispatches teammates, crosschecks every PR, and lands the epic
+  more repos — plans, dispatches teammates, crosschecks every PR, and merges the epic
   autonomously. Use when the user points at an epic/tracker issue and wants orchestrated,
   batched, autonomous implementation.
 ---
@@ -18,7 +18,7 @@ a hard blocker (see Stop conditions).
 ## Invariants
 - **Repo facts come from `lore workflow`, never re-derived in prose.** Resolve target branch and deploy gate
   once at Map time with `lore workflow epic-policy <repo_root>` → `{target_branch, deploy_gate}`.
-  `epic/<issue>` is cut from `target_branch` and lands back on it via one final PR; feature PRs target the
+  `epic/<issue>` is created from `target_branch` and merges back into it via one final PR; feature PRs target the
   epic branch.
 - **Merges are pre-authorized** — you merge on a passing crosscheck, never asking. Sole exception: when
   `epic-policy` returns `deploy_gate: true`, the final epic→target merge (only that one) requires one human
@@ -43,12 +43,12 @@ target repo(s). If it came from `/lore-workflow:to-epic`, its **Roadmap** table 
 Type | Blocked by) is the canonical DAG, and HITL-flagged features are escalation points, not
 auto-implemented. Resolve `lore workflow epic-policy` once per repo.
 
-**Resume.** The entry point — reached before the gate, before cutting the epic branch. Two reads recover a
+**Resume.** The entry point — reached before the gate, before creating the epic branch. Two reads recover a
 prior run:
 1. **Board** — fetch the epic issue's board comment and pipe it to `lore workflow parse-board` → rows
    `{feature, issue, tier, batch, state, pr}`. Never scrape it with the model. Reconcile against the epic
    branch's real state: a `merged` row is done (skip, never redispatch); a `queued`/`blocked` row is
-   redispatched; an existing epic branch is reused, never re-cut. Edit that same comment in place for every
+   redispatched; an existing epic branch is reused, never re-created. Edit that same comment in place for every
    later update; never open a second.
 2. **Working context** — `lore_resume` / `lore_context_pack` (epic-linked) surface prior orchestrator epic
    notes: why a feature blocked, the tier rationale, the in-flight decisions the board omits.
@@ -62,7 +62,7 @@ into dependency-ordered batches (features in a batch are independent). Pick the 
 eye: **compact** iff `repos == 1`, every `Type` is AFK, and either the DAG offers no real parallelism — every
 batch holds exactly one feature, i.e. a straight chain of any length — or `rows ≤ 3`; **standard** otherwise
 (full batched loop, concurrency cap N). Fan-out only pays when features actually run side by side. Record the
-band in your epic note, then cut and push `epic/<issue>` from the up-to-date `target_branch`.
+band in your epic note, then create and push `epic/<issue>` from the up-to-date `target_branch`.
 
 **Emit the board.** One comment on the epic issue, edited in place at a few deliberate points (batch start,
 each merge, each blocker, completion) — never a second comment. It MUST carry, verbatim, the marker and
@@ -88,7 +88,7 @@ excerpts** — never the whole map. Shape it as the four-part subagent brief eve
 - **Task boundaries** — the scope fence and shared-file touchpoints to stay clear of.
 
 **Dispatch.** Per feature in the batch: worktree off `epic/<issue>`, spawn a background teammate pinned to it
-(cap N, default 4) **with `LORE_SUPPRESS_CAPTURE=1` in its environment**, so it lands its work in your epic
+(cap N, default 4) **with `LORE_SUPPRESS_CAPTURE=1` in its environment**, so it records its work in your epic
 note rather than scattering a standalone fragment. Choose the model tier from the feature's assessed
 complexity (cheaper for well-scoped work, strongest for cross-cutting) and pass the resolved model in the
 spawn call (`lore tier resolve <tier>`, see [TIER-DELEGATION.md](../../TIER-DELEGATION.md)); no delegation
@@ -142,21 +142,21 @@ dispatching dependents. Where the repo carries migrations, verify a single migra
 heads`) — squash-merges can silently fork the migration DAG. A failed invariant blocks the batch: fix forward
 or escalate.
 
-**Document (delegated, pre-land).** Docs ship with the epic, not after it (ADR 0005). Once all features are
-merged and epic-branch CI is green, invoke `document-epic` in its **pre-land mode**: it classifies the
+**Document (delegated, pre-merge).** Docs ship with the epic, not after it (ADR 0005). Once all features are
+merged and epic-branch CI is green, invoke `document-epic` in its **pre-merge mode**: it classifies the
 cumulative diff (`<target_branch>...epic/<issue>`) into the Diátaxis four and commits the doc updates directly
 onto `epic/<issue>` — no separate docs PR. If it escalates, or its edits cannot go green after one fix pass,
-fall back: drop the docs commit, land the epic without it, and run standalone `document-epic` post-land (its
+fall back: drop the docs commit, merge the epic without it, and run standalone `document-epic` afterwards (its
 own auto-merging docs PR) — docs never block a green epic.
 
-**Land.** Features merged, docs committed, epic-branch CI green → open one PR
+**Merge the epic.** Features merged, docs committed, epic-branch CI green → open one PR
 `epic/<issue> → <target_branch>` linking every sub-issue.
 
 **Whole-epic review (delegated).** Before merging that PR, spawn one strong-tier reviewer over the cumulative
 diff (`<target_branch>...epic/<issue>`). Skip this stage entirely when the epic has ≤ 2 features — the
 crosscheck just read those same diffs; go straight to the deploy-gate check and merge. Not a per-feature
 re-review — scope it to cross-feature consistency (inconsistent naming, duplicated helpers, conflicting edits
-to shared files), the class that only surfaces once every diff lands together, plus docs-vs-behavior
+to shared files), the class that only surfaces once every diff is merged together, plus docs-vs-behavior
 mismatches now that the diff carries the docs commit. Reuse the reviewer verdict shape with this cross-feature checklist; post it on
 the epic PR. It gates the merge like a crosscheck: **PASS** → merge; **FAIL** → route the fix list to the
 teammate(s) owning the affected files, re-review once, max 2 rounds, then mark the epic blocked and escalate
@@ -167,13 +167,13 @@ epic issue done with the merge SHA.
 **Cleanup.** Delete every merged feature branch (local and remote) and remove its worktree. Leave nothing
 behind but the epic branch's own history.
 
-**Land checklist.** Before reporting completion, emit and satisfy this — each item verified true, not merely
+**Final checklist.** Before reporting completion, emit and satisfy this — each item verified true, not merely
 intended:
 - [ ] every roadmap checkbox ticked and every sub-issue closed
 - [ ] the epic PR merged, its merge SHA recorded on the epic issue
 - [ ] the board finalized to the end state (no stale queued/running rows)
 - [ ] every merged feature's branch and worktree gone, local and remote
-- [ ] the docs commit landed with the epic PR — or, on fallback, the standalone docs PR opened and merged on
+- [ ] the docs commit merged with the epic PR — or, on fallback, the standalone docs PR opened and merged on
       green
 
 **Follow-ups.** Work that surfaces during the run and does not belong to this epic — a deferred fix, the

--- a/tests/test_workflow_plain_verbs.py
+++ b/tests/test_workflow_plain_verbs.py
@@ -1,0 +1,63 @@
+"""The workflow prose uses plain verbs for branch creation and merging.
+
+"Cut" (a branch) and "land" (a pull request) are insider verbs that need a
+glossary entry before a reader can resolve them. Issue-register rule 3 asks for
+the shorter common word, so the prose says "create" and "merge" instead and the
+glossary carries no entry for either.
+
+Machine-read formats are exempt from the register and are not checked here.
+Idiomatic non-git uses ("the decision the brief lands on") are also out of
+scope: they name neither action.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS = sorted((REPO_ROOT / "lore-workflow" / "skills").glob("*/SKILL.md"))
+HOW_TOS = sorted((REPO_ROOT / "docs" / "how-to").glob("*.md"))
+CONVENTIONS = REPO_ROOT / "docs" / "conventions.md"
+
+# The git-sense uses, matched tightly enough that "shortcut", "cut the corner"
+# and "cut the fewest slices" (carving work, not opening a branch) stay legal.
+BRANCH_CUT = re.compile(
+    r"\bre-cut\b|\bcut(?:s|ting)?\s+(?:and\s+push\s+)?(?:the\s+|a\s+|an\s+)?"
+    r"(?:epic\s+)?branch\b|\bis\s+cut\s+from\b|\bcut\s+and\s+push\b",
+    re.IGNORECASE,
+)
+MERGE_LAND = re.compile(
+    r"\bpre-land\b|\bpost-land\b|\bLand\s+checklist\b|"
+    r"\blands?\s+(?:the\s+)?(?:epic|work|PR|pull request)\b|"
+    r"\bmust\s+land\b|\bland\s+in\s+one\s+PR\b|\blands\s+in\s+\*\*one\s+PR\*\*",
+    re.IGNORECASE,
+)
+
+
+def _offenders(text: str) -> list[str]:
+    return [m.group(0) for m in BRANCH_CUT.finditer(text)] + [
+        m.group(0) for m in MERGE_LAND.finditer(text)
+    ]
+
+
+@pytest.mark.parametrize(
+    "path", SKILLS + HOW_TOS + [CONVENTIONS], ids=lambda p: p.parent.name + "/" + p.name
+)
+def test_workflow_prose_uses_plain_verbs(path: Path):
+    found = _offenders(path.read_text(encoding="utf-8"))
+    assert not found, (
+        f"{path.relative_to(REPO_ROOT)} uses insider verbs for branch creation or "
+        f"merging: {sorted(set(found))!r}. Say 'create' and 'merge' — see #324."
+    )
+
+
+def test_conventions_glossary_does_not_define_cut_or_land():
+    text = CONVENTIONS.read_text(encoding="utf-8")
+    entries = re.findall(r"^- \*\*(cut|land)\*\*", text, re.IGNORECASE | re.MULTILINE)
+    assert not entries, (
+        f"docs/conventions.md still defines {entries!r} in its glossary. The plain "
+        f"verbs need no entry — remove them rather than document the jargon (#324)."
+    )


### PR DESCRIPTION
Closes #324.

"Cut" (a branch) and "land" (a pull request) are insider verbs this team does
not use. The issue register asks for the shorter common word. The workflow prose
now says "create" and "merge". The glossary carries no entry for either.

## What changed

- `docs/conventions.md` — both glossary entries removed. The plain verbs need
  no definition.
- `orchestrate-epic` — branch creation reads "created" and "create and push";
  the `**Land.**` stage is now `**Merge the epic.**` and `**Land checklist.**`
  is `**Final checklist.**`. The existing `**Merge.**` stage merges feature
  PRs, so the final stage needed a distinct name rather than a second "Merge".
- `document-epic` — the `pre-land` mode is now `pre-merge`, in the frontmatter
  description and all five prose sites.
- `file-issue`, `implement-issue` — "land in one PR" reads "go into one PR".
- `docs/how-to/resume-a-broken-epic.md`, `docs/how-to/run-an-epic.md` — same
  two verbs as the skills.
- `docs/conventions.md` also carried three references to the old `pre-land`
  mode name. Renaming the mode without them would leave a dangling reference.

## Evidence

`tests/test_workflow_plain_verbs.py` is new and was red first: six failures
naming `document-epic`, `file-issue`, `implement-issue`, `orchestrate-epic`,
`resume-a-broken-epic.md` and the two glossary entries. All 25 pass now.

The guard bites rather than passing by accident. Restoring `**Land checklist.**`
alone turns the `orchestrate-epic` case red again; reverting it turns it green.

`lore workflow parse-board` parses an unchanged board comment and returns both
rows with the right states, so the machine-read format is untouched.

Full suite: 2862 passed, 6 failed. All six fail identically on a clean tree —
`test_core_llm_wiring` (2), `test_install_dispatcher`, `test_cli_scopes`, and
`test_dead_code_gone` (2, from untracked stale `__pycache__` directories).
Ruff clean on the one Python file.

## One thing to decide

ADR 0005 ratified the mode under the name "pre-land", and its filename is
`0005-docs-land-with-the-epic.md`. This change renames the mode in the skills
and the conventions doc. The ADR now records the decision under a name the
implementation no longer uses. ADRs are the canonical record, so this change
does not touch them.

`CHANGELOG.md` keeps "pre-land" in the 0.64.0 entry, which describes a release
that shipped under that name.

## Left alone

Idiomatic uses that name neither action: "the decision the brief lands on"
(`brief`), "as each decision lands" (`grilling`), "a wiki briefing landing in a
Matrix room" (`matrix-bot.md`). "Cut the fewest slices" in `to-epic` carves
work rather than opening a branch.

`crosscheck`, `fan out` and `deploy gate` keep their glossary entries. Each
names something with no plain-English equivalent.
