### PR TITLE
docs: document the glossary join for the writing rules (#336)

### DIFF
--- a/docs/explanation/why-the-writing-rules.md
+++ b/docs/explanation/why-the-writing-rules.md
@@ -3,9 +3,10 @@
 The **writing rules** fix the prose style for issue text, PR descriptions,
 PR review comments, ADR context sections and design documents. Lore ships
 one default. A team replaces them with one file in its wiki. This page
-explains three choices. Why the rules are a prose document rather than a
-settings block. Why a team's copy wins whole rather than merging. Why the
-lint runs when the text is written, not when it is committed.
+explains the choices behind them. Why the rules are a prose document rather
+than a settings block. Why a team's copy wins whole rather than merging. Why
+the lint runs when the text is written, not when it is committed. Why the
+rules cite a glossary they do not own.
 
 The decisions here are recorded in
 [ADR 0006](../adr/0006-issue-register-whole-file-override-generation-time-lint.md).
@@ -76,10 +77,77 @@ Vale is not bundled. It is a single binary, detected on `PATH`. When it is
 absent the rules still apply as instructions and nothing blocks. Lore
 degrades to the weaker enforcement rather than failing.
 
+## Why the rules reach into the glossary
+
+The rules once stopped at prose and left terminology alone. A review of four
+issue titles in `ccatobs/system-integration` showed the cost. Six of the eight
+short names in those titles had no glossary entry, or had an entry the writer
+spelled differently. A reader outside the session cannot decode `LTA` or `P6`.
+The writer cannot decode either name a month later.
+
+Rules 1, 2 and 4 already pointed at a glossary. No skill read one, so the rules
+named an authority nobody consulted. Rules 20 and 21 close the gap, and the
+`file-issue` skill reads the repo's `CONTEXT.md` when it drafts.
+
+Lore reads the glossary at drafting time rather than only at session start.
+Gloaguen and colleagues report that context files do not generally improve task
+success, and add over 20% to inference cost
+(<https://arxiv.org/abs/2602.11988>). McMillan finds no adherence effect from
+file size or position across 1,650+ sessions, and finds compliance decaying
+inside a single session (<https://arxiv.org/abs/2605.10039>). A glossary loaded
+at session start fades before the agent writes the issue. So `file-issue` reads
+the file at step 1, beside the rules it already resolves, and the SessionStart
+directive stays one line.
+
+## A thing and a piece of work take different answers
+
+Rule 20 covers a short name for a thing. Rule 21 covers a short name for a
+piece of work. The split matters because a glossary entry for `P6` would be
+wrong.
+
+A **thing** persists. `L0`, `C-ext` and `LTA` name a data level, a credential
+class and an archive. Each name still means something after the work that
+introduced it ships. A thing earns a glossary entry, and rule 20 sends the
+writer there. Where the glossary holds no entry yet, the writer spells the
+meaning out and asks `grilling` for the entry.
+
+A **piece of work** expires. `P6`, "the G4 group" and "phase 2" each name a
+slice of a plan. Each name dies with the plan that carried it. A glossary entry
+would preserve a label for work that is already finished. Rule 21 sends the
+writer to the issue number, which stays resolvable for as long as the tracker
+lives.
+
+One question separates the two. Ask whether the name still means anything once
+the work is finished. A name that survives belongs in the glossary. A name that
+dies gets an issue number.
+
+## Why the glossary check only advises
+
+Vale flags a short name held by neither the repo's glossary nor common English.
+The check ships at warning severity, so a draft never fails on one.
+
+Severity follows GitLab's model, where an error blocks and a warning shows
+(<https://docs.gitlab.com/development/documentation/testing/vale/>). The check
+is a spelling rule aimed at a hand-written word list. The rule fires on real
+gaps and on ordinary words nobody thought to list. Contentsquare's first Vale
+run produced 673 errors and 12,910 warnings, and the team judged the output not
+actionable
+(<https://engineering.contentsquare.com/2023/using-vale-to-help-engineers-become-better-writers/>).
+A warning a writer reads and dismisses beats an error that stops the draft.
+
+A person approves every glossary entry for the same reason. `grilling` is the
+only door into `CONTEXT.md`, and `domain-modeling` proposes each wording and
+waits for the user's yes. An agent that appends its own terms defeats the check
+that would have caught them. The `nix.dev` Vale adoption shows the failure
+(<https://github.com/NixOS/nix.dev/pull/798>).
+
 ## What the writing rules do not do
 
-They do not fix terminology. One term with one meaning is a glossary problem,
-and the glossary is a separate artifact.
+They do not own the glossary. The rules cite `CONTEXT.md` and lint against it.
+The `grilling` skill fills it, and a person approves every entry.
+
+They do not check that a writer uses a term with the meaning the glossary
+gives it. No surveyed tool does. The check stays human.
 
 They do not decide what is worth filing. The `file-issue` skill owns how to
 write and file; the caller decides what to capture. A skill that second-

--- a/docs/how-to/customize-the-writing-rules.md
+++ b/docs/how-to/customize-the-writing-rules.md
@@ -74,6 +74,26 @@ default does. There is no merge and no per-repo layer.
    `[*.md]`, so a `.txt` or extensionless file reports `0 files` and exits 0
    without checking anything.
 
+5. **Expect the short-name check to fire, and read it as advice.**
+
+   The packaged config carries `WritingRules.UnknownShortName = NO`, so the
+   short-name check is off until a glossary switches it on. `lore style
+   vale-config` looks for a `CONTEXT.md` in the current repo. Where the
+   command finds one, it copies the whole config directory to the host cache
+   under `$LORE_CACHE/vale/`, writes the glossary terms to `glossary.txt`
+   beside the rules, and flips the switch line to `YES`. The printed path is
+   the cached copy. Nothing lands in your repo.
+
+   Rule 20 fires often on a first run. Lore's own `CONTEXT.md` yields 85
+   terms, and linting issue 339's body against them reported 8 warnings and 0
+   errors, exit code 0. Seven were rule 20: `ADR`, `PRD`, `AFK`, `Repo`,
+   `Dev` and `checkability`. Several findings per issue body is the normal
+   result, not a broken setup.
+
+   Read the findings and fix the text, or leave the word and move on. The
+   check never blocks: every finding is a warning, and `file-issue` reads
+   Vale by exit code.
+
 ## Notes
 
 - The banned-word list lives in the rules text and in the Vale style. A

--- a/docs/how-to/write-a-fast-path-issue.md
+++ b/docs/how-to/write-a-fast-path-issue.md
@@ -8,6 +8,13 @@ Run `lore style show writing-rules` and follow its section skeleton and EARS
 acceptance criteria. The rules are the source of truth for issue-body
 prose; the points below are what the fast path additionally needs.
 
+Open the repo's `CONTEXT.md` as well. The glossary gives each domain term one
+meaning, and rule 20 asks every short name to carry an entry. Draft with those
+terms rather than a synonym. Where a term you need has no entry, write the
+meaning out in full and ask for a `grilling` session to add the term. Never
+append to `CONTEXT.md` yourself. A repo that holds no `CONTEXT.md` never blocks
+your draft; the fast path files the issue and names the absence.
+
 The fast path reads the issue and the code map, then — only if the issue is
 ambiguous — asks **at most three** clarifying questions before it starts. A
 well-written issue spends none of that budget: the skill reads it, locates
@@ -31,16 +38,20 @@ thing.
   write the issue as an open design question. If the shape is still
   unsettled, shape it on the chain first.
 - **Multi-repo or multi-feature scope.** That is epic-shaped work.
+- **A short name for a piece of work.** Rule 21 keeps a phase name, a group
+  name and a priority code out of the title and the body. Cite the issue
+  number instead. Not "the G4 group" but "issue 412".
 
 ## Checklist
 
 - [ ] The sections the writing rules require filled, acceptance criteria in EARS.
 - [ ] One change, small and clear.
+- [ ] Every domain term taken from `CONTEXT.md`, every short name defined there.
+- [ ] No phase name, group name or priority code anywhere in the text.
 - [ ] The touched command / module / symbol named under "References".
 - [ ] Nothing in it that belongs on the epic chain.
 
 ## Done when
 
-Someone who has never seen the change could read the issue and know exactly
-what to build and how to tell it works — which is precisely what the fast
-path needs.
+Someone who has never seen the change reads the issue and knows what to build.
+The reader also knows how to tell the change works. The fast path needs both.


### PR DESCRIPTION
## Context

Epic #336 joined the writing rules to the glossary and shipped in release 0.66.0. Most of the epic's documentation landed with its features. Three gaps stayed.

`docs/explanation/why-the-writing-rules.md` still told the reader the rules leave terminology alone. The claim was true before the epic and is false now.

## Current behaviour

- The explanation page says the rules "do not fix terminology" and calls the glossary "a separate artifact".
- The how-to never says the short-name check ships off, and never says what switches the check on.
- No page teaches a writer to tell a thing from a piece of work, which is the distinction rules 20 and 21 rest on.
- No page tells an issue writer to read `CONTEXT.md` at drafting time.

## Required behaviour

**Explanation** (`docs/explanation/why-the-writing-rules.md`)

- Replace the stale section with what the rules now do and do not own.
- Add why the rules reach into the glossary, with the evidence from `ccatobs/system-integration` and the drafting-time research the PRD cites.
- Add how a writer separates a thing from a piece of work, and why a glossary entry for a work label would be wrong.
- Add why the short-name check warns rather than blocks, and why a person approves every glossary entry.

**How-to** (`docs/how-to/customize-the-writing-rules.md`)

- Add step 5. The packaged config carries `WritingRules.UnknownShortName = NO`. `lore style vale-config` copies the config to `$LORE_CACHE/vale/`, writes `glossary.txt` beside the rules and flips the switch to `YES`.
- State the measured finding count so a writer reads a wall of warnings as normal.

**How-to** (`docs/how-to/write-a-fast-path-issue.md`)

- Read `CONTEXT.md` when drafting. Route a missing term to `grilling`. Never append to the glossary.
- Keep a short name for a piece of work out of the title and the body.

## Acceptance criteria

- Where a reader opens the explanation page, the page shall describe the rules as citing a glossary that `grilling` owns.
- When a writer follows the how-to, the how-to shall name the config line that keeps the short-name check off.
- When a writer runs the shipped Vale config over the three changed pages, Vale shall report zero errors and exit 0.
- The changed pages shall hold no retired style name.

## Out of scope

- `docs/prd/` and `docs/adr/`, which this branch does not touch.
- A tutorial. The repo ships no `docs/tutorials/`, and the epic added no first-run step.
- Reference. The repo wires no Sphinx or autosummary, and `glossary_terms`, `vale_config_for` and `vale-config --packaged` already carry complete docstrings.

## References

- Epic #336, sub-issues #337 to #342.
- PRD `docs/prd/0010-join-the-writing-rules-to-the-glossary.md`.
- Merge commit `abe7cdf`, release `808143f`.

### Measured checks

Vale 3.9.1 against the shipped config, `vale --config lib/lore_core/styles/vale/vale.ini`:

```
0 errors, 4 warnings and 0 suggestions in 3 files.   EXIT=0
```

Three of the four warnings are pre-existing rule 9 and rule 12 over-fires. The fourth is "Nothing lands in your repo.", the same documented rule 9 over-fire on a capitalised `-ing` word. `file-issue` says not to mangle correct prose to silence a warning, so the sentence stays.

The baseline on `main` reported 1 error and 3 warnings across the same three files. The error was a 31-word sentence in `write-a-fast-path-issue.md`, split here.

`pytest -q`: 4 failed, 2926 passed, 30 skipped. The four are the known environment artifacts (`test_cli_scopes`, two in `test_core_llm_wiring`, `test_install_dispatcher`). No Python changed on this branch.