### PR TITLE
Isolate concurrent issue drafts and route document-epic through file-issue

### DIFF
--- a/lore-workflow/skills/document-epic/SKILL.md
+++ b/lore-workflow/skills/document-epic/SKILL.md
@@ -82,6 +82,8 @@ path is in your diff.
   and the epic's own CI gates them. Report the commit SHA and the edit plan.
 - *Standalone* (epic already merged): branch off the repo's integration branch, commit, and
   open a PR that summarizes the documented deltas and links the epic and its sub-issues.
+  Write the PR body through [`file-issue`](../file-issue/SKILL.md) in PR-body mode, so the
+  docs PR reads in the same register as everything else the chain files.
   **Auto-merge it on green CI** — documentation merges without blocking on human review; a
   human reviews post-hoc. Never auto-merge on red.
 

--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -33,15 +33,21 @@ Add `--wiki <name>` when the target repo belongs to a wiki other than the cwd's.
 
 ## 2. Draft to a file whose name ends in `.md`
 
-Write the body to this exact path:
+Write the body to this path, with `<slug>` replaced by a short kebab-case slug of the
+title you are about to use:
 
 ```
-${TMPDIR:-/tmp}/lore-file-issue.md
+${TMPDIR:-/tmp}/lore-file-issue-<slug>.md
 ```
 
 **Repeat that path literally in steps 3 and 4. Never hold it in a shell variable** —
 each step may run as its own shell, and a variable set in step 2 is gone by step 3.
 Vale would then get an empty argument and lint nothing.
+
+The slug keeps two sessions apart. A fixed filename means a second session filing at the
+same moment under the same `TMPDIR` overwrites the first session's draft, and the first
+session then lints and posts text it never wrote. You already know the title at this
+point, so the slug costs nothing and stays the same in every step.
 
 The `.md` extension is load-bearing. The Vale config scopes its rules to `[*.md]`, so a
 draft saved as `.txt`, or with no extension, lints zero files and exits 0 — step 3 would
@@ -83,7 +89,7 @@ whether Vale is on PATH.)
 With Vale present:
 
 ```bash
-vale --config "$(lore style vale-config)" "${TMPDIR:-/tmp}/lore-file-issue.md"
+vale --config "$(lore style vale-config)" "${TMPDIR:-/tmp}/lore-file-issue-<slug>.md"
 ```
 
 Read the result by exit code, not by whether anything printed:
@@ -111,12 +117,12 @@ back.
 
 ```bash
 gh issue create --repo <owner>/<repo> --title "<imperative title, max 12 words>" \
-  --body-file "${TMPDIR:-/tmp}/lore-file-issue.md"
+  --body-file "${TMPDIR:-/tmp}/lore-file-issue-<slug>.md"
 ```
 
 Use `--body-file`, never a retyped `--body` string — the bytes Vale checked must be the
 bytes that get posted. For a PR body, swap in
-`gh pr create --body-file "${TMPDIR:-/tmp}/lore-file-issue.md"`.
+`gh pr create --body-file "${TMPDIR:-/tmp}/lore-file-issue-<slug>.md"`.
 
 In batch mode the caller chooses the granularity it asked for: one issue holding the
 numbered blocks, or one issue per block. Do not silently split or merge what you were

--- a/tests/test_workflow_issue_register_wiring.py
+++ b/tests/test_workflow_issue_register_wiring.py
@@ -22,7 +22,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_ROOT = REPO_ROOT / "lore-workflow" / "skills"
 
 # Every skill that writes issue or PR text. `file-issue` itself does the writing.
-FILING_SKILLS = ("to-epic", "seed-epic", "orchestrate-epic", "implement-issue", "brief")
+FILING_SKILLS = (
+    "to-epic",
+    "seed-epic",
+    "orchestrate-epic",
+    "implement-issue",
+    "brief",
+    "document-epic",
+)
 
 # Linkage fields the roadmap table's columns are built from. Losing one of
 # these from the sub-issue template leaves `to-epic` without the data the
@@ -72,7 +79,7 @@ def _render_sub_issue(values: dict[str, str]) -> str:
 
 
 @pytest.mark.parametrize("skill", FILING_SKILLS)
-def test_filing_skills_point_at_the_funnel(skill: str) -> None:
+def test_filing_skills_point_at_file_issue(skill: str) -> None:
     assert "../file-issue/SKILL.md" in _skill_text(skill), (
         f"{skill}/SKILL.md must route its filing through file-issue"
     )

