### PR TITLE
chore: release 0.65.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore",
   "description": "LLM-optimized knowledge graph for AI-coding teams \u2014 session notes, auto-extracted knowledge, pluggable briefings, magic context injection at session start.",
-  "version": "0.65.1",
+  "version": "0.65.2",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (0.x means anything can change between minor versions until 1.0).
 
+## [0.65.2] - 2026-08-03
+
+### Changed
+
+- **`file-issue` is described by what it does** (#327): the skill's frontmatter
+  `description`, its opening, `lore-workflow/README.md`, `to-epic`, `seed-epic`
+  and the explanation doc no longer call it a "funnel" — a metaphor a reader has
+  to decode first. The `description` field drives skill selection, so it carried
+  the most weight. `tests/test_workflow_plain_verbs.py` guards the word.
+- `lore-workflow` plugin 0.4.1 → 0.4.2.
+
 ## [0.65.1] - 2026-08-03
 
 ### Changed

--- a/lore-workflow/.claude-plugin/plugin.json
+++ b/lore-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore-workflow",
   "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams. Depends on lore.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lore"
-version = "0.65.1"
+version = "0.65.2"
 description = "LLM-optimized knowledge graph for AI-coding teams"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for #327 / PR #328, which changed three `lore-workflow` skills and the plugin README.

`claude plugin update` only re-fetches on a version change, so without the bump installed caches keep the old skill `description` — the field that drives skill selection.

- `lore` 0.65.1 → 0.65.2
- `lore-workflow` 0.4.1 → 0.4.2