### PR TITLE
Flag a short name that no glossary and no dictionary holds

### DIFF
--- a/docs/how-to/customize-the-writing-rules.md
+++ b/docs/how-to/customize-the-writing-rules.md
@@ -41,19 +41,24 @@ default does. There is no merge and no per-repo layer.
    The Vale config resolves the same way:
 
    ```
-   lore style vale-config
+   lore style vale-config --packaged
    ```
 
    Copy the whole packaged `styles/vale/` directory, not the `vale.ini` alone:
 
    ```
-   cp -r "$(dirname "$(lore style vale-config)")" "$LORE_ROOT/wiki/<name>/style/vale"
+   cp -r "$(dirname "$(lore style vale-config --packaged)")" "$LORE_ROOT/wiki/<name>/style/vale"
    ```
 
    The ini sets `StylesPath = .`, so Vale looks for the rule directory next to
    the ini it loaded. An ini copied without its `WritingRules/` directory
    fails with exit code 2 and `style 'WritingRules' does not exist on
    StylesPath`.
+
+   `--packaged` is what makes the copy safe. Without it the command prints a
+   generated copy carrying the current repository's glossary. Every repository
+   attached to your wiki would then lint against that one glossary. Step 4
+   drops the option, because linting is where you want the glossary.
 
 4. **Check the rules fire.**
 
@@ -78,6 +83,9 @@ default does. There is no merge and no per-repo layer.
   file unless you intend to drop those.
 - Wikis are portable. The override travels with the wiki repo, so a team that
   takes its wiki elsewhere keeps its rules.
+- The short-name check reads each repository's own `CONTEXT.md`. Your override
+  sets the rules. The repository you lint from sets the terms. A repository
+  without a `CONTEXT.md` runs no short-name check at all.
 - `lore style show issue-register` still resolves the same document and names
   the retired term on stderr. A wiki that overrode `style/issue-register.md`
   renames that file to `style/writing-rules.md`.

--- a/lib/lore_cli/style_cmd.py
+++ b/lib/lore_cli/style_cmd.py
@@ -80,6 +80,11 @@ def vale_config(
     wiki: str = typer.Option(
         None, "--wiki", "-w", help="Wiki whose override wins (default: from cwd)."
     ),
+    packaged: bool = typer.Option(
+        False,
+        "--packaged",
+        help="Print the config to copy, without this repo's glossary folded in.",
+    ),
 ) -> None:
     """Print the Vale config path to lint against.
 
@@ -88,9 +93,14 @@ def vale_config(
     config carrying the glossary, which switches the short-name check on.
     Meant for command substitution:
     `vale --config $(lore style vale-config) <file>`.
+
+    `--packaged` prints the resolved config itself. Use it to seed a wiki
+    override: a copy taken from the generated path would carry one repo's
+    glossary into every repo attached to that wiki.
     """
     cwd = Path.cwd()
-    path = vale_config_for(git_repo_root(cwd) or cwd, wiki_dir=_wiki_dir(wiki))
+    repo_dir = None if packaged else (git_repo_root(cwd) or cwd)
+    path = vale_config_for(repo_dir, wiki_dir=_wiki_dir(wiki))
     # Plain write, not console.print: a path can contain `[...]`-shaped
     # segments and Rich's markup parser would eat them (same hazard as
     # `show`'s plain stdout write).

--- a/lib/lore_cli/style_cmd.py
+++ b/lib/lore_cli/style_cmd.py
@@ -19,12 +19,13 @@ from pathlib import Path
 
 import typer
 from lore_core.config import get_wiki_root
+from lore_core.git import git_repo_root
 from lore_core.scope_resolver import resolve_scope
 from lore_core.style import (
     DEPRECATED_ALIASES,
     UnknownStyle,
     resolve_style_path,
-    resolve_vale_config_path,
+    vale_config_for,
 )
 from rich.console import Console
 
@@ -80,12 +81,16 @@ def vale_config(
         None, "--wiki", "-w", help="Wiki whose override wins (default: from cwd)."
     ),
 ) -> None:
-    """Print the resolved Vale config path.
+    """Print the Vale config path to lint against.
 
-    `<wiki>/style/vale/vale.ini` wins, else the packaged default. Meant for
-    command substitution: `vale --config $(lore style vale-config) <file>`.
+    `<wiki>/style/vale/vale.ini` wins, else the packaged default. Where the
+    cwd's repo holds a `CONTEXT.md`, the printed path is a cached copy of that
+    config carrying the glossary, which switches the short-name check on.
+    Meant for command substitution:
+    `vale --config $(lore style vale-config) <file>`.
     """
-    path = resolve_vale_config_path(wiki_dir=_wiki_dir(wiki))
+    cwd = Path.cwd()
+    path = vale_config_for(git_repo_root(cwd) or cwd, wiki_dir=_wiki_dir(wiki))
     # Plain write, not console.print: a path can contain `[...]`-shaped
     # segments and Rich's markup parser would eat them (same hazard as
     # `show`'s plain stdout write).

--- a/lib/lore_core/style.py
+++ b/lib/lore_core/style.py
@@ -157,6 +157,10 @@ def vale_config_for(repo_dir: Path | None, wiki_dir: Path | None = None) -> Path
     and out of the installed package. Vale resolves a rule's ``ignore`` path
     against ``StylesPath``, so the list has to sit next to the rules, and the
     packaged directory is shared by every repo on the host.
+
+    Pass ``repo_dir=None`` for the resolved config itself. That is the copy to
+    seed a wiki override from: an override taken from a generated copy carries
+    one repo's glossary into every repo attached to that wiki.
     """
     base = resolve_vale_config_path(wiki_dir)
     if repo_dir is None:
