### PR TITLE
docs(glossary): hold definitions to the sentence ceiling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,20 +1,19 @@
 # Lore — domain context
 
-An AI-navigation map of Lore's domain: the terms below have one tight
-meaning each, matched against shipped code. Cross-check any claim here
-against the modules it points to before relying on it — if a term or
-behavior isn't grounded in a real symbol, it doesn't belong here.
+An AI-navigation map of Lore's domain. Every term below has one tight
+meaning, matched against shipped code. Cross-check a claim here against
+the module it points at before you rely on it. A term that no real
+symbol grounds does not belong here.
 
 ## Vault, wiki, scope
 
 - **Vault** — the directory `$LORE_ROOT` points at. Contains one
   `wiki/` subdirectory plus `.lore/` for derived, host-local state.
 - **Wiki** — a mounted knowledge store at `<vault>/wiki/<name>/`. Each
-  wiki is its own git repo; a vault can host several. A fresh wiki
-  (`lore wiki new`) is scaffolded with `projects/`, `concepts/`,
-  `decisions/`, `sessions/`, `inbox/` — session notes are the only one
-  of these Lore writes automatically; the rest are written directly
-  (by hand, or via `/lore:inbox`) when there's something worth a
+  wiki is its own git repo; a vault can host several. `lore wiki new`
+  scaffolds `projects/`, `concepts/`, `decisions/`, `sessions/`,
+  `inbox/`. Lore writes only the session notes automatically. A human
+  or `/lore:inbox` writes the rest, when something is worth a
   standalone note.
 - **Scope** — a colon-separated namespace inside a wiki
   (`ccat:data-center:data-transfer`), resolved from a working
@@ -28,8 +27,8 @@ var / wiki config / root config / code default: `docs/architecture/config.md`.
 
 Every Claude Code session that does real work gets **one session
 note** — a markdown file under `<wiki>/sessions/[<handle>/]YYYY/MM/`.
-It is a **lab notebook**, not a source of truth: git owns what
-happened to the code, the connected repo's ADRs and PRDs own what was
+It is a **lab notebook**, not a source of truth. Git owns what
+happened to the code. The connected repo's ADRs and PRDs own what was
 decided and why. The note records what a session discussed and tried,
 nothing more.
 
@@ -43,29 +42,29 @@ there:
 - **Chapter** — one chunk of the note, corresponding to one *flush*
   (see below). Chapters are strictly chronological and never edited
   once appended; the note is append-only until it closes.
-- **Topic block** — one topic within a chapter: a bold, one-sentence,
-  self-sufficient **lead** (must stand alone — no pronoun reaching into
-  the body), an optional short prose **body**, and exactly one `@N`
-  **anchor** at the end pointing at the transcript turn where the topic
-  started.
+- **Topic block** — one topic within a chapter. It holds a bold,
+  one-sentence, self-sufficient **lead**, an optional short prose
+  **body**, and exactly one `@N` **anchor**. The lead must stand alone:
+  no pronoun reaches into the body. The anchor ends the block and
+  points at the transcript turn where the topic started.
 - **Continuation block** — a topic block that resumes or corrects a
   topic raised in an earlier chapter. Renders as `**Continued: <topic>**`
   instead of a fresh lead. Earlier blocks are never rewritten; a
   correction always arrives as a new block later in the note.
 - **Skim layer** — the sequence of bold leads read top-to-bottom,
-  ignoring the bodies. Because every lead is self-sufficient, the skim
-  layer alone is a legible, boom-boom-boom summary of the whole
-  session; the bodies are there for whoever wants the detail.
-- **Marker chapter** — a chapter written by the *system*, not an LLM:
-  deterministic text recording that a chapter was **withheld** (gate
+  ignoring the bodies. Every lead is self-sufficient, so the skim layer
+  alone is a legible, boom-boom-boom summary of the whole session. The
+  bodies hold the detail.
+- **Marker chapter** — a chapter the *system* writes, not an LLM. Its
+  deterministic text records that a chapter was **withheld** (the gate
   rejected it) or **failed** (composition never produced anything
   anchor-clean). See `MARKER_WITHHELD` / `MARKER_FAILED` and
   `append_marker_chapter` in `note_document.py`.
 
-Frontmatter is machine-first and deterministic: `note_status`
+Frontmatter is machine-first and deterministic. It holds `note_status`
 (`open`/`closed`), the `chapters` list (each entry's turn range and
-kind), and a cumulative `SessionFacts` snapshot (commits, PRs,
-files touched/read, duration) that only ever grows. Nothing in
+kind), and a cumulative `SessionFacts` snapshot (commits, PRs, files
+touched/read, duration). The snapshot only ever grows. Nothing in
 frontmatter is re-narrated in the body.
 
 Exact title and body rendering shape: `CONTEXT-FORMAT.md`.