--- a/tests/test_workflow_plain_verbs.py
+++ b/tests/test_workflow_plain_verbs.py
@@ -32,7 +32,9 @@ BRANCH_CUT = re.compile(
     re.IGNORECASE,
 )
 # A metaphor for the skill that writes and files issue text. Say what it does.
-FUNNEL = re.compile(r"\bfunnels?\b", re.IGNORECASE)
+# No word boundaries: the word also hides inside identifiers like
+# `test_..._the_funnel`, where a leading \b never matches after an underscore.
+FUNNEL = re.compile(r"funnel(?:s|ed|ing)?", re.IGNORECASE)
 MERGE_LAND = re.compile(
     r"\bpre-land\b|\bpost-land\b|\bLand\s+checklist\b|"
     r"\blands?\s+(?:the\s+)?(?:epic|work|PR|pull request)\b|"
@@ -76,3 +78,24 @@ def test_wiring_test_and_readme_describe_file_issue_plainly():
             f"{rel} calls file-issue a {sorted(set(found))!r}. Say what it does "
             f"— it writes issue text and files it (#327)."
         )
+
+
+def test_file_issue_draft_path_is_per_run():
+    """Two sessions filing at once must not write the same draft file.
+
+    The path stays literal in every step — a shell variable set in one step is
+    gone by the next — so the per-run part is a slug the writer already knows.
+    """
+    text = (REPO_ROOT / "lore-workflow" / "skills" / "file-issue" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "lore-file-issue.md" not in text, (
+        "the draft path is a fixed filename; two concurrent sessions under one "
+        "TMPDIR overwrite each other's draft (#322)"
+    )
+    assert re.search(r"lore-file-issue-<[a-z-]+>\.md", text), (
+        "expected a per-run draft path like `lore-file-issue-<slug>.md` (#322)"
+    )
+    assert "$draft" not in text and "DRAFT=" not in text, (
+        "the draft path must stay literal, not live in a shell variable (#322)"
+    )


### PR DESCRIPTION
Closes #322.

Two changes, no ordering between them.

## 1. The draft path carries a per-run slug

`file-issue` wrote every draft to `${TMPDIR:-/tmp}/lore-file-issue.md`. Two
sessions filing at the same moment under one `TMPDIR` wrote the same file, so
the second draft replaced the first and the first session then linted and posted
text it never wrote.

The path is now `${TMPDIR:-/tmp}/lore-file-issue-<slug>.md`, where `<slug>` is a
kebab-case slug of the title the writer is about to use. The writer knows the
title at that point, so the slug costs nothing and stays the same in every step.

The path stays literal in all three steps. A shell variable was the previous
failure — one set in step 2 is gone by step 3, and Vale then lints an empty
argument. The `.md` extension is unchanged; the Vale config scopes rules to
`[*.md]`.

## 2. `document-epic` writes its docs-PR body through `file-issue`

The standalone docs PR wrote a summarizing body in place. `file-issue` was the
one place left that its own claim did not cover. The standalone branch now
writes the body in PR-body mode, and `document-epic` joins `FILING_SKILLS` in
the wiring test.

The pre-merge branch is unchanged — it commits onto the epic branch and opens no
PR.

## Also: a leftover from #327

`tests/test_workflow_issue_register_wiring.py` still had
`test_filing_skills_point_at_the_funnel` as a function name. The #327 guard
missed it because `\b` never matches after an `_` character, so `_funnel` slipped
through. The function is renamed and the guard now matches inside identifiers.
Restoring the old name turns the guard red.

## Evidence

Both changes red first: `test_file_issue_draft_path_is_per_run` and
`test_filing_skills_point_at_file_issue[document-epic]`. All 36 pass now.

Isolation checked by running the steps as separate shells with real Vale 3.17.0:
two drafts under distinct slugs, each lint reporting `in 1 file` against its own
file rather than `in stdin` or `0 files`.

Full suite: 2865 passed, 6 failed. All six fail identically on a clean tree —
`test_core_llm_wiring` (2), `test_install_dispatcher`, `test_cli_scopes`, and
`test_dead_code_gone` (2, from untracked stale `__pycache__` directories).
`file-issue` is 142 lines and `document-epic` 107, both under the 150 cap. Ruff
clean.

## Found while testing, filed separately

The banned-vocabulary rule matches base forms only. "leverage" is flagged;
"leverages" and "leveraging" pass. Out of scope here — it belongs to the Vale
style, not to either change above.

This body therefore carries one error-level finding at rule 3: the sentence
above quotes a banned word to name the bug. The register's own text trips the
same rule where it lists them.