@@ -164,25 +168,56 @@ def vale_config_for(repo_dir: Path | None, wiki_dir: Path | None = None) -> Path
     terms = glossary_terms(repo_dir)
     if not terms:
         return base
-    key = hashlib.sha256(f"{repo_dir}\n{base}".encode()).hexdigest()[:12]
-    out = _cache_dir() / "vale" / f"{repo_dir.name}-{key}"
+    out = _cache_dir() / "vale" / f"{repo_dir.name}-{_content_key(base, terms)}"
+    if (out / base.name).is_file():
+        return out / base.name
     try:
-        # ponytail: rebuilt from scratch every call rather than cached against
-        # the glossary's mtime. The tree is a handful of small files, and a rule
-        # left behind by an older Lore would otherwise keep firing.
-        shutil.rmtree(out, ignore_errors=True)
-        shutil.copytree(base.parent, out)
-        (out / GLOSSARY_IGNORE_FILE).write_text("\n".join(terms) + "\n", encoding="utf-8")
-        ini = out / base.name
-        # A config that never carried the switch is a hand-rolled wiki override.
-        # Leave it as its author wrote it rather than inject a rule they did not
-        # ask for; `replace` is a no-op there.
+        # The tree is built under a private name and moved into place, so a
+        # path another process already captured stays readable while this one
+        # builds. `os.replace` needs a free destination, which the content key
+        # gives it: a different glossary or rule set is a different directory.
+        # ponytail: superseded directories are left behind rather than swept.
+        # They are a few kilobytes each and only a glossary edit makes one.
+        staging = out.with_name(f"{out.name}.{os.getpid()}")
+        shutil.rmtree(staging, ignore_errors=True)
+        shutil.copytree(base.parent, staging)
+        (staging / GLOSSARY_IGNORE_FILE).write_text("\n".join(terms) + "\n", encoding="utf-8")
+        ini = staging / base.name
+        # The switch line is what the packaged config carries to keep the check
+        # off. A hand-rolled wiki override may not carry it, and there `replace`
+        # does nothing — Vale runs every rule under `BasedOnStyles` by default,
+        # so that override runs the check against the glossary copied here.
         ini.write_text(
             ini.read_text(encoding="utf-8").replace(_CHECK_OFF, _CHECK_ON), encoding="utf-8"
         )
+        try:
+            os.replace(staging, out)
+        except OSError:
+            # Another process built the same key first. Both trees hold the
+            # same bytes, so theirs serves and this one goes.
+            shutil.rmtree(staging, ignore_errors=True)
+            if not (out / base.name).is_file():
+                raise
     except OSError:
         # A cache Lore cannot write costs the short-name check, never the lint.
         # The caller runs the resolved config, whose rule is off (ADR 0006 —
         # Vale never blocks the flow).
         return base
-    return ini
+    return out / base.name
+
+
+def _content_key(base: Path, terms: list[str]) -> str:
+    """Digest of everything the generated tree is built from.
+
+    Keying the directory by content rather than by repository path means a
+    rebuild only ever writes a directory that does not exist yet. A Lore
+    upgrade that ships a changed rule lands on a new key rather than reusing a
+    stale tree.
+    """
+    digest = hashlib.sha256(str(base).encode())
+    for path in sorted(base.parent.rglob("*")):
+        if path.is_file():
+            digest.update(path.relative_to(base.parent).as_posix().encode())
+            digest.update(path.read_bytes())
+    digest.update("\n".join(terms).encode())
+    return digest.hexdigest()[:16]

--- a/lib/lore_core/style.py
+++ b/lib/lore_core/style.py
@@ -17,6 +17,10 @@ directory over: `<wiki>/style/vale/vale.ini` wins, else the packaged
 
 from __future__ import annotations
 
+import hashlib
+import os
+import re
+import shutil
 from pathlib import Path
 
 # Style names Lore ships a default for. The per-wiki override uses the same
@@ -92,3 +96,93 @@ def resolve_vale_config_path(wiki_dir: Path | None = None) -> Path:
         if override.is_file():
             return override
     return default_vale_config_path()