@@ -73,18 +72,18 @@ Exact title and body rendering shape: `CONTEXT-FORMAT.md`.
 ## Writing a note — buffer, flush, extract
 
 A session's turns accumulate in a per-transcript **buffer**
-(`lore_curator/buffer_store.py`), driven by Curator A's heartbeat
-(`lore_curator/session_curator.py`, `run_curator_a`) on ordinary
-Claude Code hook activity — there is no cron. The first heartbeat for
+(`lore_curator/buffer_store.py`). Curator A's heartbeat
+(`lore_curator/session_curator.py`, `run_curator_a`) drives the buffer
+on ordinary Claude Code hook activity. There is no cron. The first heartbeat for
 a session creates the note (disclaimer + frontmatter, zero chapters:
 `lore_curator/session_note.py:ensure_note`); later heartbeats just
 grow the buffer.
 
 A **flush** happens once, when the session is over
-(`lore_curator/chapter_flush.py:synth_and_close`). Which of a session's
-turns mattered is only knowable backward, from its ending, so nothing is
-written while it runs — mid-session triggers (cap-trip, pre-compact) only
-bookkeep and leave the buffer accumulating:
+(`lore_curator/chapter_flush.py:synth_and_close`). Which turns of a
+session mattered is only knowable backward, from its ending. Lore writes
+nothing while the session runs. Mid-session triggers (cap-trip,
+pre-compact) only bookkeep and leave the buffer accumulating:
 
 ```
 segment_session (indices only) → extract_session (1 LLM call per chunk,
@@ -96,14 +95,14 @@ segment_session (indices only) → extract_session (1 LLM call per chunk,
 
 Every LLM call a note costs is in that pipeline: the segmenter
 (`lore_curator/chunker.py`), one extraction per chunk plus one headline
-(`lore_curator/fact_extract.py`). Nothing downstream is generative — the
-body is rendered from the fact ledger by code, and each fact's refs are
-verified (`lore_core/ref_verify.py`) so a line's authority is code-stamped,
-never model-authored.
+(`lore_curator/fact_extract.py`). Nothing downstream is generative. Code
+renders the body from the fact ledger. `lore_core/ref_verify.py` verifies
+each fact's refs, so a line's authority is code-stamped, never
+model-authored.
 
 The only flush is the close flush (buffer archives, note closes):
 **session-end**, the reaper, and the startup sweep. Cap-trip (buffer cap
-120 turns / 240K chars) and pre-compact **bookkeep only** — they record
+120 turns / 240K chars) and pre-compact **bookkeep only**. Both record
 the event and leave the buffer accumulating, so the close path still
 reads the session whole. `capture_routing.CLOSE_TRIGGERS` is the single
 authority for which trigger flushes. Cap defaults live on `WikiConfig`;
@@ -113,30 +112,32 @@ per-wiki overrides live in `.lore-wiki.yml` under
 ### Failure semantics
 
 - **A chunk that cannot be extracted** becomes a *failed* marker for its
-  span, which the render reads back as a **coverage gap** — one bad chunk
-  never costs the rest of the session.
+  span. The render reads that marker back as a **coverage gap**. One bad
+  chunk never costs the rest of the session.
 - **A chunk the gate withholds** becomes a *withheld* marker plus a
   quarantine entry. The extractor retries against the gate internally, so
   a withhold that reaches the flush is terminal.
 - **Every non-`facts` chapter is a coverage gap.** A note whose ledger the
   facts do not cover in full says so; a partial reading never presents
   itself as complete.
-- **Startup sweep.** Lore acts as a singleton at start (global lock,
-  `lore_core.lockfile.curator_lock`): `chapter_flush.startup_sweep`
-  finds buffers whose owning process is provably dead, gives each one
-  extraction attempt, and closes its note either way (facts, withheld,
-  or failed marker) — a crashed session never leaves an open note
-  behind. `lore curator sweep` runs this by hand.
+- **Startup sweep.** Lore acts as a singleton at start, under the
+  global lock `lore_core.lockfile.curator_lock`.
+  `chapter_flush.startup_sweep` finds buffers whose owning process is
+  provably dead. The sweep gives each buffer one extraction attempt,
+  then closes its note either way (facts, withheld, or failed marker).
+  A crashed session never leaves an open note behind.
+  `lore curator sweep` runs the sweep by hand.
 
-Everything upstream of compose (hook fire, spawn, run decisions) is
-correlated by one **trace_id** per flush and queryable via `lore trace` /
-`lore status` / `lore doctor`; full model: `docs/architecture/observability.md`.
+One **trace_id** per flush correlates everything upstream of compose:
+hook fire, spawn, run decisions. `lore trace`, `lore status` and
+`lore doctor` query that trace. Full model:
+`docs/architecture/observability.md`.
 
 ## The publish gate + quarantine
 
 Every composed chapter passes `lore_core/publish_gate.py:evaluate`
-before it can join the shared note — this is the last check between an
-LLM's output and the shared vault, and it **fails closed**: any error
+before it joins the shared note. The gate is the last check between an
+LLM's output and the shared vault. The gate **fails closed**: any error
 anywhere in the gate withholds rather than passes.
 
 Cheapest-first, short-circuiting on the first hit:
@@ -148,31 +149,31 @@ Cheapest-first, short-circuiting on the first hit:
    lab record, never a directive; a lint hit counts as a compose
    failure and its feedback drives the retry.
 3. **One small-model detection call** (`LlmPiiDetector`, cheapest
-   tier) for fuzzy PII/secrets that slip the first two layers. This is
-   pattern recognition, not truth verification, so it's exempt from
-   the no-LLM-judges-LLM rule — but it's a tripwire, not a guarantee,
-   and is documented as such here and in the module docstring.
+   tier) for fuzzy PII/secrets that slip the first two layers. The
+   call is pattern recognition, not truth verification, so it is
+   exempt from the no-LLM-judges-LLM rule. The call is a tripwire, not
+   a guarantee. This file and the module docstring both say so.
 
-On a withhold, `apply_withhold` runs the two terminal side-effects:
-a deterministic withheld-marker chapter goes into the note (safe,
-value-free reason text — the category, never the matched string), and
-the full composed text goes into the private **quarantine** sidecar
-(`lore_core/quarantine.py`, one JSON file per entry under
-`.lore/quarantine/`, inside the already-private `.lore/` area — it
-never reaches the shared wiki). `lore quarantine list/show/clear/kill`
-is the reviewer's flow over that sidecar; `list` never prints body
-content, since an entry may hold the very secret that tripped the
-gate.
+On a withhold, `apply_withhold` runs two terminal side-effects. A
+deterministic withheld-marker chapter goes into the note, with safe,
+value-free reason text: the category, never the matched string. The
+full composed text goes into the private **quarantine** sidecar
+(`lore_core/quarantine.py`), one JSON file per entry under
+`.lore/quarantine/`. That path sits inside the already-private
+`.lore/` area and never reaches the shared wiki.
+`lore quarantine list/show/clear/kill` is the reviewer's flow over that
+sidecar. `list` never prints body content, because an entry may hold
+the very secret that tripped the gate.
 
 ## Hygiene — the retained frontmatter-only curator
 
-`lore curator [--wiki] [--apply]` (bare, no subcommand — distinct from
-`lore curator run`, which is the Curator A pass above) runs
-deterministic, frontmatter-only passes over every wiki
-(`lore_curator/hygiene.py`): supersession propagation
+`lore curator [--wiki] [--apply]` takes no subcommand. The bare form is
+distinct from `lore curator run`, the Curator A pass above. The bare
+form runs deterministic, frontmatter-only passes over every wiki
+(`lore_curator/hygiene.py`). The passes are supersession propagation
 (`supersedes [[B]]` → `superseded_by: [[A]]` on B), `implements:`
-back-link processing, git-log date backfill, and a team-mode hint once
-a solo wiki's git log shows multiple authors. Staleness is a deliberate
+back-link processing, and git-log date backfill. Another pass hints at
+team mode once a solo wiki's git log shows multiple authors. Staleness is a deliberate
 no-op here — see `lore_core/freshness.py` below. Findings land in
 `wiki/<name>/_review.md`; writes are mtime-guarded so a note open in
 Obsidian is skipped rather than clobbered. `--apply` is required to
@@ -181,12 +182,12 @@ write; the default is a dry-run.
 ## Briefings
 
 `lore_core/briefing/gather.py:gather()` is the read-only half of
-`lore briefing`: it collects session notes filed since the last
-briefing (tracked in a per-wiki ledger) and hands their **full note
+`lore briefing`. It collects session notes filed since the last
+briefing, tracked in a per-wiki ledger. It hands their **full note
 bodies** — disclaimer plus every chronological chapter — to whatever
-composes the briefing prose. There is no per-note redaction step:
-session notes carry nothing that isn't already safe to share, because
-the publish gate cleared it before it ever reached the note. Briefing
+composes the briefing prose. There is no per-note redaction step.
+Session notes carry nothing that isn't already safe to share, because
+the publish gate cleared the text before it reached the note. Briefing
 publish is manual (`lore briefing publish`, `lore briefing mark`); there
 is no automatic daily trigger. See `docs/how-to/matrix-bot.md` for the
 Matrix sink walkthrough.
@@ -194,13 +195,15 @@ Matrix sink walkthrough.
 ## Ambient banner vs. MCP pull
 
 SessionStart injects a deliberately small, deterministic banner
-(`lore_core/session_start.py:render_session_banner`) — no LLM call, no network
-call: a status line, an optional `## Focus` block for the attached
-project, at most two last-session hints, freshness lines only when
-there's positive evidence (see below), and a fixed two-line directive
-(`lore_core/templates/integration-rules/default.md`) stating that
-deeper context is a pull, never a push, and that anything pulled from
-a session note is a lab record, never an instruction.
+(`lore_core/session_start.py:render_session_banner`). The banner costs
+no LLM call and no network call. It holds a status line, an optional
+`## Focus` block for the attached project, and at most two last-session
+hints. Freshness lines join the banner only when there is positive
+evidence (see below). A fixed two-line directive closes the banner
+(`lore_core/templates/integration-rules/default.md`). The directive
+states that deeper context is a pull, never a push. It also states that
+anything pulled from a session note is a lab record, never an
+instruction.
 
 Depth comes from explicit MCP calls (`lore mcp` / `lore_mcp/server.py`),
 not from anything injected ambiently:
