### PR TITLE
Flag inflected forms of banned words in the Vale style

### DIFF
--- a/lib/lore_core/styles/vale/IssueRegister/Vocabulary.yml
+++ b/lib/lore_core/styles/vale/IssueRegister/Vocabulary.yml
@@ -1,23 +1,34 @@
-# Rule 3: use the shorter common word. List mirrors the "Banned:" list in
-# ../../issue-register.md — keep the two in sync by hand when either changes.
+# Rule 3: use the shorter common word. The base of each token mirrors the
+# "Banned:" list in ../../issue-register.md, in the same order — keep the two in
+# sync by hand when either changes. tests/test_vale_style.py compares them.
+#
+# Each token carries the word's real inflections. Vale wraps a token in word
+# boundaries, so a bare base word matches that spelling alone: "leverage" would
+# be flagged while "leverages" and "leveraging" passed.
+#
+# The branches are written out per word rather than a stem plus \w*. A stem
+# match on "elevate" also catches "elevator" and "elevation", and rule 3 is
+# error-level — a false positive there blocks a correct sentence rather than
+# leaving an advisory warning.
 extends: existence
 message: "Rule 3 (banned vocabulary): use a shorter common word instead of '%s'."
 ignorecase: true
 level: error
 tokens:
-  - leverage
-  - utilise
-  - robust
-  - seamless
-  - holistic
-  - comprehensive
-  - streamline
-  - delve
-  - underscore
-  - intricate
-  - crucial
-  - pivotal
-  - landscape
-  - journey
-  - unlock
-  - elevate
+  # Verbs ending in "e" drop it before "-ing", so that form needs its own branch.
+  - leverage(?:s|d)?|leveraging
+  - utilise(?:s|d)?|utilising
+  - robust(?:ly|ness)?
+  - seamless(?:ly)?
+  - holistic(?:ally)?
+  - comprehensive(?:ly|ness)?
+  - streamline(?:s|d)?|streamlining
+  - delve(?:s|d)?|delving
+  - underscore(?:s|d)?|underscoring
+  - intricate(?:ly)?
+  - crucial(?:ly)?
+  - pivotal(?:ly)?
+  - landscape(?:s)?
+  - journey(?:s)?
+  - unlock(?:s|ed|ing)?
+  - elevate(?:s|d)?|elevating

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -104,12 +104,39 @@ def _vocabulary_tokens() -> list[str]:
     return yaml.safe_load(path.read_text(encoding="utf-8"))["tokens"]
 
 
+def _vocabulary_bases() -> list[str]:
+    """The plain word each token is built around.
+
+    A token carries the word's inflections, so the base is the leading run of
+    letters: `leverage(?:s|d|ly)?|leveraging` is built around `leverage`.
+    """
+    bases = []
+    for token in _vocabulary_tokens():
+        match = re.match(r"[a-z]+", token)
+        assert match, f"token {token!r} does not start with a plain word"
+        bases.append(match.group(0))
+    return bases
+
+
 def test_vocabulary_rule_matches_the_register_banned_list() -> None:
     """Rule 3's words, the Vale tokens that enforce them, and the paste block's
     copy are three hand-synced lists — drift between them means the linter and
     the register disagree about what is banned."""
     banned = _listed_after("Banned:", _register_text())
-    assert _vocabulary_tokens() == banned
+    assert _vocabulary_bases() == banned
+
+
+def test_vocabulary_tokens_carry_inflections() -> None:
+    """A token that is only the base word lets the inflected forms through.
+
+    Vale wraps each token in word boundaries, so a bare `leverage` matches that
+    spelling alone and "leverages" passes the lint.
+    """
+    bare = [t for t in _vocabulary_tokens() if re.fullmatch(r"[a-z]+", t)]
+    assert not bare, (
+        f"these tokens match the base form only, so their plurals and "
+        f"participles pass the lint: {bare!r}"
+    )
 
 
 def test_paste_block_repeats_the_register_banned_list() -> None:
