### PR TITLE
file-issue routes a new term to grilling

### DIFF
--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -34,8 +34,8 @@ Add `--wiki <name>` when the target repo belongs to a wiki other than the cwd's.
 Read `CONTEXT.md` at the repo root too, if present. It defines each domain term with
 one tight meaning — draft with those terms instead of a synonym. When the repo holds no
 `CONTEXT.md`, draft without one and name the absence in one line when you report back.
-**Never write to `CONTEXT.md`** — a term worth adding belongs to `domain-modeling`, not
-this skill.
+**Never write to `CONTEXT.md`** — a term worth adding belongs to `grilling`, not this
+skill.
 
 ## 2. Draft to a file whose name ends in `.md`
 

--- a/tests/test_workflow_glossary_read.py
+++ b/tests/test_workflow_glossary_read.py
@@ -49,7 +49,7 @@ def test_missing_glossary_drafts_anyway_and_names_the_absence() -> None:
 def test_skill_never_writes_to_the_glossary() -> None:
     step = _step_one()
     assert "never write to `context.md`" in step.lower()
-    assert "domain-modeling" in step
+    assert "grilling" in step
 
 
 def test_directive_names_the_glossary_in_one_line() -> None:

--- a/tests/test_workflow_glossary_write_gate.py
+++ b/tests/test_workflow_glossary_write_gate.py
@@ -56,8 +56,7 @@ def test_implement_issue_and_brief_still_reference_domain_modeling() -> None:
 # The one sentence every drafting skill carries. Pinning it whole stops the
 # destination and the wording drifting apart across skills.
 GLOSSARY_GATE = (
-    "**never write to `context.md`** — a term worth adding belongs to "
-    "`grilling`, not this skill."
+    "**never write to `context.md`** — a term worth adding belongs to `grilling`, not this skill."
 )
 
 

--- a/tests/test_workflow_glossary_write_gate.py
+++ b/tests/test_workflow_glossary_write_gate.py
@@ -53,11 +53,18 @@ def test_implement_issue_and_brief_still_reference_domain_modeling() -> None:
         assert "domain-modeling" in text
 
 
-def test_brief_never_writes_to_the_glossary() -> None:
-    body = (
-        (REPO_ROOT / "lore-workflow" / "skills" / "brief" / "SKILL.md")
-        .read_text(encoding="utf-8")
-        .lower()
-    )
-    assert "never write to `context.md`" in body
-    assert "grilling" in body
+# The one sentence every drafting skill carries. Pinning it whole stops the
+# destination and the wording drifting apart across skills.
+GLOSSARY_GATE = (
+    "**never write to `context.md`** — a term worth adding belongs to "
+    "`grilling`, not this skill."
+)
+
+
+def test_no_drafting_skill_routes_a_new_term_anywhere_but_grilling() -> None:
+    for skill in ("brief", "file-issue"):
+        text = (REPO_ROOT / "lore-workflow" / "skills" / skill / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        # Joined on whitespace: the sentence wraps across lines in some skills.
+        assert GLOSSARY_GATE in " ".join(text.split()).lower(), skill


### PR DESCRIPTION
## Context

PRD 0010 states that `grilling` is the only door into the glossary. Sub-issue
#338 closed the open write path in `domain-modeling` and `brief`. One skill
still sent a new term elsewhere.

## Current behaviour

`lore-workflow/skills/file-issue/SKILL.md:37` routes a term worth adding to
`domain-modeling`. `lore-workflow/skills/brief/SKILL.md:60` routes the same
term to `grilling`. The two sentences are otherwise identical, so only the
destination differs. `file-issue` is the one that drifts.

`tests/test_workflow_glossary_read.py:52` asserted the old destination, so a
second file recorded the drift as correct.

## Change

- `file-issue` routes a new term to `grilling`, matching `brief` word for
  word.
- `tests/test_workflow_glossary_write_gate.py` asserts the whole sentence
  against both skills. The destination and the wording cannot drift apart
  again.
- The sibling assertion in `tests/test_workflow_glossary_read.py` names
  `grilling`. The test keeps its own guarantee that the sentence sits in
  step 1.

The new test replaces `test_brief_never_writes_to_the_glossary`, which
checked one skill and matched `grilling` anywhere in the file.

## Acceptance criteria

- WHEN a drafting skill meets a term worth adding, THE SKILL SHALL route the
  term to `grilling`.
- WHERE a drafting skill states the glossary write gate, THE SENTENCE SHALL
  match the sentence every other drafting skill carries.

## Verification

Red, against `file-issue` before the fix:

```
FAILED tests/test_workflow_glossary_write_gate.py::test_no_drafting_skill_routes_a_new_term_anywhere_but_grilling - AssertionError: file-issue
1 failed, 5 passed
```

`brief` passed in the same run, which is what makes `file-issue` the
outlier rather than the standard.

Green, after the one-word change:

```
6 passed
```

Full suite:

```
4 failed, 2955 passed, 1 skipped
```

The four failures are the pre-existing environment artifacts:
`test_cli_scopes`, two in `test_core_llm_wiring`, and
`test_install_dispatcher`. This branch adds none.

`ruff check` and `ruff format --check` pass over both changed test files.

## Out of scope

- Whether the glossary's own text follows the rules the epic ships.
- Whether rule 21's examples overlap the **Piece of work** entry.