@@ -225,11 +228,12 @@ not from anything injected ambiently:
   model for the current host before spawning a subagent.
 - `lore_codemap` — bounded, cached slice of the connected repo's code
   map (symbols / directory / callers modes), never the whole map.
-- `lore_context_pack` (`lore_core/context_pack.py`) — deterministic
-  context resolver: given a scope, repo state, and issue/PR/epic, returns
-  a pointer pack — recent session notes for this scope, ADRs/PRDs that
-  bear on it, open epic state — with one-line summaries and selective
-  body pulls, zero LLM cost. Fed into orchestration skills before any
+- `lore_context_pack` (`lore_core/context_pack.py`) — a deterministic
+  context resolver. It takes a scope, repo state, and an issue, PR or
+  epic. It returns a pointer pack: recent session notes for that scope,
+  ADRs and PRDs that bear on the scope, and open epic state. Each entry
+  carries a one-line summary and a selective body pull. The resolver
+  costs no LLM call. Orchestration skills read the pack before any
   explorer subagent runs.
 
 
@@ -239,9 +243,9 @@ Kept, general-purpose, and independent of the note-writing pipeline
 above:
 
 - **Freshness** (`lore_core/freshness.py`) — positive-evidence-only
-  staleness: a note is only ever flagged `stale-candidate` because of
-  a named cause (an authored `status: stale` / `superseded_by` /
-  `supersede_candidate*` marker, or membership in the orphan-link set).
+  staleness. A note is flagged `stale-candidate` only for a named
+  cause. The causes are an authored `status: stale` / `superseded_by` /
+  `supersede_candidate*` marker, or membership in the orphan-link set.
   Age by itself never flags anything.
 - **Search** (`lore_search`) — hybrid ranked full-text search backing
   `lore_search` / `lore_resume` / `lore_drill`.
