### PR TITLE
chore: release 0.65.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore",
   "description": "LLM-optimized knowledge graph for AI-coding teams \u2014 session notes, auto-extracted knowledge, pluggable briefings, magic context injection at session start.",
-  "version": "0.65.0",
+  "version": "0.65.1",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (0.x means anything can change between minor versions until 1.0).
 
+## [0.65.1] - 2026-08-03
+
+### Changed
+
+- **Plain verbs in the workflow prose** (#324): the skills and how-to pages say
+  "create" for opening a branch and "merge" for merging one. `orchestrate-epic`'s
+  final stage is `Merge the epic` and its checklist is `Final checklist`;
+  `document-epic`'s `pre-land` mode is now `pre-merge`. Both glossary entries in
+  `docs/conventions.md` are removed — the plain verbs need no definition.
+  `tests/test_workflow_plain_verbs.py` guards the prose. ADR 0005 keeps its
+  ratified `pre-land` wording; the divergence is accepted, not superseded.
+- `lore-workflow` plugin 0.4.0 → 0.4.1.
+
 ## [0.65.0] - 2026-08-03
 
 The issue register (#310, PRD 0009, ADR 0006): a default prose style for

--- a/lore-workflow/.claude-plugin/plugin.json
+++ b/lore-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore-workflow",
   "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams. Depends on lore.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lore"
-version = "0.65.0"
+version = "0.65.1"
 description = "LLM-optimized knowledge graph for AI-coding teams"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for #324 / PR #325, which changed four `lore-workflow` skills.

`claude plugin update` only re-fetches on a version change. Without the bump, installed caches stay on the old skill text even though `main` has moved.

- `lore` 0.65.0 → 0.65.1
- `lore-workflow` 0.4.0 → 0.4.1
- CHANGELOG entry for the plain-verb sweep

`tests/test_version_sync.py` passes on all three.