@@ -131,6 +158,34 @@ def test_vale_flags_a_banned_word(tmp_path: Path) -> None:
         text=True,
     )
     assert "leverage" in result.stdout.lower()
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+@pytest.mark.parametrize("word", ["leverages", "leveraging", "streamlining", "underscored"])
+def test_vale_flags_an_inflected_banned_word(tmp_path: Path, word: str) -> None:
+    """The plural and participle forms are the ones writers reach for."""
+    fixture = tmp_path / "issue.md"
+    fixture.write_text(f"# Title\n\nThe service {word} the existing path.\n")
+    result = subprocess.run(
+        ["vale", "--config", str(default_vale_config_path()), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, f"{word!r} passed the lint:\n{result.stdout}"
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+@pytest.mark.parametrize("word", ["elevator", "elevation"])
+def test_vale_leaves_unrelated_words_alone(tmp_path: Path, word: str) -> None:
+    """A stem match would flag these; rule 3 bans "elevate", not its cousins."""
+    fixture = tmp_path / "issue.md"
+    fixture.write_text(f"# Title\n\nThe {word} is out of scope here.\n")
+    result = subprocess.run(
+        ["vale", "--config", str(default_vale_config_path()), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"{word!r} was flagged:\n{result.stdout}"
 
 
 @pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")


### PR DESCRIPTION
Closes #332.

Rule 3's lint matched base forms only. "The service leverages the cache" passed
a check that the base form would have failed, and the same held for all sixteen
words.

## What changed

`lib/lore_core/styles/vale/IssueRegister/Vocabulary.yml` — each token now
carries the word's real inflections. Verbs ending in "e" need a separate branch
for the participle, because the "e" drops: `leverage(?:s|d)?|leveraging`.
Adjectives take the adverb form, `crucial(?:ly)?`. Nouns take the plural.

The branches are written out per word rather than a stem plus `\w*`. A stem
match on "elevate" also catches "elevator" and "elevation", and rule 3 is
error-level — a false positive there blocks a correct sentence rather than
leaving an advisory warning.

The token order still mirrors the register's "Banned:" list, so the two read
side by side.

## The drift guard still works

`test_vocabulary_rule_matches_the_register_banned_list` compared token strings
against the register's list. Tokens are no longer plain words, so it now
compares the base each token is built around — the leading run of letters.

Two tokens needed rewriting for that to be unambiguous. `landscapes?` reads as
base "landscapes" to a leading-letters match, because the `?` binds to the `s`.
They are `landscape(?:s)?` and `journey(?:s)?` instead.

## Evidence

Red first: `test_vocabulary_tokens_carry_inflections` plus four parametrized
cases of `test_vale_flags_an_inflected_banned_word`. All 18 pass now.

Verified against Vale 3.17.0 across every word, not only the four in the test.
27 inflected forms flag at exit code 1: the plural, past and participle of each
verb, the adverb of each adjective, and both plurals.

No false positives. "elevator", "elevation", "lockdown", "journal",
"journalist", "landing" and "crucible" all pass, as do three ordinary
sentences. An identifier like `unlocked_by` also passes, since a word boundary
never matches after an underscore.

Both guards bite, checked by mutation. Adding a word to the register alone fails
the sync test; reverting one token to a bare word fails the inflection test and
two behavioural cases.

`test_vale_leaves_unrelated_words_alone` is new and guards the stem-match
regression directly.

Full suite: 2866 passed, 6 failed. All six fail identically on a clean tree —
`test_core_llm_wiring` (2), `test_install_dispatcher`, `test_cli_scopes`, and
`test_dead_code_gone` (2, from untracked stale `__pycache__` directories). Ruff
clean.

## One expected change in output

The shipped register lints at 26 rule-3 findings, up from 22. The four new ones
are in its own worked example, which quotes bad writing on purpose: "leverages"
and "comprehensively" at lines 105 and 107 were passing before. The linter now
flags the text the register presents as the failure to avoid.

## Note on this body's own lint

It carries nine rule-3 findings. Every one quotes a banned word to name the
defect or the fix, and four of them exist only because this change works. The
register's own text trips the same rule where it lists the words.