@@ -293,11 +297,11 @@ Terms used in the workflow layer and orchestration:
   teammate, instead of having each teammate discover symbols independently.
   Distinct from a full `lore_context_pack`, which joins session notes and
   ADRs/PRDs; the codemap excerpt is the code-navigation half only.
-- **Epic note** — a single, composed session note that records the
-  orchestration of an epic: the roadmap DAG, per-feature tier decisions,
-  crosscheck verdicts, and any escalations. Distinct from the per-feature
-  implementation notes written by teammate agents; the epic note is the
-  orchestrator's record of supervision.
+- **Epic note** — a single, composed session note for the orchestration
+  of an epic. The note records the roadmap DAG, per-feature tier
+  decisions, crosscheck verdicts, and any escalations. Distinct from the
+  per-feature implementation notes written by teammate agents; the epic
+  note is the orchestrator's record of supervision.
 - **Handover (session)** — a working-context handover from one Claude Code
   session to a cold session starting fresh. The source session ends with a
   `/lore:handover` invoke, which drafts a structured note of context
@@ -305,14 +309,15 @@ Terms used in the workflow layer and orchestration:
   resumes with `/lore:continue`, which loads the handover note and carries
   its facts into the new session's work.
 - **Handover (epic seed)** — a tracker issue linking an epic seed (the
-  source of structured context for the `orient` step). Distinct from
-  session handover: the epic seed is filed in the issue tracker and is
-  one-time context for a shaped body of work, not a carry-forward between
-  sessions.
-- **Writing rules** — the prose style an agent writes issue text, PR bodies
-  and ADR context sections in: sentence and vocabulary rules, EARS acceptance
-  criteria, and the required section skeleton. Lore ships one default;
-  a team overrides it whole-file with `<wiki>/style/writing-rules.md`.
+  source of structured context for the `orient` step). The epic seed
+  differs from a session handover. A team files the seed in the issue
+  tracker. The seed is one-time context for a shaped body of work, not
+  a carry-forward between sessions.
+- **Writing rules** — the prose style an agent uses for issue text, PR
+  bodies and ADR context sections. The document holds sentence and vocabulary rules,
+  EARS acceptance criteria, and the required section skeleton. Lore
+  ships one default; a team overrides it whole-file with
+  `<wiki>/style/writing-rules.md`.
   `lore style show writing-rules` resolves the two. The rules fix style,
   not terminology — terminology stays with the glossary.
   Overriding the lint means copying `styles/vale/` whole — the ini plus

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,8 +2,8 @@
 
 An AI-navigation map of Lore's domain. Every term below has one tight
 meaning, matched against shipped code. Cross-check a claim here against
