### PR TITLE
Describe file-issue by what it does, not as a funnel

### DIFF
--- a/docs/explanation/why-the-issue-register.md
+++ b/docs/explanation/why-the-issue-register.md
@@ -80,7 +80,7 @@ It does not fix terminology. One term with one meaning is a glossary problem,
 and the glossary is a separate artifact.
 
 It does not decide what is worth filing. The `file-issue` skill owns how to
-write and file; the caller decides what to capture. A funnel that second-
+write and file; the caller decides what to capture. A skill that second-
 guessed the caller's judgement would turn every capture into a negotiation.
 
 ## Related

--- a/lore-workflow/README.md
+++ b/lore-workflow/README.md
@@ -31,4 +31,4 @@ delegation conventions shared across skills live in
 | `debug` | Systematic root-cause debugging with a hard circuit breaker. |
 | `document-epic` | After an epic merges, update Diátaxis docs to match the implemented state. |
 | `seed-epic` | End a session by turning follow-up context into an epic-seed tracker issue. |
-| `file-issue` | The filing funnel — resolve the issue register, draft, Vale-lint, then post the issue or PR body. |
+| `file-issue` | Writes issue text and files it — resolve the issue register, draft, Vale-lint, then post the issue or PR body. |

--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lore-workflow:file-issue
-description: The one funnel for writing and filing issue text — resolve the team's issue
+description: Writes issue text and files it — resolve the team's issue
   register, draft in its skeleton (single change, batch, a caller's template, or a PR
   body), lint with Vale when Vale is installed, then post with gh. Use whenever you are
   about to write or edit a GitHub issue, a sub-issue, or a PR description. Triggers on
@@ -9,8 +9,8 @@ description: The one funnel for writing and filing issue text — resolve the te
 
 # File Issue
 
-The single funnel for writing and filing issue text. Every workflow skill that files an
-issue or a PR body routes through here, and the user can invoke it directly.
+Writes issue text and files it. Every workflow skill that writes an issue or a PR body
+comes here to do it, and the user can invoke it directly.
 
 **The caller decides *what* to capture. This skill owns *how* to write and file it.**
 Never re-litigate the caller's judgement about whether something deserves an issue.
@@ -18,7 +18,7 @@ Never re-litigate the caller's judgement about whether something deserves an iss
 ## Hard rule: run in-context
 
 Do every step in the calling session. **Never spawn a subagent** — not to draft, not to
-lint, not to post. One subagent per issue is the cost this funnel exists to avoid.
+lint, not to post. One subagent per issue is the cost this skill exists to avoid.
 
 ## 1. Resolve the register
 

