### PR TITLE
Measurement surfacing: flag rate, review latency, accept rate (#360)

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -53,6 +53,7 @@ appended to `$LORE_ROOT/.lore/spine.jsonl` through one writer,
 | `drain` | `lore_core/drain.py` | Session-scoped "what Lore did" events (`note-filed`, `note-appended`, `surface-proposed`, `transcript-synced`) — read by `lore status`'s news section |
 | `janitor` | `lore_core/janitor.py`, `lore_core/run_retention.py`, `lore_cli/_crash_log.py` | Retention deletions/downgrades and their failures |
 | `install` | *(reserved, no producer yet)* | Onboarding-wizard events (PRD 0005 pillar C); not wired as of this writing — `lore init` doesn't emit to the spine today |
+| `flag` | `lore_core/flag.py` | `flag-write` (outcome `written`/`withheld`) and `flag-review` (verdict `accept`/`decline`/`retarget`), each carrying `flag_id` — read by `lore status`'s flags section and `lore trace flag` (`lore_core/flag_metrics.py`) |
 
 **Schema-version policy:** `SCHEMA_VERSION` (currently `1`) bumps on any
 change to the envelope *shape* — a field added, removed, renamed, or a
@@ -178,10 +179,14 @@ so a reader never has to guess where to look next.
 healthy right now?" dashboard — capture liveness (last note, last run,
 last flush, last hook fire, lock state), flush queue counts (queued /
 running / dead-lettered), per-wiki connection health (dirty / ahead /
-behind / reachable), retention usage, an absorbed **news** section
-(session + background drain events — the old `lore news`), and an
-alerts section where every warning names its exact drill-down command.
-Reads only; exit code is 0 when healthy, nonzero when any alert fires.
+behind / reachable), a **flags** section (per-wiki flags written,
+withheld, pending, accepted, declined, retargeted — `lore_core.flag_metrics`
+aggregating the `source="flag"` spine events `flag.py` emits, plus
+`flag.count_pending` for the pending count itself), retention usage, an
+absorbed **news** section (session + background drain events — the old
+`lore news`), and an alerts section where every warning names its exact
+drill-down command. Reads only; exit code is 0 when healthy, nonzero when
+any alert fires.
 
 ### `lore trace <selector>`
 