-the module it points at before you rely on it. A term that no real
-symbol grounds does not belong here.
+the module it points at before you rely on it. A term or a behavior
+that no real symbol grounds does not belong here.
 
 ## Vault, wiki, scope
 
@@ -74,8 +74,9 @@ Exact title and body rendering shape: `CONTEXT-FORMAT.md`.
 A session's turns accumulate in a per-transcript **buffer**
 (`lore_curator/buffer_store.py`). Curator A's heartbeat
 (`lore_curator/session_curator.py`, `run_curator_a`) drives the buffer
-on ordinary Claude Code hook activity. There is no cron. The first heartbeat for
-a session creates the note (disclaimer + frontmatter, zero chapters:
+on ordinary Claude Code hook activity. There is no cron. The first
+heartbeat for a session creates the note (disclaimer + frontmatter, zero
+chapters:
 `lore_curator/session_note.py:ensure_note`); later heartbeats just
 grow the buffer.
 
@@ -173,8 +174,9 @@ form runs deterministic, frontmatter-only passes over every wiki
 (`lore_curator/hygiene.py`). The passes are supersession propagation
 (`supersedes [[B]]` → `superseded_by: [[A]]` on B), `implements:`
 back-link processing, and git-log date backfill. Another pass hints at
-team mode once a solo wiki's git log shows multiple authors. Staleness is a deliberate
-no-op here — see `lore_core/freshness.py` below. Findings land in
+team mode once a solo wiki's git log shows multiple authors. Staleness
+is a deliberate no-op here — see `lore_core/freshness.py` below.
+Findings land in
 `wiki/<name>/_review.md`; writes are mtime-guarded so a note open in
 Obsidian is skipped rather than clobbered. `--apply` is required to
 write; the default is a dry-run.
@@ -314,9 +316,10 @@ Terms used in the workflow layer and orchestration:
   tracker. The seed is one-time context for a shaped body of work, not
   a carry-forward between sessions.
 - **Writing rules** — the prose style an agent uses for issue text, PR
-  bodies and ADR context sections. The document holds sentence and vocabulary rules,
-  EARS acceptance criteria, and the required section skeleton. Lore
-  ships one default; a team overrides it whole-file with
+  descriptions, PR review comments, ADR context sections and design
+  documents. Session notes stay out. The document holds sentence and
+  vocabulary rules, EARS acceptance criteria, and the required section
+  skeleton. Lore ships one default; a team overrides it whole-file with
   `<wiki>/style/writing-rules.md`.
   `lore style show writing-rules` resolves the two. The rules fix style,
   not terminology — terminology stays with the glossary.

--- a/lore-workflow/skills/domain-modeling/CONTEXT-FORMAT.md
+++ b/lore-workflow/skills/domain-modeling/CONTEXT-FORMAT.md
@@ -10,7 +10,7 @@
 ## Language
 
 **Order**:
-{A one or two sentence description of the term}
+{A short definition of the term, in full sentences}
 _Avoid_: Purchase, transaction
 
 **Invoice**:
@@ -25,7 +25,8 @@ _Avoid_: Client, buyer, account
 ## Rules
 
 - **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
-- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Write a definition under the writing rules.** Run `lore style show writing-rules` for the document. Every sentence in a definition obeys the writing rules' sentence ceiling. Write active voice and name the actor. The document holds the rest of the rules; do not copy them here.
+- **Keep definitions tight.** Define what a term IS, not what it does. A definition that needs a paragraph is hiding a second term — split it. Prefer two short sentences over one dense sentence.
 - **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
 - **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
 

--- a/tests/test_context_sentences.py
+++ b/tests/test_context_sentences.py
@@ -1,0 +1,85 @@
+"""The repo glossary obeys the writing rules' sentence ceiling.
+
+The ceiling and its regex come from the packaged Vale rule
+(`WritingRules/SentenceLength.yml`), so the linter and this test can never
+disagree about the number. The `vale` binary itself is not run here: Vale is
+PATH-detected and never bundled (ADR 0006), and CI installs no Vale, so a
+Vale-driven check would skip on every machine that matters instead of guarding
+the file. Segmenting markdown into sentences is the only part this file owns.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+from lore_core.style import default_vale_config_path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# A period that ends a sentence, not one inside `e.g.` or a file name. The
+# lookbehind rejects a single letter standing after a space or a period; the
+# trailing class lets a sentence end inside markup, as in `**Startup sweep.**`.
+SENTENCE_END = re.compile(r"(?<![\s.][A-Za-z])[.!?][*_`\"\')\]]*(?=\s|$)")
+LIST_ITEM = re.compile(r"\s*([-*+]|\d+\.)\s")
+
+
+def _sentence_length_rule() -> tuple[re.Pattern[str], int]:
+    """The Vale rule's own regex and the word count it allows."""
+    path = default_vale_config_path().parent / "WritingRules" / "SentenceLength.yml"
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))["raw"][0]
+    ceiling = re.search(r"\{(\d+),\}", raw)
+    assert ceiling, f"the Vale sentence rule lost its word count: {raw!r}"
+    return re.compile(raw), int(ceiling.group(1))
+
+
+def _prose_blocks(text: str) -> list[str]:
+    """Markdown prose, one block per paragraph or list item.
+
+    Fenced code, headings and table rows carry no sentences, and a heading left
+    in place would glue its words onto the paragraph below it.
+    """
+    blocks: list[list[str]] = [[]]
+    in_fence = False
+    for line in text.splitlines():
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        stripped = line.strip()
+        if in_fence or stripped.startswith("#") or stripped.startswith("|"):
+            continue
+        if not stripped or LIST_ITEM.match(line):
+            blocks.append([])
+        blocks[-1].append(stripped)
+    return [joined for block in blocks if (joined := " ".join(block).strip())]
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        cleaned
+        for block in _prose_blocks(text)
+        for part in SENTENCE_END.split(block)
+        if (cleaned := " ".join(part.split()))
+    ]
+
+
+def test_context_md_sentences_stay_inside_the_ceiling() -> None:
+    """A definition nobody can read fixes nothing — the glossary obeys the same
+    sentence rules as the issue text that cites it."""
+    over_long, ceiling = _sentence_length_rule()
+    offenders = [
+        f"{len(sentence.split())} words: {sentence}"
+        for sentence in _sentences((REPO_ROOT / "CONTEXT.md").read_text(encoding="utf-8"))
+        if over_long.search(sentence)
+    ]
+    assert not offenders, (
+        f"{len(offenders)} sentences run past the {ceiling}-word ceiling:\n" + "\n".join(offenders)
+    )
+
+
+def test_the_sentence_check_catches_a_long_sentence() -> None:
+    """Guards the segmenter: a check that never fires would pass on any file."""
+    over_long, ceiling = _sentence_length_rule()
+    sentence = " ".join(["word"] * (ceiling + 1)) + "."
+    assert [s for s in _sentences(f"# Title\n\n{sentence}\n") if over_long.search(s)]