+
+
+# --- the short-name check's ignore list ------------------------------------
+
+# The Vale rule reads its ignore list from `glossary.txt` beside the ini, and
+# the packaged copy ships without one. `vale_config_for` writes the pair into
+# the cache so no file lands in a repo Lore does not own (ADR 0006).
+GLOSSARY_IGNORE_FILE = "glossary.txt"
+_CHECK_OFF = "WritingRules.UnknownShortName = NO"
+_CHECK_ON = "WritingRules.UnknownShortName = YES"
+
+# A glossary entry names its term in bold — `- **Vault** — ...` in this repo,
+# `**Order**:` in the format spec. Both shapes are one bold span.
+_BOLD_TERM = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+# Vale reports `C-ext` as a single token, so a hyphen stays inside a word while
+# a space splits an entry into the separate words Vale will see.
+_WORD = re.compile(r"[0-9A-Za-z][0-9A-Za-z_'-]*")
+
+
+def _cache_dir() -> Path:
+    """Host-local derived state, same env override the rest of the CLI reads.
+
+    Duplicated from `lore_cli.context_cache` rather than imported: `lore_core`
+    does not depend on `lore_cli`.
+    """
+    return Path(os.environ.get("LORE_CACHE", str(Path.home() / ".cache" / "lore")))
+
+
+def glossary_terms(repo_dir: Path) -> list[str]:
+    """Return the words ``repo_dir``'s ``CONTEXT.md`` defines, in order, once each.
+
+    Returns an empty list where the repo holds no ``CONTEXT.md``. Bold is the
+    only signal, so a bold run that is emphasis rather than a term widens the
+    list. A widened list lets a word through that should have been flagged,
+    which is the safe direction for a check that only ever advises.
+
+    A repo that splits its glossary across a ``CONTEXT-MAP.md`` is read as
+    having none.
+    """
+    context = repo_dir / "CONTEXT.md"
+    if not context.is_file():
+        return []
+    terms: dict[str, None] = {}
+    for span in _BOLD_TERM.findall(context.read_text(encoding="utf-8")):
+        for word in _WORD.findall(span):
+            terms.setdefault(word, None)
+    return list(terms)
+
+
+def vale_config_for(repo_dir: Path | None, wiki_dir: Path | None = None) -> Path:
+    """Return the Vale config that lints a draft written for ``repo_dir``.
+
+    Where the repo names no glossary the resolved config travels unchanged, and
+    its ``WritingRules.UnknownShortName = NO`` line keeps the short-name check
+    off. Where the repo names one, the whole config directory is copied to the
+    cache, the glossary lands beside it, and the copy switches the check on.
+
+    Copying is what keeps the generated word list out of the user's checkout
+    and out of the installed package. Vale resolves a rule's ``ignore`` path
+    against ``StylesPath``, so the list has to sit next to the rules, and the
+    packaged directory is shared by every repo on the host.
+    """
+    base = resolve_vale_config_path(wiki_dir)
+    if repo_dir is None:
+        return base
+    terms = glossary_terms(repo_dir)
+    if not terms:
+        return base
+    key = hashlib.sha256(f"{repo_dir}\n{base}".encode()).hexdigest()[:12]
+    out = _cache_dir() / "vale" / f"{repo_dir.name}-{key}"
+    try:
+        # ponytail: rebuilt from scratch every call rather than cached against
+        # the glossary's mtime. The tree is a handful of small files, and a rule
+        # left behind by an older Lore would otherwise keep firing.
+        shutil.rmtree(out, ignore_errors=True)
+        shutil.copytree(base.parent, out)
+        (out / GLOSSARY_IGNORE_FILE).write_text("\n".join(terms) + "\n", encoding="utf-8")
+        ini = out / base.name
+        # A config that never carried the switch is a hand-rolled wiki override.
+        # Leave it as its author wrote it rather than inject a rule they did not
+        # ask for; `replace` is a no-op there.
+        ini.write_text(
+            ini.read_text(encoding="utf-8").replace(_CHECK_OFF, _CHECK_ON), encoding="utf-8"
+        )
+    except OSError:
+        # A cache Lore cannot write costs the short-name check, never the lint.
+        # The caller runs the resolved config, whose rule is off (ADR 0006 —
+        # Vale never blocks the flow).
+        return base
+    return ini

--- a/lib/lore_core/styles/vale/WritingRules/UnknownShortName.yml
+++ b/lib/lore_core/styles/vale/WritingRules/UnknownShortName.yml
@@ -1,0 +1,39 @@
+# Rule 20: a short name for a thing belongs in the glossary. A banned-word list
+# only catches terms someone listed beforehand, and it never holds a name an
+# agent invents during the session that writes the text. This check runs the
+# other way round — the dictionaries decide, and a word held by neither the
+# base English dictionary nor the repo's glossary is flagged.
+#
+# `custom: true` drops Vale's default spelling filters. Those filters skip
+# uppercase tokens, tokens carrying digits, hyphenated tokens and mixed case,
+# which are exactly the shapes a short name takes: with the defaults in place
+# `LTA`, `G4`, `C-ext` and `camelCase` are invisible and the check passes
+# everything. Vale's markdown scoping already excludes code spans, fenced
+# blocks and URLs, so bare prose is all this reads.
+#
+# The two filters below replace the defaults. Each drops a class that is
+# structurally not a short name, measured against real issue bodies:
+#
+#   - A token carrying a slash is a path, a repo name or an issue reference.
+#   - A hyphenated token whose every segment is an English word of three
+#     letters or more is a compound adjective, not a name. The length floor is
+#     what keeps `C-ext` visible: its first segment is one letter.
+#
+# `glossary.txt` sits beside this file in the copy `lore_core.style`'s
+# `vale_config_for` writes from a repo's CONTEXT.md. Vale resolves `ignore`
+# against StylesPath, and a missing file is not an error, so the packaged
+# config keeps the rule off instead: with no glossary every domain word is
+# unknown.
+#
+# warning, not error: `file-issue` reads Vale by exit code and only an
+# error-level finding exits 1. A heuristic over a hand-written glossary advises
+# and never blocks (docs/adr/0006-...).
+extends: spelling
+message: "Rule 20 (short name): '%s' is in neither the glossary nor common English."
+level: warning
+custom: true
+filters:
+  - '\S*/\S*'
+  - '^[A-Za-z]{3,}(?:-[A-Za-z]{3,})+$'
+ignore:
+  - glossary.txt

--- a/lib/lore_core/styles/vale/WritingRules/UnknownShortName.yml
+++ b/lib/lore_core/styles/vale/WritingRules/UnknownShortName.yml
@@ -11,13 +11,19 @@
 # everything. Vale's markdown scoping already excludes code spans, fenced
 # blocks and URLs, so bare prose is all this reads.
 #
-# The two filters below replace the defaults. Each drops a class that is
-# structurally not a short name, measured against real issue bodies:
+# The filters below replace the defaults. Each drops a class that is
+# structurally not a short name, measured against the bodies of real issues:
 #
-#   - A token carrying a slash is a path, a repo name or an issue reference.
+#   - A token carrying a slash is a path, a repository name or an issue
+#     reference.
 #   - A hyphenated token whose every segment is an English word of three
 #     letters or more is a compound adjective, not a name. The length floor is
 #     what keeps `C-ext` visible: its first segment is one letter.
