### PR TITLE
brainstorm: are session notes still worth it — divergent brief

### DIFF
--- a/brainstorms/lore-session-notes-worth.design.md
+++ b/brainstorms/lore-session-notes-worth.design.md
@@ -1,0 +1,144 @@
+# Session-note retirement + flag architecture — design export
+
+Exported 2026-08-04 from `lore-session-notes-worth.md` (divergent brief). All
+items under "Settled" were confirmed explicitly by the user, including the
+four named losses. This file is the input to grilling and PRD drafting. It is
+a design description, not a build plan. The brief stays open for the parked
+questions; reopen there if grilling breaks something.
+
+## The architecture at a glance
+
+```
+TEAM LAYER (shared brain)
+  ADRs · PRDs · issues/PRs · docs · code          ← authoritative artifacts
+  wiki: topic/project notes + flags               ← human-worthy only (C11)
+  lore = the funnel: knows where context lives, pulls it in
+
+        ▲  flags — the ONLY crossing (deliberate, one fact, stamped)
+        │
+PERSONAL LAYER (private by design — the privacy boundary)
+  own transcripts (wiki/*/.transcripts/, gitignored — locality is correct)
+  breadcrumb ledger (machine format, extends transcript-ledger.json):
+    session → repo, branch, PRs, issues, commits, files → transcript id
+  owner drills their own reasoning; nobody traverses a colleague's
+```
+
+## Settled decisions
+
+1. **Session notes as vault files are retired.** No more LLM-composed session
+   notes, in-note fact ledgers, or note renders. Accepted losses (user,
+   2026-08-04): the wedge re-phrases privacy-first (why is recorded raw +
+   crosses only via artifacts/flags); passive teammate browsing removed by
+   design; briefings need a new source or parking; onboarding rides on flag
+   quality.
+2. **Medium principle / vault is a human surface.** Machine data never
+   masquerades as wiki notes. Machine state lives in `.lore/` stores; wiki
+   holds only what a human might want to read; transcripts hold the raw
+   record. (The disclaimer-headed machine note was the symptom of the
+   mismatch.)
+3. **Breadcrumb ledger, machine format.** The deterministic per-session
+   linkage (already captured zero-LLM: repo, branch, PRs, issues, commits,
+   files, transcript id) becomes a structured store extending
+   `transcript-ledger.json` — never rendered as notes. It is derived and
+   rebuildable (from transcripts + git + GitHub); knowledge remains
+   markdown+git; transcripts remain private raw.
+4. **Privacy boundary = locality.** Transcripts stay machine-local and
+   gitignored *by design*. Personal backup is the dev's own concern (not a
+   lore feature). A colleague's "why" is reachable by asking the owner, who
+   drills their own archive.
+5. **SessionStart recap is deterministic.** The banner's continuity function
+   ("yesterday: repo X, PR #n, files …") renders from the ledger, zero LLM.
+   Rich mid-thread handoffs use the deliberate `/lore:handover` (existing
+   spec). Harness-native continuity covers the common same-session case.
+6. **The flag** — the deliberate crossing:
+   - *Initiation:* agent-primary (secretary pattern, files in the moment a
+     gem appears: trap, dead end + reason, unwritten reasoning, gap-fact) +
+     always-available human command (CLI + slash) + one agent self-check at
+     session end ("anything flag-worthy unflagged?"). No human interruption
+     anywhere. Team-relevant gems go to the flag, not private agent memory.
+   - *Content:* one fact per flag; lead sentence + short body (claim + why
+     worth keeping); deterministic origin block (author, date, transcript id,
+     `@N` anchor, repo/PR/issue/commit refs). Refs code-verified at write:
+     checkable → plain with ✓; uncheckable → stamped session-talk phrasing.
+     Hard gate: no origin, no flag. Flags stand alone for the team — the
+     anchor is an owner-only bonus (anchor asymmetry). No mandatory kind
+     taxonomy; optional tags.
+   - *Landing:* route-before-write — funnel proposes the target; append to
+     the owning topic/project note as an attributed, append-only block; new
+     topic note only when no home exists. Wiki/scope routing rides `.lore.yml`
+     unchanged. Edit policy extension: agents append, never edit; humans own
+     bodies and refactor freely.
+   - *Machinery:* MCP tool + CLI verb on the journal pattern — deterministic
+     write, no pipeline. One spine event per flag (write-side telemetry from
+     day one). Capture needs no lore-owned LLM; lore's backend becomes
+     optional (briefings only).
+7. **Measurement is mandatory before trust (S2).** Instrument flag rate from
+   day one; run a known-gem baseline (replay sessions containing known gems,
+   check they get flagged); flip-probe the directive. Under-flagging is the
+   main failure mode and is invisible without measurement.
+8. **Rollout is additive-first.** The flag primitive ships beside the
+   existing pipeline; retirement/teardown of note composition is the *last*
+   step, taken with S2 evidence in hand.
+
+## What is retired vs what stays
+
+Retired: LLM note composition (Curator A's compose path), in-note typed-fact
+ledger + rendered bodies, note files as the capture output, `sessions/*.md`
+growth. Already dead, confirmed no-regression: Curator B/C, the abstraction
+layer (concepts/decisions/threads extraction), surfaces.
+
+Stays: transcript capture + archive, deterministic linkage capture, scope
+routing (`.lore.yml`), the funnel tools (repo docs, context pack, codemap,
+search/drill over the human wiki), journals (orthogonal genre: freeform vs
+fact), sensitivity gate (now only over flags — job shrinks), 61 legacy
+concept notes (read-only stock).
+
+## Binding constraints (carried from the brief)
+
+- C2 banner budget tiny; local-backend capacity ceiling.
+- C3/ADR 0004: nothing in the vault asserts world-state on its own
+  authority — flags keep code-stamped phrasing.
+- C4: every LLM-written vault line is a poisoning surface — flags are few,
+  gated, and land where humans see them (the self-correcting loop).
+- C8: no LLM-verifies-LLM, no LLM-distills-LLM — no rescue layers.
+- C9 (governing): lightweight or unused; capture must work with no API key.
+- C10: lore stays general — no domain aggregation features.
+- C11: vault is a human surface.
+- July brief (still valid): deterministic = trusted; no insider taxonomies
+  in user-facing forms.
+
+## Open items grilling must resolve
+
+1. Flag block template (exact markdown shape of the attributed block).
+2. User-facing naming (`lore flag` / `/lore:keep` / other) and directive
+   wording + flagging threshold (tune via S2 experiment).
+3. Banner recap depth and cross-day window (yesterday only? open threads?).
+4. Ledger store shape (extend transcript-ledger.json vs sibling store) and
+   how `lore_search`/`lore_drill` expose ledger routing; read-side
+   telemetry event.
+5. Briefings (L3): new source (flag/topic-note digest) or park.
+6. Migration of the ~556-note stock (archive wholesale / freeze in place;
+   C8 forbids a reliable LLM gem-harvest).
+7. Fate of `lore_resume` (never called) and the retired machinery's config
+   surface (curator backend becomes optional).
+8. Hygiene: rewrite the vault's lore orientation note and [[use-cases]]
+   (#1 wedge phrasing, #26 "lore is the WHY" → "knows where the why
+   lives"; strike triad/surfaces remnants); update agent memories.
+9. Same-person multi-machine story for the personal layer (two half-brains)
+   — may be "document it, don't solve it".
+
+## Evidence (why this design, one line each)
+
+- Reads: 17 note retrievals/month across 307 sessions, all ≤7 days old;
+  archival reader never observed; lore_resume never called.
+- Cost: ~46 LLM calls/day, 60 errors + 91 force-flushes per 8 days for the
+  note pipeline; funnel tools out-used note retrieval ~4.5:1.
+- Specimen: 1,636-line note for one session; Done ≈ GitHub restatement;
+  6–8 genuine gems buried; every fact tripled.
+- Archive audit: 556 transcripts / 216 MB, gitignored, one machine — made
+  the privacy boundary structural instead of accidental.
+- Use-case cross-check: no veto; #16 already states the funnel identity in
+  ratified language; losses L1–L4 named and user-confirmed.
+- History: two PRDs + one prior brainstorm iterated the note *mechanism*;
+  the noise complaint persisted — the mission, not the mechanism, was the
+  problem.

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -1,6 +1,7 @@
 # Are session notes still worth it — divergent brief
-state: exploring
-updated: 2026-08-04 (pressure-test: hybrid vs organic brain)
+state: exploring → converging on architecture
+updated: 2026-08-04 (steer 3: three layers — team artifacts / personal
+transcripts+ledger / flags as the crossing; medium principle)
 
 Predecessor: `lore-session-note-shape.md` (2026-07-03, settled the *shape*;
 superseded by typed facts, PRD 0008 / ADR 0003). This brief asks the prior
@@ -31,20 +32,40 @@ quality in four months, plus the standing context-poisoning surface (C4).
 The open field: what, if anything, do session notes contribute to the brain
 that justifies machinery — or does a deliberate, occasional **flag to the
 vault** (plus deterministic breadcrumbs) replace them at a fraction of the
-price? Nothing is settled.
+price?
+
+**Steer 3 (user, 2026-08-04) — the emerging architecture, three layers:**
+
+1. **Team layer (shared brain):** the artifacts — ADR, PRD, issues/PRs,
+   docs, code — plus only *human-worthy* wiki notes (flags, topic notes,
+   orientation). "Don't we have all with ADR, PRD, github, docs plus the
+   code?" — for the team: yes. Lore is the funnel over it.
+2. **Personal layer (private, local *by design*):** each dev's own
+   transcripts plus a **machine-format breadcrumb ledger** connecting
+   transcripts ↔ artifacts. The individual drills their *own* decisions they
+   own. The privacy boundary sits here: nobody traverses into a colleague's
+   reasoning. (`transcript-ledger.json` already exists as infrastructure.)
+3. **The crossing:** flags/promotion — the only channel by which
+   reasoning-level value becomes team-visible. Deliberate, small, anchored.
+
+**Medium principle (settling):** machine data must not masquerade as human
+notes. The breadcrumb ledger is routing data no human reads — as Obsidian
+files it costs mental load (graph clutter, search hits, disclaimer headers
+telling humans not to trust what's in front of them) while serving only
+machine drill-down. Each layer in its native medium: machine index →
+structured store (`.lore/`), human knowledge → wiki notes, raw record →
+transcripts. The session note as a vault file was a medium mismatch.
 
 ## Open questions
 
-- Q10 [identity] (open): **What does the funnel need to know about sessions,
-  if anything?** The funnel routes "where does context about X live". Options:
-  (a) nothing session-specific — artifacts + vault notes + codemap suffice;
-  (b) a deterministic **distribution map**: per-session linkage frontmatter
-  (repo, branch, PRs, issues, files touched → transcript pointer) already
-  captured zero-LLM today — "X was worked in session S, its context landed in
-  PR #n" as pure breadcrumbs; (c) LLM-written note bodies (status quo).
-  Note: (b) is zero-LLM, zero-poison, and survives C8. Tension: can a
-  breadcrumb with no prose ever answer "why did we abandon that approach?" —
-  or is that exactly what flags (Q12) are for?
+- Q10 [identity] (settling — steer 3): **What does the funnel need to know
+  about sessions?** Answer converging on (b), *in machine form*: a
+  deterministic distribution map (repo, branch, PRs, issues, commits, files →
+  transcript pointer), held as a structured store extending
+  `transcript-ledger.json` — **not as vault notes** (medium principle).
+  (c) LLM note bodies is out; "why did we abandon X?" is the flags' job
+  (Q12) or stays in the owner's private transcript drill. Residual detail:
+  exact store shape and how `lore_search`/drill expose it.
 
 - Q11 [price] (open): **Is the Curator A machinery worth its cost?** Cost:
   quantified above; plus ops fragility (60 NoteClosedError in 8 days) and
@@ -88,16 +109,17 @@ price? Nothing is settled.
   actually need — normalized transcript archive + linkage, or prose notes?
   If the former, the bridge survives the Q11 trim untouched.
 
-- Q13 [durability] (open, opened by pressure-test): **What is the transcript
-  archive's durability and privacy contract?** Measured today: `.transcripts/`
-  is **gitignored** — 556 files / 216 MB, one machine, no retention policy,
-  not portable, not team-shared. The hybrid's "nothing is irreversible,
-  transcripts remain" holds only for this laptop. Options: accept locality
-  (the brain's grounding layer is per-machine; flags must carry enough to
-  stand alone); commit transcripts (collides head-on with privacy/redaction —
-  presumably why they are ignored); a separate shared archive with its own
-  access control; redact-then-commit. Durability vs privacy is a genuine
-  fork, and every anchor (`@N`) in the vault silently assumes an answer.
+- Q13 [durability] (reframed by steer 3): **locality is the design, not the
+  hole.** Transcripts hold reasoning; reasoning is private; therefore the
+  archive being machine-local is *correct* — the privacy boundary made
+  structural. What remains open shrinks to: (i) personal durability — backup
+  of one's own archive (a dev's own concern, maybe a doctor-check nudge, not
+  a lore feature per C10); (ii) same-person multi-machine fragmentation
+  (laptop + desktop = two half-brains); (iii) **anchor asymmetry**: a flag
+  shared in the wiki may carry an `@N` anchor into a transcript only its
+  author holds — drillable for the owner, dead weight for colleagues. Flags
+  must therefore stand alone; the anchor is a bonus for the author, never
+  load-bearing for the team.
 
 ## Pressure-test: hybrid vs organic brain (2026-08-04)
 
@@ -136,11 +158,14 @@ context for the work" functionally requires.
   spec'd — but deliberate, so same A5 amnesia risk); a deterministic
   breadcrumb recap in the banner ("yesterday: repo X, PR #n, files …");
   accept harness-native continuity for the common case.
-- S2 *under-flagging amnesia.* "Did we already try X?" — negative-result
-  recall is the classic labbook value, and exactly what agents will
-  under-flag (bias toward traps and successes over abandoned paths). This is
-  measurable (instrument flag rate against a known-gem baseline) and must be
-  measured, never assumed.
+- S2 *under-flagging amnesia — now with a team cost.* "Did we already try
+  X?" — negative-result recall is the classic labbook value, and exactly what
+  agents will under-flag (bias toward traps and successes over abandoned
+  paths). Under steer 3 the stakes rise: flags are the *only* channel across
+  the privacy boundary, so an unflagged gem is not just personally
+  forgotten — it is structurally invisible to the team forever (the owner's
+  transcript being private). Measurable (flag rate against a known-gem
+  baseline); must be measured, never assumed.
 - S3 *topology without a gardener.* C8 forbids a defrag/merge rescue layer,
   so flag routing must be right at write time: route-before-write (search
   first, append to the existing topic note). Otherwise the sibling-note
@@ -210,6 +235,10 @@ Not adopted — held open.
 - C10 (ratified 2026-08-04): lore stays **general**. Domain aggregations
   (pmo timelines, CCAT reporting) live in project artifacts, never as lore
   features.
+- C11 (settling, steer 3): **the vault is a human surface.** Only content a
+  human might want to read lives as wiki notes; machine state lives in
+  machine stores under `.lore/`. Machine-written files in the Obsidian graph
+  cost mental load and are a medium mismatch.
 
 ## Glossary
 
@@ -224,6 +253,14 @@ Not adopted — held open.
   [candidate]
 - gem / flag-worthy := residual fact with future value: trap, dead end with
   reason, unwritten reasoning, gap-fact. [candidate]
+- ledger := **redefined by steer 3**: the machine-format store connecting
+  transcripts ↔ artifacts (extends `transcript-ledger.json`). The old
+  meaning — the in-note typed-fact ledger of PRD 0008 — is historical.
+  [candidate — rename pending, "session ledger" vs "distribution map"]
+- privacy boundary := reasoning (transcripts) is private to its owner; only
+  artifacts and flags cross to the team. A colleague's "why" is reachable
+  only by asking them — the owner drills their own archive and answers.
+  [candidate]
 - handover/recap := carrying a working thread across a session boundary —
   next session, other harness, other human. [candidate]
 - reporting := struck 2026-08-04 — CCAT-style reports are a different
@@ -270,6 +307,13 @@ Not adopted — held open.
   cross-harness bridge demoted to "could" (Q8).
 - (settled via Q1 evidence + user) Readers: short-horizon continuity, plus a
   human recap reader *worth earning back* — not an archival audience.
+- (settling 2026-08-04, steer 3) **Session notes as vault files are retired
+  as a form.** The breadcrumb job moves to a machine-format ledger; the
+  human-worthy residue moves to flags/topic notes; the recap function is
+  served by a deterministic banner recap from the ledger, not by note files.
+  The "reader worth earning back" is earned by *removing* machine notes from
+  the human surface, not by writing better ones. Pending explicit user
+  confirmation before state flips to settled.
 - (hygiene, needs filing) Stale doctrine: the vault's lore orientation note
   (SessionStart-injected) and agent memory still describe the Curator A/B/C
   triad and daily B abstraction — misinformation fed to every session.

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -1,6 +1,6 @@
 # Are session notes still worth it — divergent brief
 state: exploring
-updated: 2026-08-04 (steer 2: funnel identity, machinery price, flag model)
+updated: 2026-08-04 (pressure-test: hybrid vs organic brain)
 
 Predecessor: `lore-session-note-shape.md` (2026-07-03, settled the *shape*;
 superseded by typed facts, PRD 0008 / ADR 0003). This brief asks the prior
@@ -88,6 +88,76 @@ price? Nothing is settled.
   actually need — normalized transcript archive + linkage, or prose notes?
   If the former, the bridge survives the Q11 trim untouched.
 
+- Q13 [durability] (open, opened by pressure-test): **What is the transcript
+  archive's durability and privacy contract?** Measured today: `.transcripts/`
+  is **gitignored** — 556 files / 216 MB, one machine, no retention policy,
+  not portable, not team-shared. The hybrid's "nothing is irreversible,
+  transcripts remain" holds only for this laptop. Options: accept locality
+  (the brain's grounding layer is per-machine; flags must carry enough to
+  stand alone); commit transcripts (collides head-on with privacy/redaction —
+  presumably why they are ignored); a separate shared archive with its own
+  access control; redact-then-commit. Durability vs privacy is a genuine
+  fork, and every anchor (`@N`) in the vault silently assumes an answer.
+
+## Pressure-test: hybrid vs organic brain (2026-08-04)
+
+Hybrid under test: auto-captured deterministic breadcrumbs (linkage
+frontmatter → transcript pointer) + transcript archive + **agent-initiated,
+topic-routed flags**. Tested against what "an organic brain that grows a
+context for the work" functionally requires.
+
+**Where it holds:**
+
+- *Topology (the strongest resonance).* A brain files by topic and
+  strengthens with use, not by date. Flags appending to living topic/project
+  notes grow the vault the way the vision describes; date-sharded session
+  sediment stops pretending to be memory. The date layer that remains
+  (breadcrumbs) is logistics, and honest about it.
+- *Lab-notebook culture (domain resonance).* Real labbooks are deliberate:
+  instruments auto-log raw data, the scientist chooses what to write down.
+  Transcripts = instrument logs; flags = notebook entries; breadcrumbs = the
+  run index. The auto-note was trying to make the instrument write the
+  notebook. The already-ratified deliberate `/lore:handover` spec shows the
+  ecosystem was drifting this way on its own.
+- *Lightweight (C9).* Capture needs no LLM backend at all — a team can adopt
+  breadcrumbs + archive with no API key, no curator config, none of the
+  pipeline's failure classes (60 NoteClosedErrors/8 days all die). The
+  machinery deletion is large and reversible (code in git, transcripts
+  regenerable-from … see G1/Q13).
+- *Forgetting + trust surface.* Fewer, better lines; positive-evidence
+  staleness applies to a reviewable volume; C4 surface shrinks drastically.
+
+**Stress points (named, not resolved):**
+
+- S1 *continuity gap.* The hybrid kills the one artifact with measured
+  organic use: the ≤7-day "what did the last session on this thread do" read
+  (~17/month). Raw-transcript drill is too expensive to replace it (C7).
+  Mitigations on the table: the deliberate `/lore:handover` (already
+  spec'd — but deliberate, so same A5 amnesia risk); a deterministic
+  breadcrumb recap in the banner ("yesterday: repo X, PR #n, files …");
+  accept harness-native continuity for the common case.
+- S2 *under-flagging amnesia.* "Did we already try X?" — negative-result
+  recall is the classic labbook value, and exactly what agents will
+  under-flag (bias toward traps and successes over abandoned paths). This is
+  measurable (instrument flag rate against a known-gem baseline) and must be
+  measured, never assumed.
+- S3 *topology without a gardener.* C8 forbids a defrag/merge rescue layer,
+  so flag routing must be right at write time: route-before-write (search
+  first, append to the existing topic note). Otherwise the sibling-note
+  problem returns at topic level. Candidate assist: the funnel itself
+  proposes the target note — the funnel serving capture, not just retrieval.
+- S4 *flags are still LLM writes.* C4 shrinks but does not vanish — and a
+  flag carries an implicit "worth keeping" endorsement, so per-line trust
+  demand *rises*. The typed-fact gates survive in miniature: no anchor, no
+  flag; stamped phrasing for anything unverifiable.
+- G1 *the safety-net hole* → promoted to Q13 (transcript durability).
+
+**Verdict of the test:** the hybrid survives the vision's core demands
+(topic-shaped growth, lightweight, deliberate culture) better than the status
+quo, with three real stress points (S1–S3) that each have candidate
+mitigations, one structural caveat (S4), and one unresolved hole (Q13).
+Not adopted — held open.
+
 ## Absorbed questions (from earlier passes)
 
 - Q2 (residual inversion) and Q6 (promotion) → folded into Q12: the
@@ -145,6 +215,8 @@ price? Nothing is settled.
 
 - funnel := the layer that knows how context is distributed across artifacts
   (ADRs, PRDs, docs, issues, code, vault) and pulls it in on demand. [agreed]
+- hybrid := auto deterministic breadcrumbs + transcript archive +
+  agent-initiated topic-routed flags; the capture model under test. [candidate]
 - flag := a deliberate, occasional capture of one keep-worthy item to the
   vault, with an anchor to its origin. [candidate]
 - distribution map := zero-LLM per-session linkage (repo, branch, PRs,
@@ -178,6 +250,12 @@ price? Nothing is settled.
   mechanism).
 - [[use-cases]] (vault): ratified problem list — any kill/trim must be
   checked against it. Still TODO for this brief.
+- [Transcript archive audit 2026-08-04]: `wiki/*/.transcripts/` gitignored;
+  556 files / 216 MB on one machine; retention janitor covers only ops logs
+  (spine/flushes/runs), transcripts unbounded and unmanaged → Q13.
+- [Handover spec (proposed 2026-05-11)]: `/lore:handover` deliberate +
+  explicit, user-invoked — prior art for deliberate capture inside lore's own
+  design history → S1, Q12.
 
 ## Parked / settled
 

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -1,6 +1,6 @@
 # Are session notes still worth it — divergent brief
 state: exploring
-updated: 2026-08-04 (Q1 evidence pass)
+updated: 2026-08-04 (Q1 evidence pass; user rulings: abstraction layer dead, functions = handover/recap + reporting)
 
 Predecessor: `lore-session-note-shape.md` (2026-07-03, settled the *shape*; its
 shape was since replaced by typed facts, PRD 0008 / ADR 0003). This brief asks
@@ -46,8 +46,12 @@ Nothing is settled.
   cannot see: (i) the SessionStart banner deterministically consumes note
   titles/summaries every session — by volume the *dominant* consumer; (ii)
   human reads in Obsidian leave no trace — only the user can answer that;
-  (iii) curator feedstock reads happen outside these transcripts. Remaining
-  open sliver: which of (i)–(iii) carries real value.
+  (iii) curator feedstock reads happen outside these transcripts. **Settled
+  2026-08-04 (user):** (ii) is near-zero *because notes aren't useful* — an
+  aspirational reader, not an absent one; (iii) is void — abstraction layer
+  dead (C8). The readers to design for: short-horizon continuity
+  (agent/human), the reporting pipeline, and a human recap reader worth
+  earning back.
 
 - Q1b [reframe] (open, spawned by Q1 evidence): **Is the session note a
   handover artifact with a ~one-week half-life, not an archive?** Every
@@ -56,12 +60,18 @@ Nothing is settled.
   schema cleanup). That is the resume/handover job, not the labbook-archive
   job. If accepted, it reframes hard: depth and ledger should optimize for a
   reader *days* away with partial context, not months away with none;
-  long-tail value would then live in *promotion* (Q6) and curator abstraction,
-  not in the note body; retention of full bodies past the horizon becomes
-  questionable (C4 poisoning surface with no measured reader). Tension: a
-  30-day observation window cannot rule out rare high-value archaeology
-  ("what broke in March?") — absence of evidence over one month is weak
-  evidence of absence over a year.
+  long-tail value would then live in *promotion* (Q6) — with abstraction dead
+  (see settled), promotion is the *only* long-tail path; retention of full
+  bodies past the horizon becomes questionable (C4 poisoning surface with no
+  measured reader). User input 2026-08-04 strengthens this from both sides:
+  the two wanted functions — handover/recap (cross-harness, cross-human) and
+  **reporting what has been worked on** — are both short-horizon by nature
+  (reporting cadence is daily/weekly). The user also confirmed they rarely
+  open old notes in Obsidian, *because they are not useful* — a symptom to
+  fix, not a reader to design away. Tension remains: a 30-day observation
+  window cannot rule out rare high-value archaeology ("what broke in
+  March?") — absence of evidence over one month is weak evidence of absence
+  over a year.
 
 - Q2 [residual] (open): **Should the note keep only what is recorded nowhere
   else?** The verification machinery already computes this per line: `✓` means
@@ -110,13 +120,14 @@ Nothing is settled.
   end-of-session filing pass may not violate that. Contested — needs the
   user's read.
 
-- Q7 [existence] (open): **The honest kill option.** Retire the note as a
-  product: keep transcript archive + anchors + frontmatter (deterministic,
-  trusted), let retrieval work over transcripts/ledgers directly, let Curator B
-  read ledgers instead of notes. What actually breaks? Known dependents:
-  SessionStart banner ("Last: [[note]]"), Curator B feedstock, briefings,
-  `lore_resume`, the vault graph. Cost of keeping notes isn't only tokens —
-  every LLM-written line is a context-poisoning surface (C4).
+- Q7 [existence] (narrowed 2026-08-04): **The honest kill option — now only
+  for the archive function.** Full kill is off the table: the user names two
+  wanted functions (handover/recap, reporting). What remains open is killing
+  the *archival* role: does anything past the ~week horizon deserve to exist
+  as a note body, or only as promoted artifacts (Q6) + transcript archive?
+  Known dependents rechecked: SessionStart banner, `lore_resume` (never
+  called — dead weight or undiscovered?), the vault graph. Curator B
+  feedstock struck as a dependent — B is dead.
 
 - Q8 [cross-cutting] (open): **Is the cross-harness / cross-team / human-AI
   promise still load-bearing?** The user's own hunch: mostly solved by
@@ -163,6 +174,12 @@ Nothing is settled.
   resolving per-wiki.
 - C7 (inherited): raw transcript is the dominant processing cost; each turn
   seen once, cheapest tier that works.
+- C8 (ratified 2026-08-04): **no LLM abstraction pass is available as a rescue
+  move.** Curator B/C-style distillation over LLM-written notes proved
+  unreliable — wrong claims entered context (poison), too many
+  inconsistencies. Whatever the note itself doesn't carry well, no downstream
+  layer fixes. Extends predecessor C1 (no LLM-verifies-LLM): also no
+  LLM-distills-LLM.
 
 ## Glossary
 
@@ -171,6 +188,10 @@ Nothing is settled.
 - gem := a residual fact with plausible future value (trap, dead end, unwritten
   reasoning). [candidate]
 - labbook signal := contested — currently defined only negatively (Q4). [contested]
+- handover/recap := carrying a working thread across a session boundary —
+  next session, other harness, or other human. [candidate]
+- reporting := periodic human-facing account of what has been worked on,
+  sourced from notes (daily/weekly cadence). [candidate]
 
 ## Sources
 
@@ -200,5 +221,19 @@ Nothing is settled.
 
 - (settled, ratified elsewhere) Notes are never authoritative — not reopened
   here.
-- (parked) Curator B/C redesign — only in scope where a note change breaks
-  their input contract.
+- (settled 2026-08-04, user) **The abstraction layer is dead.** Curator B/C
+  and the concepts/decisions/threads extraction are retired — could not be
+  made reliable; wrong claims poisoned context. Verified in the running
+  system: B last spawned 2026-06-15, zero B/C runs in the spine window, zero
+  abstraction writes since, no B/C code paths in hooks/spawn — no regression.
+  61 legacy concept notes remain as read-only stock (2 were organically read;
+  keep, don't grow).
+- (settled 2026-08-04, user) Wanted note functions: handover/recap
+  (cross-harness, cross-human) and reporting. Replaces the open-ended
+  reader list of Q1.
+- (hygiene, needs filing) Stale doctrine: the vault's lore orientation note
+  (SessionStart-injected) still describes the Curator A/B/C triad and daily
+  B abstraction; agent memory likewise. Should be corrected to match the
+  ratified state — outside this brief's questions.
+- (parked) Fate of `lore_resume` (never called) and of the 61 legacy concept
+  notes — revisit after the note redesign settles.

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -129,6 +129,19 @@ Nothing is settled.
   called — dead weight or undiscovered?), the vault graph. Curator B
   feedstock struck as a dependent — B is dead.
 
+- Q9 [audiences] (open, spawned by the 2026-08-04 rulings): **Handover and
+  reporting want different documents — one artifact or two renders?** Handover
+  wants dense, thread-scoped context for a reader resuming work; reporting
+  wants human-readable prose about what was worked on, aggregated across
+  sessions on a cadence. ADR 0003 already provides the mechanism: the note
+  body is a deterministic render of a fact store — nothing forbids *two*
+  renders (or a render + an aggregator) of the same store. Options: one note
+  serving both badly (status quo); note = handover render, reporting =
+  cross-note aggregation (deterministic, from headlines/frontmatter); separate
+  artifacts with separate extraction. Constraint check: C8 means whatever
+  feeds reporting must be right at extraction time — no distillation pass
+  will clean it later; C2 caps what the banner can carry.
+
 - Q8 [cross-cutting] (open): **Is the cross-harness / cross-team / human-AI
   promise still load-bearing?** The user's own hunch: mostly solved by
   workflows. But workflows assume GitHub-repo work. Science sessions (data

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -1,7 +1,7 @@
 # Are session notes still worth it — divergent brief
-state: exploring → converging on architecture
-updated: 2026-08-04 (steer 3: three layers — team artifacts / personal
-transcripts+ledger / flags as the crossing; medium principle)
+state: converging:flag (retirement confirmed; shaping the flag primitive)
+updated: 2026-08-04 (retirement settled with losses L1–L4 accepted; flag
+slice converging)
 
 Predecessor: `lore-session-note-shape.md` (2026-07-03, settled the *shape*;
 superseded by typed facts, PRD 0008 / ADR 0003). This brief asks the prior
@@ -79,22 +79,7 @@ transcripts. The session note as a vault file was a medium mismatch.
   transcripts remain, notes could be regenerated later from archives if a
   reliable extractor ever exists.
 
-- Q12 [flag] (open): **The deliberate-capture alternative: an occasional flag
-  when something is worth keeping.** Groundwork exists: journals
-  (`journals/ai.md` + `human.md`, non-derived, no pipeline) +
-  `lore_journal_write`; the flag variant would route into the wiki graph with
-  scope and wikilinks instead of a flat file. Design axes held open: *who
-  flags* — human command; agent-initiated (secretary pattern: the agent
-  notices "worth keeping" mid-session); end-of-session single question; *what
-  a flag captures* — the fact, why it's worth keeping, an anchor into the
-  archived transcript; *where it lands* — wiki note vs journal vs project
-  folder. What counts as flag-worthy inherits the old gem definition:
-  environment traps, dead ends with reasons, unwritten reasoning, gap-facts.
-  **The central tension (A5):** auto-capture was ratified precisely because
-  humans forget to write notes; a flag-only model reintroduces
-  amnesia-by-default. Middle grounds: Q10b breadcrumbs auto-captured +
-  flags for gems; agent-initiated flags make remembering the agent's job,
-  not the human's.
+- Q12 [flag] → converging; see **Flag shape** section below.
 
 - Q1b [horizon] (settling — accepted as observation): every measured organic
   read is short-horizon continuity (ages 1 min – 7 days; archival reader
@@ -151,13 +136,12 @@ context for the work" functionally requires.
 
 **Stress points (named, not resolved):**
 
-- S1 *continuity gap.* The hybrid kills the one artifact with measured
-  organic use: the ≤7-day "what did the last session on this thread do" read
-  (~17/month). Raw-transcript drill is too expensive to replace it (C7).
-  Mitigations on the table: the deliberate `/lore:handover` (already
-  spec'd — but deliberate, so same A5 amnesia risk); a deterministic
-  breadcrumb recap in the banner ("yesterday: repo X, PR #n, files …");
-  accept harness-native continuity for the common case.
+- S1 *continuity gap — answer-elect chosen with retirement:* the
+  deterministic breadcrumb recap in the banner ("yesterday: repo X, PR #n,
+  files …") rendered from the ledger, zero LLM, plus the deliberate
+  `/lore:handover` for rich mid-thread handoffs, plus harness-native
+  continuity for the common case. Detail shaping open (recap depth, cross-day
+  window).
 - S2 *under-flagging amnesia — now with a team cost.* "Did we already try
   X?" — negative-result recall is the classic labbook value, and exactly what
   agents will under-flag (bias toward traps and successes over abandoned
@@ -182,6 +166,79 @@ context for the work" functionally requires.
 quo, with three real stress points (S1–S3) that each have candidate
 mitigations, one structural caveat (S4), and one unresolved hole (Q13).
 Not adopted — held open.
+
+## Flag shape (converging slice, 2026-08-04)
+
+The flag: a deliberate, single-fact crossing from private reasoning to the
+team surface. Shaped along four axes — each with a lean and its reasoning;
+items marked *open* are not settled.
+
+**1. Who initiates — lean: agent-primary, human-always.**
+- Agent-initiated in the moment (secretary pattern): the session's own agent
+  recognizes a gem — trap, dead end + reason, unwritten reasoning, gap-fact —
+  and files the flag *while the context is hot*. This answers A5: remembering
+  is the agent's job, no human burden (C9), no human interruption
+  (Never-Ask survives for the human).
+- Plus the deterministic primitive, always available: a human command
+  (CLI + slash), per the ratified progressive-disclosure stance — magical
+  path *and* deterministic path.
+- Plus one boundary check: at session end the *agent* self-checks "anything
+  flag-worthy left unflagged?" — deliberateness at the boundary, mirroring
+  the ratified boundary-drain principle, still zero human interruption.
+- The directive must also resolve the memory competition: for team-relevant
+  gems, the flag beats the agent's private memory (observed double-capture:
+  the same trap filed to both). Private memory keeps only what is truly
+  personal-workflow.
+- *Open:* the directive wording and the flagging threshold — must be tuned
+  against measured flag rate (S2 is an experiment, not a setting).
+
+**2. What a flag carries — lean: one fact, standing alone, stamped.**
+- One fact per flag. A lead sentence + a short body: the claim, and why it
+  is worth keeping (what a future reader gains).
+- Origin block, deterministic: author handle, date, transcript id + `@N`
+  anchor, plus repo/PR/issue/commit refs where applicable.
+- Refs are code-verified at write (the PRD 0008 verification machinery
+  surviving in miniature): a checkable ref renders plain with its ✓; an
+  uncheckable claim renders in stamped session-talk phrasing (ADR 0004
+  discipline). Deterministic gate: no origin, no flag (S4).
+- The flag must stand alone for the team — the anchor is a bonus for the
+  owner's private drill, never load-bearing (Q13 anchor asymmetry).
+- No mandatory kind taxonomy (July brief ruling: insider taxonomies don't
+  fit users); optional tags allowed. *Open:* the exact block template.
+
+**3. Where it lands — lean: append to the owning topic/project note.**
+- Route-before-write: search first (funnel proposes the target); append to
+  the existing topic/project note as an **attributed, append-only block**;
+  create a new topic note only when no home exists. This is the organic
+  growth the vision asks for (notes strengthen with use) and the S3 defense
+  (no sibling sprawl, no gardener needed).
+- Wiki + scope routing rides the existing `.lore.yml` mechanism unchanged
+  (use case #5).
+- Edit-policy extension (the #23 rule): agent flags are append-only,
+  attributed, and never edit existing content; humans own the body and may
+  refactor flags freely afterward.
+- Self-correcting quality loop for free: flags land where humans actually
+  look (C11), so bad flags are *seen* and pruned — the feedback session
+  notes never had.
+- *Open:* whether high-churn topics eventually want a per-topic flags
+  subsection or file — decide on evidence of real churn, not upfront.
+
+**4. Machinery — lean: thin primitives, reusing what exists.**
+- An MCP tool + CLI verb mirroring the journal pattern (deterministic write,
+  no pipeline, no buffers/flushes); a spine event per flag (write-side
+  telemetry from day one — the observability gap Q1 exposed must not recur).
+- Capture needs no lore-owned LLM: the flagging text is written by the
+  session's own agent; verification is code. Lore's backend stays optional.
+- *Open:* naming — "flag" is the working term; the user-facing verb
+  (`lore flag` / `/lore:keep` / other) is a product-voice decision.
+- *Open:* whether the journal side-channels stay as-is beside flags
+  (different genre: freeform vs fact) — lean yes, they're orthogonal.
+
+**Measurement before trust (S2, mandatory):** instrument flag rate from day
+one and run a known-gem baseline (e.g. replay sessions with known gems —
+did the agent flag them?). Under-flagging is the architecture's main
+failure mode and is only detectable by measuring; the flip-probe
+methodology applies (test the directive under reversed framing too).
 
 ## Use-case cross-check (2026-08-04, against [[use-cases]] — 27 items, 2026-05-07)
 
@@ -354,13 +411,13 @@ needs a revision pass once this brief settles (hygiene).
   cross-harness bridge demoted to "could" (Q8).
 - (settled via Q1 evidence + user) Readers: short-horizon continuity, plus a
   human recap reader *worth earning back* — not an archival audience.
-- (settling 2026-08-04, steer 3) **Session notes as vault files are retired
-  as a form.** The breadcrumb job moves to a machine-format ledger; the
-  human-worthy residue moves to flags/topic notes; the recap function is
-  served by a deterministic banner recap from the ledger, not by note files.
-  The "reader worth earning back" is earned by *removing* machine notes from
-  the human surface, not by writing better ones. Pending explicit user
-  confirmation before state flips to settled.
+- (settled 2026-08-04, user — losses L1–L4 explicitly confirmed) **Session
+  notes as vault files are retired as a form.** The breadcrumb job moves to
+  a machine-format ledger; the human-worthy residue moves to flags/topic
+  notes; the recap function is served by a deterministic banner recap from
+  the ledger. Accepted prices: the wedge weakens to privacy-first phrasing
+  (L1), passive teammate browsing removed by design (L2), briefings need a
+  new source or parking (L3), onboarding rides on flag quality (L4).
 - (hygiene, needs filing) Stale doctrine: the vault's lore orientation note
   (SessionStart-injected) and agent memory still describe the Curator A/B/C
   triad and daily B abstraction — misinformation fed to every session.

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -1,252 +1,199 @@
 # Are session notes still worth it — divergent brief
 state: exploring
-updated: 2026-08-04 (Q1 evidence pass; user rulings: abstraction layer dead, functions = handover/recap + reporting)
+updated: 2026-08-04 (steer 2: funnel identity, machinery price, flag model)
 
-Predecessor: `lore-session-note-shape.md` (2026-07-03, settled the *shape*; its
-shape was since replaced by typed facts, PRD 0008 / ADR 0003). This brief asks
-the prior question that was never asked ground-up: **what is the session note
-for, now that lore-workflow exists — and is the answer "nothing"?**
+Predecessor: `lore-session-note-shape.md` (2026-07-03, settled the *shape*;
+superseded by typed facts, PRD 0008 / ADR 0003). This brief asks the prior
+question never asked ground-up: **what is the session note for — and is the
+answer "nothing"?**
 
 ## Framing
 
-When Lore started, the session was the only place decisions and reasoning
-lived; notes had to carry everything. Since then lore-workflow routes real work
-into durable, authoritative artifacts: PRD (why-product), ADR (why-technical),
-epic + issues (what/plan), PRs + git (what changed), docs (how to use). Each is
-written at the moment of highest context, by the process that owns it.
+The vision (user, 2026-08-04): **an organic brain that keeps notes and grows a
+context for the work.** The context already lives distributed — ADRs and PRDs
+(why), epics/issues/PRs (what), docs (how), code (truth). Lore's distinctive
+job is therefore not to *hold* everything but to be **the funnel: the layer
+that knows how the context is distributed and knows how to pull it in.** The
+vault holds supplementary material; domain-specific aggregation (pmo
+timelines, CCAT reports) stays in project artifacts — lore stays general.
+Governing value: **lightweight** — near-zero burden, or teams (and other
+teams) won't use it.
 
-The session note's claimed residual is "everything that didn't go through the
-workflow". The evidence says that residual is real but small, and the current
-note buries it: the 2026-08-03 epic-310 note is 1,636 lines / ~58k tokens, of
-which ~30 Done lines restate what GitHub already records (each `✓` literally
-*proves* the fact is recorded elsewhere), while the ~6–8 genuine gems
-(environment traps, silent failures, "agreed but recorded nowhere") sit
-undifferentiated in a 50-line Findings list, and the ledger then repeats every
-fact twice more.
+Measured behavior agrees with the funnel identity: in one month of transcripts
+the funnel tools (repo docs fetch/list, context pack, codemap, tier resolve)
+were called ~76 times; note retrieval 17 times, all within a ≤7-day horizon.
 
-This brief holds the whole space open: kill notes, shrink them to the residual,
-retarget them at a different reader, or split them by session population.
-Nothing is settled.
+Against that, the session-note machinery's price, quantified over the 8-day
+spine window: 367 LLM calls (~46/day), 60 errors, 193 warnings, 91 reaper
+force-flushes — plus four PRDs and three epics of engineering spent on note
+quality in four months, plus the standing context-poisoning surface (C4).
+
+The open field: what, if anything, do session notes contribute to the brain
+that justifies machinery — or does a deliberate, occasional **flag to the
+vault** (plus deterministic breadcrumbs) replace them at a fraction of the
+price? Nothing is settled.
 
 ## Open questions
 
-- Q1 [reader] (settling — evidence in, 2026-08-04): **Who actually reads a
-  session note, and when?** Measured over every Claude Code transcript on the
-  machine (307 sessions, 2026-07-05 → 2026-08-04; older transcripts rotated
-  out): **17 MCP retrieval calls total** — `lore_read` 11, `lore_search` 4,
-  `lore_drill` 2, `lore_resume` **0**. Of the reads, 9 targeted session notes,
-  2–3 concept/strategy notes. Direct filesystem `Read` of session notes: 10,
-  *all* lore-quality meta-work (PRD 0002 pilot, this brainstorm), none
-  organic. What the organic reads share: **all in ccat work, and all within a
-  short horizon — ages 1 min, ~2.5 h ×2, 1 d, 3 d ×2, 7 d. No session note
-  older than 7 days has ever been retrieved.** The "colleague months later"
-  reader — PRD 0002's explicit design target — has never appeared. Session
-  notes were retrieved *more* than Curator B's concept notes (~9:3), so the
-  abstraction layer is read even less than the raw layer. Blind spots the log
-  cannot see: (i) the SessionStart banner deterministically consumes note
-  titles/summaries every session — by volume the *dominant* consumer; (ii)
-  human reads in Obsidian leave no trace — only the user can answer that;
-  (iii) curator feedstock reads happen outside these transcripts. **Settled
-  2026-08-04 (user):** (ii) is near-zero *because notes aren't useful* — an
-  aspirational reader, not an absent one; (iii) is void — abstraction layer
-  dead (C8). The readers to design for: short-horizon continuity
-  (agent/human), the reporting pipeline, and a human recap reader worth
-  earning back.
+- Q10 [identity] (open): **What does the funnel need to know about sessions,
+  if anything?** The funnel routes "where does context about X live". Options:
+  (a) nothing session-specific — artifacts + vault notes + codemap suffice;
+  (b) a deterministic **distribution map**: per-session linkage frontmatter
+  (repo, branch, PRs, issues, files touched → transcript pointer) already
+  captured zero-LLM today — "X was worked in session S, its context landed in
+  PR #n" as pure breadcrumbs; (c) LLM-written note bodies (status quo).
+  Note: (b) is zero-LLM, zero-poison, and survives C8. Tension: can a
+  breadcrumb with no prose ever answer "why did we abandon that approach?" —
+  or is that exactly what flags (Q12) are for?
 
-- Q1b [reframe] (open, spawned by Q1 evidence): **Is the session note a
-  handover artifact with a ~one-week half-life, not an archive?** Every
-  observed organic read is thread-continuity: "what did the last session on
-  this do" (docs strategy, queue discovery, report flow, deploy-role fix,
-  schema cleanup). That is the resume/handover job, not the labbook-archive
-  job. If accepted, it reframes hard: depth and ledger should optimize for a
-  reader *days* away with partial context, not months away with none;
-  long-tail value would then live in *promotion* (Q6) — with abstraction dead
-  (see settled), promotion is the *only* long-tail path; retention of full
-  bodies past the horizon becomes questionable (C4 poisoning surface with no
-  measured reader). User input 2026-08-04 strengthens this from both sides:
-  the two wanted functions — handover/recap (cross-harness, cross-human) and
-  **reporting what has been worked on** — are both short-horizon by nature
-  (reporting cadence is daily/weekly). The user also confirmed they rarely
-  open old notes in Obsidian, *because they are not useful* — a symptom to
-  fix, not a reader to design away. Tension remains: a 30-day observation
-  window cannot rule out rare high-value archaeology ("what broke in
-  March?") — absence of evidence over one month is weak evidence of absence
-  over a year.
+- Q11 [price] (open): **Is the Curator A machinery worth its cost?** Cost:
+  quantified above; plus ops fragility (60 NoteClosedError in 8 days) and
+  the adoption burden every new team inherits. Measured benefit: 17
+  reads/month, ≤7-day horizon. Options: keep as-is; **trim to deterministic
+  capture** — transcript archive + linkage frontmatter, zero LLM anywhere
+  (keeps drill-down and the Q10b distribution map, kills noise, poison, and
+  price together); keep LLM notes only for session classes that want them
+  (old Q3 — e.g. science sessions with no artifact trail); kill capture
+  entirely. Constraint check: the trim option destroys nothing irreversibly —
+  transcripts remain, notes could be regenerated later from archives if a
+  reliable extractor ever exists.
 
-- Q2 [residual] (open): **Should the note keep only what is recorded nowhere
-  else?** The verification machinery already computes this per line: `✓` means
-  "an authoritative store has this", the hedge stamps ("agreed in discussion,
-  recorded nowhere", "reported done, recorded nowhere") mean "this exists only
-  here". Inversion on the table: `✓` lines collapse to a one-line breadcrumb
-  ("epic #310 landed — 8 PRs, see GitHub"), and the note body *is* the
-  recorded-nowhere residual. Tension: the Done list has skim value as a
-  timeline even when redundant; and a breadcrumb-only note depends on GitHub
-  permanence and access (C5).
+- Q12 [flag] (open): **The deliberate-capture alternative: an occasional flag
+  when something is worth keeping.** Groundwork exists: journals
+  (`journals/ai.md` + `human.md`, non-derived, no pipeline) +
+  `lore_journal_write`; the flag variant would route into the wiki graph with
+  scope and wikilinks instead of a flat file. Design axes held open: *who
+  flags* — human command; agent-initiated (secretary pattern: the agent
+  notices "worth keeping" mid-session); end-of-session single question; *what
+  a flag captures* — the fact, why it's worth keeping, an anchor into the
+  archived transcript; *where it lands* — wiki note vs journal vs project
+  folder. What counts as flag-worthy inherits the old gem definition:
+  environment traps, dead ends with reasons, unwritten reasoning, gap-facts.
+  **The central tension (A5):** auto-capture was ratified precisely because
+  humans forget to write notes; a flag-only model reintroduces
+  amnesia-by-default. Middle grounds: Q10b breadcrumbs auto-captured +
+  flags for gems; agent-initiated flags make remembering the agent's job,
+  not the human's.
 
-- Q3 [population] (open): **Are there two session populations needing two note
-  depths?** Workflow-run sessions leave a dense artifact trail — residual is
-  gems + traps only. Ad-hoc sessions (debugging, science analysis, brainstorms,
-  ops) leave *no* trail — the note is the only record. Options: adaptive depth
-  (workflow sessions → stub + links; ad-hoc → full labbook); uniform format
-  with the workflow case naturally shrinking via Q2's inversion; explicit
-  session-type stamp from lore-workflow skills. Tension: detection is fuzzy;
-  most sessions are mixed.
+- Q1b [horizon] (settling — accepted as observation): every measured organic
+  read is short-horizon continuity (ages 1 min – 7 days; archival reader
+  never observed; user confirms Obsidian reads ≈ 0 *because notes aren't
+  useful*). Design implication contingent on Q11/Q12: whatever is kept must
+  serve a reader days away with partial context; long-tail value travels
+  only via flags/promotion, never via note bodies nobody re-finds.
 
-- Q4 [signal] (open): **What is labbook signal, defined positively?** "What's
-  left over" is a negative definition. Candidates from the specimen note:
-  environment traps (`gh pr edit` fails silently → use REST;
-  `LORE_SUPPRESS_CAPTURE=1` leaks into pytest; Vale's three silent-clean
-  traps), dead ends with the reason they were abandoned, reasoning that didn't
-  make the ADR cut, effort calibration (what was tried, how many rounds),
-  gap-facts. Tension: several of these want to *stop being* session-note
-  content — a trap worth remembering wants to be an issue, a doc line, or a
-  memory, not a line in a dated note nobody re-finds (see Q6).
+- Q8 [bridge] (open, demoted to "could"): lore **could** be the
+  cross-harness bridge (cursor → claude etc.) — same-harness continuity is
+  already solved by each harness. Minimal question: what would the bridge
+  actually need — normalized transcript archive + linkage, or prose notes?
+  If the former, the bridge survives the Q11 trim untouched.
 
-- Q5 [ledger] (open): **Who is the ledger for, and where should it live?** It
-  triples file size (JSON comment + bold restatement + quote per fact) to
-  provide grounding and drill-down. Options: sidecar file next to the archived
-  transcript; keep inline; drop quotes and keep JSON only; ledger *is* the
-  note (machine format) and any human reading is rendered on demand. Cuts
-  across Q1: if the primary reader is a machine, the rendered body is the
-  optional layer, not the ledger.
+## Absorbed questions (from earlier passes)
 
-- Q6 [promotion] (open): **Should recorded-nowhere facts be pushed toward a
-  real home instead of warehoused?** A session that surfaces "the epic
-  workflow never bumps versions" could end by *filing* that (issue via the
-  file-issue skill, memory entry, doc patch) rather than leaving it as note
-  residue. Then the note's job shrinks to: index of the session + pointer to
-  where each fact went. Tension with the ratified Capture-Retrieve-Never-Ask
-  stance — no capture-time nudges to the *human*; but an *agent*
-  end-of-session filing pass may not violate that. Contested — needs the
-  user's read.
-
-- Q7 [existence] (narrowed 2026-08-04): **The honest kill option — now only
-  for the archive function.** Full kill is off the table: the user names two
-  wanted functions (handover/recap, reporting). What remains open is killing
-  the *archival* role: does anything past the ~week horizon deserve to exist
-  as a note body, or only as promoted artifacts (Q6) + transcript archive?
-  Known dependents rechecked: SessionStart banner, `lore_resume` (never
-  called — dead weight or undiscovered?), the vault graph. Curator B
-  feedstock struck as a dependent — B is dead.
-
-- Q9 [audiences] (open, spawned by the 2026-08-04 rulings): **Handover and
-  reporting want different documents — one artifact or two renders?** Handover
-  wants dense, thread-scoped context for a reader resuming work; reporting
-  wants human-readable prose about what was worked on, aggregated across
-  sessions on a cadence. ADR 0003 already provides the mechanism: the note
-  body is a deterministic render of a fact store — nothing forbids *two*
-  renders (or a render + an aggregator) of the same store. Options: one note
-  serving both badly (status quo); note = handover render, reporting =
-  cross-note aggregation (deterministic, from headlines/frontmatter); separate
-  artifacts with separate extraction. Constraint check: C8 means whatever
-  feeds reporting must be right at extraction time — no distillation pass
-  will clean it later; C2 caps what the banner can carry.
-
-- Q8 [cross-cutting] (open): **Is the cross-harness / cross-team / human-AI
-  promise still load-bearing?** The user's own hunch: mostly solved by
-  workflows. But workflows assume GitHub-repo work. Science sessions (data
-  reduction, calibration runs) have no repo artifact trail and a real labbook
-  tradition — possibly the strongest surviving case, and the population Q3
-  points at. Untested: does the ccat/science wiki actually accumulate useful
-  session notes today?
+- Q2 (residual inversion) and Q6 (promotion) → folded into Q12: the
+  recorded-nowhere residual is the flag-worthiness criterion; promotion *is*
+  the flag, agent-initiated.
+- Q4 (positive signal definition) → folded into Q12 (flag-worthiness).
+- Q5 (ledger) and Q3 (per-class depth) → contingent on Q11's outcome.
+- Q7 (kill) → absorbed: full kill superseded by Q11's option set.
+- Q9 (handover vs reporting renders) → parked; built on the reporting
+  function, which was struck (see settled).
 
 ## Assumptions
 
-- A1 (broken → reframed Q1b): we assumed *someone* reads session notes after
-  the day they were written, on an archival horizon. Measured: reads exist but
-  are rare (~17 in a month, ≲5% of sessions pull anything) and confined to a
-  ≤7-day continuity window; the archival reader never appeared in the
-  observable record. Unmeasured remainder: Obsidian (human) reads, banner
-  consumption, curator feedstock.
-- A2 (live): the archived transcript persists and is drillable, so a note
-  never needs to restate — only to index and point.
-- A3 (live): workflow artifacts adequately capture the why at ratification
-  time; mid-implementation reasoning that never reached PR/ADR text is
-  genuinely at risk of loss (supports a nonzero residual).
-- A4 (live, inherited from predecessor C0): deterministic = trusted;
-  LLM-written = suspect. Frontmatter session facts are already zero-LLM.
+- A1 (broken → reframed Q1b): archival readers exist. Measured: reads are
+  rare (~17/month, ≲5% of sessions) and ≤7 days old; archival reader never
+  appeared. Obsidian reads ≈ 0, confirmed by user — because notes aren't
+  useful.
+- A2 (live): the archived transcript persists and is drillable — capture of
+  *transcripts* is not in question, only what is derived from them.
+- A3 (affirmed by user): ADRs/PRDs/docs already grow the work's context "to
+  some degree" — the artifact layer is the primary store; sessions are
+  secondary.
+- A4 (live): deterministic = trusted; LLM-written = suspect. Linkage
+  frontmatter is already zero-LLM.
+- A5 (contested — founding doctrine reopened 2026-08-04): "capture must be
+  automatic because humans forget to write notes" (the Capture, Retrieve,
+  Never Ask model). The flag model revises this; it must answer the amnesia
+  risk it was built against. Not yet resolved either way.
 
 ## Domain constraints
 
-- C1: capture is lights-out (SessionEnd/reaper); any design must work with
-  zero human effort at write time. Ratified product stance: Capture, Retrieve,
-  Never Ask.
-- C2: SessionStart context budget is tiny and local backends have a hard
-  capacity ceiling (~120B model silently returns empty on oversized prompts) —
-  whatever the note becomes must compress to a banner line.
-- C3: notes are constitutionally non-authoritative (ADR 0004 code-stamped
-  authority phrasing; disclaimer header). Any redesign keeping notes must keep
-  this; any redesign promoting content must route through real artifacts.
-- C4: every LLM-authored line in the vault is a context-poisoning surface —
-  future sessions re-ingest it, curators abstract it, claims acquire sources
-  (Stille-Post). Noise is not neutral bulk; it is active risk.
-- C5: verification-against-GitHub only exists for repo-linked sessions;
-  science/ad-hoc sessions have no authority store to verify against — any
-  Q2-style inversion needs a story for them.
-- C6: wikis are portable; whatever replaces or shrinks notes must keep links
-  resolving per-wiki.
-- C7 (inherited): raw transcript is the dominant processing cost; each turn
-  seen once, cheapest tier that works.
-- C8 (ratified 2026-08-04): **no LLM abstraction pass is available as a rescue
-  move.** Curator B/C-style distillation over LLM-written notes proved
-  unreliable — wrong claims entered context (poison), too many
-  inconsistencies. Whatever the note itself doesn't carry well, no downstream
-  layer fixes. Extends predecessor C1 (no LLM-verifies-LLM): also no
-  LLM-distills-LLM.
+- C2: SessionStart context budget is tiny; local backends have a hard
+  capacity ceiling — whatever survives must compress to a banner line.
+- C3: notes are constitutionally non-authoritative (ADR 0004); anything
+  promoted to authority must route through real artifacts.
+- C4: every LLM-authored line in the vault is a context-poisoning surface
+  (Stille-Post). Noise is active risk, not neutral bulk.
+- C5: verification-against-GitHub exists only for repo-linked sessions;
+  science/ad-hoc sessions have no authority store.
+- C6: wikis are portable; links resolve per-wiki.
+- C7: raw transcript is the dominant processing cost; each turn seen once.
+- C8 (ratified 2026-08-04): **no LLM abstraction pass exists as a rescue
+  move** — Curator B/C distillation proved unreliable (wrong claims,
+  inconsistencies). No LLM-verifies-LLM, no LLM-distills-LLM.
+- C9 (ratified 2026-08-04, governing): **lightweight or unused.** Lore must
+  impose near-zero burden — setup, runtime, cognitive — or teams and other
+  teams won't adopt. Note the asymmetry: the funnel is read-only and needs no
+  per-user buy-in; capture machinery must be installed and trusted by
+  everyone whose sessions it eats.
+- C10 (ratified 2026-08-04): lore stays **general**. Domain aggregations
+  (pmo timelines, CCAT reporting) live in project artifacts, never as lore
+  features.
 
 ## Glossary
 
-- residual := facts established in a session that no authoritative artifact
-  (git, GitHub, ADR/PRD, docs, memory) records. [candidate]
-- gem := a residual fact with plausible future value (trap, dead end, unwritten
-  reasoning). [candidate]
-- labbook signal := contested — currently defined only negatively (Q4). [contested]
+- funnel := the layer that knows how context is distributed across artifacts
+  (ADRs, PRDs, docs, issues, code, vault) and pulls it in on demand. [agreed]
+- flag := a deliberate, occasional capture of one keep-worthy item to the
+  vault, with an anchor to its origin. [candidate]
+- distribution map := zero-LLM per-session linkage (repo, branch, PRs,
+  issues, files → transcript) that tells the funnel where context landed.
+  [candidate]
+- gem / flag-worthy := residual fact with future value: trap, dead end with
+  reason, unwritten reasoning, gap-fact. [candidate]
 - handover/recap := carrying a working thread across a session boundary —
-  next session, other harness, or other human. [candidate]
-- reporting := periodic human-facing account of what has been worked on,
-  sourced from notes (daily/weekly cadence). [candidate]
+  next session, other harness, other human. [candidate]
+- reporting := struck 2026-08-04 — CCAT-style reports are a different
+  animal, not a lore note function. [struck]
 
 ## Sources
 
-- [PRD 0008 / epic #282]: end-mode typed facts, Done/Findings/Open render,
-  epistemic stamping — shipped; produced the current note form → bears on Q2, Q5.
-- [ADR 0003]: body is a deterministic render of the append-only ledger → Q5.
-- [ADR 0004]: authority phrasing is code-stamped → C3, Q2.
-- [Specimen: wiki/private/sessions/2026/08/03-1759 (epic-310 landing)]: 1,636
-  lines; Done ≈ GitHub restatement; 6–8 gems in Findings; ledger 3× duplication
-  → Q2, Q4, Q5.
-- [PRD 0002 / epic #151]: one-note-per-session, exemplar-bleed fixes → history
-  of "make notes useful" attempts; two PRDs in, the noise complaint persists —
-  evidence the problem may be the mission, not the mechanism → Q7.
-- [Predecessor brief lore-session-note-shape.md]: settled chapter shape
-  2026-07-03; superseded within a month — same evidence → Q7.
-- [[use-cases]] (vault): ratified list of problems Lore solves — any kill or
-  shrink must be checked against it. Not yet re-read for this brief: TODO.
-- [Transcript sweep 2026-08-04]: all `~/.claude/projects` transcripts (307
-  sessions, Jul 5–Aug 4) grepped for lore MCP calls and direct vault reads;
-  method: tool_use extraction, both plugin prefixes → settles most of Q1,
-  breaks A1, spawns Q1b. Caveats: 30-day retention window; banner, Obsidian,
-  and curator reads invisible. Lore's own read path emits no telemetry
-  (spine.jsonl is write-side only) — measuring this permanently would need a
+- [Transcript sweep 2026-08-04]: 307 sessions Jul 5–Aug 4; 17 note
+  retrievals (read 11 / search 4 / drill 2, resume 0), all ≤7 days old;
+  funnel tools ~76 calls; direct session-note Reads all meta-work. Caveats:
+  30-day retention; Obsidian and banner consumption invisible. Lore has no
+  read-side telemetry (spine is write-only) — permanent measurement needs a
   read-side spine event.
+- [Spine cost window 2026-07-27→08-04]: 367 LLM calls, 60 errors (NoteClosed),
+  193 warnings, 91 reaper force-flushes, 152 session-starts in 8 days.
+- [Journal groundwork]: `lib/lore_core/journal.py` — non-derived channels,
+  feature-flagged, MCP + CLI; `journals/ai.md` + `human.md` exist in vault →
+  Q12 starting point.
+- [Specimen: wiki/private/sessions/2026/08/03-1759]: 1,636 lines / ~58k
+  tokens; Done ≈ GitHub restatement; 6–8 gems; ledger 3× duplication.
+- [PRD 0002, PRD 0008, ADR 0003, ADR 0004]: the two prior "make notes useful"
+  attempts and their ratified mechanics; the recurrence of the complaint
+  across both is itself evidence (the problem may be the mission, not the
+  mechanism).
+- [[use-cases]] (vault): ratified problem list — any kill/trim must be
+  checked against it. Still TODO for this brief.
 
 ## Parked / settled
 
-- (settled, ratified elsewhere) Notes are never authoritative — not reopened
-  here.
-- (settled 2026-08-04, user) **The abstraction layer is dead.** Curator B/C
-  and the concepts/decisions/threads extraction are retired — could not be
-  made reliable; wrong claims poisoned context. Verified in the running
-  system: B last spawned 2026-06-15, zero B/C runs in the spine window, zero
-  abstraction writes since, no B/C code paths in hooks/spawn — no regression.
-  61 legacy concept notes remain as read-only stock (2 were organically read;
-  keep, don't grow).
-- (settled 2026-08-04, user) Wanted note functions: handover/recap
-  (cross-harness, cross-human) and reporting. Replaces the open-ended
-  reader list of Q1.
+- (settled, ratified elsewhere) Notes are never authoritative.
+- (settled 2026-08-04, user) **Abstraction layer dead.** Curator B/C retired;
+  verified no regression (B last spawned 2026-06-15, zero B/C runs, zero
+  abstraction writes since, no code paths). 61 legacy concept notes remain
+  read-only stock.
+- (settled 2026-08-04, user) Reporting struck as a note function; CCAT daily
+  reports are out of scope for lore.
+- (settled 2026-08-04, user) Same-harness continuity is the harness's job;
+  cross-harness bridge demoted to "could" (Q8).
+- (settled via Q1 evidence + user) Readers: short-horizon continuity, plus a
+  human recap reader *worth earning back* — not an archival audience.
 - (hygiene, needs filing) Stale doctrine: the vault's lore orientation note
-  (SessionStart-injected) still describes the Curator A/B/C triad and daily
-  B abstraction; agent memory likewise. Should be corrected to match the
-  ratified state — outside this brief's questions.
-- (parked) Fate of `lore_resume` (never called) and of the 61 legacy concept
-  notes — revisit after the note redesign settles.
+  (SessionStart-injected) and agent memory still describe the Curator A/B/C
+  triad and daily B abstraction — misinformation fed to every session.
+- (parked) Fate of `lore_resume` (never called), the 61 legacy concept
+  notes, and Q9's render mechanics — revisit after Q10–Q12 settle.

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -1,7 +1,7 @@
 # Are session notes still worth it — divergent brief
-state: converging:flag (retirement confirmed; shaping the flag primitive)
+state: converging:flag (slice exported → lore-session-notes-worth.design.md)
 updated: 2026-08-04 (retirement settled with losses L1–L4 accepted; flag
-slice converging)
+slice shaped and exported; brief stays open for parked questions)
 
 Predecessor: `lore-session-note-shape.md` (2026-07-03, settled the *shape*;
 superseded by typed facts, PRD 0008 / ADR 0003). This brief asks the prior

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -1,6 +1,6 @@
 # Are session notes still worth it — divergent brief
-state: seeding
-updated: 2026-08-04
+state: exploring
+updated: 2026-08-04 (Q1 evidence pass)
 
 Predecessor: `lore-session-note-shape.md` (2026-07-03, settled the *shape*; its
 shape was since replaced by typed facts, PRD 0008 / ADR 0003). This brief asks
@@ -30,16 +30,38 @@ Nothing is settled.
 
 ## Open questions
 
-- Q1 [reader] (open): **Who actually reads a session note, and when?**
-  Candidate readers: (a) future agent session pulling context via
-  `lore_search`/`lore_drill`; (b) the human following up days later ("what did
-  that background job actually try?"); (c) Curator B as feedstock for
-  concept/decision extraction; (d) team briefings. Tension: these want
-  *different* documents — (a) wants dense facts, (b) wants narrative of
-  reasoning and dead ends, (c) wants raw material, (d) wants headlines. If
-  (c)/(d) are the only real consumers, the note is an intermediate format, not
-  a product, and "human-readable labbook" is the wrong design target entirely.
-  Empirical handle exists: actual drill/search hit logs could say who reads.
+- Q1 [reader] (settling — evidence in, 2026-08-04): **Who actually reads a
+  session note, and when?** Measured over every Claude Code transcript on the
+  machine (307 sessions, 2026-07-05 → 2026-08-04; older transcripts rotated
+  out): **17 MCP retrieval calls total** — `lore_read` 11, `lore_search` 4,
+  `lore_drill` 2, `lore_resume` **0**. Of the reads, 9 targeted session notes,
+  2–3 concept/strategy notes. Direct filesystem `Read` of session notes: 10,
+  *all* lore-quality meta-work (PRD 0002 pilot, this brainstorm), none
+  organic. What the organic reads share: **all in ccat work, and all within a
+  short horizon — ages 1 min, ~2.5 h ×2, 1 d, 3 d ×2, 7 d. No session note
+  older than 7 days has ever been retrieved.** The "colleague months later"
+  reader — PRD 0002's explicit design target — has never appeared. Session
+  notes were retrieved *more* than Curator B's concept notes (~9:3), so the
+  abstraction layer is read even less than the raw layer. Blind spots the log
+  cannot see: (i) the SessionStart banner deterministically consumes note
+  titles/summaries every session — by volume the *dominant* consumer; (ii)
+  human reads in Obsidian leave no trace — only the user can answer that;
+  (iii) curator feedstock reads happen outside these transcripts. Remaining
+  open sliver: which of (i)–(iii) carries real value.
+
+- Q1b [reframe] (open, spawned by Q1 evidence): **Is the session note a
+  handover artifact with a ~one-week half-life, not an archive?** Every
+  observed organic read is thread-continuity: "what did the last session on
+  this do" (docs strategy, queue discovery, report flow, deploy-role fix,
+  schema cleanup). That is the resume/handover job, not the labbook-archive
+  job. If accepted, it reframes hard: depth and ledger should optimize for a
+  reader *days* away with partial context, not months away with none;
+  long-tail value would then live in *promotion* (Q6) and curator abstraction,
+  not in the note body; retention of full bodies past the horizon becomes
+  questionable (C4 poisoning surface with no measured reader). Tension: a
+  30-day observation window cannot rule out rare high-value archaeology
+  ("what broke in March?") — absence of evidence over one month is weak
+  evidence of absence over a year.
 
 - Q2 [residual] (open): **Should the note keep only what is recorded nowhere
   else?** The verification machinery already computes this per line: `✓` means
@@ -106,9 +128,12 @@ Nothing is settled.
 
 ## Assumptions
 
-- A1 (shaky): *someone* reads session notes after the day they were written.
-  No evidence either way in hand — the drill/search logs could break or
-  confirm this. If broken, Q1 collapses toward machine-only readers.
+- A1 (broken → reframed Q1b): we assumed *someone* reads session notes after
+  the day they were written, on an archival horizon. Measured: reads exist but
+  are rare (~17 in a month, ≲5% of sessions pull anything) and confined to a
+  ≤7-day continuity window; the archival reader never appeared in the
+  observable record. Unmeasured remainder: Obsidian (human) reads, banner
+  consumption, curator feedstock.
 - A2 (live): the archived transcript persists and is drillable, so a note
   never needs to restate — only to index and point.
 - A3 (live): workflow artifacts adequately capture the why at ratification
@@ -163,6 +188,13 @@ Nothing is settled.
   2026-07-03; superseded within a month — same evidence → Q7.
 - [[use-cases]] (vault): ratified list of problems Lore solves — any kill or
   shrink must be checked against it. Not yet re-read for this brief: TODO.
+- [Transcript sweep 2026-08-04]: all `~/.claude/projects` transcripts (307
+  sessions, Jul 5–Aug 4) grepped for lore MCP calls and direct vault reads;
+  method: tool_use extraction, both plugin prefixes → settles most of Q1,
+  breaks A1, spawns Q1b. Caveats: 30-day retention window; banner, Obsidian,
+  and curator reads invisible. Lore's own read path emits no telemetry
+  (spine.jsonl is write-side only) — measuring this permanently would need a
+  read-side spine event.
 
 ## Parked / settled
 

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -1,0 +1,172 @@
+# Are session notes still worth it — divergent brief
+state: seeding
+updated: 2026-08-04
+
+Predecessor: `lore-session-note-shape.md` (2026-07-03, settled the *shape*; its
+shape was since replaced by typed facts, PRD 0008 / ADR 0003). This brief asks
+the prior question that was never asked ground-up: **what is the session note
+for, now that lore-workflow exists — and is the answer "nothing"?**
+
+## Framing
+
+When Lore started, the session was the only place decisions and reasoning
+lived; notes had to carry everything. Since then lore-workflow routes real work
+into durable, authoritative artifacts: PRD (why-product), ADR (why-technical),
+epic + issues (what/plan), PRs + git (what changed), docs (how to use). Each is
+written at the moment of highest context, by the process that owns it.
+
+The session note's claimed residual is "everything that didn't go through the
+workflow". The evidence says that residual is real but small, and the current
+note buries it: the 2026-08-03 epic-310 note is 1,636 lines / ~58k tokens, of
+which ~30 Done lines restate what GitHub already records (each `✓` literally
+*proves* the fact is recorded elsewhere), while the ~6–8 genuine gems
+(environment traps, silent failures, "agreed but recorded nowhere") sit
+undifferentiated in a 50-line Findings list, and the ledger then repeats every
+fact twice more.
+
+This brief holds the whole space open: kill notes, shrink them to the residual,
+retarget them at a different reader, or split them by session population.
+Nothing is settled.
+
+## Open questions
+
+- Q1 [reader] (open): **Who actually reads a session note, and when?**
+  Candidate readers: (a) future agent session pulling context via
+  `lore_search`/`lore_drill`; (b) the human following up days later ("what did
+  that background job actually try?"); (c) Curator B as feedstock for
+  concept/decision extraction; (d) team briefings. Tension: these want
+  *different* documents — (a) wants dense facts, (b) wants narrative of
+  reasoning and dead ends, (c) wants raw material, (d) wants headlines. If
+  (c)/(d) are the only real consumers, the note is an intermediate format, not
+  a product, and "human-readable labbook" is the wrong design target entirely.
+  Empirical handle exists: actual drill/search hit logs could say who reads.
+
+- Q2 [residual] (open): **Should the note keep only what is recorded nowhere
+  else?** The verification machinery already computes this per line: `✓` means
+  "an authoritative store has this", the hedge stamps ("agreed in discussion,
+  recorded nowhere", "reported done, recorded nowhere") mean "this exists only
+  here". Inversion on the table: `✓` lines collapse to a one-line breadcrumb
+  ("epic #310 landed — 8 PRs, see GitHub"), and the note body *is* the
+  recorded-nowhere residual. Tension: the Done list has skim value as a
+  timeline even when redundant; and a breadcrumb-only note depends on GitHub
+  permanence and access (C5).
+
+- Q3 [population] (open): **Are there two session populations needing two note
+  depths?** Workflow-run sessions leave a dense artifact trail — residual is
+  gems + traps only. Ad-hoc sessions (debugging, science analysis, brainstorms,
+  ops) leave *no* trail — the note is the only record. Options: adaptive depth
+  (workflow sessions → stub + links; ad-hoc → full labbook); uniform format
+  with the workflow case naturally shrinking via Q2's inversion; explicit
+  session-type stamp from lore-workflow skills. Tension: detection is fuzzy;
+  most sessions are mixed.
+
+- Q4 [signal] (open): **What is labbook signal, defined positively?** "What's
+  left over" is a negative definition. Candidates from the specimen note:
+  environment traps (`gh pr edit` fails silently → use REST;
+  `LORE_SUPPRESS_CAPTURE=1` leaks into pytest; Vale's three silent-clean
+  traps), dead ends with the reason they were abandoned, reasoning that didn't
+  make the ADR cut, effort calibration (what was tried, how many rounds),
+  gap-facts. Tension: several of these want to *stop being* session-note
+  content — a trap worth remembering wants to be an issue, a doc line, or a
+  memory, not a line in a dated note nobody re-finds (see Q6).
+
+- Q5 [ledger] (open): **Who is the ledger for, and where should it live?** It
+  triples file size (JSON comment + bold restatement + quote per fact) to
+  provide grounding and drill-down. Options: sidecar file next to the archived
+  transcript; keep inline; drop quotes and keep JSON only; ledger *is* the
+  note (machine format) and any human reading is rendered on demand. Cuts
+  across Q1: if the primary reader is a machine, the rendered body is the
+  optional layer, not the ledger.
+
+- Q6 [promotion] (open): **Should recorded-nowhere facts be pushed toward a
+  real home instead of warehoused?** A session that surfaces "the epic
+  workflow never bumps versions" could end by *filing* that (issue via the
+  file-issue skill, memory entry, doc patch) rather than leaving it as note
+  residue. Then the note's job shrinks to: index of the session + pointer to
+  where each fact went. Tension with the ratified Capture-Retrieve-Never-Ask
+  stance — no capture-time nudges to the *human*; but an *agent*
+  end-of-session filing pass may not violate that. Contested — needs the
+  user's read.
+
+- Q7 [existence] (open): **The honest kill option.** Retire the note as a
+  product: keep transcript archive + anchors + frontmatter (deterministic,
+  trusted), let retrieval work over transcripts/ledgers directly, let Curator B
+  read ledgers instead of notes. What actually breaks? Known dependents:
+  SessionStart banner ("Last: [[note]]"), Curator B feedstock, briefings,
+  `lore_resume`, the vault graph. Cost of keeping notes isn't only tokens —
+  every LLM-written line is a context-poisoning surface (C4).
+
+- Q8 [cross-cutting] (open): **Is the cross-harness / cross-team / human-AI
+  promise still load-bearing?** The user's own hunch: mostly solved by
+  workflows. But workflows assume GitHub-repo work. Science sessions (data
+  reduction, calibration runs) have no repo artifact trail and a real labbook
+  tradition — possibly the strongest surviving case, and the population Q3
+  points at. Untested: does the ccat/science wiki actually accumulate useful
+  session notes today?
+
+## Assumptions
+
+- A1 (shaky): *someone* reads session notes after the day they were written.
+  No evidence either way in hand — the drill/search logs could break or
+  confirm this. If broken, Q1 collapses toward machine-only readers.
+- A2 (live): the archived transcript persists and is drillable, so a note
+  never needs to restate — only to index and point.
+- A3 (live): workflow artifacts adequately capture the why at ratification
+  time; mid-implementation reasoning that never reached PR/ADR text is
+  genuinely at risk of loss (supports a nonzero residual).
+- A4 (live, inherited from predecessor C0): deterministic = trusted;
+  LLM-written = suspect. Frontmatter session facts are already zero-LLM.
+
+## Domain constraints
+
+- C1: capture is lights-out (SessionEnd/reaper); any design must work with
+  zero human effort at write time. Ratified product stance: Capture, Retrieve,
+  Never Ask.
+- C2: SessionStart context budget is tiny and local backends have a hard
+  capacity ceiling (~120B model silently returns empty on oversized prompts) —
+  whatever the note becomes must compress to a banner line.
+- C3: notes are constitutionally non-authoritative (ADR 0004 code-stamped
+  authority phrasing; disclaimer header). Any redesign keeping notes must keep
+  this; any redesign promoting content must route through real artifacts.
+- C4: every LLM-authored line in the vault is a context-poisoning surface —
+  future sessions re-ingest it, curators abstract it, claims acquire sources
+  (Stille-Post). Noise is not neutral bulk; it is active risk.
+- C5: verification-against-GitHub only exists for repo-linked sessions;
+  science/ad-hoc sessions have no authority store to verify against — any
+  Q2-style inversion needs a story for them.
+- C6: wikis are portable; whatever replaces or shrinks notes must keep links
+  resolving per-wiki.
+- C7 (inherited): raw transcript is the dominant processing cost; each turn
+  seen once, cheapest tier that works.
+
+## Glossary
+
+- residual := facts established in a session that no authoritative artifact
+  (git, GitHub, ADR/PRD, docs, memory) records. [candidate]
+- gem := a residual fact with plausible future value (trap, dead end, unwritten
+  reasoning). [candidate]
+- labbook signal := contested — currently defined only negatively (Q4). [contested]
+
+## Sources
+
+- [PRD 0008 / epic #282]: end-mode typed facts, Done/Findings/Open render,
+  epistemic stamping — shipped; produced the current note form → bears on Q2, Q5.
+- [ADR 0003]: body is a deterministic render of the append-only ledger → Q5.
+- [ADR 0004]: authority phrasing is code-stamped → C3, Q2.
+- [Specimen: wiki/private/sessions/2026/08/03-1759 (epic-310 landing)]: 1,636
+  lines; Done ≈ GitHub restatement; 6–8 gems in Findings; ledger 3× duplication
+  → Q2, Q4, Q5.
+- [PRD 0002 / epic #151]: one-note-per-session, exemplar-bleed fixes → history
+  of "make notes useful" attempts; two PRDs in, the noise complaint persists —
+  evidence the problem may be the mission, not the mechanism → Q7.
+- [Predecessor brief lore-session-note-shape.md]: settled chapter shape
+  2026-07-03; superseded within a month — same evidence → Q7.
+- [[use-cases]] (vault): ratified list of problems Lore solves — any kill or
+  shrink must be checked against it. Not yet re-read for this brief: TODO.
+
+## Parked / settled
+
+- (settled, ratified elsewhere) Notes are never authoritative — not reopened
+  here.
+- (parked) Curator B/C redesign — only in scope where a note change breaks
+  their input contract.

--- a/brainstorms/lore-session-notes-worth.md
+++ b/brainstorms/lore-session-notes-worth.md
@@ -183,6 +183,52 @@ quo, with three real stress points (S1–S3) that each have candidate
 mitigations, one structural caveat (S4), and one unresolved hole (Q13).
 Not adopted — held open.
 
+## Use-case cross-check (2026-08-04, against [[use-cases]] — 27 items, 2026-05-07)
+
+**Verdict: no veto.** Nothing in the ratified list hard-requires session notes
+as vault files — but the check surfaces four honest losses needing explicit
+user confirmation, one identity rewrite, and several sharpenings.
+
+**The list already contains the steer-3 identity.** Use case #16
+(implementation-arc narrative): "Artifacts stay in their canonical homes …;
+Lore is the threading layer that makes the arc walkable across time, harness,
+and teammate." That *is* the funnel + ledger, in ratified language. #26's
+"Lore is the WHY" overstates under steer 3 and wants rewriting to "Lore knows
+where the why lives and threads it".
+
+**Losses to confirm (the price of retirement):**
+
+- L1 — #1 (the wedge, "capture the why via auto-extracted session notes"):
+  the promise weakens from "the why is captured automatically" to "the why is
+  recorded raw (private transcript) and crosses to the team only via
+  artifacts and deliberate flags". This is A5 at the product-promise level.
+- L2 — #14 (teammate handoff): passive "browse what a colleague's sessions
+  did last week" is *removed by design* (privacy boundary). Handoff becomes
+  deliberate (`/lore:handover`) + artifacts + flags. No evidence it was ever
+  used passively (all measured reads were same-user).
+- L3 — #6 (briefings/active distribution): loses its source (session notes)
+  on top of its dead engine (Curator B). Needs a new source (flag/topic-note
+  digest?) or parking.
+- L4 — #15 (onboarding): was "falls out of #3 cross-handle synthesis" —
+  #3 is dead (C8). Onboarding now rides on project orientation + topic-note
+  quality, i.e. on flags working (S2).
+
+**Sharpened by the architecture:** #7 sensitivity gate (only small deliberate
+flags ever cross — the gate's job shrinks structurally); #16, #17 (banner
+recap gets cheaper and deterministic), #19/#20 (capture needs *no lore-owned
+LLM at all* — flags are written by the session's own agent; lore's backend
+becomes optional, briefings-only), #22 (knowledge = markdown+git stays;
+ledger = derived, rebuildable index; transcripts = private raw), #27
+(journals — "potential to grow into a pillar" reads prescient).
+
+**Needs a rule:** #23 edit discipline — flags append to topic-note bodies,
+which the vault edit policy reserved for humans. Proposed shape: flags are
+append-only blocks, attributed, never editing existing content. Open.
+
+**Already stale independent of this brainstorm:** #3, #10, #11 (curator
+triad, surfaces — superseded by earlier epics); the use-cases note itself
+needs a revision pass once this brief settles (hygiene).
+
 ## Absorbed questions (from earlier passes)
 
 - Q2 (residual inversion) and Q6 (promotion) → folded into Q12: the
@@ -285,8 +331,9 @@ Not adopted — held open.
   attempts and their ratified mechanics; the recurrence of the complaint
   across both is itself evidence (the problem may be the mission, not the
   mechanism).
-- [[use-cases]] (vault): ratified problem list — any kill/trim must be
-  checked against it. Still TODO for this brief.
+- [[use-cases]] (vault, 2026-05-07): ratified problem list — cross-checked
+  2026-08-04, see the cross-check section: no veto, four losses (L1–L4) to
+  confirm.
 - [Transcript archive audit 2026-08-04]: `wiki/*/.transcripts/` gitignored;
   556 files / 216 MB on one machine; retention janitor covers only ops logs
   (spine/flushes/runs), transcripts unbounded and unmanaged → Q13.


### PR DESCRIPTION
Seed of a divergent-brainstorm brief reopening the session-note question ground-up: now that lore-workflow routes work into PRDs/ADRs/epics/issues/docs, what residual do session notes carry — shrink, retarget, split, or kill. Brief will evolve on this branch as the brainstorm continues; not for merge until the discussion settles.