### PR TITLE
fix(workflow): brief routes new terms to grilling, never writes them

### DIFF
--- a/lore-workflow/skills/brief/SKILL.md
+++ b/lore-workflow/skills/brief/SKILL.md
@@ -57,7 +57,7 @@ Reuse the existing gates verbatim — no new document types:
   context / a real trade-off) to the decision the brief lands on. All three hold → draft the
   ADR at `docs/adr/NNNN-kebab.md` as part of the downstream work. Any one missing → skip
   silently, no placeholder. (See [`domain-modeling`](../domain-modeling/SKILL.md).)
-- **Glossary / CONTEXT.md** — touch only if the brief actually coined a *new* domain term.
+- **Never write to `CONTEXT.md`** — a term worth adding belongs to `grilling`, not this skill.
 - **No PRD, no epic tracker.** Those belong to the chain.
 - **No brief file.** Lore's auto session capture already records the exchange; a persisted
   brief would duplicate what session notes do.

--- a/tests/test_workflow_glossary_write_gate.py
+++ b/tests/test_workflow_glossary_write_gate.py
@@ -51,3 +51,13 @@ def test_implement_issue_and_brief_still_reference_domain_modeling() -> None:
             encoding="utf-8"
         )
         assert "domain-modeling" in text
+
+
+def test_brief_never_writes_to_the_glossary() -> None:
+    body = (
+        (REPO_ROOT / "lore-workflow" / "skills" / "brief" / "SKILL.md")
+        .read_text(encoding="utf-8")
+        .lower()
+    )
+    assert "never write to `context.md`" in body
+    assert "grilling" in body


### PR DESCRIPTION
## Context

The whole-epic review of #350 found an open glossary write path that #338 was
meant to close. `brief/SKILL.md` told the skill to touch `CONTEXT.md` "only if
the brief actually coined a *new* domain term", with no approval step.

PRD 0010 states the opposite twice: `grilling` is the only door into the
glossary, and any write path outside `grilling` is out of scope. #338's own
acceptance criterion asserted that `brief` never touches the glossary.

`file-issue` and `domain-modeling` both close their write paths. `brief` kept
one open for exactly the case #338 exists to prevent: a term the skill itself
coined, which only a person can tell apart from a label for a piece of work.

## Current behaviour

- `brief/SKILL.md:60` permits a write to `CONTEXT.md`.
- `test_implement_issue_and_brief_still_reference_domain_modeling` asserts only
  that the string `domain-modeling` appears, which the old bullet satisfied.

## Required behaviour

- `brief` states that it never writes to `CONTEXT.md` and routes a new term to
  `grilling`.
- A test fails when `brief` holds a write path.

## Red step

`38fa140` holds the test alone:

```
FAILED tests/test_workflow_glossary_write_gate.py::test_brief_never_writes_to_the_glossary
AssertionError: assert 'never write to `context.md`' in '...touch only if the brief actually coined a *new* domain term...'
```

`c03253e` makes it pass. `tests/test_workflow_glossary_write_gate.py`: 6 passed.

## Notes

The teammate that wrote these two commits died on a network fault before it
could push. The orchestrator pushed its finished branch unchanged and opened
this PR.