+#   - A possessive is unknown only because of the trailing `'s`, so `another's`
+#     would be flagged while `another` passes. Vale filters possessives by
+#     default and `custom: true` drops that filter with the rest.
+#   - A token opening with a hyphen is what a stripped code span leaves behind:
+#     an `error`-level alert reaches the check as `-level`.
 #
 # `glossary.txt` sits beside this file in the copy `lore_core.style`'s
 # `vale_config_for` writes from a repo's CONTEXT.md. Vale resolves `ignore`
@@ -35,5 +41,7 @@ custom: true
 filters:
   - '\S*/\S*'
   - '^[A-Za-z]{3,}(?:-[A-Za-z]{3,})+$'
+  - '^\w+[''’]s$'
+  - '^-'
 ignore:
   - glossary.txt

--- a/lib/lore_core/styles/vale/vale.ini
+++ b/lib/lore_core/styles/vale/vale.ini
@@ -7,3 +7,8 @@ MinAlertLevel = suggestion
 
 [*.md]
 BasedOnStyles = WritingRules
+# Off in the packaged config: the short-name check treats the repo's glossary
+# as its ignore list, and a repo with no glossary would see every domain word
+# flagged. `lore style vale-config` flips this line to YES in the copy it
+# writes when it finds a CONTEXT.md.
+WritingRules.UnknownShortName = NO

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -9,6 +9,7 @@ decisions.
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
@@ -20,7 +21,9 @@ from lore_cli.__main__ import app
 from lore_core.style import (
     default_style_path,
     default_vale_config_path,
+    glossary_terms,
     resolve_vale_config_path,
+    vale_config_for,
 )
 from typer.testing import CliRunner
 
@@ -29,10 +32,20 @@ runner = CliRunner()
 VALE_MISSING = shutil.which("vale") is None
 
 
+@pytest.fixture(autouse=True)
+def _cache_in_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep every generated Vale config out of the developer's real cache dir."""
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+
+
 @pytest.fixture()
 def lore_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("LORE_ROOT", str(tmp_path))
     (tmp_path / "wiki" / "notes").mkdir(parents=True)
+    # `vale-config` reads the cwd's repo for a glossary. The checkout this
+    # suite runs from holds one, so the CLI cases start from a directory that
+    # does not — otherwise they compare against a generated copy.
+    monkeypatch.chdir(tmp_path)
     return tmp_path
 
 
@@ -207,3 +220,139 @@ def test_vale_flags_a_sentence_over_25_words(tmp_path: Path) -> None:
     )
     assert "sentence" in result.stdout.lower()
     assert result.returncode != 0
