### PR TITLE
docs: release flow lands via PR — main is branch-protected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@
 Every merge to `main` that ships plugin-relevant behavior (hooks, MCP server,
 curator/capture code, skills) **must** end with a version bump — bump
 `.claude-plugin/plugin.json`, `pyproject.toml`, and `CHANGELOG.md` together in
-one `chore: release X.Y.Z` commit, then push. `claude plugin update lore@lore`
+one `chore: release X.Y.Z` commit, landed via its own PR. `main` is
+branch-protected: the `test` check must pass, and direct pushes are blocked
+(admins included). `claude plugin update lore@lore`
 only re-fetches on a version *change*; without the bump, installed plugin
 caches silently stay on the old code even though `main` has moved on (this bit
 us once already — see `CHANGELOG.md`'s own header note and commit `004d033`).


### PR DESCRIPTION
## Context

- Christof asked for branch protection on main after two red-main incidents on 2026-08-03.
- Claude enabled classic branch protection on main at 2026-08-04 (API PUT, repo buchbend/lore): required status check `test`, `enforce_admins: true`, force pushes and deletions blocked.
- CLAUDE.md's release rule said "then push". A protected main rejects direct pushes.

## Change

- CLAUDE.md release section now states: the `chore: release X.Y.Z` commit lands via its own PR.
- CLAUDE.md now records the protection: green `test` check required, direct pushes blocked, admins included.

## Acceptance criteria

- [ ] When a contributor reads the Releasing section, CLAUDE.md shall state the PR-based release path.
- [ ] When a release commit targets main directly, GitHub shall reject the push.