### PR TITLE
chore: release 0.65.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore",
   "description": "LLM-optimized knowledge graph for AI-coding teams \u2014 session notes, auto-extracted knowledge, pluggable briefings, magic context injection at session start.",
-  "version": "0.65.2",
+  "version": "0.65.3",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (0.x means anything can change between minor versions until 1.0).
 
+## [0.65.3] - 2026-08-03
+
+### Fixed
+
+- **Concurrent issue drafts no longer collide** (#322): `file-issue` drafts to
+  `${TMPDIR:-/tmp}/lore-file-issue-<slug>.md` instead of a fixed filename. Two
+  sessions filing at the same moment under one `TMPDIR` wrote the same file, so
+  one posted text it never wrote. The path stays literal in every step — a shell
+  variable was the earlier failure.
+
+### Changed
+
+- **`document-epic` writes its standalone docs-PR body through `file-issue`**
+  (#322), in PR-body mode. It was the last place still writing a PR body inline.
+- `lore-workflow` plugin 0.4.2 → 0.4.3.
+
 ## [0.65.2] - 2026-08-03
 
 ### Changed

--- a/lore-workflow/.claude-plugin/plugin.json
+++ b/lore-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lore-workflow",
   "description": "Deterministic epic/PRD/TDD workflow skills for AI-coding teams. Depends on lore.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "Christof Buchbender"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lore"
-version = "0.65.2"
+version = "0.65.3"
 description = "LLM-optimized knowledge graph for AI-coding teams"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for #322 / PR #330, which changed `file-issue` and `document-epic`.

- `lore` 0.65.2 → 0.65.3
- `lore-workflow` 0.4.2 → 0.4.3