--- a/tests/test_context_sentences.py
+++ b/tests/test_context_sentences.py
@@ -18,10 +18,13 @@ from lore_core.style import default_vale_config_path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-# A period that ends a sentence, not one inside `e.g.` or a file name. The
-# lookbehind rejects a single letter standing after a space or a period; the
+# A period that ends a sentence, not one inside an abbreviation or a file name.
+# The first lookbehind rejects a single letter standing after a space or a
+# period, which covers an initial; ABBREVIATIONS covers the longer forms. The
 # trailing class lets a sentence end inside markup, as in `**Startup sweep.**`.
-SENTENCE_END = re.compile(r"(?<![\s.][A-Za-z])[.!?][*_`\"\')\]]*(?=\s|$)")
+ABBREVIATIONS = ("etc", "vs", "cf", "approx", "resp")
+_NOT_ABBREVIATION = "".join(rf"(?<!{re.escape(word)})" for word in ABBREVIATIONS)
+SENTENCE_END = re.compile(rf"(?<![\s.][A-Za-z]){_NOT_ABBREVIATION}[.!?][*_`\"\')\]]*(?=\s|$)")
 LIST_ITEM = re.compile(r"\s*([-*+]|\d+\.)\s")
 
 
@@ -83,3 +86,14 @@ def test_the_sentence_check_catches_a_long_sentence() -> None:
     over_long, ceiling = _sentence_length_rule()
     sentence = " ".join(["word"] * (ceiling + 1)) + "."
     assert [s for s in _sentences(f"# Title\n\n{sentence}\n") if over_long.search(s)]
