### PR TITLE
Repair the epic's own artifacts against the rules it ships

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -335,3 +335,10 @@ Terms used in the workflow layer and orchestration:
   section, landing as one PR, with no ordering dependency between the
   changes. A change that needs its own context, or that must land before
   another, leaves the batch.
+- **Short name** — an abbreviation, acronym or code a team writes in place
+  of a longer term. `L0` and `LTA` name things; a phase number or a priority
+  code names a piece of work. The writing rules cover the two kinds
+  separately.
+- **Piece of work** — a body of work a team plans and tracks. An issue, a
+  pull request, an epic and a batch of issues are pieces of work. A team
+  points at one by its issue number, never by a coined short name.

--- a/docs/prd/0010-join-the-writing-rules-to-the-glossary.md
+++ b/docs/prd/0010-join-the-writing-rules-to-the-glossary.md
@@ -66,11 +66,12 @@ Two further observations, both in this repo:
 
 - The document carried a worked example that used `L0` twice, and no glossary
   defines `L0`. The example that agents copy broke the rule the document is
-  about to add. Commit `9fcd172` removed that example while compacting the
+  about to add. Commit `e17807a` removed that example while compacting the
   document from 245 lines to 139.
-- Lore's own `CONTEXT.md` runs 29 of its 126 sentences past the 25-word
-  ceiling. `ccatobs/system-integration/CONTEXT.md` runs 3 of 24 past it. A
-  definition nobody can read fixes nothing.
+- The segmenter in `tests/test_context_sentences.py` counts 27 of the 114
+  sentences in Lore's `CONTEXT.md` past the 25-word ceiling, measured on
+  `main` before this epic. `ccatobs/system-integration/CONTEXT.md` runs 3 of
+  24 past it. A definition nobody can read fixes nothing.
 
 ## Solution
 
@@ -191,8 +192,11 @@ Test the CLI and the file contents, not skill prose. Prior art: the existing
 - Assert `CONTEXT-FORMAT.md` carries the sentence ceiling.
 - Assert the SessionStart directive still renders one line, and that the
   line names the glossary.
-- Assert the whole document passes its own Vale style. The check
-  passes as of commit `9fcd172` and must keep passing as rules are added.
+- Assert the document passes its own Vale style on every line except rule
+  3's banned-word list. That line names all 16 banned words, so Vale flags
+  each one and the file can never exit 0. Vale reports 16 errors at commit
+  `e17807a`, all on that line. The check must keep passing as rules are
+  added.
 - Run the Vale spelling check against a fixture holding one glossary term
   and one invented short name. Skip when Vale is absent, as
   `tests/test_vale_style.py` already does.

--- a/tests/test_context_sentences.py
+++ b/tests/test_context_sentences.py
@@ -81,6 +81,16 @@ def test_context_md_sentences_stay_inside_the_ceiling() -> None:
     )
 
 
+def test_the_format_spec_names_the_sentence_ceiling() -> None:
+    """An agent writing a definition reads the format spec, not this test, so
+    the spec has to name the ceiling and point at the document holding it."""
+    spec = (REPO_ROOT / "lore-workflow/skills/domain-modeling/CONTEXT-FORMAT.md").read_text(
+        encoding="utf-8"
+    )
+    assert "sentence ceiling" in spec
+    assert "lore style show writing-rules" in spec
+
+
 def test_the_sentence_check_catches_a_long_sentence() -> None:
     """Guards the segmenter: a check that never fires would pass on any file."""
     over_long, ceiling = _sentence_length_rule()

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -1,10 +1,15 @@
 """Tests for the packaged Vale style: resolution, `lore style vale-config`,
-and the real-binary integration.
+the single source of the banned-word list, and the real-binary integration.
 
-Vale is PATH-detected and not bundled with Lore (ADR 0006). The integration
-tests below run the actual binary against a fixture with one banned word and
-one 30-word sentence, and skip when Vale is absent — see PRD 0009's testing
-decisions.
+Vale is PATH-detected and not bundled with Lore (ADR 0006), so every test
+that runs the binary skips when Vale is absent. Those tests cover a banned
+word and its inflections, a sentence over the ceiling, the packaged document
+measured against its own style, and the unknown-short-name check: the repo
+glossary switches the check on and supplies its ignore list, and the check
+stays quiet over a path, a repo slug, an English compound, a possessive and
+a fragment left by a code span. The remaining tests cover the generated
+config's cache and the copy recipe the how-to gives. PRD 0009 and PRD 0010
+record the testing decisions.
 """
 
 from __future__ import annotations
