### PR TITLE
Transcript-ledger expansion: linkage, migration, recap, drill routing (#358)

### DIFF
--- a/docs/architecture/lore-drill.md
+++ b/docs/architecture/lore-drill.md
@@ -28,10 +28,12 @@ One MCP call, one envelope, structured trace alongside the result:
     {"stage": "search", "query": "...", "hits": 7, "elapsed_ms": 12},
     {"stage": "read",   "paths": ["wiki/foo.md", "wiki/bar.md"], "elapsed_ms": 23},
     {"stage": "expand", "wikilinks": ["[[baz]]", "[[qux]]"], "elapsed_ms": 18},
-    {"stage": "read_expanded", "paths": ["wiki/baz.md"], "elapsed_ms": 9}
+    {"stage": "read_expanded", "paths": ["wiki/baz.md"], "elapsed_ms": 9},
+    {"stage": "ledger", "sessions": 2, "elapsed_ms": 3}
   ],
   "result": {
-    "notes": [ /* { path, frontmatter, body } per note */ ]
+    "notes": [ /* { path, frontmatter, body } per note */ ],
+    "sessions": [ /* transcript pointers; see "Ledger routing" */ ]
   }
 }
 ```
@@ -87,6 +89,34 @@ trace as a tree (rich) and the result as a paginated note list. No
 special-casing — the trace ships in the response either way; the CLI
 just chooses to format it visibly.
 
+## Ledger routing
+
+A query that names an issue (`#358`), a PR (`PR 364`) or a file path
+also routes to the transcript ledger, which answers "which sessions
+touched this?" from the linkage block capture writes on every entry.
+The matches come back under `result.sessions` as transcript pointers:
+
+```json
+{"transcript_id": "…", "integration": "claude-code", "path": "/…/x.jsonl",
+ "directory": "/…/proj", "last_active": "2026-08-04T09:00:00+00:00",
+ "repo": "buchbend/lore", "branch": "feat/358-ledger",
+ "issues": [358], "prs": [364]}
+```
+
+Properties:
+
+* **Owner-local.** The pointers name transcript files on one machine
+  (ADR 0009). They are never quoted to anyone but their owner, and
+  nothing about them crosses into a wiki.
+* **One event per query.** The lookup emits a single `ledger-query`
+  record on the event spine (`source: "mcp"`), so read-side use of the
+  archive is countable next to every other counter.
+* **Resolved first, recorded last.** The lookup runs before the search
+  stage but its trace step is appended after `read_expanded`, so the
+  note stages keep the fixed trace positions clients already index by.
+* A query with no ref and no path-like token is not a ledger query: it
+  returns `sessions: []` and emits nothing.
+
 ## Trace contract for clients
 
 The trace shape is part of the MCP response and is now public. Clients
@@ -104,6 +134,8 @@ should:
   keys) surface paths whose ``handle_read`` returned an error. The
   presence of a path here means it's listed under ``paths`` but its
   body is **not** in ``result.notes``.
+* ``ledger.sessions`` is a count; the pointers themselves live under
+  ``result.sessions``.
 * ``read_expanded.truncated`` / ``kept`` only appear when the
   ``expand_limit`` cap actually stopped the loop. A smaller resolved
   set than ``expand_limit`` (because slugs were unresolvable, not

--- a/docs/architecture/state.md
+++ b/docs/architecture/state.md
@@ -168,7 +168,12 @@ credential**, not scrubbing history.
 **Transcripts and buffers never leave local state.** They live under
 `<lore_root>/.lore/` (`transcript-ledger.json`, `buffers/`), a sibling
 of `wiki/` — never a descendant — so a `git push` of a wiki directory
-structurally cannot ship them. Only composed, gate-passed notes
+structurally cannot ship them. Each ledger entry carries a `linkage`
+block — `repo`, `branch`, `prs`, `issues`, `commits`, `files` — written
+by capture with no LLM call. It is what `lore_drill` reads to answer
+"which sessions touched X" and what the SessionStart recap renders from.
+The block is derived and rebuildable, and stays machine-local with the
+rest of the ledger. Only composed, gate-passed notes
 written into `wiki/<name>/sessions/` are ever pushed.
 
 ---

--- a/lib/lore_cli/drill_cmd.py
+++ b/lib/lore_cli/drill_cmd.py
@@ -6,8 +6,10 @@
 
 Calls the same handler as the `lore_drill` MCP tool: search → read top
 hits → expand wikilinks → read expanded set, all in one round-trip.
-The trace shows what happened at each stage so retrieval failures stay
-debuggable.
+A query naming an issue, a PR, or a file also returns the transcript
+pointers for the sessions that touched it, read from the transcript
+ledger. The trace shows what happened at each stage so retrieval
+failures stay debuggable.
 
 See `docs/architecture/lore-drill.md`.
 """
@@ -46,7 +48,9 @@ def _render_trace(trace: list[dict]) -> Tree:
             tree.add(f"[dim]{stage}[/dim] — skipped ({step['skipped']})")
             continue
         node = tree.add(f"[cyan]{stage}[/cyan] [dim]({elapsed} ms)[/dim]")
-        if stage == "search":
+        if stage == "ledger":
+            node.add(f"{step.get('sessions', 0)} session pointers")
+        elif stage == "search":
             node.add(f"query: {step.get('query', '')!r}  hits: {step.get('hits', 0)}")
         elif stage == "read":
             for path in step.get("paths", []):
@@ -96,9 +100,23 @@ def drill(
 
     console.print(_render_trace(out["trace"]))
     console.print()
+    sessions = out["result"].get("sessions") or []
+    if sessions:
+        console.print(f"[bold]{len(sessions)} sessions:[/bold]")
+        for s in sessions:
+            day = s["last_active"][:10]
+            # highlight=False: rich's number highlighter otherwise splits
+            # "feat/358-ledger" and the date across colour spans.
+            console.print(
+                f"  • [magenta]{s['transcript_id']}[/magenta] [dim]{day}"
+                f"  {s['repo']} {s['branch']}[/dim]",
+                highlight=False,
+            )
+        console.print()
     notes = out["result"]["notes"]
     if not notes:
-        console.print("[yellow]No notes returned.[/yellow]")
+        if not sessions:
+            console.print("[yellow]No notes returned.[/yellow]")
         return
     console.print(f"[bold]{len(notes)} notes:[/bold]")
     for note in notes:

--- a/lib/lore_cli/migrate_cmd.py
+++ b/lib/lore_cli/migrate_cmd.py
@@ -5,6 +5,8 @@ Three verbs, all idempotent and all dry-run by default:
 * ``lore migrate frontmatter`` — schema-evolution rewrites of note frontmatter
 * ``lore migrate slugs``       — rename session notes whose filename slug is cryptic
 * ``lore migrate open-items``  — rewrite legacy `## Open items` sections to v2
+* ``lore migrate retire-session-notes`` — backfill the transcript ledger's
+  linkage blocks, then delete the session-note stock
 
 These are upgrades you run once when a vault falls behind the current
 schema. `lore backfill` is unrelated — that imports historical
@@ -98,6 +100,76 @@ def cmd_open_items(
     from lore_curator.open_items_migration import run_open_items_migration
 
     run_open_items_migration(wiki_filter=wiki, dry_run=not apply)
+
+
+@app.command("retire-session-notes")
+def cmd_retire_session_notes(
+    wiki: str = typer.Option(
+        None,
+        "--wiki",
+        "-w",
+        help="Scope the deletion to one wiki. Default: every wiki.",
+    ),
+    apply: bool = typer.Option(
+        False, "--apply", help="Actually backfill and delete. Without this, runs dry."
+    ),
+) -> None:
+    """Retire session notes into the transcript ledger.
+
+    Backfills each archived transcript's linkage block (repo, branch,
+    PRs, issues, commits, files) from the transcript and git, then
+    deletes the session-note files under every wiki's ``sessions/``
+    tree.
+
+    ``--wiki`` scopes the deletion. The backfill always covers the whole
+    ledger — it is one machine-local store, not a per-wiki one, and
+    stamping a linkage block is additive.
+
+    Prints the plan and changes nothing unless ``--apply`` is passed.
+    Notes are markdown in git — recover a mistaken run from the wiki's
+    history.
+    """
+    from lore_curator.retire_session_notes import apply_retirement, plan_retirement
+
+    from lore_cli._cli_helpers import lore_root_or_die
+
+    lore_root = lore_root_or_die(err_console)
+    plan = plan_retirement(lore_root, wiki=wiki)
+
+    with_refs = sum(
+        1 for i in plan.backfill if i.linkage.get("issues") or i.linkage.get("prs")
+    )
+    unreadable = sum(1 for i in plan.backfill if i.transcript_missing)
+    # soft_wrap keeps every path on one logical line: a deletion plan is
+    # only useful if the paths in it can be read and pasted verbatim.
+    console.print(
+        f"[bold]Backfill[/bold] — {len(plan.backfill)} ledger entries "
+        f"({with_refs} with issue/PR refs, {unreadable} without a readable transcript)",
+        highlight=False,
+    )
+    console.print(
+        f"[bold]Delete[/bold] — {len(plan.deletions)} session note(s)", highlight=False
+    )
+    for path in plan.deletions:
+        console.print(f"  [red]-[/red] {path}", highlight=False, soft_wrap=True)
+    for path in plan.kept:
+        console.print(
+            f"  [dim]keep (not a note)[/dim] {path}", highlight=False, soft_wrap=True
+        )
+
+    if not apply:
+        console.print(
+            "\n[dim]dry-run; nothing changed. Pass --apply to backfill and delete.[/dim]"
+        )
+        return
+
+    report = apply_retirement(lore_root, plan)
+    console.print(
+        f"\n[green]Backfilled {report.backfilled} ledger entries; "
+        f"deleted {report.deleted} note(s).[/green]"
+    )
+    for path, reason in report.failed:
+        console.print(f"  [red]fail[/red] {path}: {reason}")
 
 
 @app.command("slugs")

--- a/lib/lore_core/ledger.py
+++ b/lib/lore_core/ledger.py
@@ -8,13 +8,15 @@ see a partial file.
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lore_core.io import atomic_write_text
+from lore_core.spine import SpineWriter
 
 if TYPE_CHECKING:
     from lore_core.types import Scope
@@ -37,6 +39,13 @@ class TranscriptLedgerEntry:
     session_note: str | None  # wikilink, e.g. "[[2026-04-19-slug]]"
     orphan: bool = False  # cwd permanently gone; excluded from pending()
     total_turns: int = 0  # turns observed at last sync; gate metric for spawn
+    #: Where this session worked and what it produced — the personal
+    #: layer's linkage store. Keys: ``repo``, ``branch`` (str), ``prs``,
+    #: ``issues`` (list[int]), ``commits``, ``files`` (list[str]).
+    #: Derived and rebuildable; written by capture with no LLM call.
+    #: Kept a plain dict rather than a dataclass so an entry written by a
+    #: future Lore with extra keys still round-trips through an older one.
+    linkage: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -123,6 +132,7 @@ class TranscriptLedger:
             "session_note": e.session_note,
             "orphan": e.orphan,
             "total_turns": e.total_turns,
+            "linkage": e.linkage,
         }
 
     @staticmethod
@@ -148,6 +158,7 @@ class TranscriptLedger:
             session_note=raw.get("session_note"),
             orphan=raw.get("orphan", False),
             total_turns=raw.get("total_turns", 0),
+            linkage=raw.get("linkage") or {},
         )
 
     def all_entries(self) -> list[TranscriptLedgerEntry]:
@@ -361,6 +372,92 @@ class TranscriptLedger:
             entry.curator_a_run = curator_a_run
         raw[key] = self._entry_to_raw(entry)
         self._write_raw(raw)
+
+
+#: A query token routes to the ledger when it looks like a path — it
+#: carries a directory separator or a file extension. Numeric refs are
+#: classified separately by ``lore_core.linkage.classify_refs``.
+_PATHISH_RE = re.compile(r"[\w./~-]*(?:/[\w.-]+|\.[A-Za-z]{1,5})\b")
+
+
+def find_sessions(
+    lore_root: Path,
+    query: str,
+    *,
+    limit: int = 5,
+) -> list[dict]:
+    """Return transcript pointers for the sessions that touched ``query``.
+
+    Routes on what the query names: an issue or PR number, or a file
+    path. Anything else is not a ledger query and returns ``[]`` without
+    touching the ledger — the caller's own search still answers it.
+
+    Newest first, capped at ``limit``. Emits one read-side spine event
+    per routed query so "who is actually drilling the archive?" is
+    answerable from the same file as every other counter.
+
+    Owner-local by contract (ADR 0009): the pointers are paths on this
+    machine and never leave it.
+    """
+    from lore_core.linkage import classify_refs
+
+    issues, prs, epics = classify_refs(query)
+    refs = issues | prs | epics
+    paths = {m.group(0) for m in _PATHISH_RE.finditer(query) if m.group(0)}
+    if not refs and not paths:
+        return []
+
+    matched = [
+        e
+        for e in TranscriptLedger(lore_root).all_entries()
+        if _entry_matches(e, refs, paths)
+    ]
+    matched.sort(key=lambda e: e.last_mtime, reverse=True)
+    hits = [
+        {
+            "transcript_id": e.transcript_id,
+            "integration": e.integration,
+            "path": str(e.path),
+            "directory": str(e.directory),
+            "last_active": e.last_mtime.isoformat(),
+            "repo": e.linkage.get("repo", ""),
+            "branch": e.linkage.get("branch", ""),
+            "issues": e.linkage.get("issues", []),
+            "prs": e.linkage.get("prs", []),
+        }
+        for e in matched[:limit]
+    ]
+
+    SpineWriter(lore_root).emit(
+        source="mcp",
+        event="ledger-query",
+        data={
+            "refs": sorted(refs),
+            "paths": sorted(paths),
+            "hits": len(hits),
+            "matched": len(matched),
+        },
+    )
+    return hits
+
+
+def _entry_matches(entry: TranscriptLedgerEntry, refs: set[int], paths: set[str]) -> bool:
+    """True when the entry's linkage names any queried ref or file.
+
+    File comparison is suffix-symmetric so a bare ``ledger.py`` finds a
+    stored ``lib/lore_core/ledger.py``, and a caller pasting an absolute
+    path finds the repo-relative one capture stored.
+    """
+    linkage = entry.linkage
+    if refs and refs & {
+        int(n) for n in (linkage.get("issues") or []) + (linkage.get("prs") or [])
+    }:
+        return True
+    for stored in linkage.get("files") or []:
+        for token in paths:
+            if stored.endswith(token) or token.endswith(stored):
+                return True
+    return False
 
 
 class WikiLedger:

--- a/lib/lore_core/ledger.py
+++ b/lib/lore_core/ledger.py
@@ -375,9 +375,11 @@ class TranscriptLedger:
 
 
 #: A query token routes to the ledger when it looks like a path — it
-#: carries a directory separator or a file extension. Numeric refs are
-#: classified separately by ``lore_core.linkage.classify_refs``.
-_PATHISH_RE = re.compile(r"[\w./~-]*(?:/[\w.-]+|\.[A-Za-z]{1,5})\b")
+#: carries a directory separator, or an extension of two-plus letters.
+#: Two-plus keeps prose abbreviations ("e.g.", "i.e.") from costing a
+#: ledger parse and a spine event on an ordinary topical query. Numeric
+#: refs are classified separately by ``lore_core.linkage.classify_refs``.
+_PATHISH_RE = re.compile(r"[\w./~-]*(?:/[\w.-]+|\.[A-Za-z]{2,5})\b")
 
 
 def find_sessions(

--- a/lib/lore_core/linkage.py
+++ b/lib/lore_core/linkage.py
@@ -67,14 +67,19 @@ def extract_linkage(
     commit_texts: list[str] | None = None,
     wiki_root: Path | None = None,
     handle: str = "",
+    branch: str | None = None,
 ) -> Linkage:
     """Derive linkage from git state, branch name, and commit text.
 
     `commit_texts` is one string per commit (subject + body); the caller
     resolves it (e.g. via `collect_commits_by_sha`) since fetching commit
     text is a curator-layer concern, not this module's.