+
+
+def test_an_abbreviation_does_not_split_a_long_sentence() -> None:
+    """A period inside an abbreviation is not a sentence end. Treating it as
+    one hides an over-long sentence behind two short halves."""
+    over_long, ceiling = _sentence_length_rule()
+    for abbreviation in ABBREVIATIONS:
+        head = "word " * 7
+        tail = "word " * (ceiling - 6)
+        sentence = f"{head}{abbreviation}. {tail}".strip() + "."
+        assert [s for s in _sentences(sentence) if over_long.search(s)], abbreviation


### PR DESCRIPTION
## Context

A glossary definition follows the same sentence rules as the text that cites
it. `CONTEXT-FORMAT.md` said one thing about how to write a definition: "Keep
definitions tight. One or two sentences max." A definition can be two dense
sentences and still pass that rule.

Lore's own `CONTEXT.md` was the worst offender in this repo. The new guard
found 27 of its sentences past the 25-word ceiling on 2026-08-04, in the
worktree `/home/buchbend/git/lore/.claude/worktrees/feat-340`.

Closes #340. Targets `epic/336`.

## Change

- `CONTEXT-FORMAT.md` points at the writing rules for the sentence ceiling and
  the active-voice rule. The document does not restate the rules.
- `CONTEXT.md` keeps all 26 terms. Every over-long sentence is split or
  tightened. Headings are unchanged.
- `tests/test_context_sentences.py` fails when a sentence in `CONTEXT.md` runs
  past the ceiling.

## Test approach

The test reads the ceiling and its regex from the packaged Vale rule
`lib/lore_core/styles/vale/WritingRules/SentenceLength.yml`, then applies that
same regex per sentence. The linter and the test cannot disagree about the
number.