--- a/lore-workflow/skills/seed-epic/SKILL.md
+++ b/lore-workflow/skills/seed-epic/SKILL.md
@@ -50,7 +50,7 @@ that is the handover value. Pointers are starting points, not gospel (they may g
 
 ### 4. Publish
 File each seed through [`file-issue`](../file-issue/SKILL.md) in caller-template mode, handing
-it the seed template below — the funnel keeps that structure exactly and applies the register's
+it the seed template below — that skill keeps the structure exactly and applies the register's
 writing rules inside it. Label each seed `epic-seed` (create the label if missing), link the
 originating epic and merged PRs, and do not modify the finished epic.
 

--- a/lore-workflow/skills/to-epic/SKILL.md
+++ b/lore-workflow/skills/to-epic/SKILL.md
@@ -185,7 +185,7 @@ below keeps the literal token, which is what the roadmap validator and `/lore-wo
 ## Sub-issue template
 
 An epic-linkage header, then the register's own section skeleton. File it through
-[`file-issue`](../file-issue/SKILL.md) in caller-template mode — the funnel resolves the
+[`file-issue`](../file-issue/SKILL.md) in caller-template mode — that skill resolves the
 register and applies its writing rules inside this structure, so none of those rules are
 repeated here. Keep "Required behaviour" to the slice's end-to-end behavior — not a
 layer-by-layer implementation — and path-free (same prototype exception as above).

--- a/tests/test_workflow_issue_register_wiring.py
+++ b/tests/test_workflow_issue_register_wiring.py
@@ -1,9 +1,9 @@
-"""The writing skills file through the `file-issue` funnel (sub-issue #309).
+"""The writing skills write their issue text through `file-issue` (sub-issue #309).
 
 PRD 0009 says to test external behaviour, not skill wording, so nothing here
 asserts prose. What is asserted is the machine-consumed part:
 
-- the filing skills point at the funnel instead of prescribing filing,
+- the filing skills point at that skill instead of prescribing filing,
 - `to-epic`'s sub-issue template carries the register's own section skeleton,
 - and an epic body composed from that template's linkage fields still passes
   the roadmap validator, which is what `orchestrate-epic` reads.
@@ -21,7 +21,7 @@ from lore_workflow import roadmap_validator
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_ROOT = REPO_ROOT / "lore-workflow" / "skills"
 
-# Every skill that writes issue or PR text. `file-issue` itself is the funnel.
+# Every skill that writes issue or PR text. `file-issue` itself does the writing.
 FILING_SKILLS = ("to-epic", "seed-epic", "orchestrate-epic", "implement-issue", "brief")
 
 # Linkage fields the roadmap table's columns are built from. Losing one of
@@ -74,7 +74,7 @@ def _render_sub_issue(values: dict[str, str]) -> str:
 @pytest.mark.parametrize("skill", FILING_SKILLS)
 def test_filing_skills_point_at_the_funnel(skill: str) -> None:
     assert "../file-issue/SKILL.md" in _skill_text(skill), (
-        f"{skill}/SKILL.md must route its filing through the file-issue funnel"
+        f"{skill}/SKILL.md must route its filing through file-issue"
     )
 
 

--- a/tests/test_workflow_plain_verbs.py
+++ b/tests/test_workflow_plain_verbs.py
@@ -1,9 +1,11 @@
 """The workflow prose uses plain verbs for branch creation and merging.
 
 "Cut" (a branch) and "land" (a pull request) are insider verbs that need a
-glossary entry before a reader can resolve them. Issue-register rule 3 asks for
-the shorter common word, so the prose says "create" and "merge" instead and the
-glossary carries no entry for either.
+glossary entry before a reader can resolve them. "Funnel" is a metaphor a reader
+has to map onto the thing before the sentence means anything. Issue-register
+rule 3 asks for the shorter common word, so the prose says "create", "merge",
+and plainly what `file-issue` does, and the glossary carries no entry for the
+two verbs.
 
 Machine-read formats are exempt from the register and are not checked here.
 Idiomatic non-git uses ("the decision the brief lands on") are also out of
@@ -29,6 +31,8 @@ BRANCH_CUT = re.compile(
     r"(?:epic\s+)?branch\b|\bis\s+cut\s+from\b|\bcut\s+and\s+push\b",
     re.IGNORECASE,
 )
+# A metaphor for the skill that writes and files issue text. Say what it does.
+FUNNEL = re.compile(r"\bfunnels?\b", re.IGNORECASE)
 MERGE_LAND = re.compile(
     r"\bpre-land\b|\bpost-land\b|\bLand\s+checklist\b|"
     r"\blands?\s+(?:the\s+)?(?:epic|work|PR|pull request)\b|"
@@ -38,8 +42,8 @@ MERGE_LAND = re.compile(
 
 
 def _offenders(text: str) -> list[str]:
-    return [m.group(0) for m in BRANCH_CUT.finditer(text)] + [
-        m.group(0) for m in MERGE_LAND.finditer(text)
+    return [
+        m.group(0) for pattern in (BRANCH_CUT, MERGE_LAND, FUNNEL) for m in pattern.finditer(text)
     ]
 
 
@@ -49,8 +53,8 @@ def _offenders(text: str) -> list[str]:
 def test_workflow_prose_uses_plain_verbs(path: Path):
     found = _offenders(path.read_text(encoding="utf-8"))
     assert not found, (
-        f"{path.relative_to(REPO_ROOT)} uses insider verbs for branch creation or "
-        f"merging: {sorted(set(found))!r}. Say 'create' and 'merge' — see #324."
+        f"{path.relative_to(REPO_ROOT)} uses insider wording: {sorted(set(found))!r}. "
+        f"Say 'create', 'merge', and what the skill does — see #324 and #327."
     )
 
 
@@ -61,3 +65,14 @@ def test_conventions_glossary_does_not_define_cut_or_land():
         f"docs/conventions.md still defines {entries!r} in its glossary. The plain "
         f"verbs need no entry — remove them rather than document the jargon (#324)."
     )
+
+
+def test_wiring_test_and_readme_describe_file_issue_plainly():
+    """The skill table and the wiring test carry the same plain wording."""
+    for rel in ("lore-workflow/README.md", "tests/test_workflow_issue_register_wiring.py"):
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        found = FUNNEL.findall(text)
+        assert not found, (
+            f"{rel} calls file-issue a {sorted(set(found))!r}. Say what it does "
+            f"— it writes issue text and files it (#327)."
+        )


### PR DESCRIPTION
Closes #327.

"Funnel" is a metaphor a reader has to map onto the thing before the sentence
means anything. The prose now says what `file-issue` does. It writes issue text
and files it.

Follows #324, which removed "cut" and "land" for the same reason.

## What changed

- `file-issue` — the frontmatter `description` now opens "Writes issue text and
  files it". That field is what an agent reads when it picks a skill, so it
  carried the most weight. The opening sentence and the no-subagent rule follow.
- `lore-workflow/README.md` — the skill table row.
- `to-epic`, `seed-epic` — "the funnel resolves the register" reads "that skill
  resolves the register".
- `docs/explanation/why-the-issue-register.md` — one sentence.
- `tests/test_workflow_issue_register_wiring.py` — docstring, two comments, and
  the assertion message, so a failure reads in the same words as the prose.

## Evidence

`tests/test_workflow_plain_verbs.py` gains the word to its guard and a second
test covering the README and the wiring test. Red first: four failures naming
`file-issue`, `to-epic`, `seed-epic` and the README. All 26 pass now.

The guard bites. Restoring "The filing funnel —" in the README alone turns it
red; reverting turns it green.

Full suite: 2863 passed, 6 failed. All six fail identically on a clean tree —
`test_core_llm_wiring` (2), `test_install_dispatcher`, `test_cli_scopes`, and
`test_dead_code_gone` (2, from untracked stale `__pycache__` directories).
`file-issue` is 136 lines against its 150 cap. Ruff clean.

## Left alone

`docs/prd/0009-issue-register.md` and `docs/adr/0006-...` use the word twice
each. Both are the canonical record and stay as ratified, the same call #324
made for ADR 0005.

`CHANGELOG.md` keeps the word in the 0.65.0 entry, which describes a release
that shipped under that wording.
