### PR TITLE
Add the two short-name rules and widen the scope line

### DIFF
--- a/docs/explanation/why-the-writing-rules.md
+++ b/docs/explanation/why-the-writing-rules.md
@@ -1,7 +1,7 @@
 # Why the writing rules are a document, not config
 
 The **writing rules** fix the prose style for issue text, PR descriptions,
-and ADR context sections. Lore ships one default. A team replaces them with one
+PR review comments, ADR context sections and design documents. Lore ships one default. A team replaces them with one
 file in its wiki. This page explains three choices. Why the rules are a prose
 document rather than a settings block. Why a team's copy wins whole rather than
 merging. Why the lint runs when the text is written, not when it is committed.

--- a/docs/explanation/why-the-writing-rules.md
+++ b/docs/explanation/why-the-writing-rules.md
@@ -1,10 +1,11 @@
 # Why the writing rules are a document, not config
 
 The **writing rules** fix the prose style for issue text, PR descriptions,
-PR review comments, ADR context sections and design documents. Lore ships one default. A team replaces them with one
-file in its wiki. This page explains three choices. Why the rules are a prose
-document rather than a settings block. Why a team's copy wins whole rather than
-merging. Why the lint runs when the text is written, not when it is committed.
+PR review comments, ADR context sections and design documents. Lore ships
+one default. A team replaces them with one file in its wiki. This page
+explains three choices. Why the rules are a prose document rather than a
+settings block. Why a team's copy wins whole rather than merging. Why the
+lint runs when the text is written, not when it is committed.
 
 The decisions here are recorded in
 [ADR 0006](../adr/0006-issue-register-whole-file-override-generation-time-lint.md).

--- a/lib/lore_core/styles/writing-rules.md
+++ b/lib/lore_core/styles/writing-rules.md
@@ -146,6 +146,6 @@ below). In short:
 
 - The glossary's own contents. Separate artifact, separate problem.
 - Code comments, chat, session notes and commit messages, which already have a
-  convention. Rule 21 is the one exception.
+  convention. Rule 21 still covers a commit message.
 - Machine-read text: roadmap tables, board comments, reviewer verdict blocks.
 - Vocabulary size in "Context", where domain precision beats simplicity.

--- a/lib/lore_core/styles/writing-rules.md
+++ b/lib/lore_core/styles/writing-rules.md
@@ -1,7 +1,7 @@
 # Writing Rules
 
 Status: draft
-Scope: issue text, PR descriptions, ADR context sections
+Scope: issue text, PR descriptions, PR review comments, ADR context sections and design documents
 
 ## Why this exists
 
@@ -51,10 +51,15 @@ Rule 19 carries more weight than the rest. Most text that is hard to decode
 holds no banned word. It holds a confident sentence written over a missing
 fact.
 
+### Short names
+
+20. A short name for a thing belongs in the glossary. Where the glossary holds no entry, write the meaning out. `L0` means a data level.
+21. A short name for a piece of work never enters a title, a description, a document or a commit message. A phase, a group and a priority code are such names. Cite the issue number instead. Not "the G4 group" but "issue 412".
+
 Enforcement differs per rule. Vale lints rules 3 and 6, the banned words and
 the sentence length. Rules 9 and 12 run as regex heuristics that catch the
 common forms and miss the rest. Rules 4 and 10 need a human reviewer, because
-Vale does not tag parts of speech. Rules 1 and 2 need the glossary.
+Vale does not tag parts of speech. Rules 1, 2 and 20 need the glossary.
 
 ## EARS patterns for acceptance criteria
 