@@ -192,8 +197,12 @@ flush — every spine record sharing a trace_id, as a Rich tree (or `
 of the old `lore log` / `lore runs` / `lore proc`. The selector accepts a
 trace_id, a session_id (resolves every trace_id that session touched,
 newest first), `last`, `dead` (lists dead-lettered flushes instead of one
-tree), or a note path / `[[wikilink]]` (reverse-resolved through the
-note's own `linkage.trace_id`).
+tree), `flag` (lists every flag-write/flag-review spine event as a flat,
+chronological table instead of a flush tree — a flag carries no
+trace_id, it is a standing-alone fact, not a flush; pairing one flag's
+write and verdict lines by `flag_id` gives its review latency), or a
+note path / `[[wikilink]]` (reverse-resolved through the note's own
+`linkage.trace_id`).
 
 ### `lore doctor [--fix]`
 
@@ -243,4 +252,7 @@ janitor pass.
 - [`cli-contract.md`](cli-contract.md) — the shape every `lore <verb>`
   command follows, including these three and the deprecated aliases.
 - How-to: [`../how-to/onboarding.md`](../how-to/onboarding.md),
-  [`../how-to/troubleshooting.md`](../how-to/troubleshooting.md).
+  [`../how-to/troubleshooting.md`](../how-to/troubleshooting.md),
+  [`../how-to/measure-flag-quality.md`](../how-to/measure-flag-quality.md)
+  — the known-gem baseline and directive flip-probe that use the flags
+  section and `lore trace flag`.

--- a/docs/how-to/measure-flag-quality.md
+++ b/docs/how-to/measure-flag-quality.md
@@ -25,10 +25,32 @@ the raw event timeline to check your judgment against.
 - **`lore trace flag`** — every flag-write and flag-review spine event,
   chronologically, each carrying a timestamp and a `flag_id`. Use it to
   find a specific flag's write event and pair it with its verdict.
-  `lore trace flag --json` gives the raw records for scripting a report.
+  `lore trace flag --json` gives the raw records for scripting a report;
+  pipe that through `jq`/Python and filter by `wiki` or `ts` yourself —
+  the selector itself takes no time-window or wiki filter.
 - **Review latency** for one flag is the gap between its `flag-write`
   and `flag-review` timestamps in that output — both events carry the
-  same `flag_id`, so pairing them is a lookup, not a derivation.
+  same `flag_id`, so pairing them is a lookup, not a derivation. A
+  retarget verdict does not count as the review: the flag stays pending
+  after a retarget, so the latency that matters is write-to-accept (or
+  write-to-decline), skipping over any retargets in between.
+- **`pending` and the write/verdict counters come from two different
+  sources and are not expected to sum.** `pending` is a live scan of the
+  wiki's notes for the unreviewed marker; the other counters replay
+  spine events. Hand-accepting a flag by editing the note directly gives
+  `written 2 · pending 1 · accepted 0` (the marker scan sees the edit,
+  no `flag-review` event exists for it); deleting a flagged note outside
+  Lore gives `written 2 · pending 0 · accepted 0 · declined 0` (both
+  flags vanish from the scan with no event recording why). Neither
+  output is wrong — they are honest about what each source can see.
+- **The counters are a rotation-bounded window, not an unbounded total.**
+  They read the live spine plus its most recent rotated sibling
+  (`retention.cold_days`, default 30 days) — older events are gone once
+  the janitor deletes that cold file. A baseline campaign running longer
+  than that window will undercount its earlier sessions with no error.
+  `accepted` (or `declined`) exceeding `written` is the signature that
+  some of a flag's write events have rotated out from under its verdict
+  — read it as "older than the window", not as a bug.
 
 ## Procedure 1: known-gem baseline replay
 
@@ -43,8 +65,9 @@ worth keeping.
 2. **Run or replay the session** under the current flagging directive.
 3. **Check whether the gem became a flag.** Read the session's
    transcript or its private notes, then check the wiki for a matching
-   flag block, or run `lore trace flag` scoped to the session's time
-   window and look for a write event whose lead matches the gem.
+   flag block, or run `lore trace flag --json` and filter the output
+   yourself (by `wiki`, or by eyeballing timestamps near the session)
+   for a write event whose lead matches the gem.
 4. **Record a hit or a miss per gem**, not per session — one session can
    contain several gems, and a session that flags one gem and misses
    another is a partial result, not a pass.

--- a/docs/how-to/measure-flag-quality.md
+++ b/docs/how-to/measure-flag-quality.md
@@ -1,0 +1,79 @@
+# Measure flag quality: known-gem baseline and directive flip-probe
+
+**Goal:** catch under-flagging before it erodes trust in the flag
+architecture. The flag is the only crossing from a private session to
+the team wiki — a fact an agent should have flagged and didn't leaves no
+trace anywhere a human would look. Under-flagging is measurable only by
+deliberately checking for it; it does not show up as an error, a
+dead-lettered flush, or any other alert `lore status` already earns.
+
+Background: the flag shape and the "measurement before trust" rule are
+recorded in [`brainstorms/lore-session-notes-worth.md`](../../brainstorms/lore-session-notes-worth.md)
+("Flag shape" and "S2 under-flagging amnesia").
+
+Both procedures below are **human-run**. Nothing here is a CLI command
+or an automated check — you read transcripts, judge outcomes, and record
+results yourself. What Lore gives you is the read side: the counters and
+the raw event timeline to check your judgment against.
+
+## Read side: what to check the results against
+
+- **`lore status`** — the `flags` section shows, per wiki: flags
+  written, withheld, pending, accepted, declined (and retargeted, when
+  any exist). Compare this against how many gems you expected the
+  session to surface.
+- **`lore trace flag`** — every flag-write and flag-review spine event,
+  chronologically, each carrying a timestamp and a `flag_id`. Use it to
+  find a specific flag's write event and pair it with its verdict.
+  `lore trace flag --json` gives the raw records for scripting a report.
+- **Review latency** for one flag is the gap between its `flag-write`
+  and `flag-review` timestamps in that output — both events carry the
+  same `flag_id`, so pairing them is a lookup, not a derivation.
+
+## Procedure 1: known-gem baseline replay
+
+Checks whether the agent actually flags the facts a human would judge
+worth keeping.
+
+1. **Pick sessions with a known gem.** A gem is a trap avoided, a dead
+   end with its reason, reasoning that was never written down elsewhere,
+   or a gap-fact (something the team would otherwise re-discover the
+   hard way). Use past sessions you remember clearly, or seed a fresh
+   session with a scripted scenario that contains one deliberately.
+2. **Run or replay the session** under the current flagging directive.
+3. **Check whether the gem became a flag.** Read the session's
+   transcript or its private notes, then check the wiki for a matching
+   flag block, or run `lore trace flag` scoped to the session's time
+   window and look for a write event whose lead matches the gem.
+4. **Record a hit or a miss per gem**, not per session — one session can
+   contain several gems, and a session that flags one gem and misses
+   another is a partial result, not a pass.
+5. **Repeat across enough sessions to trust the rate.** A single miss is
+   a data point, not a verdict; the goal is a flag rate against a known
+   baseline, tracked over time as the directive changes.
+
+## Procedure 2: directive flip-probe
+
+Checks whether a flagging decision reflects the fact's actual worth, or
+just the way the directive happens to be worded.
+
+1. **Take one scenario** — a session or a synthetic transcript
+   containing a candidate fact whose flag-worthiness is genuinely
+   debatable.
+2. **Run it once under the directive as written.**
+3. **Run it again under the directive reversed** — for example, ask the
+   agent to argue for *not* flagging the fact, or invert the framing
+   from "flag what's worth keeping" to "skip what's safe to lose".
+4. **Trust only the signal that survives both framings.** If the
+   fact gets flagged under the normal framing but dropped under the
+   reversed one (or vice versa), that is directive bias, not a real
+   judgment about the fact's worth — the directive wording needs work,
+   not the fact.
+
+## Done when
+
+You have a flag rate against a known-gem baseline (procedure 1) and at
+least one flip-probe result (procedure 2) for the current directive
+wording. Neither procedure has a fixed passing threshold — the point is
+a repeatable measurement to compare across directive changes, not a
+one-time gate.

--- a/lib/lore_cli/status_cmd.py
+++ b/lib/lore_cli/status_cmd.py
@@ -1,7 +1,7 @@
 """``lore status`` v2 — unified health dashboard (issue #193).
 
 The single glanceable "is Lore healthy right now?" surface. One line per
-concern across six sections, every alert paired with the exact drill-down
+concern across seven sections, every alert paired with the exact drill-down
 command (PRD 0005, "Dashboard grammar"):
 
     lore: active · private/proj:test · attached at ~/project
@@ -21,6 +21,9 @@ command (PRD 0005, "Dashboard grammar"):
     wikis
       · private      clean · ahead 0 · behind 0 · reachable
 
+    flags
+      · private      written 3 · pending 1 · accepted 2 · declined 0
+
     retention
       · hot 0.0/10 MB · janitor 5m ago
 
@@ -31,10 +34,11 @@ command (PRD 0005, "Dashboard grammar"):
       · none
 
 Reads only — the event spine (#185), flush store (#189), retention janitor
-status (#190), and per-wiki git state. Absorbs ``lore news`` (drain events
-for the current session, cursor advance preserved). Rendered as plain text
-(no ANSI) so it degrades cleanly for non-TTY / ``--plain`` and scripting.
-Exit code is 0 when healthy and nonzero when any alert is earned.
+status (#190), the flag spine (#360, ``lore_core.flag_metrics``), and
+per-wiki git state. Absorbs ``lore news`` (drain events for the current
+session, cursor advance preserved). Rendered as plain text (no ANSI) so it
+degrades cleanly for non-TTY / ``--plain`` and scripting. Exit code is 0
+when healthy and nonzero when any alert is earned.
 """
 
 from __future__ import annotations
@@ -270,6 +274,36 @@ def _wikis_lines(lore_root: Path, offline: bool) -> list[str]:
     if not dirs:
         return [_line(_HEALTHY, "no wikis")]
     return [_render_wiki_line(d.name, offline, lore_root) for d in dirs]
+
+
+# ---------------------------------------------------------------------------
+# flags section — per-wiki counters from the flag spine (#360)
+#
+# The flag is the only crossing from a private session to the team wiki
+# (PRD 0010); under-flagging is invisible without this. Reads only —
+# lore_core.flag_metrics aggregates flag.py's own spine events plus
+# flag.count_pending (never reconstructed, ADR 0008).
+# ---------------------------------------------------------------------------
+
+
+def _render_flags_line(lore_root: Path, wiki_name: str) -> str:
+    from lore_core.flag_metrics import flag_counts
+
+    c = flag_counts(lore_root, wiki_name)
+    withheld = f" ({c.withheld} withheld)" if c.withheld else ""
+    retargeted = f" · retargeted {c.retargeted}" if c.retargeted else ""
+    msg = (
+        f"{wiki_name:12s} written {c.written}{withheld} · pending {c.pending} "
+        f"· accepted {c.accepted} · declined {c.declined}{retargeted}"
+    )
+    return _line(_HEALTHY, msg)
+
+
+def _flags_lines(lore_root: Path) -> list[str]:
+    dirs = _wiki_dirs(lore_root)
+    if not dirs:
+        return [_line(_HEALTHY, "no wikis")]
+    return [_render_flags_line(lore_root, d.name) for d in dirs]
 
 
 # ---------------------------------------------------------------------------
@@ -544,6 +578,9 @@ def _json_payload(state: CaptureState, lore_root: Path, now: datetime, offline: 
             }
         )
     data["wikis"] = wikis
+    from lore_core.flag_metrics import flag_counts
+
+    data["flags"] = {d.name: asdict(flag_counts(lore_root, d.name)) for d in _wiki_dirs(lore_root)}
     data["alerts"] = _compute_alerts(state, now, lore_root)
     return data
 
@@ -600,6 +637,9 @@ def status(
         "",
         "wikis" + ("  (offline)" if offline else ""),
         *_wikis_lines(lore_root, offline),
+        "",
+        "flags",
+        *_flags_lines(lore_root),
         "",
         "retention",
         *_retention_lines(lore_root, now),

--- a/lib/lore_cli/trace_cmd.py
+++ b/lib/lore_cli/trace_cmd.py
@@ -124,13 +124,48 @@ def _print_dead(*, records, json_out: bool) -> None:
         console.print(f"[red]{line}[/red]", highlight=False)
 
 
+def _flag_detail(data: dict) -> str:
+    """``outcome=...`` for a write, ``verdict=...`` for a review verdict."""
+    if "outcome" in data:
+        detail = f"outcome={data['outcome']}"
+        if data.get("category"):
+            detail += f" category={data['category']}"
+        return detail
+    return f"verdict={data.get('verdict', '?')}"
+
+
+def _print_flags(*, records: list[dict], json_out: bool) -> None:
+    """Flat, chronological listing of flag-write/flag-review spine events.
+
+    Not one correlated flush tree (flag events carry no trace_id — a flag
+    is a standing-alone fact, not a flush) — a flat table, same shape as
+    ``_print_dead``. Review latency for one flag is exactly the gap
+    between its ``flag-write`` and ``flag-review`` lines here, both
+    keyed by the same ``flag_id``.
+    """
+    if json_out:
+        for rec in records:
+            sys.stdout.write(json.dumps(rec) + "\n")
+        return
+    if not records:
+        console.print("[dim]No flag events.[/dim]")
+        return
+    for rec in records:
+        data = rec.get("data") or {}
+        line = (
+            f"{rec.get('ts', '?')}  {rec.get('event', '?')}  {rec.get('wiki') or '-'}  "
+            f"flag_id={data.get('flag_id', '?')}  {_flag_detail(data)}"
+        )
+        console.print(line, highlight=False)
+
+
 @app.callback(invoke_without_command=True)
 def trace(
     # Argument default is None (not `...`) so this callback-only Typer app
     # collapses to a single command instead of a click Group requiring a
     # subcommand after the argument — same workaround as drill_cmd/search_cmd.
     selector: str = typer.Argument(
-        None, help="trace-id | session-id | last | dead | note path or [[wikilink]]"
+        None, help="trace-id | session-id | last | dead | flag | note path or [[wikilink]]"
     ),
     plain: bool = typer.Option(False, "--plain", help="Aligned text, no tree glyphs/color."),
     json_out: bool = typer.Option(False, "--json", help="Raw spine event list (JSONL)."),
@@ -147,6 +182,12 @@ def trace(
     except Exception as exc:
         console.print("[red]LORE_ROOT not set.[/red]")
         raise typer.Exit(1) from exc
+
+    if selector == "flag":
+        from lore_core.flag_metrics import flag_events
+
+        _print_flags(records=flag_events(lore_root), json_out=json_out)
+        return
 
     try:
         resolved = resolve_selector(lore_root, selector)

--- a/lib/lore_core/flag_metrics.py
+++ b/lib/lore_core/flag_metrics.py
@@ -1,0 +1,126 @@
+"""Read-side flag measurement — aggregating `flag.py`'s spine events (#360).
+
+Under-flagging is the flag architecture's main failure mode (PRD 0010)
+and is invisible without measurement: the flag is the only crossing from
+a private session to the team wiki, so a fact an agent should have
+flagged and didn't leaves no trace anywhere a human would look. This
+module reads what `flag.py` already emits — nothing here writes, and
+nothing here duplicates the pending scan (`flag.count_pending` stays the
+one source of pending state, ADR 0008).
+
+Backs `lore status`'s per-wiki flag counters and `lore trace`'s flag
+filter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from lore_core.flag import EV_REVIEW, EV_WRITE, SPINE_SOURCE, count_pending
+from lore_core.spine import read_spine
+
+
+@dataclass(frozen=True)
+class FlagCounts:
+    """Per-wiki flag counters for `lore status`."""
+
+    written: int
+    withheld: int
+    pending: int
+    accepted: int
+    declined: int
+    retargeted: int
+
+
+def flag_events(lore_root: Path, *, wiki: str | None = None) -> list[dict[str, Any]]:
+    """Every flag-write/flag-review spine record, chronological.
+
+    Sorted by ``ts`` — the spine is append-only but not guaranteed
+    strictly time-ordered (rotation, clock skew), the same caveat every
+    other spine reader carries.
+    """
+    records = read_spine(lore_root, source=SPINE_SOURCE)
+    if wiki is not None:
+        records = [r for r in records if r.get("wiki") == wiki]
+    return sorted(records, key=lambda r: r.get("ts", ""))
+
+
+def flag_counts(lore_root: Path, wiki: str) -> FlagCounts:
+    """Aggregate flag counters for one wiki.
+
+    ``written``/``withheld`` split the flag-write outcome apart: a
+    withheld flag never reaches the note (its payload carries no flag
+    text, by design), so folding it into "written" would hide the
+    withhold rate the flag slice deliberately made measurable.
+
+    ``pending`` is never replayed from events — it is
+    ``flag.count_pending``, the one derivation ADR 0008 allows (a note
+    scan, not an index), so a note a human edited by hand still counts
+    correctly.
+
+    ``retargeted`` stays apart from accepted/declined: a retarget moves
+    a flag to a better home, it does not resolve the review — the flag
+    keeps its unreviewed marker and stays pending afterward.
+    """
+    written = withheld = accepted = declined = retargeted = 0
+    for rec in flag_events(lore_root, wiki=wiki):
+        data = rec.get("data") or {}
+        event = rec.get("event")
+        if event == EV_WRITE:
+            outcome = data.get("outcome")
+            if outcome == "written":
+                written += 1
+            elif outcome == "withheld":
+                withheld += 1
+        elif event == EV_REVIEW:
+            verdict = data.get("verdict")
+            if verdict == "accept":
+                accepted += 1
+            elif verdict == "decline":
+                declined += 1
+            elif verdict == "retarget":
+                retargeted += 1
+    pending = count_pending(lore_root / "wiki" / wiki)
+    return FlagCounts(
+        written=written,
+        withheld=withheld,
+        pending=pending,
+        accepted=accepted,
+        declined=declined,
+        retargeted=retargeted,
+    )
+
+
+def _parse_ts(raw: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def review_latency_seconds(events: list[dict[str, Any]], flag_id: str) -> float | None:
+    """Seconds between one flag's write and its review verdict.
+
+    ``None`` when the flag has no write event, no verdict yet (still
+    pending), or either timestamp fails to parse. Takes ``events`` — the
+    same list `flag_events` returns — rather than reading the spine
+    itself, so a caller filtering to one wiki or one time window gets a
+    latency computed over exactly what it already read.
+    """
+    write_ts = review_ts = None
+    for rec in events:
+        if (rec.get("data") or {}).get("flag_id") != flag_id:
+            continue
+        if rec.get("event") == EV_WRITE and write_ts is None:
+            write_ts = rec.get("ts")
+        elif rec.get("event") == EV_REVIEW and review_ts is None:
+            review_ts = rec.get("ts")
+    if write_ts is None or review_ts is None:
+        return None
+    a, b = _parse_ts(write_ts), _parse_ts(review_ts)
+    if a is None or b is None:
+        return None
+    return (b - a).total_seconds()

--- a/lib/lore_core/flag_metrics.py
+++ b/lib/lore_core/flag_metrics.py
@@ -15,7 +15,7 @@ filter.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -38,11 +38,25 @@ class FlagCounts:
 def flag_events(lore_root: Path, *, wiki: str | None = None) -> list[dict[str, Any]]:
     """Every flag-write/flag-review spine record, chronological.
 
+    Reads both the live spine and its rotated cold sibling
+    (``spine.jsonl.1``), unlike a plain ``read_spine`` call. A known-gem
+    baseline campaign or a flag's review can outlive one rotation
+    (``retention.hot_days``, default 7) — the janitor rotates the hot
+    spine opportunistically from the hook path, so this is live
+    behaviour, not a hypothetical. Reading the cold file too widens the
+    counted window to ``retention.cold_days`` (default 30) instead of
+    silently resetting mid-campaign. Still bounded: the janitor deletes
+    cold records past that, so a campaign or an outstanding review
+    longer than that window is not covered — see
+    ``docs/how-to/measure-flag-quality.md``.
+
     Sorted by ``ts`` — the spine is append-only but not guaranteed
     strictly time-ordered (rotation, clock skew), the same caveat every
     other spine reader carries.
     """
-    records = read_spine(lore_root, source=SPINE_SOURCE)
+    cold_path = lore_root / ".lore" / "spine.jsonl.1"
+    records = read_spine(lore_root, source=SPINE_SOURCE, path=cold_path)
+    records += read_spine(lore_root, source=SPINE_SOURCE)
     if wiki is not None:
         records = [r for r in records if r.get("wiki") == wiki]
     return sorted(records, key=lambda r: r.get("ts", ""))
@@ -95,28 +109,48 @@ def flag_counts(lore_root: Path, wiki: str) -> FlagCounts:
 
 
 def _parse_ts(raw: str) -> datetime | None:
+    """Parse an ISO timestamp, normalizing a naive one to UTC.
+
+    A naive and an aware ``datetime`` can't be subtracted, so a caller
+    diffing two parsed timestamps would crash on a naive one even though
+    every value this module produces is well-formed — a hand-edited or
+    otherwise malformed record must degrade this function's contract
+    (``None``), not raise past it. Same idiom as
+    ``spine._oldest_record_age_days`` / ``status_cmd._resolve_now``.
+    """
     try:
-        return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        ts = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
     except (ValueError, TypeError):
         return None
+    return ts if ts.tzinfo else ts.replace(tzinfo=UTC)
 
 
 def review_latency_seconds(events: list[dict[str, Any]], flag_id: str) -> float | None:
-    """Seconds between one flag's write and its review verdict.
+    """Seconds between one flag's write and its first RESOLVING verdict.
 
-    ``None`` when the flag has no write event, no verdict yet (still
-    pending), or either timestamp fails to parse. Takes ``events`` — the
-    same list `flag_events` returns — rather than reading the spine
-    itself, so a caller filtering to one wiki or one time window gets a
+    ``None`` when the flag has no write event, no resolving verdict yet
+    (still pending, possibly after one or more retargets), or a
+    timestamp fails to parse. A retarget does not resolve review —
+    ``flag.retarget`` keeps the block's unreviewed marker and leaves it
+    in the walk — so a retarget verdict is skipped when picking the
+    review timestamp; only the first accept/decline counts. This mirrors
+    ``flag_counts``'s own treatment of ``retargeted`` as distinct from an
+    accept/decline outcome: write 10:00 -> retarget 10:01 -> accept
+    12:00 must report the write-to-accept gap, not write-to-retarget.
+
+    Takes ``events`` — the same list `flag_events` returns — rather than
+    reading the spine itself, so a caller filtering to one wiki gets a
     latency computed over exactly what it already read.
     """
     write_ts = review_ts = None
     for rec in events:
-        if (rec.get("data") or {}).get("flag_id") != flag_id:
+        data = rec.get("data") or {}
+        if data.get("flag_id") != flag_id:
             continue
-        if rec.get("event") == EV_WRITE and write_ts is None:
+        event = rec.get("event")
+        if event == EV_WRITE and write_ts is None:
             write_ts = rec.get("ts")
-        elif rec.get("event") == EV_REVIEW and review_ts is None:
+        elif event == EV_REVIEW and review_ts is None and data.get("verdict") != "retarget":
             review_ts = rec.get("ts")
     if write_ts is None or review_ts is None:
         return None

--- a/lib/lore_core/spine.py
+++ b/lib/lore_core/spine.py
@@ -310,14 +310,21 @@ def validate_envelope(rec: dict[str, Any]) -> None:
         raise ValueError("data must be a dict")
 
 
-def read_spine(lore_root: Path, *, source: str | None = None) -> list[dict[str, Any]]:
+def read_spine(
+    lore_root: Path, *, source: str | None = None, path: Path | None = None
+) -> list[dict[str, Any]]:
     """Return spine records (live file only), optionally filtered by ``source``.
 
     Malformed lines are skipped (an interrupted final write can only be a
-    single unparseable line). Reads ``spine.jsonl`` only — parity with the
-    prior hook-events readers, which never walked the rotated sibling.
+    single unparseable line). Reads ``spine.jsonl`` only by default —
+    parity with the prior hook-events readers, which never walked the
+    rotated sibling. Pass ``path`` to point this same malformed-line-
+    tolerant parse at a different file — e.g. the rotated cold sibling
+    (``spine.jsonl.1``), which is how a reader widens its window past one
+    hot-spine rotation (``lore_core.flag_metrics``) without duplicating
+    this parsing logic.
     """
-    path = lore_root / ".lore" / "spine.jsonl"
+    path = path or lore_root / ".lore" / "spine.jsonl"
     if not path.exists():
         return []
     out: list[dict[str, Any]] = []

--- a/tests/test_flag_metrics.py
+++ b/tests/test_flag_metrics.py
@@ -189,3 +189,111 @@ def test_review_latency_none_for_unknown_flag_id(tmp_path: Path):
 
     events = flag_events(root)
     assert review_latency_seconds(events, "no-such-id") is None
+
+
+def test_review_latency_skips_retarget_pairs_with_first_resolving_verdict(tmp_path: Path):
+    """write 10:00 -> retarget 10:01 -> accept 12:00 must report the
+    write-to-accept gap (7200s), not write-to-retarget (60s). A retarget
+    does not resolve review (flag.retarget's own docstring: the block
+    keeps its unreviewed marker and stays in the walk), so it must not be
+    picked as the review timestamp — mirrors flag_counts's own treatment
+    of retarget as distinct from a review outcome.
+    """
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="retarget", flag_id="a", note="x.md")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="accept", flag_id="a")
+    _rewrite_ts(
+        root,
+        ["2026-08-05T10:00:00Z", "2026-08-05T10:01:00Z", "2026-08-05T12:00:00Z"],
+    )
+
+    events = flag_events(root)
+    assert review_latency_seconds(events, "a") == 7200.0
+
+
+def test_review_latency_no_resolving_verdict_yet_is_none(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="retarget", flag_id="a", note="x.md")
+
+    events = flag_events(root)
+    assert review_latency_seconds(events, "a") is None
+
+
+def test_review_latency_handles_naive_timestamp_without_crashing(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="accept", flag_id="a")
+    # Naive (no offset) timestamps — a malformed or hand-edited record must
+    # not crash a function contracted to return None, it must return a
+    # value (mixing naive-as-UTC with aware is well-defined once normalized).
+    _rewrite_ts(root, ["2026-08-05T10:00:00", "2026-08-05T10:00:30Z"])
+
+    events = flag_events(root)
+    assert review_latency_seconds(events, "a") == 30.0
+
+
+# ---------------------------------------------------------------------------
+# Rotation window — flag_events/flag_counts must not silently reset when
+# the hot spine rotates to spine.jsonl.1 (janitor, #190).
+# ---------------------------------------------------------------------------
+
+
+def test_flag_counts_reads_across_hot_and_cold_rotation(tmp_path: Path):
+    root = _vault(tmp_path)
+    # Cold sibling holds an older write; hot spine holds its later verdict —
+    # exactly the shape a mid-campaign rotation produces.
+    cold = root / ".lore" / "spine.jsonl.1"
+    line = _spine_line(
+        event=flag.EV_WRITE,
+        wiki="private",
+        ts="2026-07-01T00:00:00Z",
+        outcome="written",
+        flag_id="old",
+    )
+    cold.write_text(line + "\n")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="accept", flag_id="old")
+
+    counts = flag_counts(root, "private")
+    assert counts.written == 1
+    assert counts.accepted == 1
+
+
+def test_flag_events_merges_hot_and_cold_chronologically(tmp_path: Path):
+    root = _vault(tmp_path)
+    cold = root / ".lore" / "spine.jsonl.1"
+    line = _spine_line(
+        event=flag.EV_WRITE,
+        wiki="private",
+        ts="2026-07-01T00:00:00Z",
+        outcome="written",
+        flag_id="old",
+    )
+    cold.write_text(line + "\n")
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="new")
+    _rewrite_ts(root, ["2026-08-01T00:00:00Z"])
+
+    events = flag_events(root)
+    assert [e["data"]["flag_id"] for e in events] == ["old", "new"]
+
+
+def _spine_line(*, event: str, wiki: str, ts: str, **data) -> str:
+    import json
+
+    return json.dumps(
+        {
+            "ts": ts,
+            "v": 1,
+            "source": flag.SPINE_SOURCE,
+            "event": event,
+            "level": "info",
+            "trace_id": None,
+            "session_id": None,
+            "run_id": None,
+            "wiki": wiki,
+            "scope": None,
+            "error_code": None,
+            "data": data,
+        }
+    )

--- a/tests/test_flag_metrics.py
+++ b/tests/test_flag_metrics.py
@@ -1,0 +1,191 @@
+"""Flag measurement — spine aggregation for `lore status`/`lore trace` (#360).
+
+Fixture spine records only, written directly with SpineWriter (matching
+test_trace_cmd.py's pattern) — no live sessions, no LLM. One test drives
+the real flag.write/accept path to prove the pending counter reuses
+flag.count_pending rather than reconstructing it from events.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lore_core import flag
+from lore_core.flag_metrics import FlagCounts, flag_counts, flag_events, review_latency_seconds
+from lore_core.spine import SpineWriter
+
+
+def _emit(lore_root: Path, *, event: str, wiki: str, **data) -> None:
+    SpineWriter(lore_root).emit(source=flag.SPINE_SOURCE, event=event, wiki=wiki, data=data)
+
+
+def _vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / ".lore").mkdir(parents=True)
+    (root / "wiki" / "private").mkdir(parents=True)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# flag_counts — written/withheld/accepted/declined/retargeted from events,
+# pending from flag.count_pending (never reconstructed).
+# ---------------------------------------------------------------------------
+
+
+def test_written_and_withheld_counted_separately(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="b")
+    _emit(
+        root, event=flag.EV_WRITE, wiki="private", outcome="withheld", flag_id="c", category="email"
+    )
+
+    counts = flag_counts(root, "private")
+    assert counts.written == 2
+    assert counts.withheld == 1
+
+
+def test_accepted_declined_retargeted_counted_from_verdicts(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="accept", flag_id="a")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="accept", flag_id="b")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="decline", flag_id="c")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="retarget", flag_id="d", note="x.md")
+
+    counts = flag_counts(root, "private")
+    assert counts.accepted == 2
+    assert counts.declined == 1
+    assert counts.retargeted == 1
+
+
+def test_counts_scoped_to_one_wiki(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+    _emit(root, event=flag.EV_WRITE, wiki="team", outcome="written", flag_id="b")
+
+    assert flag_counts(root, "private").written == 1
+    assert flag_counts(root, "team").written == 1
+
+
+def test_pending_reuses_flag_count_pending_not_replayed_events(tmp_path: Path, monkeypatch):
+    """Pending must come from the note scan (ADR 0008), not from counting
+    write-minus-review events — a human-edited note or a note touched
+    outside the flag module must still be reflected correctly.
+    """
+    root = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(root))
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    (root / "wiki" / "private" / "concepts").mkdir(parents=True)
+    (root / ".lore").mkdir(parents=True)
+
+    written = flag.write(
+        "One fact.",
+        wiki="private",
+        target="concepts/topic.md",
+        transcript="tr-1",
+        author="claude",
+        now="2026-08-05",
+    )
+    flag.write(
+        "Another fact.",
+        wiki="private",
+        target="concepts/topic.md",
+        transcript="tr-2",
+        author="claude",
+        now="2026-08-05",
+    )
+    flag.accept(root / "wiki" / "private", written.flag_id)
+
+    counts = flag_counts(root, "private")
+    assert counts.written == 2
+    assert counts.pending == 1  # one accepted, one still unreviewed
+    assert counts.pending == flag.count_pending(root / "wiki" / "private")
+
+
+def test_flag_counts_is_a_frozen_dataclass_shape(tmp_path: Path):
+    root = _vault(tmp_path)
+    counts = flag_counts(root, "private")
+    assert isinstance(counts, FlagCounts)
+    assert counts == FlagCounts(
+        written=0, withheld=0, pending=0, accepted=0, declined=0, retargeted=0
+    )
+
+
+# ---------------------------------------------------------------------------
+# flag_events — chronological, optionally wiki-filtered
+# ---------------------------------------------------------------------------
+
+
+def test_flag_events_sorted_chronologically(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="accept", flag_id="a")
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+    _rewrite_ts(root, ["2026-08-05T10:05:00Z", "2026-08-05T10:00:00Z"])
+
+    events = flag_events(root)
+    assert [e["event"] for e in events] == [flag.EV_WRITE, flag.EV_REVIEW]
+
+
+def test_flag_events_filtered_by_wiki(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+    _emit(root, event=flag.EV_WRITE, wiki="team", outcome="written", flag_id="b")
+
+    events = flag_events(root, wiki="private")
+    assert len(events) == 1
+    assert events[0]["data"]["flag_id"] == "a"
+
+
+def test_flag_events_excludes_other_sources(tmp_path: Path):
+    root = _vault(tmp_path)
+    SpineWriter(root).emit(source="hook", event="session-start", wiki="private", data={})
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+
+    events = flag_events(root)
+    assert len(events) == 1
+    assert events[0]["source"] == flag.SPINE_SOURCE
+
+
+def _rewrite_ts(root: Path, ts_list: list[str]) -> None:
+    import json
+
+    path = root / ".lore" / "spine.jsonl"
+    lines = path.read_text().splitlines()
+    out = []
+    for line, ts in zip(lines, ts_list, strict=True):
+        rec = json.loads(line)
+        rec["ts"] = ts
+        out.append(json.dumps(rec))
+    path.write_text("\n".join(out) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# review_latency_seconds — computable from one flag's write + verdict
+# ---------------------------------------------------------------------------
+
+
+def test_review_latency_computed_from_write_and_verdict(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="accept", flag_id="a")
+    _rewrite_ts(root, ["2026-08-05T10:00:00Z", "2026-08-05T10:30:00Z"])
+
+    events = flag_events(root)
+    assert review_latency_seconds(events, "a") == 1800.0
+
+
+def test_review_latency_none_when_still_pending(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+
+    events = flag_events(root)
+    assert review_latency_seconds(events, "a") is None
+
+
+def test_review_latency_none_for_unknown_flag_id(tmp_path: Path):
+    root = _vault(tmp_path)
+    _emit(root, event=flag.EV_WRITE, wiki="private", outcome="written", flag_id="a")
+    _emit(root, event=flag.EV_REVIEW, wiki="private", verdict="accept", flag_id="a")
+
+    events = flag_events(root)
+    assert review_latency_seconds(events, "no-such-id") is None

--- a/tests/test_spine.py
+++ b/tests/test_spine.py
@@ -323,6 +323,21 @@ def test_read_spine_skips_malformed_lines(tmp_path: Path) -> None:
     assert [r["event"] for r in recs] == ["ok"]
 
 
+def test_read_spine_path_override_reads_a_different_file(tmp_path: Path) -> None:
+    """``path=`` lets a caller point read_spine at the rotated cold sibling
+    (or any other JSONL file) with the same malformed-line tolerance,
+    instead of the default live spine.jsonl — used by flag_metrics to
+    widen its window past one hot-spine rotation (#360 fix round 2).
+    """
+    cold = tmp_path / ".lore" / "spine.jsonl.1"
+    cold.parent.mkdir(parents=True)
+    cold.write_text('{"source":"flag","event":"flag-write"}\n')
+    recs = read_spine(tmp_path, source="flag", path=cold)
+    assert [r["event"] for r in recs] == ["flag-write"]
+    # Default behaviour (no path=) is unchanged — still the live spine.
+    assert read_spine(tmp_path, source="flag") == []
+
+
 # ---------------------------------------------------------------------------
 # hook producer adapter — maps the legacy flat kwargs onto the envelope
 # ---------------------------------------------------------------------------

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -169,14 +169,14 @@ def _invoke(lore_root: Path, cwd: Path | None, *extra: str, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_dashboard_renders_six_sections(tmp_path: Path, monkeypatch) -> None:
+def test_dashboard_renders_seven_sections(tmp_path: Path, monkeypatch) -> None:
     lore_root, project = _seed_vault(tmp_path)
     _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
 
     result = _invoke(lore_root, project, "--plain", monkeypatch=monkeypatch)
     out = result.output
 
-    for header in ("capture", "flushes", "wikis", "retention", "news", "alerts"):
+    for header in ("capture", "flushes", "wikis", "flags", "retention", "news", "alerts"):
         assert f"\n{header}\n" in out or out.startswith(header + "\n") or f"\n{header} " in out, (
             f"missing section header {header!r} in:\n{out}"
         )
@@ -185,6 +185,8 @@ def test_dashboard_renders_six_sections(tmp_path: Path, monkeypatch) -> None:
         assert label in out, f"missing capture line {label!r} in:\n{out}"
     # Flushes counts line.
     assert "queued 0 · running 0 · dead-lettered 0" in out
+    # Flags counts line — empty vault, nothing written yet.
+    assert "written 0 · pending 0 · accepted 0 · declined 0" in out
     # No ANSI escapes leaked.
     assert "\x1b[" not in out
 
@@ -228,6 +230,75 @@ def test_flush_counts_reflect_store(tmp_path: Path, monkeypatch) -> None:
     # Last flush line reflects the most-recently-updated record (published, 10m).
     assert "Last flush" in out
     assert "published" in out
+
+
+# ---------------------------------------------------------------------------
+# Flags section (#360) — per-wiki flag counters
+# ---------------------------------------------------------------------------
+
+
+def _emit_flag(lore_root: Path, *, event: str, wiki: str = "private", **data) -> None:
+    from lore_core import flag
+    from lore_core.spine import SpineWriter
+
+    SpineWriter(lore_root).emit(source=flag.SPINE_SOURCE, event=event, wiki=wiki, data=data)
+
+
+def test_flags_section_shows_written_accepted_declined(tmp_path: Path, monkeypatch) -> None:
+    from lore_core import flag
+
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    _emit_flag(lore_root, event=flag.EV_WRITE, outcome="written", flag_id="a")
+    _emit_flag(lore_root, event=flag.EV_WRITE, outcome="written", flag_id="b")
+    _emit_flag(lore_root, event=flag.EV_REVIEW, verdict="accept", flag_id="a")
+    _emit_flag(lore_root, event=flag.EV_REVIEW, verdict="decline", flag_id="b")
+
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
+    assert "flags" in out
+    assert "written 2 · pending 0 · accepted 1 · declined 1" in out
+
+
+def test_flags_section_shows_withheld_apart_from_written(tmp_path: Path, monkeypatch) -> None:
+    from lore_core import flag
+
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    _emit_flag(lore_root, event=flag.EV_WRITE, outcome="written", flag_id="a")
+    _emit_flag(lore_root, event=flag.EV_WRITE, outcome="withheld", flag_id="b", category="email")
+
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
+    assert "written 1" in out
+    assert "1 withheld" in out
+
+
+def test_flags_pending_reflects_note_scan(tmp_path: Path, monkeypatch) -> None:
+    from lore_core import flag
+
+    lore_root, project = _seed_vault(tmp_path)
+    _seed_happy_run(lore_root, ago=timedelta(hours=2), notes_new=1)
+    monkeypatch.setenv("LORE_ROOT", str(lore_root))
+    (lore_root / "wiki" / "private" / "concepts").mkdir(parents=True)
+    written = flag.write(
+        "One fact.",
+        wiki="private",
+        target="concepts/topic.md",
+        transcript="tr-1",
+        author="claude",
+        now="2026-08-05",
+    )
+    flag.write(
+        "Another fact.",
+        wiki="private",
+        target="concepts/topic.md",
+        transcript="tr-2",
+        author="claude",
+        now="2026-08-05",
+    )
+    flag.accept(lore_root / "wiki" / "private", written.flag_id)
+
+    out = _invoke(lore_root, project, monkeypatch=monkeypatch).output
+    assert "pending 1" in out
 
 
 # ---------------------------------------------------------------------------
@@ -424,6 +495,8 @@ def test_json_mode(tmp_path: Path, monkeypatch) -> None:
     # v2 sections present.
     assert "flushes" in data
     assert "retention" in data
+    assert "flags" in data
+    assert data["flags"]["private"]["written"] == 0
 
 
 def test_help_mentions_status() -> None:

--- a/tests/test_trace_cmd.py
+++ b/tests/test_trace_cmd.py
@@ -165,6 +165,70 @@ def test_unknown_selector_errors_without_crashing(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# "flag" selector — lists flag-write/flag-review spine events (#360)
+# ---------------------------------------------------------------------------
+
+
+def _emit_flag(lore_root: Path, *, event: str, wiki: str = "private", **data) -> None:
+    from lore_core.flag import SPINE_SOURCE
+
+    SpineWriter(lore_root).emit(source=SPINE_SOURCE, event=event, wiki=wiki, data=data)
+
+
+def test_flag_selector_lists_write_and_review_events_with_timestamps(tmp_path, monkeypatch):
+    from lore_core.flag import EV_REVIEW, EV_WRITE
+
+    lore_root = _lore_root(tmp_path)
+    _emit_flag(lore_root, event=EV_WRITE, outcome="written", flag_id="abc123")
+    _emit_flag(lore_root, event=EV_REVIEW, verdict="accept", flag_id="abc123")
+
+    result = _invoke(lore_root, "flag", "--plain", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    assert "flag-write" in result.output
+    assert "flag-review" in result.output
+    assert "abc123" in result.output
+    # A timestamp (spine-stamped ISO string) renders on each line.
+    assert result.output.count("T") >= 2
+
+
+def test_flag_selector_orders_chronologically(tmp_path, monkeypatch):
+    from lore_core.flag import EV_REVIEW, EV_WRITE
+
+    lore_root = _lore_root(tmp_path)
+    _emit_flag(lore_root, event=EV_REVIEW, verdict="accept", flag_id="a")
+    _emit_flag(lore_root, event=EV_WRITE, outcome="written", flag_id="a")
+    _rewrite_timestamps(
+        lore_root,
+        {0: "2026-08-05T10:05:00Z", 1: "2026-08-05T10:00:00Z"},
+    )
+
+    result = _invoke(lore_root, "flag", "--plain", monkeypatch=monkeypatch)
+    write_pos = result.output.index("flag-write")
+    review_pos = result.output.index("flag-review")
+    assert write_pos < review_pos, "earlier write event must render first"
+
+
+def test_flag_selector_json_emits_raw_records(tmp_path, monkeypatch):
+    from lore_core.flag import EV_WRITE
+
+    lore_root = _lore_root(tmp_path)
+    _emit_flag(lore_root, event=EV_WRITE, outcome="written", flag_id="a")
+
+    result = _invoke(lore_root, "flag", "--json", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    records = [json.loads(ln) for ln in result.output.splitlines() if ln.strip()]
+    assert len(records) == 1
+    assert records[0]["event"] == EV_WRITE
+    assert records[0]["data"]["flag_id"] == "a"
+
+
+def test_flag_selector_empty_does_not_crash(tmp_path, monkeypatch):
+    lore_root = _lore_root(tmp_path)
+    result = _invoke(lore_root, "flag", "--plain", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
 # AC2 — header is the current flush status; steps carry model/tokens, note path
 # ---------------------------------------------------------------------------
 
@@ -330,6 +394,7 @@ def test_trace_never_writes_to_lore_root(tmp_path, monkeypatch):
         ["trace-readonly", "--json"],
         ["last"],
         ["dead"],
+        ["flag"],
         [str(note_dir / "n.md")],
     ):
         _invoke(lore_root, *args, monkeypatch=monkeypatch)


### PR DESCRIPTION
## Summary

Closes #360. Under-flagging is the flag architecture's main failure mode
(PRD 0010) and is invisible without measurement — the flag is the only
crossing from a private session to the team wiki. This slice surfaces the
spine events `flag.py` already emits (`flag-write`, `flag-review`); it adds
no new capture machinery and touches no write path.

- **`lore_core/flag_metrics.py`** (new, read-only) — aggregates the
  `source="flag"` spine. `flag_counts(lore_root, wiki)` returns written /
  withheld / pending / accepted / declined / retargeted; `flag_events()`
  returns the chronological write+review timeline, optionally wiki-filtered;
  `review_latency_seconds(events, flag_id)` pairs one flag's write and
  verdict by `flag_id`.
- **`lore status`** — new `flags` section, one line per wiki (mirrors the
  existing `wikis` section), plus a `flags` key in `--json`.
- **`lore trace flag`** — flat, chronological listing of flag-write/
  flag-review events with timestamps, same `--plain`/`--json` shape as the
  existing `dead` selector. A flag carries no `trace_id` (it's a
  standing-alone fact, not a flush), so it can't be one correlated tree —
  pairing a flag's write/review lines by `flag_id` gives its review
  latency directly in the output.
- **`docs/how-to/measure-flag-quality.md`** (new) — the known-gem baseline
  replay and directive flip-probe procedures. Both stay human-run; this
  documents the procedure and points at the read side (`lore status`,
  `lore trace flag`) to check results against, per the issue's scope.
- **`docs/architecture/observability.md`** — documents both surfaces above,
  and adds the `flag` row that was missing from the spine producer table
  (a pre-existing gap from the flag-lifecycle slice, #357).

## Judgement calls (issue asked these be stated explicitly)

1. **What "written" counts when a flag was withheld by the gate.** `written`
   counts only `outcome="written"` — flags that actually landed on the
   wiki. A withheld flag's payload carries no flag text and the note is
   untouched (deliberately, per `flag.py`), so folding it into "written"
   would hide the withhold rate the flag slice made measurable on purpose.
   Withheld flags get their own counter (`withheld`), shown in `lore status`
   as `written N (M withheld)` when nonzero, so the withhold rate stays
   visible without inflating the written figure.
2. **Whether `retarget` shows up in the counters at all.** Yes, as its own
   `retargeted` counter — kept apart from `accepted`/`declined`. A retarget
   moves a flag to a better home; it does not resolve the review (the flag
   keeps its unreviewed marker and stays pending afterward, per
   `flag.retarget`'s own docstring), so counting it as either a review
   outcome would misrepresent what happened.

## Task boundaries respected

Read-side only. No changes to `flag.py`, the gate, the ledger, or any
capture/compose code (`session_curator.py`, `fact_extract.py`, `chunker.py`,
`chapter_flush.py`, `stub_note.py`, `session_note.py`, `session_filer.py` —
all untouched). `CONTEXT.md` and `lib/lore_cli/__main__.py` untouched — no
new CLI verb is registered, only options/selectors added to the two verbs
already registered.

## Test plan (red → green, TDD)

Fixture spine records only (`SpineWriter` direct emits, matching the
existing `test_trace_cmd.py`/`test_status_cmd.py` pattern) — no live
sessions, no LLM anywhere.

**Red** (`lib/lore_core/flag_metrics.py` didn't exist yet):
```
$ PYTHONPATH=lib python -m pytest -q tests/test_flag_metrics.py
ImportError while importing test module '.../tests/test_flag_metrics.py'.
E   ModuleNotFoundError: No module named 'lore_core.flag_metrics'
1 error in 0.51s
```
`tests/test_status_cmd.py` / `tests/test_trace_cmd.py` red before the CLI
wiring landed:
```
FAILED tests/test_status_cmd.py::test_dashboard_renders_seven_sections - AssertionError: missing section header 'flags' in: ...
FAILED tests/test_status_cmd.py::test_flags_section_shows_written_accepted_declined - AssertionError: assert 'written 2 · pending 0 · accepted 1 · declined 1' in ...
FAILED tests/test_status_cmd.py::test_flags_section_shows_withheld_apart_from_written - AssertionError: assert 'written 1' in ...
FAILED tests/test_status_cmd.py::test_flags_pending_reflects_note_scan - AssertionError: assert 'pending 1' in ...
FAILED tests/test_status_cmd.py::test_json_mode - AssertionError: assert 'flags' in {...}
5 failed, 16 passed in 1.20s

FAILED tests/test_trace_cmd.py::test_flag_selector_lists_write_and_review_events_with_timestamps - assert 1 == 0
FAILED tests/test_trace_cmd.py::test_flag_selector_orders_chronologically - ValueError: substring not found
FAILED tests/test_trace_cmd.py::test_flag_selector_json_emits_raw_records - assert 1 == 0
FAILED tests/test_trace_cmd.py::test_flag_selector_empty_does_not_crash - assert 1 == 0
4 failed, 13 passed in 0.51s
```

**Green** (after implementation):
```
$ PYTHONPATH=lib python -m pytest -q tests/test_flag_metrics.py tests/test_status_cmd.py tests/test_trace_cmd.py
49 passed in 1.41s
```

**Full suite** (`PYTHONPATH=lib python -m pytest -q`): 3022 passed, 30
skipped, 4 failed — the 4 are the pre-existing rich/ANSI rendering failures
on `epic/362` named in the dispatch brief (`test_cli_scopes.py`,
`test_core_llm_wiring.py` x2, `test_install_dispatcher.py`), unrelated to
this change and unchanged by it.

`ruff check` / `ruff format --check` on all touched files: clean (one
pre-existing unformatted line in `status_cmd.py:448`, outside my diff,
left alone).

- [x] `lore status` shows flags written/pending/accepted/declined per wiki
- [x] `lore trace flag` lists write and verdict events with timestamps
- [x] Review latency computable from write+verdict events of one flag
      (`review_latency_seconds`, exercised in tests and in a live smoke run)
- [x] How-to documents the known-gem baseline replay and directive flip-probe