### PR TITLE
fix(workflow): close the glossary write path, grilling recaps terms

### DIFF
--- a/lore-workflow/skills/domain-modeling/SKILL.md
+++ b/lore-workflow/skills/domain-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lore-workflow:domain-modeling
-description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
+description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, or record an architectural decision.
 ---
 
 # Domain Modeling
@@ -59,7 +59,7 @@ When the user states how something works, check whether the code agrees. If you 
 
 ### Update CONTEXT.md inline
 
-When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+When a term is resolved, propose its wording and wait for the user's yes. A person approves every glossary entry before it is written — never write a term the user has not confirmed. Once approved, update `CONTEXT.md` right there; don't batch these up, capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
 
 `CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
 

--- a/lore-workflow/skills/grilling/SKILL.md
+++ b/lore-workflow/skills/grilling/SKILL.md
@@ -21,6 +21,8 @@ How much /lore-workflow:domain-modeling runs alongside the interview is a mode, 
 - **Plain ("grill me"), default.** Once all questions are solved to satisfaction, check if /lore-workflow:domain-modeling is needed and, if so, align with the user before updating the domain model.
 - **With docs ("grill with docs").** Run /lore-workflow:domain-modeling alongside the interview from the start — record ADRs and glossary terms as each decision lands, not only at the end.
 
+When the interview ends, list every term `domain-modeling` wrote or changed — one line per term, quoting the term and its new or changed definition. Where it wrote none, say that plainly instead of printing an empty list.
+
 Once all questions and any domain-model updates are satisfactory, say so and invoke /lore-workflow:to-epic.
 
 If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/tests/test_workflow_glossary_write_gate.py
+++ b/tests/test_workflow_glossary_write_gate.py
@@ -1,0 +1,53 @@
+"""Glossary write gate: human-approved, grilling-only (sub-issue #338).
+
+A short name that means a piece of work (`P6`, `G4`) reads exactly like a
+real data level (`L0`). `domain-modeling` used to invite any skill to
+maintain the domain model — that invitation is the open write path this
+closes. `grilling` now recaps every term it wrote or changed so the user
+sees the glossary diff without opening `CONTEXT.md`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOMAIN_MODELING_SKILL = REPO_ROOT / "lore-workflow" / "skills" / "domain-modeling" / "SKILL.md"
+GRILLING_SKILL = REPO_ROOT / "lore-workflow" / "skills" / "grilling" / "SKILL.md"
+
+
+def _frontmatter_description(text: str) -> str:
+    for line in text.splitlines():
+        if line.startswith("description:"):
+            return line.removeprefix("description:").strip()
+    raise AssertionError("no description line in frontmatter")
+
+
+def test_domain_modeling_description_does_not_invite_other_skills() -> None:
+    description = _frontmatter_description(DOMAIN_MODELING_SKILL.read_text(encoding="utf-8"))
+    assert "another skill" not in description
+    assert "maintain the domain model" not in description
+
+
+def test_domain_modeling_states_a_person_approves_every_entry() -> None:
+    body = DOMAIN_MODELING_SKILL.read_text(encoding="utf-8")
+    assert "approves" in body
+    assert "before it is written" in body
+
+
+def test_grilling_recaps_written_terms() -> None:
+    body = GRILLING_SKILL.read_text(encoding="utf-8").lower()
+    assert "list every term" in body
+
+
+def test_grilling_recap_covers_the_empty_case() -> None:
+    body = GRILLING_SKILL.read_text(encoding="utf-8").lower()
+    assert "printing an empty list" in body
+
+
+def test_implement_issue_and_brief_still_reference_domain_modeling() -> None:
+    for skill in ("implement-issue", "brief"):
+        text = (REPO_ROOT / "lore-workflow" / "skills" / skill / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        assert "domain-modeling" in text


### PR DESCRIPTION
## Summary

Closes #338 (epic #336).

- `domain-modeling`'s frontmatter description no longer invites other skills to maintain the domain model — it only describes when a *user* wants to pin down terminology or record a decision.
- `domain-modeling`'s "Update CONTEXT.md inline" section now states a person approves every glossary entry before it is written; propose the wording and wait for the user's yes before writing.
- `grilling` now lists every term `domain-modeling` wrote or changed when an interview ends, or says plainly it wrote none instead of printing an empty list.
- `implement-issue` and `brief` still reference `domain-modeling` for its ADR criteria only — untouched, verified with a test.

## Why

A short name that means a piece of work (`P6`, `G4`) reads exactly like a real data level (`L0`). Only a person can tell them apart, so only a person may add a term — and `grilling` (via `domain-modeling`) is the only door into the glossary.

## Red → green

New test file `tests/test_workflow_glossary_write_gate.py`, run before the fix:

```
$ PYTHONPATH=lib python -m pytest tests/test_workflow_glossary_write_gate.py -q
FFFF.                                                                    [100%]
=================================== FAILURES ===================================
________ test_domain_modeling_description_does_not_invite_other_skills _________
E       AssertionError: assert 'another skill' not in 'Build and s...omain model.'
E         'another skill' is contained here:
E           , or when another skill needs to maintain the domain model.
__________ test_domain_modeling_states_a_person_approves_every_entry ___________
E       assert 'approves' in "---\nname: lore-workflow:domain-modeling\n..."
______________________ test_grilling_recaps_written_terms ______________________
E       AssertionError: assert 'list every term' in '---\nname: lore-workflow:grilling\n...'
__________________ test_grilling_recap_covers_the_empty_case ___________________
E       AssertionError: assert 'printing an empty list' in '---\nname: lore-workflow:grilling\n...'
4 failed, 1 passed in 0.23s
```

After the fix, same file:

```
$ PYTHONPATH=lib python -m pytest tests/test_workflow_glossary_write_gate.py -q
.....                                                                    [100%]
5 passed in 0.11s
```

Full suite: `2875 passed` locally (25 pre-existing failures in `test_hooks_capture.py`, `test_mvp_capture_e2e.py`, `test_auto_diagnostics_e2e.py`, `test_cli_scopes.py`, `test_core_llm_wiring.py`, `test_install_dispatcher.py`, `test_mvp_capture_subprocess_e2e.py` — confirmed identical on `epic/336` before this change via `git stash`, unrelated to this PR's scope: capture/curator subprocess wiring, not touched here).

## Test plan

- [x] `PYTHONPATH=lib python -m pytest tests/test_workflow_glossary_write_gate.py tests/test_workflow_plugin_structural.py -q` — 59 passed
- [x] `ruff check` / `ruff format --check` clean on all changed files
- [x] Manually confirmed `implement-issue`/`brief` references to `domain-modeling` untouched (ADR-criteria only)