@@ -109,13 +114,19 @@ the writing rules.
 ```markdown
 ## Issue writing
 
-When you write or edit an issue, a PR description, or an ADR context section,
-follow the writing rules (`lore style show writing-rules`, or the copy your
-team pasted below). In short:
+These rules cover issue text, PR descriptions, PR review comments, ADR
+context sections and design documents. When you write or edit one, follow the
+writing rules (`lore style show writing-rules`, or the copy your team pasted
+below). In short:
 
 - Use the required section structure. Keep empty sections.
 - One term, one meaning. Take terms from the glossary. Do not invent domain
   terms; ask instead.
+- A short name for a thing belongs in the glossary. Where no entry exists,
+  write the meaning out.
+- A short name for a piece of work never enters a title, a description, a
+  document or a commit message. A phase, a group and a priority code are such
+  names. Cite the issue number.
 - Maximum 20 words per instruction, 25 per description. One instruction per
   sentence.
 - Active voice with a named actor. No participial clause openers. No noun
@@ -134,6 +145,7 @@ team pasted below). In short:
 ## Not constrained
 
 - The glossary's own contents. Separate artifact, separate problem.
-- Code comments, chat, and commit messages, which already have a convention.
+- Code comments, chat, session notes and commit messages, which already have a
+  convention. Rule 21 is the one exception.
 - Machine-read text: roadmap tables, board comments, reviewer verdict blocks.
 - Vocabulary size in "Context", where domain precision beats simplicity.

--- a/tests/test_writing_rules.py
+++ b/tests/test_writing_rules.py
@@ -165,19 +165,30 @@ def test_context_md_defines_the_new_terms() -> None:
     assert "**Register**" not in text, "the old term must be gone from the glossary"
 
 
+COVERED_ARTIFACTS = (
+    "issue text",
+    "PR descriptions",
+    "PR review comments",
+    "ADR context sections",
+    "design documents",
+)
+
+
 def test_scope_line_names_every_covered_artifact() -> None:
     """PR review comments and design documents follow the same rules. Session
     notes do not — PRD 0009 places them outside, with their own voice."""
     scope = next(line for line in _default_text().splitlines() if line.startswith("Scope:"))
-    for artifact in (
-        "issue text",
-        "PR descriptions",
-        "PR review comments",
-        "ADR context sections",
-        "design documents",
-    ):
+    for artifact in COVERED_ARTIFACTS:
         assert artifact in scope, scope
     assert "session note" not in scope.lower(), scope
+
+
+def test_the_explanation_page_states_the_same_scope() -> None:
+    """A page that names a narrower scope than the document it explains is the
+    drift this epic removes."""
+    page = " ".join((REPO_ROOT / "docs/explanation/why-the-writing-rules.md").read_text().split())
+    for artifact in COVERED_ARTIFACTS:
+        assert artifact in page, artifact
 
 
 def test_short_name_rules_split_a_thing_from_a_piece_of_work() -> None:

--- a/tests/test_writing_rules.py
+++ b/tests/test_writing_rules.py
@@ -119,8 +119,16 @@ def test_rules_define_change_and_batch_issue() -> None:
     assert "one PR" in section
 
 
+def _rule(number: int) -> str:
+    prefix = f"{number}. "
+    for line in _default_text().splitlines():
+        if line.startswith(prefix):
+            return line
+    raise AssertionError(f"the writing rules carry no rule {number}")
+
+
 def test_rule_14_accepts_code_flavored_provenance() -> None:
-    rule = next(line for line in _default_text().splitlines() if line.startswith("14. "))
+    rule = _rule(14)
     for form in ("file path", "command output", "test name"):
         assert form in rule, rule
 
@@ -155,6 +163,49 @@ def test_context_md_defines_the_new_terms() -> None:
     for term in ("**Writing rules**", "**Change**", "**Batch issue**"):
         assert term in text, term
     assert "**Register**" not in text, "the old term must be gone from the glossary"
+
+
+def test_scope_line_names_every_covered_artifact() -> None:
+    """PR review comments and design documents follow the same rules. Session
+    notes do not — PRD 0009 places them outside, with their own voice."""
+    scope = next(line for line in _default_text().splitlines() if line.startswith("Scope:"))
+    for artifact in (
+        "issue text",
+        "PR descriptions",
+        "PR review comments",
+        "ADR context sections",
+        "design documents",
+    ):
+        assert artifact in scope, scope
+    assert "session note" not in scope.lower(), scope
+
+
+def test_short_name_rules_split_a_thing_from_a_piece_of_work() -> None:
+    """The two shapes are identical, so only meaning separates them. `L0` is a
+    data level and belongs in the glossary; `G4` labels one session's work and
+    belongs in no glossary at all."""
+    thing, work = _rule(20), _rule(21)
+    assert "glossary" in thing, thing
+    assert "meaning" in thing, thing
+    for place in ("title", "description", "document", "commit message"):
+        assert place in work, work
+    assert "issue number" in work, work
+    assert "glossary" not in work, work
+
+
+def test_paste_block_carries_both_short_name_rules() -> None:
+    """Teams without Lore read the block and nothing else."""
+    paste = _default_text().split("## Block for CLAUDE.md and AGENTS.md", 1)[1]
+    bullets = [b for b in paste.split("\n- ") if "short name" in b]
+    assert len(bullets) == 2, bullets
+    assert any("glossary" in b for b in bullets), bullets
+    assert any("issue number" in b for b in bullets), bullets
+
+
+def test_rules_stay_under_the_line_budget() -> None:
+    """An over-specified instruction file is a known failure mode. The document
+    was compacted from 245 lines to 139; every addition replaces text."""
+    assert len(_default_text().splitlines()) < 180
 
 
 # --- the writing rules and the deprecated alias --------------------------


### PR DESCRIPTION
# Add the two short-name rules and widen the scope line

## Context

A short name means a thing in the domain or means a piece of work. The two
need opposite answers. `L0` is a data level and belongs in the glossary. `G4`
labels one session's work and belongs in no glossary at all. The shapes are
identical, so no pattern separates them. PRD 0010 records the decision that the
document carries two rules, not one.

Sub-issue of buchbend/lore#336. Closes buchbend/lore#339. Targets `epic/336`.

## Current behaviour

The document at `lib/lore_core/styles/writing-rules.md` runs rules 1 to 19 and
names no rule about a short name. The scope line reads "issue text, PR
descriptions, ADR context sections". The "Not constrained" section exempts
commit messages without exception.

## Required behaviour

Rule 20 requires the glossary to hold a short name for a thing. A writer
without an entry writes the meaning out.

Rule 21 keeps a short name for a piece of work out of a title, a description,
a document and a commit message. A phase, a group and a priority code are such
names. The writer cites the issue number instead.

The scope line names PR review comments and design documents. Session notes
stay out, because PRD 0009 places them outside these rules.

## Acceptance criteria

- [x] The document shall carry a rule requiring a short name that means a thing to be in the glossary.
- [x] Where the glossary holds no entry, the rule shall require the writer to write out the meaning.
- [x] The document shall carry a rule forbidding a short name that means a piece of work in a title, a description, a document or a commit message.
- [x] The rule for a work name shall name the issue number as the way to point at the work.
- [x] The paste block shall carry both rules.
- [x] The scope line shall name PR review comments and design documents.
- [x] The scope line shall not name session notes.
- [x] The whole document shall pass its own Vale style.
- [x] The document shall stay under 180 lines.
- [x] The test suite shall pass.

## Red

`tests/test_writing_rules.py` gained four tests before the document changed.
Command: `PYTHONPATH=lib python -m pytest tests/test_writing_rules.py -q`.

```
E           AssertionError: Scope: issue text, PR descriptions, ADR context sections
E           assert 'PR review comments' in 'Scope: issue text, PR descriptions, ADR context sections'
tests/test_writing_rules.py:179: AssertionError