@@ -222,6 +227,27 @@ def test_vale_flags_a_sentence_over_25_words(tmp_path: Path) -> None:
     )
     assert "sentence" in result.stdout.lower()
     assert result.returncode != 0
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+def test_the_document_passes_its_own_style_apart_from_the_banned_word_line() -> None:
+    """Rule 3 names every banned word, so Vale flags that one line once per
+    word and the document can never exit 0. Every other line stays clean."""
+    document = default_style_path("writing-rules")
+    banned_line = next(
+        number
+        for number, line in enumerate(document.read_text(encoding="utf-8").splitlines(), 1)
+        if "Banned:" in line
+    )
+    result = subprocess.run(
+        ["vale", "--output=JSON", "--config", str(default_vale_config_path()), str(document)],
+        capture_output=True,
+        text=True,
+    )
+    findings = [f for hits in json.loads(result.stdout or "{}").values() for f in hits]
+    assert findings, f"vale reported nothing, so the run itself broke:\n{result.stderr}"
+    offenders = [f"{f['Line']}: {f['Message']}" for f in findings if f["Line"] != banned_line]
+    assert not offenders, offenders
 
 
 # --- unknown short names: the glossary is the ignore list -----------------

--- a/tests/test_writing_rules.py
+++ b/tests/test_writing_rules.py
@@ -160,7 +160,13 @@ def test_rules_keep_the_ears_patterns_and_section_skeleton() -> None:
 
 def test_context_md_defines_the_new_terms() -> None:
     text = (REPO_ROOT / "CONTEXT.md").read_text()
-    for term in ("**Writing rules**", "**Change**", "**Batch issue**"):
+    for term in (
+        "**Writing rules**",
+        "**Change**",
+        "**Batch issue**",
+        "**Short name**",
+        "**Piece of work**",
+    ):
         assert term in text, term
     assert "**Register**" not in text, "the old term must be gone from the glossary"
 


### PR DESCRIPTION
## Context

The whole-epic review of #350 found the epic's own artifacts breaking three
rules the epic ships. PRD 0010 is the source of truth for the epic.

A citation that resolves nowhere fails rule 14. A verification claim that
was never true fails rule 19. A new domain term without a glossary entry
fails rule 2. Six fixes follow.

## Current behaviour

- PRD 0010 cites commit `9fcd172` twice. The commit is unreachable from
  `origin/epic/336` and from `origin/main`. The orchestrator rebased the PRD
  branch onto `main`, which rewrote the commit.
- PRD 0010 claims the whole document passes its own Vale style. Vale exits 1
  with 16 findings.
- PRD 0010 counts 29 of 126 sentences past the ceiling. The segmenter this
  epic ships counts 27 of 114.
- Rules 20 and 21 turn on **short name** and **piece of work**. The glossary
  defines neither.
- A testing decision names `CONTEXT-FORMAT.md` and the sentence ceiling. No
  test asserts it.
- The docstring of `tests/test_vale_style.py` describes a fixture with one
  banned word and one 30-word sentence. The file holds more than fifty tests.

## Change

- Both citations name `e17807a`, which is reachable from `epic/336`.
- The Vale decision states the true scope, and a test measures it.
- The sentence count names the tool that produced it.
- `CONTEXT.md` defines **Short name** and **Piece of work**.
- A test asserts `CONTEXT-FORMAT.md` names the sentence ceiling.
- The docstring describes the tests the file holds.

## The glossary entries and the write gate

Sub-issue #338 in this epic made a glossary write a human-approved action.
These two entries do not bypass that gate. PRD 0010 ratified both terms, and
the shipped rules 20 and 21 already use them. Writing them down records an
approved decision. A person approved the terms when they approved the PRD.
Coining a new term still needs `grilling`.

## Measured Vale output

Vale 3.9.1, run against the packaged document:

```
$ vale --config lib/lore_core/styles/vale/vale.ini lib/lore_core/styles/writing-rules.md
✖ 16 errors, 0 warnings and 0 suggestions in 1 file.
$ echo $?
1
```

Every finding is `WritingRules.Vocabulary` on line 26, the banned-word list.
Rule 3 names all 16 banned words on that line, so Vale flags each one. The
file can never exit 0.

The same run at `e17807a`, against `issue-register.md` under the old rule
directory, also reports 16 errors, all on line 26. The claim was never true.

## Verification

```
$ pytest -q
4 failed, 2954 passed, 1 skipped
```

The four failures are the pre-existing environment artifacts:
`test_cli_scopes`, two in `test_core_llm_wiring`, and
`test_install_dispatcher`. This branch adds none.

`ruff check` and `ruff format --check` pass over all three changed Python
files. The repo carries 554 pre-existing ruff findings under `lib/`, which
this branch does not touch.

## Notes for the reviewer

- Commit `2fbdaf0` is red and commit `cee7bd6` greens it. The red run fails
  on `AssertionError: **Short name**`.
- The two tests in `7850f2a` do not start red. Both properties already held
  in the tree; the PRD asserted them and shipped no check. Each test turns
  an asserted claim into a measured one. A red commit was available only by
  first committing a test encoding the false claim, which this branch does
  not do.
- `LORE_SUPPRESS_CAPTURE=1` breaks six tests in `tests/test_hooks_capture.py`
  and `tests/test_mvp_capture_e2e.py`, which assert on capture behaviour. The
  suite must run without it.