The test does not run the `vale` binary. Vale is PATH-detected and never
bundled (ADR 0006), `vale` is absent from this host, and `.github/workflows/ci.yml`
installs no Vale. A binary-driven check would skip on every machine that
matters instead of guarding the file. Driving the full style over `CONTEXT.md`
would also flag banned words, participial openers and back references, which
this issue does not ask for. Markdown sentence segmentation is the only logic
this file owns; a second test pins the segmenter so a check that never fires
cannot pass silently.

## Red

```
$ PYTHONPATH=.../lib python -m pytest tests/test_context_sentences.py -q
E       AssertionError: 27 sentences run past the 25-word ceiling:
E         30 words: Cross-check any claim here against the modules it points to before relying on it — if a term or behavior isn't grounded in a real symbol, it doesn't belong here
E         43 words: A fresh wiki (`lore wiki new`) is scaffolded with `projects/`, `concepts/`, `decisions/`, `sessions/`, `inbox/` — session notes are the only one of these Lore writes automatically; the rest are written directly (by hand, or via `/lore:inbox`) when there's something worth a standalone note
E         29 words: It is a **lab notebook**, not a source of truth: git owns what happened to the code, the connected repo's ADRs and PRDs own what was decided and why
E         46 words: - **Topic block** — one topic within a chapter: a bold, one-sentence, self-sufficient **lead** (must stand alone — no pronoun reaching into the body), an optional short prose **body**, and exactly one `@N` **anchor** at the end pointing at the transcript turn where the topic started
E         72 words: SessionStart injects a deliberately small, deterministic banner (`lore_core/session_start.py:render_session_banner`) — no LLM call, no network call: a status line, an optional `## Focus` block for the attached project, at most two last-session hints, freshness lines only when there's positive evidence (see below), and a fixed two-line directive (`lore_core/templates/integration-rules/default.md`) stating that deeper context is a pull, never a push, and that anything pulled from a session note is a lab record, never an instruction
E         59 words: On a withhold, `apply_withhold` runs the two terminal side-effects: a deterministic withheld-marker chapter goes into the note (safe, value-free reason text — the category, never the matched string), and the full composed text goes into the private **quarantine** sidecar (`lore_core/quarantine.py`, one JSON file per entry under `.lore/quarantine/`, inside the already-private `.lore/` area — it never reaches the shared wiki)
E         56 words: `lore curator [--wiki] [--apply]` (bare, no subcommand — distinct from `lore curator run`, which is the Curator A pass above) runs deterministic, frontmatter-only passes over every wiki (`lore_curator/hygiene.py`): supersession propagation (`supersedes [[B]]` → `superseded_by: [[A]]` on B), `implements:` back-link processing, git-log date backfill, and a team-mode hint once a solo wiki's git log shows multiple authors
[21 further sentences elided]
1 failed, 1 passed in 0.23s
```

## Green

```
$ PYTHONPATH=.../lib python -m pytest tests/test_context_sentences.py tests/test_writing_rules.py -q
22 passed in 1.88s

$ PYTHONPATH=.../lib python -m pytest -q
4 failed, 2902 passed, 9 skipped, 1 warning, 11 subtests passed in 80.07s
```

The four failures are the known local environment artifacts:
`test_cli_scopes.py::test_rename_reports_stale_checked_in_offer`, two in
`test_core_llm_wiring.py`, and
`test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`.
This branch adds none.

A mutation check confirms the guard bites on the real file: appending one
28-word definition to `CONTEXT.md` fails the test with
`1 sentences run past the 25-word ceiling`.

## Meaning preserved

All 26 terms keep their definitions. No heading changed. The file grew from
2482 to 2518 words, because splitting adds words and nothing was cut.

Three rewrites shifted an assertion and were corrected before commit:

- `lore_context_pack` — zero LLM cost belongs to the resolver, not to each
  pack entry.
- Hygiene curator — the team-mode hint is one pass among several, with no
  stated ordering.
- **Writing rules** — the definition keeps its actor ("the prose style an
  agent uses for...").

No definition lost meaning. Two definitions now run to four sentences where
the original ran to one, because tightening alone could not reach the ceiling:
**Startup sweep** and the SessionStart banner paragraph.