E       AssertionError: the writing rules carry no rule 20
tests/test_writing_rules.py:127: AssertionError

E       AssertionError: []
E       assert 0 == 2
E        +  where 0 = len([])
tests/test_writing_rules.py:200: AssertionError

FAILED tests/test_writing_rules.py::test_scope_line_names_every_covered_artifact
FAILED tests/test_writing_rules.py::test_short_name_rules_split_a_thing_from_a_piece_of_work
FAILED tests/test_writing_rules.py::test_paste_block_carries_both_short_name_rules
3 failed, 21 passed in 2.13s
```

`test_rules_stay_under_the_line_budget` passed at 139 lines and guards the
budget from here on.

## Green

```
tests/test_writing_rules.py tests/test_vale_style.py: 49 passed, 8 skipped
Full suite: 4 failed, 2904 passed, 9 skipped, 11 subtests passed
```

The four failures are pre-existing on this host: `test_cli_scopes`,
`test_core_llm_wiring` twice, and `test_install_dispatcher`. The eight skips
are the Vale integration tests, which skip when Vale is off PATH.

`ruff check` and `ruff format --check` pass on `tests/test_writing_rules.py`.
The repo carries 554 pre-existing ruff findings and CI runs ruff with
`continue-on-error` until buchbend/lore#196 lands.

## Vale

Vale is not installed on this host, so `tests/test_vale_style.py` skipped its
eight integration tests. A stand-in applied the four packaged `WritingRules`
regexes to the document, sentence by sentence, skipping fenced code blocks.
The document reports 16 findings before the change and 16 after, all of them
the rule 3 line that names the banned words. The new text adds no finding.

Every new sentence was word-counted against rule 6. The longest runs 20 words,
which is the instruction ceiling.

## Out of scope

- `CONTEXT.md` and `CONTEXT-FORMAT.md`, which buchbend/lore#340 owns.
- The Vale check for a short name in neither glossary nor English, which
  buchbend/lore#342 adds.
- Any version bump.

## References

- `docs/prd/0010-join-the-writing-rules-to-the-glossary.md`, the decision
  "The document carries two rules, not one".
- Commit `9fcd172`, which compacted the document from 245 lines to 139. The
  document now runs 151 lines, under the 180-line budget.