+
+    `branch` overrides the checkout's current branch. A migration reading
+    an archived session must use the branch that session was on, not the
+    one the working copy happens to be on today.
     """
-    branch = current_branch(cwd) or ""
+    branch = branch if branch is not None else (current_branch(cwd) or "")
     repo = current_repo(cwd) or ""
 
     issues: set[int] = set()

--- a/lib/lore_core/session_start.py
+++ b/lib/lore_core/session_start.py
@@ -290,6 +290,46 @@ def last_session_hint(wiki: Path, max_notes: int = 2) -> list[tuple[str, str]]:
     return results
 
 
+def last_active_day_recap(lore_root: Path) -> tuple[str, ...]:
+    """Recap the most recent day the transcript ledger saw work.
+
+    Three lines at most — where (repo + session count), what branches,
+    which refs — rendered straight off the ledger's linkage blocks. No
+    LLM call, no gh call, no note read: this is what continuity looks
+    like once session notes are gone.
+
+    Empty when the ledger is empty or carries no dated entry. Orphaned
+    entries are retired sessions and never define the last active day.
+    """
+    from lore_core.ledger import TranscriptLedger
+
+    try:
+        entries = [e for e in TranscriptLedger(lore_root).all_entries() if not e.orphan]
+    except Exception:  # noqa: BLE001 - the banner degrades, it never fails
+        return ()
+    if not entries:
+        return ()
+
+    last_day = max(e.last_mtime.date() for e in entries)
+    day = [e for e in entries if e.last_mtime.date() == last_day]
+
+    repos = sorted({(e.linkage.get("repo") or "") for e in day} - {""})
+    branches = sorted({(e.linkage.get("branch") or "") for e in day} - {""})
+    refs = sorted(
+        {int(n) for e in day for n in (e.linkage.get("issues") or [])}
+        | {int(n) for e in day for n in (e.linkage.get("prs") or [])}
+    )
+
+    noun = "session" if len(day) == 1 else "sessions"
+    where = f" in {', '.join(repos)}" if repos else ""
+    lines = [f"Last active {last_day.isoformat()} — {len(day)} {noun}{where}"]
+    if branches:
+        lines.append(f"Branches: {', '.join(branches)}")
+    if refs:
+        lines.append("Refs: " + ", ".join(f"#{n}" for n in refs))
+    return tuple(lines)
+
+
 def cross_scope_breadcrumbs(lore_root: Path, current_wiki: str) -> list[str]:
     """One-liner per other-wiki with activity in the last 24h."""
     from collections import Counter
@@ -355,9 +395,13 @@ class SessionFacts:
     repo: str | None
     scope: str = ""
     project_entry: dict | None = None
+    #: Collected for the freshness audit only — the banner stopped
+    #: rendering note hints when the recap replaced them.
     session_hints: tuple[tuple[str, str], ...] = ()
     freshness_audit_lines: tuple[str, ...] = ()
     pending_chip: str | None = None
+    #: Last-active-day recap off the transcript ledger (≤3 lines).
+    recap: tuple[str, ...] = ()
 
 
 def collect_session_facts(
@@ -377,6 +421,9 @@ def collect_session_facts(
         session_hints_full, max_notes=2
     )
     pending_chip = pending_verdict_chip(wiki) or None
+    # ``<lore_root>/wiki/<name>`` is the fixed vault layout, so the ledger
+    # is reachable without threading lore_root through every caller.
+    recap = last_active_day_recap(wiki.parent.parent)
     return SessionFacts(
         wiki_name=wiki.name,
         repo=repo,
@@ -385,26 +432,32 @@ def collect_session_facts(
         session_hints=tuple(session_hints),
         freshness_audit_lines=tuple(freshness_audit_lines),
         pending_chip=pending_chip,
+        recap=recap,
     )
 
 
 def render_session_banner(facts: SessionFacts) -> str:
     """Format a SessionStart banner from collected facts.
 
-    Ambient-minimum shape: status line (no issue/PR counts), optional
-    Focus block, at most two last-session hints, freshness lines only
-    on positive evidence, and the single collapsed directive as a
-    postscript — so users see what Lore did *first* and the rule
-    re-assertion second.
+    Ambient-minimum shape: status line (no gh fetch), optional Focus
+    block, the last-active-day recap read off the transcript ledger,
+    freshness lines only on positive evidence, and the single collapsed
+    directive as a postscript — so users see what Lore did *first* and
+    the rule re-assertion second.
+
+    The recap replaced the last-session note hints: notes are retired,
+    and continuity now comes from a store that costs no LLM call to
+    write and survives the note files being deleted.
     """
     injected_bits: list[str] = []
     if facts.scope:
         injected_bits.append(facts.scope)
     elif facts.project_entry is not None:
         injected_bits.append(f"[[{facts.project_entry['name']}]]")
-    if facts.session_hints:
-        _, first_summary = facts.session_hints[0]
-        injected_bits.append(f"last: {first_summary}")
+    if facts.recap:
+        # Chip form of the recap's first line — the block below carries
+        # the detail; the chip only has to say "there is a last day".
+        injected_bits.append(facts.recap[0].split(" — ")[0].lower())
     if facts.pending_chip:
         injected_bits.append(facts.pending_chip)
     status_line = f"lore {lore_version()}: active" + (
@@ -425,9 +478,8 @@ def render_session_banner(facts: SessionFacts) -> str:
         )
         parts.append("")
 
-    if facts.session_hints:
-        for slug, desc in facts.session_hints[:2]:
-            parts.append(f"Last: [[{slug}]] — {desc}")
+    if facts.recap:
+        parts.extend(facts.recap)
         parts.append("")
 
     if facts.freshness_audit_lines:

--- a/lib/lore_core/spine.py
+++ b/lib/lore_core/spine.py
@@ -57,7 +57,9 @@ from typing import Any
 SCHEMA_VERSION = 1
 
 # Closed producer set. A source outside this set is a bug, not data.
-SOURCES: frozenset[str] = frozenset({"hook", "curator", "drain", "janitor", "install"})
+SOURCES: frozenset[str] = frozenset(
+    {"hook", "curator", "drain", "janitor", "install", "mcp"}
+)
 
 LEVELS: frozenset[str] = frozenset({"info", "warn", "error"})
 

--- a/lib/lore_core/spine.py
+++ b/lib/lore_core/spine.py
@@ -57,9 +57,7 @@ from typing import Any
 SCHEMA_VERSION = 1
 
 # Closed producer set. A source outside this set is a bug, not data.
-SOURCES: frozenset[str] = frozenset(
-    {"hook", "curator", "drain", "janitor", "install", "mcp"}
-)
+SOURCES: frozenset[str] = frozenset({"hook", "curator", "drain", "janitor", "install", "mcp"})
 
 LEVELS: frozenset[str] = frozenset({"info", "warn", "error"})
 

--- a/lib/lore_curator/capture_routing.py
+++ b/lib/lore_curator/capture_routing.py
@@ -48,6 +48,7 @@ def register_pending_transcripts(
     *,
     adapter: Any,
     transcript: Path | None = None,
+    deep: bool = False,
 ) -> None:
     """List transcripts for ``cwd`` and upsert into the ledger.
 