+
+
+# --- unknown short names: the glossary is the ignore list -----------------
+
+
+def _repo_with_glossary(parent: Path, *terms: str) -> Path:
+    """A repo directory whose CONTEXT.md defines ``terms`` in bold."""
+    repo = parent / "repo"
+    repo.mkdir(exist_ok=True)
+    entries = "\n".join(f"- **{term}** — a defined thing." for term in terms)
+    (repo / "CONTEXT.md").write_text(f"# Context\n\n## Language\n\n{entries}\n")
+    return repo
+
+
+def _vale(config: Path, fixture: Path) -> tuple[int, list[dict]]:
+    """Run the real binary and return its exit code plus a flat alert list.
+
+    JSON output rather than the console format: a long message wraps across
+    console lines, so a substring assertion on the flagged word is unreliable.
+    """
+    result = subprocess.run(
+        ["vale", "--output=JSON", "--config", str(config), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 2, f"vale could not run:\n{result.stdout}{result.stderr}"
+    by_file = json.loads(result.stdout or "{}")
+    return result.returncode, [alert for alerts in by_file.values() for alert in alerts]
+
+
+def test_packaged_ini_ships_the_short_name_check_switched_off() -> None:
+    """The packaged config lints repos that have no glossary, so the check
+    stays off until one switches it on. `vale_config_for` rewrites this exact
+    line, so a config that drops it silently loses the check."""
+    ini = default_vale_config_path().read_text(encoding="utf-8")
+    assert "WritingRules.UnknownShortName = NO" in ini
+
+
+def test_glossary_terms_takes_the_bold_terms(tmp_path: Path) -> None:
+    repo = _repo_with_glossary(tmp_path, "L0", "Topic block", "C-ext")
+    assert glossary_terms(repo) == ["L0", "Topic", "block", "C-ext"]
+
+
+def test_glossary_terms_is_empty_without_a_context_md(tmp_path: Path) -> None:
+    assert glossary_terms(tmp_path) == []
+
+
+def test_config_for_a_repo_without_a_glossary_is_the_packaged_default(tmp_path: Path) -> None:
+    assert vale_config_for(tmp_path) == default_vale_config_path()
+
+
+def test_config_for_a_repo_with_a_glossary_switches_the_check_on(tmp_path: Path) -> None:
+    repo = _repo_with_glossary(tmp_path, "L0")
+    config = vale_config_for(repo)
+    assert config != default_vale_config_path()
+    assert "WritingRules.UnknownShortName = YES" in config.read_text(encoding="utf-8")
+    assert (config.parent / "glossary.txt").read_text(encoding="utf-8").split() == ["L0"]
+    # The whole rule directory travels, or the other rules stop firing.
+    assert (config.parent / "WritingRules" / "Vocabulary.yml").is_file()
+
+
+def test_the_generated_config_stays_out_of_the_repo(tmp_path: Path) -> None:
+    """ADR 0006 keeps Lore from writing into a checkout it does not own."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    config = vale_config_for(repo)
+    assert repo not in config.parents
+
+
+def test_vale_config_cli_switches_the_check_on_inside_a_glossary_repo(
+    lore_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo_with_glossary(lore_root, "L0")
+    monkeypatch.chdir(repo)
+    result = runner.invoke(app, ["style", "vale-config"])
+    assert result.exit_code == 0, result.output
+    printed = Path(result.output.strip())
+    assert "WritingRules.UnknownShortName = YES" in printed.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+@pytest.mark.parametrize("name", ["G4", "LTA", "C-ext", "camelCase"])
+def test_vale_flags_an_invented_short_name(tmp_path: Path, name: str) -> None:
+    """Digit-bearing, uppercase, hyphenated and mixed-case tokens are the
+    shapes Vale's default spelling filters skip. `custom: true` drops those
+    filters, so all four reach the dictionary."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    fixture = tmp_path / "issue.md"
+    fixture.write_text(f"# Title\n\nThe {name} loader reads the file.\n")
+    code, alerts = _vale(vale_config_for(repo), fixture)
+    assert name in [alert["Match"] for alert in alerts]
+    assert code == 0, "an advisory finding must not read as a blocking one"
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_vale_leaves_a_glossary_short_name_alone(tmp_path: Path) -> None:
+    repo = _repo_with_glossary(tmp_path, "L0")
+    fixture = tmp_path / "issue.md"
+    fixture.write_text("# Title\n\nThe L0 stage feeds the G4 loader.\n")
+    _, alerts = _vale(vale_config_for(repo), fixture)
+    matches = [alert["Match"] for alert in alerts]
+    assert "G4" in matches, "the check did not run, so the L0 result proves nothing"
+    assert "L0" not in matches
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_the_short_name_check_reports_at_warning(tmp_path: Path) -> None:
+    repo = _repo_with_glossary(tmp_path, "L0")
+    fixture = tmp_path / "issue.md"
+    fixture.write_text("# Title\n\nThe G4 loader reads the file.\n")
+    _, alerts = _vale(vale_config_for(repo), fixture)
+    assert [alert["Severity"] for alert in alerts] == ["warning"]
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_a_banned_word_still_exits_1_beside_the_new_check(tmp_path: Path) -> None:
+    """`file-issue` reads Vale by exit code: 1 is a blocking finding. The new
+    warning must neither create one nor hide one."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    fixture = tmp_path / "issue.md"
+    fixture.write_text("# Title\n\nWe should leverage the G4 loader.\n")
+    code, alerts = _vale(vale_config_for(repo), fixture)
+    assert code == 1
+    assert {alert["Check"] for alert in alerts} == {
+        "WritingRules.Vocabulary",
+        "WritingRules.UnknownShortName",
+    }
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_a_repo_without_a_glossary_runs_no_short_name_check(tmp_path: Path) -> None:
+    """With no glossary the check would flag every domain word, so it is off."""
+    fixture = tmp_path / "issue.md"
+    fixture.write_text("# Title\n\nThe G4 loader reads the file.\n")
+    code, alerts = _vale(vale_config_for(tmp_path), fixture)
+    assert alerts == []
+    assert code == 0

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -19,6 +19,8 @@ import pytest
 import yaml
 from lore_cli.__main__ import app
 from lore_core.style import (
+    _CHECK_OFF,
+    GLOSSARY_IGNORE_FILE,
     default_style_path,
     default_vale_config_path,
     glossary_terms,
@@ -417,3 +419,72 @@ def test_the_check_passes_over_a_fragment_left_by_a_code_span(tmp_path: Path) ->
     fixture.write_text("# Title\n\nVale reports an `error`-level alert here.\n")
     _, alerts = _vale(vale_config_for(repo), fixture)
     assert [alert["Match"] for alert in alerts] == []
+
+
+# --- the copy recipe the how-to gives ------------------------------------
+
+
+def test_packaged_flag_prints_a_config_carrying_no_glossary(lore_root: Path) -> None:
+    """`docs/how-to/customize-the-writing-rules.md` copies this directory into a
+    wiki override. A generated copy would carry one repo's glossary into every
+    repo attached to that wiki."""
+    repo = _repo_with_glossary(lore_root, "L0")
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.chdir(repo)
+    try:
+        result = runner.invoke(app, ["style", "vale-config", "--packaged"])
+    finally:
+        monkeypatch.undo()
+    assert result.exit_code == 0, result.output
+    printed = Path(result.output.strip())
+    assert printed == default_vale_config_path()
+    assert not (printed.parent / GLOSSARY_IGNORE_FILE).exists()
+    assert _CHECK_OFF in printed.read_text(encoding="utf-8")
+
+
+def test_the_how_to_copies_the_packaged_directory() -> None:
+    """The bare command prints a generated copy from any repo holding a
+    glossary, so the copy step names `--packaged` or it clones that glossary."""
+    how_to = Path(__file__).resolve().parents[1] / "docs" / "how-to"
+    text = (how_to / "customize-the-writing-rules.md").read_text(encoding="utf-8")
+    copy_step = next(line for line in text.splitlines() if line.lstrip().startswith("cp -r"))
+    assert "lore style vale-config --packaged" in copy_step
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_a_wiki_override_copied_packaged_runs_no_check(tmp_path: Path) -> None:
+    """A second repo attached to that wiki, holding no glossary of its own,
+    must not lint against the first repo's word list."""
+    wiki = tmp_path / "wiki"
+    (wiki / "style").mkdir(parents=True)
+    shutil.copytree(default_vale_config_path().parent, wiki / "style" / "vale")
+    repo_b = tmp_path / "b"
+    repo_b.mkdir()
+    fixture = repo_b / "issue.md"
+    fixture.write_text("# Title\n\nThe G4 loader reads the file.\n")
+    code, alerts = _vale(vale_config_for(repo_b, wiki_dir=wiki), fixture)
+    assert alerts == []
+    assert code == 0
+
+
+def test_a_captured_config_path_survives_a_rebuild(tmp_path: Path) -> None:
+    """`file-issue` captures the path in `$(...)` and runs Vale with it a step
+    later. A rebuild in between must not unlink what it captured, or Vale exits
+    2 and the skill reads a broken invocation."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    captured = vale_config_for(repo)
+    (repo / "CONTEXT.md").write_text("# Context\n\n- **G4** — another thing.\n")
+    rebuilt = vale_config_for(repo)
+    assert rebuilt != captured
+    assert captured.is_file()
+    assert "L0" in (captured.parent / GLOSSARY_IGNORE_FILE).read_text(encoding="utf-8")
+
+
+def test_an_unchanged_glossary_reuses_the_tree(tmp_path: Path) -> None:
+    """The content key means a second call finds its own tree and writes
+    nothing, so there is no window for a reader to fall into."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    first = vale_config_for(repo)
+    stamp = first.stat().st_mtime_ns
+    assert vale_config_for(repo) == first
+    assert first.stat().st_mtime_ns == stamp

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -356,3 +356,40 @@ def test_a_repo_without_a_glossary_runs_no_short_name_check(tmp_path: Path) -> N
     code, alerts = _vale(vale_config_for(tmp_path), fixture)
     assert alerts == []
     assert code == 0
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+@pytest.mark.parametrize("token", ["buchbend/lore#336", "buchbend/lore", "lore_core/style.py"])
+def test_the_check_passes_over_a_path_or_a_repo_slug(tmp_path: Path, token: str) -> None:
+    """A token carrying a slash is a path, a repo name or an issue reference.
+    Issue bodies are full of them and none is a short name for a thing."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    fixture = tmp_path / "issue.md"
+    fixture.write_text(f"# Title\n\nThe change lands in {token} today.\n")
+    _, alerts = _vale(vale_config_for(repo), fixture)
+    assert alerts == []
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+@pytest.mark.parametrize("token", ["banned-word", "mixed-case", "generation-time", "paste-block"])
+def test_the_check_passes_over_an_english_compound(tmp_path: Path, token: str) -> None:
+    """Vale reads a hyphenated compound as one token, and no dictionary holds
+    the compound. Every segment being an English word of three letters or more
+    marks the compound as prose rather than a name."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    fixture = tmp_path / "issue.md"
+    fixture.write_text(f"# Title\n\nThe {token} rule reads the file.\n")
+    _, alerts = _vale(vale_config_for(repo), fixture)
+    assert alerts == []
+
+
+def test_an_unwritable_cache_falls_back_to_the_plain_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ADR 0006 keeps the lint from blocking the flow. A cache Lore cannot
+    write costs the short-name check, not the whole `vale --config` call."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    monkeypatch.setenv("LORE_CACHE", str(blocker))
+    assert vale_config_for(repo) == default_vale_config_path()

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -393,3 +393,27 @@ def test_an_unwritable_cache_falls_back_to_the_plain_config(
     blocker.write_text("not a directory")
     monkeypatch.setenv("LORE_CACHE", str(blocker))
     assert vale_config_for(repo) == default_vale_config_path()
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+@pytest.mark.parametrize("token", ["another's", "repo's", "cwd's"])
+def test_the_check_passes_over_a_possessive(tmp_path: Path, token: str) -> None:
+    """Only the trailing `'s` makes `another's` unknown. Vale filters
+    possessives by default, and `custom: true` drops that filter with the
+    rest, so the rule restores it."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    fixture = tmp_path / "issue.md"
+    fixture.write_text(f"# Title\n\nThe check reads {token} first line.\n")
+    _, alerts = _vale(vale_config_for(repo), fixture)
+    assert [alert["Match"] for alert in alerts] == []
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_the_check_passes_over_a_fragment_left_by_a_code_span(tmp_path: Path) -> None:
+    """Vale strips the code span from ``an `error`-level alert`` and leaves
+    `-level` behind. A token opening with a hyphen is that leftover."""
+    repo = _repo_with_glossary(tmp_path, "L0")
+    fixture = tmp_path / "issue.md"
+    fixture.write_text("# Title\n\nVale reports an `error`-level alert here.\n")
+    _, alerts = _vale(vale_config_for(repo), fixture)
+    assert [alert["Match"] for alert in alerts] == []


### PR DESCRIPTION
## Context

Closes #342. Part of epic #336.

Rule 20 of the writing rules says a short name for a thing belongs in the
glossary. Line 62 of `lib/lore_core/styles/writing-rules.md` records that Vale
cannot enforce rule 20 without the glossary. This pull request gives Vale the
glossary.

A banned-word list only catches terms someone listed beforehand. Vale's
`spelling` check runs the other way round. It flags any word the dictionaries
it holds do not contain. Common English is the base dictionary. The
repository's `CONTEXT.md` terms are the ignore list.

## Required behaviour

- Vale flags a short name absent from the glossary and from common English.
- Vale reports nothing for a short name the glossary defines.
- The check reads uppercase names, mixed-case names, hyphenated names and
  names carrying digits.
- The check reports at warning severity.
- The check never turns an exit 0 into an exit 1.
- A repository without a `CONTEXT.md` runs no check.

## How the check learns the glossary

`lore_core.style.vale_config_for(repo_dir, wiki_dir)` resolves the Vale
configuration as before. It then takes one of two paths:

- The repository names no `CONTEXT.md`. The resolved configuration travels
  unchanged. Its `WritingRules.UnknownShortName = NO` line keeps the check off.
- The repository names one. `vale_config_for` copies the whole configuration
  directory to `$LORE_CACHE/vale/<name>-<hash>/`. It writes `glossary.txt`
  beside the rules and flips that line to `YES` in the copy.

`glossary_terms` reads every bold span in `CONTEXT.md` and splits each into the
words Vale will see. A hyphen stays inside a word, so `C-ext` survives as one
token. Bold is the only signal, so a bold run that is emphasis rather than a
term widens the ignore list. A widened list lets a word through that should
have been flagged, which is the safe direction for an advisory check.

`lore style vale-config` passes the current directory's git repository. So
`vale --config "$(lore style vale-config)" <draft>` needs no new argument, and
`file-issue` needs no edit.

### Why the generated file lands in the cache

Vale resolves a rule's `ignore` path against `StylesPath`. The word list has to
sit next to the rules. Two homes were unavailable:

- The user's checkout. ADR 0006 keeps Lore from writing into a checkout it does
  not own.
- The packaged directory. Every repository on the host shares that directory.
  One team's glossary would silence another team's names.

`$LORE_CACHE`, default `~/.cache/lore`, is the existing home for host-local
derived state. `lore_cli/context_cache.py` already reads that variable.

The tree is rebuilt on every call rather than invalidated against a timestamp.
It holds six small files. A rule left behind by an older Lore would otherwise
keep firing.

An `OSError` from the copy returns the plain configuration. A cache Lore cannot
write costs the check, never the lint.

## The filter configuration

The rule sits in
`lib/lore_core/styles/vale/WritingRules/UnknownShortName.yml`:

```yaml
custom: true
filters:
  - '\S*/\S*'
  - '^[A-Za-z]{3,}(?:-[A-Za-z]{3,})+$'
  - '^\w+['']s$'
  - '^-'
```

`custom: true` drops Vale's default filters. I measured why. I ran Vale 3.9.1
over a fixture holding `L0`, `C-ext`, `LTA`, `G4` and `camelCase`:

| Configuration | Names Vale reported |
|---|---|
| default filters | `camelCase` only |
| `custom: true`, no filters | all five |

Each replacement filter drops a class that is structurally not a short name:

- A token carrying a slash is a path, a repository name or an issue reference.
  Issue bodies carry many. None names a thing.
- A hyphenated token whose every segment is an English word of three letters
  or more is a compound adjective. The three-letter floor keeps `C-ext`
  visible, because its first segment is one letter.
- A possessive is unknown only because of the trailing `'s`. Vale filters
  possessives by default, and `custom: true` drops that filter with the rest.
- A token opening with a hyphen is what a stripped code span leaves behind. An
  `error`-level alert reaches the check as `-level`.

Vale's markdown scoping already excludes code spans, fenced blocks and web
addresses. The check reads bare prose only, so no filter covers those.

## Evidence on the exit-code contract

`file-issue` reads Vale by exit code. Vale drives that code from the presence
of an `error`-level alert, not from `MinAlertLevel`. I measured four cases with
Vale 3.9.1:

| Fixture | Configuration | Findings | Exit |
|---|---|---|---|
| `The G4 loader reads the file.` | generated | 1 warning | 0 |
| `We should leverage the G4 loader.` | generated | 1 error, 1 warning | 1 |
| `We should leverage the G4 loader.` | packaged | 1 error | 1 |
| a 30 word sentence | packaged | 1 error | 1 |

Row three is the case where a repository holds no glossary. The packaged
configuration reports the error and passes over `G4`. `test_a_banned_word_still_exits_1_beside_the_new_check`
and `test_vale_flags_an_invented_short_name` pin rows one and two.

## Red to green

Commit `46e5185` carries the failing tests alone. Commit `5b3dbde` carries the
code. The red run, from
`PYTHONPATH=<worktree>/lib python -m pytest tests/test_vale_style.py -q`:

```
tests/test_vale_style.py:21: in <module>
    from lore_core.style import (
E   ImportError: cannot import name 'glossary_terms' from 'lore_core.style'
ERROR tests/test_vale_style.py
!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!
1 error in 0.54s
```

The eleven filter tests added afterwards also ran red first. Each named the
token it now passes over:

```
FAILED test_the_check_passes_over_a_path_or_a_repo_slug[buchbend/lore#336]
FAILED test_the_check_passes_over_a_path_or_a_repo_slug[buchbend/lore]
FAILED test_the_check_passes_over_a_path_or_a_repo_slug[lore_core/style.py]
FAILED test_the_check_passes_over_an_english_compound[banned-word]
FAILED test_the_check_passes_over_an_english_compound[mixed-case]
FAILED test_the_check_passes_over_an_english_compound[generation-time]
FAILED test_the_check_passes_over_an_english_compound[paste-block]
FAILED test_the_check_passes_over_a_possessive[another's]
FAILED test_the_check_passes_over_a_possessive[repo's]
FAILED test_the_check_passes_over_a_possessive[cwd's]
FAILED test_the_check_passes_over_a_fragment_left_by_a_code_span
```

Green, full suite, Vale on PATH:

```
4 failed, 2936 passed, 1 skipped, 1 warning, 11 subtests passed in 98.31s
```

The four failures are `test_cli_scopes.py::test_rename_reports_stale_checked_in_offer`,
two in `test_core_llm_wiring.py`, and
`test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`.
All four fail on the branch point `7c105ab` as well.

`ruff check` and `ruff format --check` pass on the three Python files this pull
request touches. The wider tree is not clean, and the workflow marks both steps
`continue-on-error`, per #196.

## What I verified, and what I could not

Vale is absent from this host's PATH. `tests/test_vale_style.py` therefore
skips its real-binary cases by default. I did not want to reason from the
documentation alone. I downloaded Vale 3.9.1 into the job's scratch
directory. I then ran the suite with that binary on PATH.

- All 46 tests in `tests/test_vale_style.py` pass. 26 of them drive the binary.
- The full suite with Vale present reports 2936 passed.

Two things stay unverified:

- Only Vale 3.9.1 was measured. The default-filter behaviour these filters work
  around is version-dependent. `camelCase` already reaches the dictionary in
  3.9.1, although the issue lists mixed case among the shapes Vale skips.
- The workflow runs whatever Vale version its image holds. It skips these cases
  when it holds none.

## A finding the reviewer should weigh

The check is noisier on real prose than the acceptance criteria imply. I ran
the generated configuration over the bodies of issues #342 and #339, against
this repository's own `CONTEXT.md`:

| Body | Findings, two filters | Findings, four filters |
|---|---|---|
| #342 | 17 | 8 |
| #339 | 15 | 7 |

Eight findings on issue #342 cover six distinct words. The residual splits
three ways:

- `ADR`, `PRD` and `AFK` are domain short names this repository writes often
  and never defines. Rule 20 asks for exactly that, so these findings are
  correct.
- `Repo` and `Dev` come from the sub-issue template's own headings, not from
  author prose.
- `repo`, `config` and `checkability` are informal English the base dictionary
  lacks.

Every finding is advisory and exits 0. A tighter result needs glossary
entries, not more filters. `CONTEXT.md` belongs to #340, so I left it alone.

## Scope

Files touched:

- `lib/lore_core/styles/vale/vale.ini`
- `lib/lore_core/styles/vale/WritingRules/UnknownShortName.yml`
- `lib/lore_core/style.py`
- `lib/lore_cli/style_cmd.py`
- `tests/test_vale_style.py`

`pyproject.toml` already globs `styles/vale/WritingRules/*.yml`, so the new
rule ships without a packaging change. No version bump, per the epic brief.

The three existing tests of `lore style vale-config` now start from a directory
holding no `CONTEXT.md`. Without that they compare against a generated copy,
because the checkout this suite runs from carries a glossary.


---

## Fix round 1

### The wiki-override leak (blocking)

`lore style vale-config` prints a generated path from any repository holding a
`CONTEXT.md`. Step 3 of `docs/how-to/customize-the-writing-rules.md` told a
user to copy that directory into a wiki override, so the override took one
repository's `glossary.txt` and its enabling switch with it. A second
repository attached to the same wiki then linted against terms it never
defined.

- `lore style vale-config --packaged` prints the resolved configuration
  itself. It reuses the existing `repo_dir=None` branch, so the option adds
  one line of dispatch.
- Step 3 of the how-to names `--packaged` in both the resolve command and the
  `cp -r` recipe. Step 4 keeps the bare command, because linting is where the
  glossary belongs. A paragraph in step 3 and a note at the foot say why.
- `test_packaged_flag_prints_a_config_carrying_no_glossary` asserts the printed
  directory holds no `glossary.txt` and keeps the `NO` line.
- `test_the_how_to_copies_the_packaged_directory` reads the how-to's `cp -r`
  line, so the recipe cannot drift back.
- `test_a_wiki_override_copied_packaged_runs_no_check` drives the real binary:
  a wiki override seeded that way, linted from a repository holding no
  glossary, reports nothing and exits 0.

### The comment at `lib/lore_core/style.py`

The comment claimed an override without the switch line is left as its author
wrote it. That was wrong. I built such an override and ran Vale 3.9.1 against
it: `G4` was flagged and `L0` passed, because Vale runs every rule under
`BasedOnStyles` by default. The comment now states that a wiki override without
the switch line runs the check against the copied glossary.

### The rebuild window

`rmtree` then `copytree` unlinked a path another process may already have
captured. `os.replace` alone does not fix that, because it needs a free
destination and cannot replace a non-empty directory.

The tree is now keyed by a digest of the rule files plus the glossary terms.
A rebuild therefore only ever writes a directory that does not exist yet, which
is what lets `os.replace` do its job:

- The same glossary returns the existing tree and writes nothing.
- A changed glossary lands on a new key, so the captured path survives.
- A Lore upgrade shipping a changed rule also lands on a new key, so no stale
  tree is reused.
- A concurrent build of the same key loses the `os.replace` and removes its own
  staging copy. Both trees hold the same bytes.

Measured with a loop holding four rebuild threads while 25 Vale runs use a
captured path:

| Build | Exit 0 | Exit 2 |
|---|---|---|
| `rmtree` then `copytree` | 6 | 19 |
| content key and `os.replace` | 25 | 0 |

`test_a_captured_config_path_survives_a_rebuild` and
`test_an_unchanged_glossary_reuses_the_tree` pin the property without a race,
so a regression fails deterministically rather than sometimes.

Superseded trees are left on disk rather than swept. Each is a few kilobytes
and only a glossary edit makes one. The `ponytail:` comment names that ceiling.

### Verification

- `tests/test_vale_style.py`: 51 passed with Vale 3.9.1 on PATH.
- Full suite: `4 failed, 2945 passed`. The four are the pre-existing failures
  named above.
- `ruff check` and `ruff format --check` pass on the three Python files.
- The how-to lints at exit 0. Its 12 remaining warnings are the residue class
  agreed as inherent: `repo`, `config`, `ini`, `stderr`. None sits on a line
  this pull request adds.

### Left alone, as agreed

The 4 to 7 distinct findings per issue body stay. `ADR`, `PRD` and `AFK` are
the check reporting a glossary gap a person must close. `Repo` and `Dev` come
from the sub-issue template's headings. `checkability` and `config` cannot be
separated from the first class by any filter, since both are absent from the
dictionary.