@@ -66,6 +67,10 @@ def register_pending_transcripts(
 
     Bulk-upserted in one ledger serialisation regardless of how many
     handles change — keeps the call well within the hook budget.
+
+    ``deep`` promotes the linkage stamp from git state alone to a full
+    transcript read (edited files, commit SHAs). Only a session boundary
+    passes it; a per-prompt heartbeat must not pay that parse.
     """
     from lore_core.state.attachments import AttachmentsFile
 
@@ -109,7 +114,65 @@ def register_pending_transcripts(
             entry.last_mtime = h.mtime
             to_write.append(entry)
     if to_write:
+        _stamp_linkage(to_write, cwd, adapter=adapter, deep=deep)
         tledger.bulk_upsert(to_write)
+
+
+def _stamp_linkage(
+    entries: list[TranscriptLedgerEntry],
+    cwd: Path,
+    *,
+    adapter: Any,
+    deep: bool,
+) -> None:
+    """Merge a freshly-derived linkage block into each entry, in place.
+
+    Merged, not replaced: a shallow pass carries no ``commits``/``files``
+    key, so the last deep pass's results survive it.
+
+    Every entry in one call shares the same ``cwd``, so the git-derived
+    half is derived once. The deep half is per-transcript and reads the
+    file, which is why it only runs at a session boundary.
+    """
+    from lore_curator.ledger_linkage import build_linkage
+
+    shallow = build_linkage(cwd)
+    for entry in entries:
+        block = dict(shallow)
+        if deep:
+            block.update(_deep_linkage(cwd, entry, adapter=adapter))
+        entry.linkage = {**entry.linkage, **block}
+
+
+def _deep_linkage(
+    cwd: Path,
+    entry: TranscriptLedgerEntry,
+    *,
+    adapter: Any,
+) -> dict[str, Any]:
+    """Linkage read out of one transcript, or ``{}`` if it cannot be read.
+
+    ponytail: parses the whole transcript. Median cost is ~15 ms and the
+    tail is ~300 ms on a 25 MB session, paid once per session boundary
+    rather than per prompt. Read incrementally from the digested
+    watermark if that tail ever shows up in hook telemetry.
+    """
+    from lore_core.types import TranscriptHandle
+
+    from lore_curator.ledger_linkage import build_linkage
+
+    try:
+        handle = TranscriptHandle(
+            integration=entry.integration,
+            id=entry.transcript_id,
+            path=entry.path,
+            cwd=entry.directory,
+            mtime=entry.last_mtime,
+        )
+        turns = list(adapter.read_slice(handle, 0))
+    except Exception:  # noqa: BLE001 - linkage is derived; capture must not fail on it
+        return {}
+    return build_linkage(cwd, turns=turns)
 
 
 def poll_buffer_handover(
@@ -353,7 +416,13 @@ def route_capture(
         progress = {}
 
     tledger = TranscriptLedger(lore_root)
-    register_pending_transcripts(lore_root, cwd, adapter=adapter, transcript=transcript)
+    # The boundary events are the only ones that promote capture to the
+    # deep linkage pass: the transcript is complete there, and one full
+    # parse per session is affordable where one per prompt is not.
+    register_pending_transcripts(
+        lore_root, cwd, adapter=adapter, transcript=transcript,
+        deep=event in ("session-end", "pre-compact"),
+    )
 
     # Buffer-and-flush: at session-end, stamp ``flush_requested`` on this
     # session's live buffers so the detached curator-A spawn (or a manual

--- a/lib/lore_curator/ledger_linkage.py
+++ b/lib/lore_curator/ledger_linkage.py
@@ -1,0 +1,113 @@
+"""Build the transcript ledger's linkage block. Zero LLM, zero network.
+
+The block answers "where did this session work, and what did it touch?" —
+``repo``, ``branch``, ``prs``, ``issues``, ``commits``, ``files``. It is
+the personal layer's only index: the owner drills their own archive with
+it, and the SessionStart recap renders from it.
+
+Two depths, because the two sources cost very different amounts:
+
+* **shallow** (``turns=None``) — git state and the branch name only. Two
+  ``git`` invocations; cheap enough for every capture hook. Returns
+  ``repo``/``branch``/``prs``/``issues`` and nothing else, so a caller
+  merging it over a stored block never clobbers a deep pass's results.
+* **deep** (``turns`` supplied) — adds ``commits`` and ``files`` read out
+  of the transcript itself, and widens the ref set with the commit
+  subjects. Costs a full transcript parse, so callers run it at a session
+  boundary or in a migration, not per prompt.
+
+Refs are classified by syntax (``lore_core.linkage``), never by asking
+GitHub: a bare ``#42`` stays an issue. Under-claiming beats a network
+round-trip per ref.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lore_core.linkage import extract_linkage
+
+if TYPE_CHECKING:
+    from lore_core.types import Turn
+
+__all__ = ["build_linkage"]
+
+#: Per-entry caps. The ledger sits on the capture hot path — it is read
+#: five-plus times per hook — so one runaway session must not double the
+#: file every reader parses. First-seen order is kept, so the caps drop
+#: the tail of a long session, not its opening.
+#: ponytail: fixed caps; make them config keys only if a real session
+#: loses linkage that someone actually went looking for.
+MAX_FILES = 50
+MAX_COMMITS = 20
+
+
+def build_linkage(
+    cwd: Path | str | None,
+    *,
+    turns: list[Turn] | None = None,
+    branch: str | None = None,
+) -> dict[str, Any]:
+    """Return the linkage block for a session working in ``cwd``.
+
+    Keys present depend on the depth — see the module docstring. Callers
+    merge the result over the entry's stored block rather than replacing
+    it.
+
+    ``branch`` overrides git's current branch, for a caller reading a
+    session that ran on a branch the checkout has since left.
+    """
+    commit_texts: list[str] = []
+    commits: list[str] = []
+    files: list[str] = []
+
+    if turns is not None:
+        from lore_curator.session_activity import (
+            _all_turn_text,
+            _commit_shas_from_bash_results,
+            _files_modified_from_turns,
+        )
+
+        commits = _commit_shas_from_bash_results(turns)[:MAX_COMMITS]
+        files = [
+            _repo_relative(p, cwd)
+            for p in _files_modified_from_turns(turns)[:MAX_FILES]
+        ]
+        commit_texts = [_all_turn_text(turns)]
+
+    linkage = extract_linkage(cwd=cwd, commit_texts=commit_texts, branch=branch)
+
+    # An epic is an issue on GitHub; the ledger indexes both under
+    # ``issues`` so "which sessions touched #362" answers for an epic too.
+    issues = sorted(set(linkage.issues) | set(linkage.epics))
+
+    block: dict[str, Any] = {
+        "repo": linkage.repo,
+        "branch": linkage.branch,
+        "prs": list(linkage.prs),
+        "issues": issues,
+    }
+    if turns is not None:
+        block["commits"] = commits
+        block["files"] = files
+    return block
+
+
+def _repo_relative(path: str, cwd: Path | str | None) -> str:
+    """Strip the checkout prefix so the same file matches across worktrees.
+
+    Falls back to the path as written when it lies outside the repo (or
+    when there is no repo) — a wrong-looking absolute path is still a
+    usable pointer; a silently dropped one is not.
+    """
+    from lore_core.git import git_repo_root
+
+    root = git_repo_root(Path(cwd)) if cwd else None
+    if root is None:
+        return path
+    try:
+        return str(Path(path).relative_to(root))
+    except ValueError:
+        return path
+

--- a/lib/lore_curator/ledger_linkage.py
+++ b/lib/lore_curator/ledger_linkage.py
@@ -7,10 +7,17 @@ it, and the SessionStart recap renders from it.
 
 Two depths, because the two sources cost very different amounts:
 
-* **shallow** (``turns=None``) — git state and the branch name only. Two
-  ``git`` invocations; cheap enough for every capture hook. Returns
-  ``repo``/``branch``/``prs``/``issues`` and nothing else, so a caller
-  merging it over a stored block never clobbers a deep pass's results.
+* **shallow** (``turns=None``) — git state and the branch name only.
+  Four ``git`` invocations (``rev-parse --abbrev-ref``, ``rev-parse
+  --show-toplevel``, ``remote get-url upstream``, ``remote get-url
+  origin``), and it runs on every capture hook including each
+  ``UserPromptSubmit``. Returns ``repo``/``branch``/``prs``/``issues``
+  and nothing else, so a caller merging it over a stored block never
+  clobbers a deep pass's results.
+  ponytail: not memoised. The hook is a fresh process per invocation, so
+  an in-process cache would save nothing; a cross-process one would have
+  to invalidate on every branch switch. Give it a stamped cache in
+  ``.lore/`` only if the ~15 ms shows up in hook telemetry.
 * **deep** (``turns`` supplied) — adds ``commits`` and ``files`` read out
   of the transcript itself, and widens the ref set with the commit
   subjects. Costs a full transcript parse, so callers run it at a session
@@ -26,6 +33,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from lore_core.git import git_repo_root
 from lore_core.linkage import extract_linkage
 
 if TYPE_CHECKING:
@@ -70,9 +78,12 @@ def build_linkage(
         )
 
         commits = _commit_shas_from_bash_results(turns)[:MAX_COMMITS]
+        # Resolve the repo root once, not once per file: this ran a
+        # `git rev-parse --show-toplevel` per edited file, so a 50-file
+        # session spawned 50 subprocesses on every session boundary.
+        repo_root = git_repo_root(Path(cwd)) if cwd else None
         files = [
-            _repo_relative(p, cwd)
-            for p in _files_modified_from_turns(turns)[:MAX_FILES]
+            _repo_relative(p, repo_root) for p in _files_modified_from_turns(turns)[:MAX_FILES]
         ]
         commit_texts = [_all_turn_text(turns)]
 
@@ -94,20 +105,16 @@ def build_linkage(
     return block
 
 
-def _repo_relative(path: str, cwd: Path | str | None) -> str:
+def _repo_relative(path: str, repo_root: Path | None) -> str:
     """Strip the checkout prefix so the same file matches across worktrees.
 
     Falls back to the path as written when it lies outside the repo (or
     when there is no repo) — a wrong-looking absolute path is still a
     usable pointer; a silently dropped one is not.
     """
-    from lore_core.git import git_repo_root
-
-    root = git_repo_root(Path(cwd)) if cwd else None
-    if root is None:
+    if repo_root is None:
         return path
     try:
-        return str(Path(path).relative_to(root))
+        return str(Path(path).relative_to(repo_root))
     except ValueError:
         return path
-

--- a/lib/lore_curator/retire_session_notes.py
+++ b/lib/lore_curator/retire_session_notes.py
@@ -1,0 +1,254 @@
+"""Retire the session-note stock into the transcript ledger.
+
+Backs the `lore migrate retire-session-notes` verb. Two halves, in this
+order:
+
+1. **Backfill** — derive a linkage block for every archived transcript
+   and write it onto its ledger entry. Sources are the transcript itself
+   (edited files, commit SHAs, refs in the turn text, and the branch the
+   session ran on) plus git (the repo the cwd resolves to). No LLM call
+   and no network call: an old note's prose is not distilled into the
+   ledger, and a bare ``#42`` is classified by syntax rather than by
+   asking GitHub what kind of ref it is. Backfilling 500-plus sessions
+   would otherwise mean a request per ref inside a command that then
+   deletes files.
+2. **Delete** — remove the session-note markdown under each wiki's
+   ``sessions/`` tree, then prune the directories that empty out.
+
+The plan is the contract. :func:`plan_retirement` reads and computes but
+writes nothing; :func:`apply_retirement` executes exactly the plan it is
+handed, so a dry run and a real run can be compared file by file.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "BackfillItem",
+    "RetirementPlan",
+    "RetirementReport",
+    "apply_retirement",
+    "plan_retirement",
+]
+
+
+@dataclass(frozen=True)
+class BackfillItem:
+    """One ledger entry and the linkage block to stamp on it."""
+
+    integration: str
+    transcript_id: str
+    linkage: dict[str, Any]
+    #: Set when the transcript file is gone; the block is then whatever
+    #: git and the stored cwd could still answer.
+    transcript_missing: bool = False
+
+
+@dataclass(frozen=True)
+class RetirementPlan:
+    """Everything the command would do. Produced without writing."""
+
+    backfill: list[BackfillItem] = field(default_factory=list)
+    #: Session-note files to delete, sorted by path.
+    deletions: list[Path] = field(default_factory=list)
+    #: Non-markdown files found under a ``sessions/`` tree. Left in place.
+    kept: list[Path] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RetirementReport:
+    backfilled: int
+    deleted: int
+    deleted_paths: list[Path]
+    failed: list[tuple[Path, str]] = field(default_factory=list)
+
+
+def plan_retirement(lore_root: Path, *, wiki: str | None = None) -> RetirementPlan:
+    """Compute the backfill and deletion plan. Writes nothing."""
+    return RetirementPlan(
+        backfill=_plan_backfill(lore_root),
+        deletions=sorted(_iter_session_notes(lore_root, wiki)),
+        kept=sorted(_iter_non_notes(lore_root, wiki)),
+    )
+
+
+def apply_retirement(lore_root: Path, plan: RetirementPlan) -> RetirementReport:
+    """Execute ``plan``: stamp the linkage blocks, then delete the notes.
+
+    Backfill runs first so a crash mid-delete still leaves the ledger
+    holding what the notes were about.
+    """
+    from lore_core.ledger import TranscriptLedger
+
+    ledger = TranscriptLedger(lore_root)
+    updated = []
+    for item in plan.backfill:
+        entry = ledger.get(item.integration, item.transcript_id)
+        if entry is None:
+            continue
+        entry.linkage = {**entry.linkage, **item.linkage}
+        updated.append(entry)
+    ledger.bulk_upsert(updated)
+
+    deleted: list[Path] = []
+    failed: list[tuple[Path, str]] = []
+    roots = {p for p in (_sessions_root_of(lore_root, d) for d in plan.deletions) if p}
+    for path in plan.deletions:
+        try:
+            _assert_deletable(lore_root, path)
+            path.unlink()
+            deleted.append(path)
+        except (OSError, ValueError) as exc:
+            failed.append((path, str(exc)))
+
+    for root in roots:
+        _prune_empty_dirs(root)
+
+    return RetirementReport(
+        backfilled=len(updated),
+        deleted=len(deleted),
+        deleted_paths=deleted,
+        failed=failed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backfill
+# ---------------------------------------------------------------------------
+
+
+def _plan_backfill(lore_root: Path) -> list[BackfillItem]:
+    from lore_adapters import get_adapter
+    from lore_core.ledger import TranscriptLedger
+    from lore_core.types import TranscriptHandle
+
+    from lore_curator.ledger_linkage import build_linkage
+
+    items: list[BackfillItem] = []
+    for entry in TranscriptLedger(lore_root).all_entries():
+        turns = None
+        if entry.path.exists():
+            try:
+                adapter = get_adapter(entry.integration)
+                handle = TranscriptHandle(
+                    integration=entry.integration,
+                    id=entry.transcript_id,
+                    path=entry.path,
+                    cwd=entry.directory,
+                    mtime=entry.last_mtime,
+                )
+                turns = list(adapter.read_slice(handle, 0))
+            except Exception:  # noqa: BLE001 - one unreadable archive must not stop the migration
+                turns = None
+        items.append(
+            BackfillItem(
+                integration=entry.integration,
+                transcript_id=entry.transcript_id,
+                linkage=build_linkage(
+                    entry.directory,
+                    turns=turns,
+                    branch=_recorded_branch(entry.path),
+                ),
+                transcript_missing=turns is None,
+            )
+        )
+    return items
+
+
+def _recorded_branch(transcript: Path) -> str | None:
+    """The branch the session ran on, as the integration recorded it.
+
+    Claude Code stamps ``gitBranch`` on each transcript line. That is the
+    only honest source for an archived session: the checkout has moved on
+    since, so asking git today would attribute old work to today's
+    branch. Returns ``None`` when the field is absent, which leaves the
+    git-derived branch in place.
+    """
+    try:
+        with transcript.open("r", encoding="utf-8", errors="replace") as fp:
+            for raw in fp:
+                try:
+                    branch = json.loads(raw).get("gitBranch")
+                except (json.JSONDecodeError, AttributeError):
+                    continue
+                if isinstance(branch, str) and branch:
+                    return branch
+    except OSError:
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Deletion
+# ---------------------------------------------------------------------------
+
+
+def _wiki_dirs(lore_root: Path, wiki: str | None) -> list[Path]:
+    root = lore_root / "wiki"
+    if not root.is_dir():
+        return []
+    if wiki:
+        target = root / wiki
+        return [target] if target.is_dir() else []
+    return sorted(d for d in root.iterdir() if d.is_dir())
+
+
+def _iter_session_notes(lore_root: Path, wiki: str | None):
+    for wiki_dir in _wiki_dirs(lore_root, wiki):
+        sessions = wiki_dir / "sessions"
+        if not sessions.is_dir():
+            continue
+        for path in sessions.rglob("*.md"):
+            if path.is_file() and not path.is_symlink():
+                yield path
+
+
+def _iter_non_notes(lore_root: Path, wiki: str | None):
+    for wiki_dir in _wiki_dirs(lore_root, wiki):
+        sessions = wiki_dir / "sessions"
+        if not sessions.is_dir():
+            continue
+        for path in sessions.rglob("*"):
+            if path.is_file() and path.suffix != ".md":
+                yield path
+
+
+def _sessions_root_of(lore_root: Path, path: Path) -> Path | None:
+    for parent in path.parents:
+        if parent.name == "sessions" and parent.parent.parent == lore_root / "wiki":
+            return parent
+    return None
+
+
+def _assert_deletable(lore_root: Path, path: Path) -> None:
+    """Refuse anything that is not a plain ``.md`` file inside a
+    ``<lore_root>/wiki/<name>/sessions/`` tree.
+
+    The plan is computed from the same walk, so this can only fire if the
+    tree changed under us or a caller hand-built a plan — which is
+    exactly when a delete loop must stop rather than guess.
+    """
+    if path.suffix != ".md":
+        raise ValueError(f"not a session note: {path}")
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"not a regular file: {path}")
+    inside = _sessions_root_of(lore_root, path.resolve()) or _sessions_root_of(lore_root, path)
+    if inside is None:
+        raise ValueError(f"outside any wiki sessions tree: {path}")
+
+
+def _prune_empty_dirs(root: Path) -> None:
+    """Remove directories left empty under ``root``, deepest first."""
+    if not root.is_dir():
+        return
+    for directory in sorted(root.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        if directory.is_dir():
+            with contextlib.suppress(OSError):
+                directory.rmdir()
+    with contextlib.suppress(OSError):
+        root.rmdir()

--- a/lib/lore_curator/retire_session_notes.py
+++ b/lib/lore_curator/retire_session_notes.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -97,16 +98,19 @@ def apply_retirement(lore_root: Path, plan: RetirementPlan) -> RetirementReport:
 
     deleted: list[Path] = []
     failed: list[tuple[Path, str]] = []
-    roots = {p for p in (_sessions_root_of(lore_root, d) for d in plan.deletions) if p}
+    # Every wiki's roots, not just the planned wiki's: the guard needs
+    # the legitimate universe, and a scoped plan only holds its own paths.
+    allowed = _sessions_roots(lore_root)
+    prune_roots = {p for p in (_sessions_root_of(lore_root, d) for d in plan.deletions) if p}
     for path in plan.deletions:
         try:
-            _assert_deletable(lore_root, path)
+            _assert_deletable(allowed, path)
             path.unlink()
             deleted.append(path)
         except (OSError, ValueError) as exc:
             failed.append((path, str(exc)))
 
-    for root in roots:
+    for root in prune_roots:
         _prune_empty_dirs(root)
 
     return RetirementReport(
@@ -198,57 +202,107 @@ def _wiki_dirs(lore_root: Path, wiki: str | None) -> list[Path]:
     return sorted(d for d in root.iterdir() if d.is_dir())
 
 
-def _iter_session_notes(lore_root: Path, wiki: str | None):
+def _iter_sessions_dirs(lore_root: Path, wiki: str | None):
+    """Yield each wiki's ``sessions/`` directory as the vault names it.
+
+    Unresolved on purpose: the plan should print the path the owner
+    knows. :func:`_contained` resolves each candidate before it is
+    allowed into the plan.
+    """
     for wiki_dir in _wiki_dirs(lore_root, wiki):
         sessions = wiki_dir / "sessions"
-        if not sessions.is_dir():
-            continue
+        if sessions.is_dir() and not sessions.is_symlink():
+            yield sessions
+
+
+def _iter_session_notes(lore_root: Path, wiki: str | None):
+    roots = _sessions_roots(lore_root, wiki)
+    for sessions in _iter_sessions_dirs(lore_root, wiki):
         for path in sessions.rglob("*.md"):
-            if path.is_file() and not path.is_symlink():
+            if path.is_file() and not path.is_symlink() and _contained(roots, path):
                 yield path
 
 
 def _iter_non_notes(lore_root: Path, wiki: str | None):
-    for wiki_dir in _wiki_dirs(lore_root, wiki):
-        sessions = wiki_dir / "sessions"
-        if not sessions.is_dir():
-            continue
+    roots = _sessions_roots(lore_root, wiki)
+    for sessions in _iter_sessions_dirs(lore_root, wiki):
         for path in sessions.rglob("*"):
-            if path.is_file() and path.suffix != ".md":
+            if path.is_file() and path.suffix != ".md" and _contained(roots, path):
                 yield path
 
 
 def _sessions_root_of(lore_root: Path, path: Path) -> Path | None:
+    """The in-vault ``sessions/`` directory above ``path``, lexically.
+
+    Used only to pick which directory to tidy after a delete —
+    containment is :func:`_contained`'s job, on resolved paths.
+    """
     for parent in path.parents:
         if parent.name == "sessions" and parent.parent.parent == lore_root / "wiki":
             return parent
     return None
 
 
-def _assert_deletable(lore_root: Path, path: Path) -> None:
-    """Refuse anything that is not a plain ``.md`` file inside a
-    ``<lore_root>/wiki/<name>/sessions/`` tree.
+def _sessions_roots(lore_root: Path, wiki: str | None = None) -> list[Path]:
+    """Every wiki's real ``sessions/`` directory, resolved.
 
-    The plan is computed from the same walk, so this can only fire if the
-    tree changed under us or a caller hand-built a plan — which is
-    exactly when a delete loop must stop rather than guess.
+    Containment is measured against the resolved *wiki's* sessions tree,
+    not against the vault root. A wiki is routinely a symlink into its
+    own git repo — wikis are portable units — so resolving against the
+    root instead drops every symlinked wiki from the plan without a
+    word.
+
+    A ``sessions`` entry that is itself a symlink is skipped. That one
+    points the tree out of its own wiki, which is the escape rather than
+    the layout: it let a plan list a link target's files under
+    in-vault-looking paths, and ``--apply`` delete them.
+    """
+    roots: list[Path] = []
+    for wiki_dir in _wiki_dirs(lore_root, wiki):
+        sessions = wiki_dir / "sessions"
+        if sessions.is_dir() and not sessions.is_symlink():
+            roots.append(sessions.resolve())
+    return roots
+
+
+def _contained(roots: list[Path], path: Path) -> bool:
+    """True when ``path`` resolves inside one of ``roots``.
+
+    Resolving the candidate is the whole guard: ``sessions/../../../x``
+    and a symlinked shard below ``sessions/`` both land outside every
+    root and are refused. Comparing an unresolved path — or falling back
+    to a lexical check when the resolved one misses — re-admits exactly
+    those two.
+    """
+    target = path.resolve()
+    return any(target.is_relative_to(root) for root in roots)
+
+
+def _assert_deletable(roots: list[Path], path: Path) -> None:
+    """Refuse anything that is not a plain ``.md`` file inside ``roots``.
+
+    The plan is computed from the same roots and the same predicate, so
+    this can only fire if the tree changed under us or a caller
+    hand-built a plan — which is exactly when a delete loop must stop
+    rather than guess.
     """
     if path.suffix != ".md":
         raise ValueError(f"not a session note: {path}")
     if path.is_symlink() or not path.is_file():
         raise ValueError(f"not a regular file: {path}")
-    inside = _sessions_root_of(lore_root, path.resolve()) or _sessions_root_of(lore_root, path)
-    if inside is None:
+    if not _contained(roots, path):
         raise ValueError(f"outside any wiki sessions tree: {path}")
 
 
 def _prune_empty_dirs(root: Path) -> None:
-    """Remove directories left empty under ``root``, deepest first."""
-    if not root.is_dir():
+    """Remove directories left empty under ``root``, deepest first.
+
+    ``os.walk(followlinks=False)`` rather than ``rglob``: rglob descends
+    through a directory symlink, which would let the prune rmdir empty
+    directories outside the vault.
+    """
+    if not root.is_dir() or root.is_symlink():
         return
-    for directory in sorted(root.rglob("*"), key=lambda p: len(p.parts), reverse=True):
-        if directory.is_dir():
-            with contextlib.suppress(OSError):
-                directory.rmdir()
-    with contextlib.suppress(OSError):
-        root.rmdir()
+    for dirpath, _dirnames, _filenames in os.walk(root, topdown=False, followlinks=False):
+        with contextlib.suppress(OSError):
+            Path(dirpath).rmdir()

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -9,7 +9,8 @@ Exposed tools:
     lore_resume             — unified context gather (recent/wiki/keyword/scope)
     lore_drill              — composite multi-stage retrieval (search→read→
                               expand→read_expanded) in one envelope with a
-                              structured trace
+                              structured trace, plus transcript pointers for
+                              queries naming an issue, a PR, or a file
     lore_inbox_classify     — read-only inbox walk (file list with type +
                               routing hint); skill composes notes, then shells
                               out to `lore inbox archive`
@@ -34,7 +35,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from lore_core.config import get_wiki_root
+from lore_core.config import get_lore_root, get_wiki_root
 from lore_core.errors import mcp_error as _mcp_error
 from lore_core.freshness import (
     compute_freshness,
@@ -44,6 +45,7 @@ from lore_core.freshness import (
     signal_to_dict,
 )
 from lore_core.freshness_filter import apply_search_filter
+from lore_core.ledger import find_sessions
 from lore_core.schema import extract_wikilinks, parse_frontmatter
 from lore_search.fts import FtsBackend
 
@@ -537,6 +539,25 @@ def handle_drill(
     trace: list[dict[str, Any]] = []
     notes: list[dict[str, Any]] = []
 
+    # Ledger routing. "Which sessions touched PR/issue/file X" is answered
+    # from the transcript ledger, not the note index — owner-local, and
+    # unaffected by what the vault does or doesn't hold. Resolved once per
+    # drill so the read-side spine event stays one-per-query; its trace
+    # step is appended last so the note stages keep their fixed positions.
+    t0 = _time.monotonic()
+    sessions = find_sessions(get_lore_root(), query)
+    ledger_step = {
+        "stage": "ledger",
+        "sessions": len(sessions),
+        "elapsed_ms": int((_time.monotonic() - t0) * 1000),
+    }
+
+    def _envelope() -> dict[str, Any]:
+        return {
+            "trace": [*trace, ledger_step],
+            "result": {"notes": notes, "sessions": sessions},
+        }
+
     # Stage 1: search
     t0 = _time.monotonic()
     hits = handle_search(query=query, wiki=wiki, k=k)
@@ -552,7 +573,7 @@ def handle_drill(
         # uniform — easier for clients to parse than missing entries.
         for stage in ("read", "expand", "read_expanded"):
             trace.append({"stage": stage, "skipped": "search_returned_zero", "elapsed_ms": 0})
-        return {"trace": trace, "result": {"notes": notes}}
+        return _envelope()
 
     # Stage 2: read top hits
     # Drill is the user-invoked deep-dive surface (PRD #92 retrieval
@@ -589,7 +610,7 @@ def handle_drill(
     if not expanded_slugs:
         trace.append({"stage": "expand", "skipped": "no_wikilinks", "elapsed_ms": int((_time.monotonic() - t0) * 1000)})
         trace.append({"stage": "read_expanded", "skipped": "no_wikilinks", "elapsed_ms": 0})
-        return {"trace": trace, "result": {"notes": notes}}
+        return _envelope()
     expand_step: dict[str, Any] = {
         "stage": "expand",
         "wikilinks": expanded_slugs,
@@ -607,7 +628,7 @@ def handle_drill(
     if not expanded_slugs:
         # `expand_only` filtered everything out — record skipped + return.
         trace.append({"stage": "read_expanded", "skipped": "expand_only_empty", "elapsed_ms": 0})
-        return {"trace": trace, "result": {"notes": notes}}
+        return _envelope()
 
     # Stage 4: read expanded (cap at expand_limit, skip unresolvable slugs).
     # `truncated` only applies when we actually hit the cap — an unresolvable
@@ -648,7 +669,7 @@ def handle_drill(
         trace_step["read_failed"] = read_failed_expanded
     trace.append(trace_step)
 
-    return {"trace": trace, "result": {"notes": notes}}
+    return _envelope()
 
 
 def handle_verdict(
@@ -1110,7 +1131,14 @@ def _tool_schema() -> list[dict]:
                 "exactly those without recomputing search. `expand_only` is "
                 "intersection-only (it cannot add slugs that weren't in the "
                 "discovered set; only narrow). "
-                "Prefer `lore_drill` for cold-start exploration of a topic. "
+                "A query naming an issue (`#358`), a PR (`PR 364`) or a file "
+                "path also returns `result.sessions` — pointers to the local "
+                "transcripts of the sessions that touched it, read from the "
+                "transcript ledger. Those pointers are machine-local: they name "
+                "files on this machine only, so never quote them to anyone but "
+                "their owner. "
+                "Prefer `lore_drill` for cold-start exploration of a topic, and "
+                "for \"which sessions touched X?\". "
                 "Prefer `lore_search` (then `lore_read`) when you already know "
                 "the rough path/slug or want to steer between stages."
             ),

--- a/tests/test_ledger_drill_routing.py
+++ b/tests/test_ledger_drill_routing.py
@@ -136,3 +136,12 @@ def test_drill_cli_prints_the_transcript_pointers(
     assert "t-ledger" in out
     assert "feat/358-ledger" in out
     assert "2026-08-04" in out
+
+
+def test_prose_abbreviations_do_not_route_to_the_ledger(tmp_path: Path) -> None:
+    """"e.g." is not a filename. A single-letter suffix must not cost a
+    ledger parse and a spine event on an ordinary topical query."""
+    _seed(tmp_path)
+
+    assert find_sessions(tmp_path, "the retry policy, e.g. the backoff") == []
+    assert [r for r in read_spine(tmp_path) if r["event"] == "ledger-query"] == []

--- a/tests/test_ledger_drill_routing.py
+++ b/tests/test_ledger_drill_routing.py
@@ -1,0 +1,138 @@
+"""Owner-local drill routing: "which sessions touched PR / issue / file X".
+
+The transcript ledger answers from its linkage blocks and returns
+transcript pointers. Machine-local by design (ADR 0009) — nothing here
+crosses to the team layer.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry, find_sessions
+from lore_core.spine import read_spine, validate_envelope
+
+
+def _seed(lore_root: Path) -> None:
+    def entry(tid: str, day: int, **linkage) -> TranscriptLedgerEntry:
+        return TranscriptLedgerEntry(
+            integration="claude-code",
+            transcript_id=tid,
+            path=lore_root / f"{tid}.jsonl",
+            directory=lore_root / "proj",
+            digested_hash=None,
+            digested_index_hint=None,
+            synthesised_hash=None,
+            last_mtime=datetime(2026, 8, day, 9, 0, tzinfo=UTC),
+            curator_a_run=None,
+            noteworthy=None,
+            session_note=None,
+            linkage=linkage,
+        )
+
+    TranscriptLedger(lore_root).bulk_upsert([
+        entry("t-ledger", 4, repo="buchbend/lore", branch="feat/358-ledger",
+              issues=[358], prs=[364], files=["lib/lore_core/ledger.py"]),
+        entry("t-flag", 3, repo="buchbend/lore", branch="feat/357-flag",
+              issues=[357], prs=[], files=["lib/lore_core/publish_gate.py"]),
+    ])
+
+
+def test_query_naming_an_issue_returns_that_session_pointer(tmp_path: Path) -> None:
+    _seed(tmp_path)
+
+    hits = find_sessions(tmp_path, "what did we do on #357")
+
+    assert [h["transcript_id"] for h in hits] == ["t-flag"]
+    assert hits[0]["path"] == str(tmp_path / "t-flag.jsonl")
+    assert hits[0]["integration"] == "claude-code"
+    assert hits[0]["branch"] == "feat/357-flag"
+
+
+def test_query_naming_a_pr_returns_that_session_pointer(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    assert [h["transcript_id"] for h in find_sessions(tmp_path, "PR 364")] == ["t-ledger"]
+
+
+def test_query_naming_a_file_returns_the_sessions_that_edited_it(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    assert [h["transcript_id"] for h in find_sessions(tmp_path, "ledger.py")] == ["t-ledger"]
+
+
+def test_query_with_no_routable_token_returns_nothing(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    assert find_sessions(tmp_path, "retry semantics") == []
+
+
+def test_a_routed_query_emits_exactly_one_read_side_spine_event(tmp_path: Path) -> None:
+    """AC6: one event per ledger-backed query, on the shared envelope."""
+    _seed(tmp_path)
+
+    find_sessions(tmp_path, "#358")
+
+    records = [r for r in read_spine(tmp_path) if r["event"] == "ledger-query"]
+    assert len(records) == 1
+    validate_envelope(records[0])
+    assert records[0]["data"]["hits"] == 1
+
+
+def test_an_unroutable_query_emits_no_event(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    find_sessions(tmp_path, "retry semantics")
+    assert [r for r in read_spine(tmp_path) if r["event"] == "ledger-query"] == []
+
+
+def test_drill_returns_transcript_pointers_for_a_routed_query(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC6 at the tool surface: `lore_drill` carries the pointers."""
+    from lore_mcp import server
+
+    _seed(tmp_path)
+    (tmp_path / "wiki" / "demo").mkdir(parents=True)
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    monkeypatch.setattr(server, "handle_search", lambda **kw: [])
+
+    out = server.handle_drill(query="#358", wiki="demo")
+
+    assert [s["transcript_id"] for s in out["result"]["sessions"]] == ["t-ledger"]
+    assert len([r for r in read_spine(tmp_path) if r["event"] == "ledger-query"]) == 1
+
+
+def test_drill_cli_prints_the_transcript_pointers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from lore_cli import drill_cmd
+    from typer.testing import CliRunner
+
+    _seed(tmp_path)
+    monkeypatch.setattr(
+        drill_cmd,
+        "handle_drill",
+        lambda **kw: {
+            "trace": [],
+            "result": {
+                "notes": [],
+                "sessions": [
+                    {
+                        "transcript_id": "t-ledger",
+                        "integration": "claude-code",
+                        "path": str(tmp_path / "t-ledger.jsonl"),
+                        "directory": str(tmp_path / "proj"),
+                        "last_active": "2026-08-04T09:00:00+00:00",
+                        "repo": "buchbend/lore",
+                        "branch": "feat/358-ledger",
+                        "issues": [358],
+                        "prs": [364],
+                    }
+                ],
+            },
+        },
+    )
+
+    out = CliRunner().invoke(drill_cmd.app, ["#358"]).output
+
+    assert "t-ledger" in out
+    assert "feat/358-ledger" in out
+    assert "2026-08-04" in out

--- a/tests/test_ledger_drill_routing.py
+++ b/tests/test_ledger_drill_routing.py
@@ -4,6 +4,7 @@ The transcript ledger answers from its linkage blocks and returns
 transcript pointers. Machine-local by design (ADR 0009) — nothing here
 crosses to the team layer.
 """
+
 from __future__ import annotations
 
 from datetime import UTC, datetime
@@ -31,12 +32,28 @@ def _seed(lore_root: Path) -> None:
             linkage=linkage,
         )
 
-    TranscriptLedger(lore_root).bulk_upsert([
-        entry("t-ledger", 4, repo="buchbend/lore", branch="feat/358-ledger",
-              issues=[358], prs=[364], files=["lib/lore_core/ledger.py"]),
-        entry("t-flag", 3, repo="buchbend/lore", branch="feat/357-flag",
-              issues=[357], prs=[], files=["lib/lore_core/publish_gate.py"]),
-    ])
+    TranscriptLedger(lore_root).bulk_upsert(
+        [
+            entry(
+                "t-ledger",
+                4,
+                repo="buchbend/lore",
+                branch="feat/358-ledger",
+                issues=[358],
+                prs=[364],
+                files=["lib/lore_core/ledger.py"],
+            ),
+            entry(
+                "t-flag",
+                3,
+                repo="buchbend/lore",
+                branch="feat/357-flag",
+                issues=[357],
+                prs=[],
+                files=["lib/lore_core/publish_gate.py"],
+            ),
+        ]
+    )
 
 
 def test_query_naming_an_issue_returns_that_session_pointer(tmp_path: Path) -> None:
@@ -139,7 +156,7 @@ def test_drill_cli_prints_the_transcript_pointers(
 
 
 def test_prose_abbreviations_do_not_route_to_the_ledger(tmp_path: Path) -> None:
-    """"e.g." is not a filename. A single-letter suffix must not cost a
+    """ "e.g." is not a filename. A single-letter suffix must not cost a
     ledger parse and a spine event on an ordinary topical query."""
     _seed(tmp_path)
 

--- a/tests/test_ledger_linkage.py
+++ b/tests/test_ledger_linkage.py
@@ -1,0 +1,295 @@
+"""Transcript-ledger linkage block — round-trip and back-compat.
+
+The ledger is the personal layer's linkage store: every entry carries
+where the session worked (repo, branch), what it referenced (PRs,
+issues), and what it produced (commits, files).
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry
+
+
+def _entry(lore_root: Path, **kw) -> TranscriptLedgerEntry:
+    defaults = {
+        "integration": "claude-code",
+        "transcript_id": "t1",
+        "path": lore_root / "t1.jsonl",
+        "directory": lore_root / "proj",
+        "digested_hash": None,
+        "digested_index_hint": None,
+        "synthesised_hash": None,
+        "last_mtime": datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+        "curator_a_run": None,
+        "noteworthy": None,
+        "session_note": None,
+    }
+    defaults.update(kw)
+    return TranscriptLedgerEntry(**defaults)
+
+
+def test_linkage_block_round_trips_through_the_ledger_file(tmp_path: Path) -> None:
+    ledger = TranscriptLedger(tmp_path)
+    ledger.upsert(
+        _entry(
+            tmp_path,
+            linkage={
+                "repo": "buchbend/lore",
+                "branch": "feat/358-ledger-expansion",
+                "prs": [364],
+                "issues": [358],
+                "commits": ["abc1234"],
+                "files": ["lib/lore_core/ledger.py"],
+            },
+        )
+    )
+
+    read_back = TranscriptLedger(tmp_path).get("claude-code", "t1")
+
+    assert read_back is not None
+    assert read_back.linkage == {
+        "repo": "buchbend/lore",
+        "branch": "feat/358-ledger-expansion",
+        "prs": [364],
+        "issues": [358],
+        "commits": ["abc1234"],
+        "files": ["lib/lore_core/ledger.py"],
+    }
+
+
+def test_entry_written_before_this_change_loads_with_an_empty_linkage(tmp_path: Path) -> None:
+    """AC2: pre-linkage ledgers stay readable. Same one-release
+    back-compat contract as the ``host`` → ``integration`` key."""
+    legacy = {
+        "claude-code::old": {
+            "host": "claude-code",
+            "transcript_id": "old",
+            "path": str(tmp_path / "old.jsonl"),
+            "directory": str(tmp_path / "proj"),
+            "digested_hash": None,
+            "digested_index_hint": None,
+            "synthesised_hash": None,
+            "last_mtime": "2026-04-18T10:00:00+00:00",
+            "curator_a_run": None,
+            "noteworthy": None,
+            "session_note": None,
+        }
+    }
+    (tmp_path / ".lore").mkdir(parents=True)
+    (tmp_path / ".lore" / "transcript-ledger.json").write_text(json.dumps(legacy))
+
+    entry = TranscriptLedger(tmp_path).get("claude-code", "old")
+
+    assert entry is not None
+    assert entry.linkage == {}
+
+
+# ---------------------------------------------------------------------------
+# AC1 — capture populates the block
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(repo_root: Path, *, branch: str, remote_url: str) -> None:
+    import subprocess
+
+    repo_root.mkdir(parents=True, exist_ok=True)
+    run = lambda *a: subprocess.run(a, cwd=repo_root, check=True)  # noqa: E731
+    run("git", "init", "-q", "-b", branch)
+    run("git", "config", "user.email", "test@example.com")
+    run("git", "config", "user.name", "Test")
+    run("git", "config", "commit.gpgsign", "false")
+    run("git", "remote", "add", "origin", remote_url)
+    (repo_root / "f.txt").write_text("x")
+    run("git", "add", "-A")
+    run("git", "commit", "-q", "-m", "init", "--no-verify")
+
+
+class _FakeAdapter:
+    integration = "fake"
+
+    def __init__(self, handles, turns=()):
+        self._handles = handles
+        self._turns = list(turns)
+
+    def list_transcripts(self, directory):
+        return self._handles
+
+    def read_slice(self, handle, from_index=0):
+        yield from self._turns
+
+    def read_slice_after_hash(self, *a, **kw):
+        yield from ()
+
+    def is_complete(self, handle):
+        return True
+
+
+def test_capture_stamps_repo_branch_and_branch_issue_on_a_new_entry(tmp_path: Path) -> None:
+    """AC1: the entry capture writes carries the linkage block."""
+    from lore_core.types import TranscriptHandle
+    from lore_curator.capture_routing import register_pending_transcripts
+
+    repo = tmp_path / "proj"
+    _init_repo(
+        repo,
+        branch="feat/358-ledger-expansion",
+        remote_url="git@github.com:buchbend/lore.git",
+    )
+    lore_root = tmp_path / "vault"
+    handle = TranscriptHandle(
+        integration="fake",
+        id="t1",
+        path=repo / "t1.jsonl",
+        cwd=repo,
+        mtime=datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+    )
+
+    register_pending_transcripts(lore_root, repo, adapter=_FakeAdapter([handle]))
+
+    entry = TranscriptLedger(lore_root).get("fake", "t1")
+    assert entry is not None
+    assert entry.linkage["repo"] == "buchbend/lore"
+    assert entry.linkage["branch"] == "feat/358-ledger-expansion"
+    assert entry.linkage["issues"] == [358]
+
+
+def _edit_turn(index: int, file_path: str):
+    from lore_core.types import ToolCall, Turn
+
+    return Turn(
+        index=index,
+        timestamp=None,
+        role="assistant",
+        tool_call=ToolCall(
+            name="Edit",
+            input={"file_path": file_path},
+            id=f"c{index}",
+            category="file_edit",
+        ),
+    )
+
+
+def _commit_turns(index: int, sha: str):
+    from lore_core.types import ToolCall, ToolResult, Turn
+
+    call = Turn(
+        index=index,
+        timestamp=None,
+        role="assistant",
+        tool_call=ToolCall(
+            name="Bash",
+            input={"command": 'git commit -m "closes #99"'},
+            id=f"b{index}",
+            category="shell_exec",
+        ),
+    )
+    result = Turn(
+        index=index + 1,
+        timestamp=None,
+        role="tool_result",
+        tool_result=ToolResult(
+            tool_call_id=f"b{index}",
+            output=f"[feat/358 {sha}] closes #99\n 1 file changed",
+        ),
+    )
+    return [call, result]
+
+
+def test_deep_capture_reads_files_and_commits_out_of_the_transcript(tmp_path: Path) -> None:
+    """AC1: at a session boundary the block also carries what the
+    session produced — edited files (repo-relative) and commit SHAs."""
+    from lore_core.types import TranscriptHandle
+    from lore_curator.capture_routing import register_pending_transcripts
+
+    repo = tmp_path / "proj"
+    _init_repo(
+        repo,
+        branch="feat/358-ledger-expansion",
+        remote_url="git@github.com:buchbend/lore.git",
+    )
+    lore_root = tmp_path / "vault"
+    handle = TranscriptHandle(
+        integration="fake",
+        id="t1",
+        path=repo / "t1.jsonl",
+        cwd=repo,
+        mtime=datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+    )
+    turns = [_edit_turn(0, str(repo / "lib" / "a.py")), *_commit_turns(1, "abc1234")]
+
+    register_pending_transcripts(
+        lore_root, repo, adapter=_FakeAdapter([handle], turns), deep=True
+    )
+
+    linkage = TranscriptLedger(lore_root).get("fake", "t1").linkage
+    assert linkage["files"] == ["lib/a.py"]
+    assert linkage["commits"] == ["abc1234"]
+
+
+def test_a_later_shallow_capture_keeps_the_deep_results(tmp_path: Path) -> None:
+    """Shallow passes run on every prompt; they must not wipe the
+    files/commits a boundary pass already derived."""
+    from lore_core.types import TranscriptHandle
+    from lore_curator.capture_routing import register_pending_transcripts
+
+    repo = tmp_path / "proj"
+    _init_repo(repo, branch="feat/358-x", remote_url="git@github.com:buchbend/lore.git")
+    lore_root = tmp_path / "vault"
+    handle = TranscriptHandle(
+        integration="fake", id="t1", path=repo / "t1.jsonl", cwd=repo,
+        mtime=datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+    )
+    adapter = _FakeAdapter([handle], [_edit_turn(0, str(repo / "lib" / "a.py"))])
+    register_pending_transcripts(lore_root, repo, adapter=adapter, deep=True)
+
+    grown = TranscriptHandle(
+        integration="fake", id="t1", path=repo / "t1.jsonl", cwd=repo,
+        mtime=datetime(2026, 8, 1, 11, 0, tzinfo=UTC),
+    )
+    register_pending_transcripts(
+        lore_root, repo, adapter=_FakeAdapter([grown]), deep=False
+    )
+
+    assert TranscriptLedger(lore_root).get("fake", "t1").linkage["files"] == ["lib/a.py"]
+
+
+def test_session_end_capture_takes_the_deep_pass(tmp_path: Path, monkeypatch) -> None:
+    """AC1 routing: the boundary event is what promotes capture to deep."""
+    from lore_curator import capture_routing
+
+    seen: list[bool] = []
+    monkeypatch.setattr(
+        capture_routing,
+        "register_pending_transcripts",
+        lambda *a, **kw: seen.append(kw.get("deep", False)),
+    )
+    monkeypatch.setattr(capture_routing, "load_wiki_config", None, raising=False)
+    _run_route(tmp_path, capture_routing, event="session-start")
+    _run_route(tmp_path, capture_routing, event="session-end")
+    _run_route(tmp_path, capture_routing, event="pre-compact")
+
+    assert seen == [False, True, True]
+
+
+def _run_route(tmp_path: Path, capture_routing, *, event: str) -> None:
+    from lore_core.types import Scope
+
+    scope = Scope(
+        wiki="demo",
+        scope="demo:proj",
+        backend="none",
+        claude_md_path=tmp_path / "CLAUDE.md",
+    )
+    (tmp_path / "wiki" / "demo").mkdir(parents=True, exist_ok=True)
+    capture_routing.route_capture(
+        tmp_path,
+        tmp_path / "proj",
+        scope,
+        event=event,
+        adapter=_FakeAdapter([]),
+        transcript=None,
+        spawn_curator_a=lambda *a, **kw: False,
+    )

--- a/tests/test_ledger_linkage.py
+++ b/tests/test_ledger_linkage.py
@@ -4,6 +4,7 @@ The ledger is the personal layer's linkage store: every entry carries
 where the session worked (repo, branch), what it referenced (PRs,
 issues), and what it produced (commits, files).
 """
+
 from __future__ import annotations
 
 import json
@@ -220,9 +221,7 @@ def test_deep_capture_reads_files_and_commits_out_of_the_transcript(tmp_path: Pa
     )
     turns = [_edit_turn(0, str(repo / "lib" / "a.py")), *_commit_turns(1, "abc1234")]
 
-    register_pending_transcripts(
-        lore_root, repo, adapter=_FakeAdapter([handle], turns), deep=True
-    )
+    register_pending_transcripts(lore_root, repo, adapter=_FakeAdapter([handle], turns), deep=True)
 
     linkage = TranscriptLedger(lore_root).get("fake", "t1").linkage
     assert linkage["files"] == ["lib/a.py"]
@@ -239,19 +238,23 @@ def test_a_later_shallow_capture_keeps_the_deep_results(tmp_path: Path) -> None:
     _init_repo(repo, branch="feat/358-x", remote_url="git@github.com:buchbend/lore.git")
     lore_root = tmp_path / "vault"
     handle = TranscriptHandle(
-        integration="fake", id="t1", path=repo / "t1.jsonl", cwd=repo,
+        integration="fake",
+        id="t1",
+        path=repo / "t1.jsonl",
+        cwd=repo,
         mtime=datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
     )
     adapter = _FakeAdapter([handle], [_edit_turn(0, str(repo / "lib" / "a.py"))])
     register_pending_transcripts(lore_root, repo, adapter=adapter, deep=True)
 
     grown = TranscriptHandle(
-        integration="fake", id="t1", path=repo / "t1.jsonl", cwd=repo,
+        integration="fake",
+        id="t1",
+        path=repo / "t1.jsonl",
+        cwd=repo,
         mtime=datetime(2026, 8, 1, 11, 0, tzinfo=UTC),
     )
-    register_pending_transcripts(
-        lore_root, repo, adapter=_FakeAdapter([grown]), deep=False
-    )
+    register_pending_transcripts(lore_root, repo, adapter=_FakeAdapter([grown]), deep=False)
 
     assert TranscriptLedger(lore_root).get("fake", "t1").linkage["files"] == ["lib/a.py"]
 

--- a/tests/test_mcp_drill.py
+++ b/tests/test_mcp_drill.py
@@ -60,7 +60,9 @@ def test_drill_full_chain_records_each_stage():
     assert "result" in out
 
     stages = [step["stage"] for step in out["trace"]]
-    assert stages == ["search", "read", "expand", "read_expanded"]
+    # ``ledger`` runs first but is recorded last so the note stages keep
+    # their fixed trace positions.
+    assert stages == ["search", "read", "expand", "read_expanded", "ledger"]
 
     # search recorded query + hit count
     assert out["trace"][0]["hits"] == 2
@@ -90,7 +92,9 @@ def test_drill_short_circuits_when_search_returns_zero():
 
     stages = [step["stage"] for step in out["trace"]]
     # search runs; the rest are recorded as skipped without doing work.
-    assert stages == ["search", "read", "expand", "read_expanded"]
+    # ``ledger`` runs first but is recorded last so the note stages keep
+    # their fixed trace positions.
+    assert stages == ["search", "read", "expand", "read_expanded", "ledger"]
     assert out["trace"][0]["hits"] == 0
     assert out["trace"][1].get("skipped") == "search_returned_zero"
     assert out["trace"][2].get("skipped") == "search_returned_zero"

--- a/tests/test_retire_session_notes.py
+++ b/tests/test_retire_session_notes.py
@@ -4,6 +4,7 @@ The command deletes files, so the plan is the contract: what a dry run
 prints is exactly what `--apply` does. Every test runs against a fixture
 vault built under tmp_path.
 """
+
 from __future__ import annotations
 
 import json
@@ -12,7 +13,11 @@ from pathlib import Path
 
 import pytest
 from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry
-from lore_curator.retire_session_notes import apply_retirement, plan_retirement
+from lore_curator.retire_session_notes import (
+    RetirementPlan,
+    apply_retirement,
+    plan_retirement,
+)
 from typer.testing import CliRunner
 
 
@@ -126,7 +131,9 @@ def test_plan_lists_every_session_note_and_leaves_the_vault_untouched(vault: Pat
     plan = plan_retirement(vault)
 
     assert [p.name for p in plan.deletions] == [
-        "01-0900-thing.md", "02-1000-other.md", "_recent.md",
+        "01-0900-thing.md",
+        "02-1000-other.md",
+        "_recent.md",
     ]
     assert sorted(vault.rglob("*.md")) == before
     assert TranscriptLedger(vault).get("claude-code", "t1").linkage == {}
@@ -205,3 +212,70 @@ def test_cli_with_apply_deletes(vault: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert result.exit_code == 0
     assert not (vault / "wiki" / "demo" / "sessions" / "2026" / "08" / "01-0900-thing.md").exists()
     assert TranscriptLedger(vault).get("claude-code", "t1").linkage["issues"] == [358]
+
+
+# ---------------------------------------------------------------------------
+# Containment — the delete path must never leave the vault
+# ---------------------------------------------------------------------------
+
+
+def test_a_symlinked_sessions_tree_is_never_walked_or_deleted(vault: Path, tmp_path: Path) -> None:
+    """A `sessions/` symlink pointed outside the vault made the plan print
+    the target's files under in-vault-looking paths, and `--apply` deleted
+    them."""
+    outside = tmp_path / "OUTSIDE"
+    (outside / "deep").mkdir(parents=True)
+    victim = outside / "victim.md"
+    victim.write_text("mine")
+    nested = outside / "deep" / "nested.md"
+    nested.write_text("also mine")
+
+    linked = vault / "wiki" / "beta"
+    linked.mkdir(parents=True)
+    (linked / "sessions").symlink_to(outside, target_is_directory=True)
+
+    plan = plan_retirement(vault)
+    assert victim not in plan.deletions
+    assert not any("OUTSIDE" in str(p.resolve()) for p in plan.deletions)
+
+    apply_retirement(vault, plan)
+
+    assert victim.exists()
+    assert nested.exists()
+    assert (outside / "deep").is_dir()
+
+
+def test_apply_refuses_a_traversal_out_of_the_sessions_tree(vault: Path) -> None:
+    """`sessions/../../../x.md` resolves outside the vault. Refuse it and
+    record the refusal — never delete it silently."""
+    precious = vault.parent / "PRECIOUS.md"
+    precious.write_text("keep")
+    escape = vault / "wiki" / "demo" / "sessions" / ".." / ".." / ".." / ".." / "PRECIOUS.md"
+
+    report = apply_retirement(vault, RetirementPlan(deletions=[escape]))
+
+    assert precious.exists()
+    assert report.deleted == 0
+    assert [p for p, _ in report.failed] == [escape]
+
+
+def test_a_wiki_symlinked_to_its_own_repo_is_still_planned_and_deleted(
+    vault: Path, tmp_path: Path
+) -> None:
+    """Wikis are portable units — a wiki is routinely a symlink into its
+    own git repo. Containment is measured against that wiki's resolved
+    sessions tree, not against the vault root, which would drop every
+    symlinked wiki without a word."""
+    elsewhere = tmp_path / "orgs" / "ccat-knowledge"
+    note = elsewhere / "sessions" / "2026" / "08" / "04-1200-real.md"
+    _note(note, "real")
+    (vault / "wiki" / "gamma").symlink_to(elsewhere, target_is_directory=True)
+
+    plan = plan_retirement(vault)
+    assert (
+        vault / "wiki" / "gamma" / "sessions" / "2026" / "08" / "04-1200-real.md" in plan.deletions
+    )
+
+    apply_retirement(vault, plan)
+
+    assert not note.exists()

--- a/tests/test_retire_session_notes.py
+++ b/tests/test_retire_session_notes.py
@@ -1,0 +1,207 @@
+"""`lore migrate retire-session-notes` — backfill the ledger, drop the notes.
+
+The command deletes files, so the plan is the contract: what a dry run
+prints is exactly what `--apply` does. Every test runs against a fixture
+vault built under tmp_path.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry
+from lore_curator.retire_session_notes import apply_retirement, plan_retirement
+from typer.testing import CliRunner
+
+
+def _transcript(path: Path, *, branch: str, edited: str, sha: str) -> None:
+    """A minimal Claude Code JSONL: one edit, one committing bash call."""
+    lines = [
+        {
+            "type": "user",
+            "gitBranch": branch,
+            "timestamp": "2026-08-01T09:00:00Z",
+            "message": {"role": "user", "content": "fix #358"},
+        },
+        {
+            "type": "assistant",
+            "gitBranch": branch,
+            "timestamp": "2026-08-01T09:01:00Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "c1",
+                        "name": "Edit",
+                        "input": {"file_path": edited},
+                    },
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "gitBranch": branch,
+            "timestamp": "2026-08-01T09:02:00Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "b1",
+                        "name": "Bash",
+                        "input": {"command": 'git commit -m "done"'},
+                    },
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "gitBranch": branch,
+            "timestamp": "2026-08-01T09:03:00Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "b1",
+                        "content": f"[{branch} {sha}] done\n 1 file changed",
+                    },
+                ],
+            },
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(x) for x in lines) + "\n")
+
+
+def _note(path: Path, title: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\ntype: session\ntitle: {title}\n---\n\nbody\n")
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """A vault with one archived transcript and three session notes."""
+    lore_root = tmp_path / "vault"
+    project = tmp_path / "proj"
+    project.mkdir(parents=True)
+    _transcript(
+        project / "t1.jsonl",
+        branch="feat/358-ledger",
+        edited=str(project / "lib" / "a.py"),
+        sha="abc1234",
+    )
+
+    TranscriptLedger(lore_root).upsert(
+        TranscriptLedgerEntry(
+            integration="claude-code",
+            transcript_id="t1",
+            path=project / "t1.jsonl",
+            directory=project,
+            digested_hash=None,
+            digested_index_hint=None,
+            synthesised_hash=None,
+            last_mtime=datetime(2026, 8, 1, 9, 0, tzinfo=UTC),
+            curator_a_run=None,
+            noteworthy=True,
+            session_note="[[01-0900-thing]]",
+        )
+    )
+
+    sessions = lore_root / "wiki" / "demo" / "sessions"
+    _note(sessions / "2026" / "08" / "01-0900-thing.md", "thing")
+    _note(sessions / "2026" / "08" / "02-1000-other.md", "other")
+    _note(sessions / "_recent.md", "index")
+    _note(lore_root / "wiki" / "demo" / "concepts" / "keeper.md", "keeper")
+    return lore_root
+
+
+def test_plan_lists_every_session_note_and_leaves_the_vault_untouched(vault: Path) -> None:
+    """AC3: a dry run changes nothing."""
+    before = sorted(p for p in vault.rglob("*.md"))
+
+    plan = plan_retirement(vault)
+
+    assert [p.name for p in plan.deletions] == [
+        "01-0900-thing.md", "02-1000-other.md", "_recent.md",
+    ]
+    assert sorted(vault.rglob("*.md")) == before
+    assert TranscriptLedger(vault).get("claude-code", "t1").linkage == {}
+
+
+def test_plan_never_lists_a_note_outside_the_sessions_tree(vault: Path) -> None:
+    assert not any("concepts" in p.parts for p in plan_retirement(vault).deletions)
+
+
+def test_apply_backfills_linkage_from_the_transcript_then_deletes_the_notes(vault: Path) -> None:
+    """AC4: linkage first, deletion second."""
+    report = apply_retirement(vault, plan_retirement(vault))
+
+    linkage = TranscriptLedger(vault).get("claude-code", "t1").linkage
+    assert linkage["branch"] == "feat/358-ledger"
+    assert linkage["issues"] == [358]
+    assert linkage["commits"] == ["abc1234"]
+    assert linkage["files"] == [str(vault.parent / "proj" / "lib" / "a.py")]
+
+    assert list((vault / "wiki" / "demo").rglob("sessions/**/*.md")) == []
+    assert (vault / "wiki" / "demo" / "concepts" / "keeper.md").exists()
+    assert report.deleted == 3
+    assert report.backfilled == 1
+
+
+def test_applied_deletions_are_exactly_what_the_plan_listed(vault: Path) -> None:
+    plan = plan_retirement(vault)
+    report = apply_retirement(vault, plan)
+    assert report.deleted_paths == plan.deletions
+
+
+def test_apply_leaves_a_non_note_file_in_the_sessions_tree_alone(vault: Path) -> None:
+    """Defensive: only ``.md`` files go. Anything else is reported, not removed."""
+    stray = vault / "wiki" / "demo" / "sessions" / "keep.json"
+    stray.write_text("{}")
+
+    plan = plan_retirement(vault)
+    apply_retirement(vault, plan)
+
+    assert stray.exists()
+    assert plan.kept == [stray]
+
+
+def test_wiki_filter_scopes_the_plan(vault: Path) -> None:
+    _note(vault / "wiki" / "other" / "sessions" / "2026" / "08" / "03-1100-x.md", "x")
+    assert [p.name for p in plan_retirement(vault, wiki="other").deletions] == ["03-1100-x.md"]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_without_apply_prints_the_plan_and_changes_nothing(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC3 at the verb."""
+    from lore_cli import migrate_cmd
+
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    result = CliRunner().invoke(migrate_cmd.app, ["retire-session-notes"])
+
+    assert result.exit_code == 0
+    assert "--apply" in result.output
+    assert "01-0900-thing.md" in result.output
+    assert (vault / "wiki" / "demo" / "sessions" / "2026" / "08" / "01-0900-thing.md").exists()
+
+
+def test_cli_with_apply_deletes(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC4 at the verb."""
+    from lore_cli import migrate_cmd
+
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    result = CliRunner().invoke(migrate_cmd.app, ["retire-session-notes", "--apply"])
+
+    assert result.exit_code == 0
+    assert not (vault / "wiki" / "demo" / "sessions" / "2026" / "08" / "01-0900-thing.md").exists()
+    assert TranscriptLedger(vault).get("claude-code", "t1").linkage["issues"] == [358]

--- a/tests/test_session_banner.py
+++ b/tests/test_session_banner.py
@@ -1,9 +1,12 @@
 """Golden test for ``render_session_banner``.
 
-Pins the ambient-minimum shape settled in the trim-to-safe-core PRD: one
-status line (no issue/PR counts), an optional Focus block, at most two
-last-session hints, freshness lines only on positive evidence, and a
+Pins the ambient-minimum shape: one status line (nothing fetched from
+gh), an optional Focus block, the last-active-day recap read off the
+transcript ledger, freshness lines only on positive evidence, and a
 single collapsed directive. No other section is emitted.
+
+The recap replaced the last-session note hints when session notes were
+retired — same three-line budget, a source that costs no LLM call.
 """
 
 from __future__ import annotations
@@ -29,6 +32,11 @@ SESSION_HINTS = (
     ("12-1530-fix-thing", "fixed the thing"),
     ("12-0900-prep", "prep for sprint"),
 )
+RECAP = (
+    "Last active 2026-08-04 — 2 sessions in ccatobs/data-transfer",
+    "Branches: feat/12-fix-thing",
+    "Refs: #12",
+)
 
 
 V1_FACTS = SessionFacts(
@@ -39,16 +47,18 @@ V1_FACTS = SessionFacts(
     session_hints=SESSION_HINTS,
     freshness_audit_lines=(),
     pending_chip=None,
+    recap=RECAP,
 )
 
 V1_EXPECTED = (
-    "lore 9.9.9: active · [[data-transfer]] · last: fixed the thing\n"
+    "lore 9.9.9: active · [[data-transfer]] · last active 2026-08-04\n"
     "\n"
     "## Focus: [[data-transfer]]\n"
     "Long-haul data pipeline\n"
     "\n"
-    "Last: [[12-1530-fix-thing]] — fixed the thing\n"
-    "Last: [[12-0900-prep]] — prep for sprint\n"
+    "Last active 2026-08-04 — 2 sessions in ccatobs/data-transfer\n"
+    "Branches: feat/12-fix-thing\n"
+    "Refs: #12\n"
     "\n"
     "## Directive\n"
     "- pull, not push"
@@ -63,16 +73,18 @@ V2_FACTS = SessionFacts(
     session_hints=SESSION_HINTS,
     freshness_audit_lines=(),
     pending_chip=None,
+    recap=RECAP,
 )
 
 V2_EXPECTED = (
-    "lore 9.9.9: active · ccat:data-center:data-transfer · last: fixed the thing\n"
+    "lore 9.9.9: active · ccat:data-center:data-transfer · last active 2026-08-04\n"
     "\n"
     "## Focus: [[data-transfer]]\n"
     "Long-haul data pipeline\n"
     "\n"
-    "Last: [[12-1530-fix-thing]] — fixed the thing\n"
-    "Last: [[12-0900-prep]] — prep for sprint\n"
+    "Last active 2026-08-04 — 2 sessions in ccatobs/data-transfer\n"
+    "Branches: feat/12-fix-thing\n"
+    "Refs: #12\n"
     "\n"
     "## Directive\n"
     "- pull, not push"
@@ -108,8 +120,8 @@ def test_render_session_banner_includes_pending_chip_and_no_project_note() -> No
 
 
 def test_render_session_banner_has_exactly_the_agreed_elements() -> None:
-    """The ambient-minimum contract: status line, Focus block, ≤2 session
-    hints, freshness lines, and a single directive — nothing else. Feed
+    """The ambient-minimum contract: status line, Focus block, ≤3 recap
+    lines, freshness lines, and a single directive — nothing else. Feed
     every optional slot so a stray extra section would show up."""
     facts = SessionFacts(
         wiki_name="ccat",
@@ -119,18 +131,20 @@ def test_render_session_banner_has_exactly_the_agreed_elements() -> None:
         session_hints=SESSION_HINTS,
         freshness_audit_lines=("### Filtered for staleness", "- 1 excluded"),
         pending_chip="1 pending verdict",
+        recap=RECAP,
     )
     out = render_session_banner(facts)
 
     expected = (
         "lore 9.9.9: active · ccat:data-center:data-transfer · "
-        "last: fixed the thing · 1 pending verdict\n"
+        "last active 2026-08-04 · 1 pending verdict\n"
         "\n"
         "## Focus: [[data-transfer]]\n"
         "Long-haul data pipeline\n"
         "\n"
-        "Last: [[12-1530-fix-thing]] — fixed the thing\n"
-        "Last: [[12-0900-prep]] — prep for sprint\n"
+        "Last active 2026-08-04 — 2 sessions in ccatobs/data-transfer\n"
+        "Branches: feat/12-fix-thing\n"
+        "Refs: #12\n"
         "\n"
         "### Filtered for staleness\n"
         "- 1 excluded\n"
@@ -140,10 +154,9 @@ def test_render_session_banner_has_exactly_the_agreed_elements() -> None:
     )
     assert out == expected
 
-    # No count-shaped bits ("N issues" / "N PRs") anywhere — the banner
-    # never fetches gh for counts.
-    assert "issue" not in out.lower()
-    assert "PR" not in out
+    # The recap's refs come from the ledger's linkage block, which capture
+    # wrote from git. The banner still fetches nothing from gh — see
+    # ``test_session_facts_has_no_issue_or_pr_fields``.
 
     # Exactly one directive heading — the three former blocks (vault-first
     # + freshness nudges, citation suppression, journal invitation) are

--- a/tests/test_session_banner_recap.py
+++ b/tests/test_session_banner_recap.py
@@ -1,0 +1,129 @@
+"""SessionStart recap of the last active day, rendered from the ledger.
+
+Replaces the last-session note hints: deterministic, zero LLM calls, and
+alive after the session-note files are gone.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lore_core.ledger import TranscriptLedger, TranscriptLedgerEntry
+from lore_core.session_start import collect_session_facts, last_active_day_recap
+
+
+def _entry(lore_root: Path, tid: str, when: datetime, **linkage) -> TranscriptLedgerEntry:
+    return TranscriptLedgerEntry(
+        integration="claude-code",
+        transcript_id=tid,
+        path=lore_root / f"{tid}.jsonl",
+        directory=lore_root / "proj",
+        digested_hash=None,
+        digested_index_hint=None,
+        synthesised_hash=None,
+        last_mtime=when,
+        curator_a_run=None,
+        noteworthy=None,
+        session_note=None,
+        linkage=linkage,
+    )
+
+
+def test_recap_summarises_the_last_active_day(tmp_path: Path) -> None:
+    """AC5: repo, branch, PRs, issues and the session count for the most
+    recent day that has entries — at most three lines."""
+    ledger = TranscriptLedger(tmp_path)
+    ledger.bulk_upsert([
+        _entry(
+            tmp_path, "old", datetime(2026, 7, 30, 9, 0, tzinfo=UTC),
+            repo="buchbend/lore", branch="main", prs=[], issues=[1],
+        ),
+        _entry(
+            tmp_path, "a", datetime(2026, 8, 4, 9, 0, tzinfo=UTC),
+            repo="buchbend/lore", branch="feat/358-ledger", prs=[364], issues=[358],
+        ),
+        _entry(
+            tmp_path, "b", datetime(2026, 8, 4, 17, 0, tzinfo=UTC),
+            repo="buchbend/lore", branch="feat/357-flag", prs=[], issues=[357],
+        ),
+    ])
+
+    lines = last_active_day_recap(tmp_path)
+
+    assert len(lines) <= 3
+    assert lines[0] == "Last active 2026-08-04 — 2 sessions in buchbend/lore"
+    assert "feat/357-flag" in lines[1] and "feat/358-ledger" in lines[1]
+    assert "#357" in lines[2] and "#358" in lines[2] and "#364" in lines[2]
+
+
+def test_recap_is_empty_when_the_ledger_is(tmp_path: Path) -> None:
+    assert last_active_day_recap(tmp_path) == ()
+
+
+def test_recap_skips_orphaned_entries(tmp_path: Path) -> None:
+    """An orphan is a retired session; it must not define the last day."""
+    ledger = TranscriptLedger(tmp_path)
+    live = _entry(
+        tmp_path, "live", datetime(2026, 8, 1, 9, 0, tzinfo=UTC), repo="o/r", branch="main"
+    )
+    dead = _entry(
+        tmp_path, "dead", datetime(2026, 8, 4, 9, 0, tzinfo=UTC), repo="o/r", branch="gone"
+    )
+    dead.orphan = True
+    ledger.bulk_upsert([live, dead])
+
+    assert last_active_day_recap(tmp_path)[0].startswith("Last active 2026-08-01 — 1 session ")
+
+
+def test_collect_session_facts_carries_the_recap(tmp_path: Path) -> None:
+    lore_root = tmp_path
+    wiki = lore_root / "wiki" / "demo"
+    wiki.mkdir(parents=True)
+    TranscriptLedger(lore_root).upsert(
+        _entry(
+            lore_root, "a", datetime(2026, 8, 4, 9, 0, tzinfo=UTC),
+            repo="buchbend/lore", branch="main",
+        )
+    )
+
+    facts = collect_session_facts(wiki, None)
+
+    assert facts.recap[0] == "Last active 2026-08-04 — 1 session in buchbend/lore"
+
+
+# ---------------------------------------------------------------------------
+# Render side — the recap replaces the last-session note hints
+# ---------------------------------------------------------------------------
+
+
+def test_banner_renders_the_recap_instead_of_session_note_hints() -> None:
+    import pytest
+    from lore_core import session_start
+    from lore_core.session_start import SessionFacts, render_session_banner
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(session_start, "lore_version", lambda: "9.9.9")
+    mp.setattr(session_start, "load_directive_lines", lambda: ["## Directive"])
+    try:
+        facts = SessionFacts(
+            wiki_name="ccat",
+            repo="o/r",
+            scope="ccat:data-center",
+            project_entry=None,
+            session_hints=(("12-1530-fix", "fixed the thing"),),
+            recap=(
+                "Last active 2026-08-04 — 2 sessions in buchbend/lore",
+                "Branches: feat/358-ledger",
+                "Refs: #358, #364",
+            ),
+        )
+        out = render_session_banner(facts)
+    finally:
+        mp.undo()
+
+    assert "Last: [[12-1530-fix]]" not in out
+    assert "fixed the thing" not in out
+    assert "Last active 2026-08-04 — 2 sessions in buchbend/lore" in out
+    assert "Branches: feat/358-ledger" in out
+    assert "Refs: #358, #364" in out
+    assert out.splitlines()[0] == "lore 9.9.9: active · ccat:data-center · last active 2026-08-04"

--- a/tests/test_session_banner_recap.py
+++ b/tests/test_session_banner_recap.py
@@ -3,6 +3,7 @@
 Replaces the last-session note hints: deterministic, zero LLM calls, and
 alive after the session-note files are gone.
 """
+
 from __future__ import annotations
 
 from datetime import UTC, datetime
@@ -33,20 +34,37 @@ def test_recap_summarises_the_last_active_day(tmp_path: Path) -> None:
     """AC5: repo, branch, PRs, issues and the session count for the most
     recent day that has entries — at most three lines."""
     ledger = TranscriptLedger(tmp_path)
-    ledger.bulk_upsert([
-        _entry(
-            tmp_path, "old", datetime(2026, 7, 30, 9, 0, tzinfo=UTC),
-            repo="buchbend/lore", branch="main", prs=[], issues=[1],
-        ),
-        _entry(
-            tmp_path, "a", datetime(2026, 8, 4, 9, 0, tzinfo=UTC),
-            repo="buchbend/lore", branch="feat/358-ledger", prs=[364], issues=[358],
-        ),
-        _entry(
-            tmp_path, "b", datetime(2026, 8, 4, 17, 0, tzinfo=UTC),
-            repo="buchbend/lore", branch="feat/357-flag", prs=[], issues=[357],
-        ),
-    ])
+    ledger.bulk_upsert(
+        [
+            _entry(
+                tmp_path,
+                "old",
+                datetime(2026, 7, 30, 9, 0, tzinfo=UTC),
+                repo="buchbend/lore",
+                branch="main",
+                prs=[],
+                issues=[1],
+            ),
+            _entry(
+                tmp_path,
+                "a",
+                datetime(2026, 8, 4, 9, 0, tzinfo=UTC),
+                repo="buchbend/lore",
+                branch="feat/358-ledger",
+                prs=[364],
+                issues=[358],
+            ),
+            _entry(
+                tmp_path,
+                "b",
+                datetime(2026, 8, 4, 17, 0, tzinfo=UTC),
+                repo="buchbend/lore",
+                branch="feat/357-flag",
+                prs=[],
+                issues=[357],
+            ),
+        ]
+    )
 
     lines = last_active_day_recap(tmp_path)
 
@@ -81,8 +99,11 @@ def test_collect_session_facts_carries_the_recap(tmp_path: Path) -> None:
     wiki.mkdir(parents=True)
     TranscriptLedger(lore_root).upsert(
         _entry(
-            lore_root, "a", datetime(2026, 8, 4, 9, 0, tzinfo=UTC),
-            repo="buchbend/lore", branch="main",
+            lore_root,
+            "a",
+            datetime(2026, 8, 4, 9, 0, tzinfo=UTC),
+            repo="buchbend/lore",
+            branch="main",
         )
     )
 


### PR DESCRIPTION
Implements sub-issue #358 of epic #362 (PRD 0010, ADR 0007 / ADR 0009).

The transcript ledger becomes the personal layer's linkage store, and the
session-note stock retires into it.

## What changed

- **`TranscriptLedgerEntry.linkage`** — a plain dict holding `repo`,
  `branch`, `prs`, `issues`, `commits`, `files`. Old entries load with
  `{}`, on the same one-release back-compat pattern as the existing
  `host` → `integration` key.
- **`lore_curator/ledger_linkage.py`** (new) — `build_linkage(cwd, turns=…,
  branch=…)`. Two depths: git state alone (two `git` calls), or that plus
  edited files and commit SHAs read from the transcript. It reuses
  `lore_core.linkage.extract_linkage` and the existing turn extractors in
  `session_activity`; no second extractor was written.
- **Capture** — `register_pending_transcripts` stamps the block whenever it
  writes an entry. `route_capture` promotes the stamp to the deep pass at
  `session-end` / `pre-compact` only. Shallow passes merge, never replace,
  so a per-prompt heartbeat cannot wipe a boundary pass's files/commits.
- **`lore migrate retire-session-notes`** — `plan_retirement` reads and
  computes; `apply_retirement` executes exactly the plan it is handed, so
  the dry run and the real run are comparable file by file.
- **Banner** — `last_active_day_recap(lore_root)` renders at most three
  lines (repo + session count, branches, refs) from the ledger. It replaced
  the `Last: [[slug]] — summary` hints and the `last: …` status chip.
- **Drill** — `find_sessions(lore_root, query)` answers "which sessions
  touched this?" for a query naming an issue, a PR or a file, and emits one
  `ledger-query` spine event per routed query. `handle_drill` returns the
  pointers under `result.sessions`; `lore drill` prints them.

## Acceptance criteria → tests

| AC | Test |
|----|------|
| capture upserts → entry carries the linkage block | `test_ledger_linkage.py::test_capture_stamps_repo_branch_and_branch_issue_on_a_new_entry`, `::test_deep_capture_reads_files_and_commits_out_of_the_transcript` |
| pre-change entry loads without error | `test_ledger_linkage.py::test_entry_written_before_this_change_loads_with_an_empty_linkage` |
| no `--apply` → prints the plan, changes nothing | `test_retire_session_notes.py::test_plan_lists_every_session_note_and_leaves_the_vault_untouched`, `::test_cli_without_apply_prints_the_plan_and_changes_nothing` |
| `--apply` → backfills, then deletes | `test_retire_session_notes.py::test_apply_backfills_linkage_from_the_transcript_then_deletes_the_notes`, `::test_cli_with_apply_deletes` |
| banner renders the recap, zero LLM calls | `test_session_banner_recap.py` (4 tests) + the updated goldens in `test_session_banner.py` |
| drill returns pointers + one spine event | `test_ledger_drill_routing.py::test_drill_returns_transcript_pointers_for_a_routed_query`, `::test_a_routed_query_emits_exactly_one_read_side_spine_event` |

## Red → green evidence

Every cycle was a failing test first. The new and changed test files run
against the base commit (`4083a63`):

```
tests/test_ledger_drill_routing.py:7: ImportError: cannot import name
  'find_sessions' from 'lore_core.ledger'
tests/test_retire_session_notes.py:15: ModuleNotFoundError: No module named
  'lore_curator.retire_session_notes'
tests/test_session_banner_recap.py:12: ImportError: cannot import name
  'last_active_day_recap' from 'lore_core.session_start'
tests/test_session_banner.py:42: TypeError: SessionFacts.__init__() got an
  unexpected keyword argument 'recap'
!!!!!!!!!!!!!!!!!!! Interrupted: 4 errors during collection !!!!!!!!!!!!!!

$ pytest tests/test_ledger_linkage.py tests/test_mcp_drill.py   # collectable
8 failed, 11 passed
```

Sample per-cycle reds from the loop:

```
tests/test_ledger_linkage.py:87: AttributeError: 'TranscriptLedgerEntry'
  object has no attribute 'linkage'
tests/test_ledger_linkage.py:150: KeyError: 'repo'
tests/test_ledger_linkage.py:257: assert [False, False] == [False, True]
tests/test_ledger_drill_routing.py:100: KeyError: 'sessions'
```

On this branch:

```
$ pytest -q
4 failed, 2953 passed, 30 skipped, 11 subtests passed in 82s
```

The four failures are pre-existing and unrelated (rich colourises
parenthesised text on this machine, so three substring assertions in
`test_core_llm_wiring.py`, `test_install_dispatcher.py` and
`test_cli_scopes.py` miss). Verified failing identically on `4083a63` with
none of this branch's code present. `ruff check` is clean on every file
touched.

## Planning decisions

Autonomous mode; decisions taken against the acceptance criteria and existing
conventions:

- **Deep pass only at a session boundary.** Files and commits are only
  derivable from the transcript, and parsing one costs ~15 ms median /
  ~300 ms on a 25 MB session (measured over the 304 local transcripts).
  Once per session boundary is affordable; once per `UserPromptSubmit` is
  not. Marked with a `ponytail:` comment naming the ceiling and the upgrade
  path (read incrementally from the digested watermark).
- **No GitHub calls in the migration.** #358 lists GitHub as a backfill
  source. Skipped deliberately: its only contribution would be classifying
  a bare `#42` as issue-vs-PR, and the real vault holds 1194 ledger
  entries — a request per ref inside a command that then deletes files is a
  bad trade. Syntax classification (`lore_core.linkage.classify_refs`) is
  deterministic and offline; it under-claims rather than guessing, and ADR
  0007 keeps the ledger rebuildable, so a later pass can enrich it.
- **Drill only, not `lore_search`.** AC6 binds `lore_drill`. `handle_search`
  returns a bare `list[dict]` of note hits with no room for a second entity
  type, and every consumer indexes `h["path"]`; adding pointers there would
  either break those consumers or fake note-shaped fields. `lore drill` and
  `lore_drill` are the answer surface, and its description now says so.
- **`Linkage` (the note-frontmatter dataclass) untouched.** The ledger block
  is its own dict, so nothing this PR does changes what the compose pipeline
  writes into note frontmatter.
- **Ledger trace step recorded last.** The lookup runs before the search
  stage, but its trace entry is appended after `read_expanded` so existing
  clients (and the existing tests) that index the trace positionally keep
  working.
- **`--wiki` scopes deletion only.** The ledger is one machine-local store,
  not a per-wiki one, and stamping a linkage block is additive. Documented
  in the verb's help.
- **`_recent.md` is deleted with the rest.** It is a derived index inside the
  `sessions/` tree; leaving it behind would leave a file of broken
  wikilinks.
- **Migration caps.** 50 files and 20 commits per entry, first-seen order.
  The ledger sits on the capture hot path and is read five-plus times per
  hook; one runaway session must not double the file every reader parses.

## Verification against the real vault (dry run only)

```
$ LORE_ROOT=~/git/vault lore migrate retire-session-notes
Backfill — 1194 ledger entries (85 with issue/PR refs, 1027 without a
  readable transcript)
Delete — 539 session note(s)
  - /home/…/vault/wiki/ccat/sessions/_recent.md
  - /home/…/vault/wiki/ccat/sessions/buchbend/2026/04/20-1242-run-ubuntu-24-04-…md
  …
dry-run; nothing changed. Pass --apply to backfill and delete.
```

25 s wall clock; the ledger's md5 was byte-identical before and after, and
the vault's `git status` was unchanged. **Never run with `--apply`.**

Two things worth knowing before that command is ever run for real:

- 1027 of 1194 entries no longer have a readable transcript on disk, so
  their backfill is git-derived only. The command reports the count rather
  than pretending otherwise.
- Until the migration runs (or a few sessions accrue linkage), the recap
  degrades to one honest line — `Last active 2026-08-05 — 6 sessions` —
  because no entry carries linkage yet. No fallback to the note hints was
  added: they are the surface this replaces.

## Not touched

The compose pipeline, `lore_core/resume.py` / `resume_cmd.py` (#359), and
flag machinery (#357). `SessionFacts.session_hints` stays because
`collect_session_facts` still needs the hint walk to produce the freshness
audit lines; the renderer no longer reads it, and the field goes with the
teardown.

Closes #358.
