### PR TITLE
Fix the epic's five cross-feature docs defects

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -206,7 +206,7 @@ last day the ledger saw work, its session count and its repos. Line two
 names the branches those sessions ran on. Line three names the issue and
 PR numbers they touched. The recap replaced the last-session note hints.
 Freshness lines join the banner only when there is positive evidence
-(see below). A fixed two-line directive closes the banner
+(see below). A fixed directive closes the banner
 (`lore_core/templates/integration-rules/default.md`). The directive
 states that deeper context is a pull, never a push. It also states that
 anything pulled from a session note is a lab record, never an

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -199,9 +199,14 @@ Matrix sink walkthrough.
 SessionStart injects a deliberately small, deterministic banner
 (`lore_core/session_start.py:render_session_banner`). The banner costs
 no LLM call and no network call. It holds a status line, an optional
-`## Focus` block for the attached project, and at most two last-session
-hints. Freshness lines join the banner only when there is positive
-evidence (see below). A fixed two-line directive closes the banner
+`## Focus` block for the attached project, and a last-active-day recap
+(`lore_core/session_start.py:last_active_day_recap`). The recap renders
+off the transcript ledger in at most three lines. Line one names the
+last day the ledger saw work, its session count and its repos. Line two
+names the branches those sessions ran on. Line three names the issue and
+PR numbers they touched. The recap replaced the last-session note hints.
+Freshness lines join the banner only when there is positive evidence
+(see below). A fixed two-line directive closes the banner
 (`lore_core/templates/integration-rules/default.md`). The directive
 states that deeper context is a pull, never a push. It also states that
 anything pulled from a session note is a lab record, never an
@@ -217,8 +222,10 @@ not from anything injected ambiently:
 - `lore_inbox_classify` — read-only gather that a skill turns into
   prose, then commits via a CLI verb.
 - `lore_flag` — file one team-relevant fact into its owning topic note,
-  marked unreviewed (`lore_core/flag.py`). The only write an agent makes
-  to a wiki, and the only crossing from a session to the team surface.
+  marked unreviewed (`lore_core/flag.py`). The only wiki write an agent
+  makes from a session. Curator A's compose pipeline still writes session
+  notes into the wiki. The flag becomes the sole crossing from a session
+  to the team surface once the teardown retires that pipeline.
 - `lore_journal_write` — the AI/human scratch journal
   (`lore_core/journal.py`); freeform, no LLM abstraction, no
   propagation, never a source for ambient context.

--- a/docs/adr/0001-session-note-reopen-relaxes-close-immutability.md
+++ b/docs/adr/0001-session-note-reopen-relaxes-close-immutability.md
@@ -1,6 +1,6 @@
 # ADR 0001: Session-note reopen relaxes close-immutability (one file per session)
 
-- Status: Accepted
+- Status: Superseded by ADR 0007
 - Date: 2026-07-06
 - Context: epic [#151](https://github.com/buchbend/lore/issues/151),
   PRD [0002](../prd/0002-useful-session-notes.md), sub-issue

--- a/docs/adr/0003-note-body-is-a-derived-render-of-the-ledger.md
+++ b/docs/adr/0003-note-body-is-a-derived-render-of-the-ledger.md
@@ -1,6 +1,6 @@
 # ADR 0003: The session-note body is a deterministic render of the ledger
 
-- Status: Accepted
+- Status: Superseded by ADR 0007
 - Date: 2026-07-12
 - Context: epic [#282](https://github.com/buchbend/lore/issues/282),
   PRD [0008](../prd/0008-typed-fact-session-notes.md), sub-issue

--- a/docs/adr/0007-session-notes-retired-flags-are-the-crossing.md
+++ b/docs/adr/0007-session-notes-retired-flags-are-the-crossing.md
@@ -1,0 +1,68 @@
+# ADR 0007: Session notes are retired; the flag is the only session-to-wiki crossing
+
+- Status: Accepted
+- Date: 2026-08-05
+- Context: design export `brainstorms/lore-session-notes-worth.design.md`,
+  PRD [0011](../prd/0011-session-note-retirement-flag-architecture.md);
+  supersedes ADR 0001 and ADR 0003
+
+## Context
+
+Telemetry from the 2026-08 sweep (recorded in
+`brainstorms/lore-session-notes-worth.md`):
+
+- Readers pulled session notes 17 times per month across 307 sessions.
+  Every pulled note was at most 7 days old.
+- The note pipeline cost about 46 LLM calls per day. Eight days of runs
+  produced 60 errors and 91 force-flushes.
+- The context-finder tools out-used note retrieval about 4.5 to 1.
+- `lore_resume` was never called.
+- One session produced a 1,636-line note holding 6–8 genuine gems.
+
+PRD 0002 and PRD 0008 each reworked the note mechanism. The noise
+complaint outlived both. The mission was wrong, not the mechanism.
+
+## Decision
+
+Three layers replace the session-note pipeline:
+
+- Team layer: repo artifacts (ADRs, PRDs, issues, PRs, docs, code) and
+  wiki topic/project notes plus flags.
+- Personal layer: raw transcripts and the transcript ledger,
+  machine-local (ADR 0009).
+- Crossing: the flag — one stamped fact appended to the owning topic
+  note (ADR 0008).
+
+Retired: the Curator A compose path, the in-note fact ledger, note
+renders, `sessions/*.md` growth, and `lore_resume`. The SessionStart
+recap renders from the transcript ledger with zero LLM calls. Lore
+deletes the existing session notes and backfills the ledger from the
+archived transcripts. Rollout is additive-first: the flag primitive
+ships beside the pipeline; teardown is the last step, taken with
+flag-rate measurement in hand.
+
+## Consequences / Trade-offs
+
+Easier: capture runs with zero LLM calls and needs no API key. The
+sensitivity gate checks only flag text. The daily LLM spend of the
+pipeline disappears.
+
+Harder (losses accepted by the owner, 2026-08-04): passive teammate
+browsing of session notes is gone. Briefings lose their source and are
+parked. Onboarding quality rides on flag quality. Under-flagging is
+invisible without measurement, so measurement is mandatory before
+teardown.
+
+## Alternatives considered
+
+- Rework the note mechanism again. Rejected: PRD 0002, PRD 0008, and a
+  prior brainstorm tried; the complaint persisted.
+- Harvest gems from the note stock with an LLM pass. Rejected: the
+  no-LLM-distills-LLM constraint forbids rescue layers.
+- Keep notes as an optional mode. Rejected: an unused surface still
+  costs maintenance, gate scope, and trust.
+
+## Status
+
+Accepted. Supersedes ADR 0001 (reopen semantics) and ADR 0003 (derived
+note body); both describe retired machinery.

--- a/docs/adr/0008-flag-lands-marked-unreviewed.md
+++ b/docs/adr/0008-flag-lands-marked-unreviewed.md
@@ -1,0 +1,55 @@
+# ADR 0008: A flag lands in the wiki at write time, marked unreviewed
+
+- Status: Accepted
+- Date: 2026-08-05
+- Context: grilling session 2026-08-05 on
+  `brainstorms/lore-session-notes-worth.design.md`,
+  PRD [0011](../prd/0011-session-note-retirement-flag-architecture.md)
+
+## Context
+
+A flag is LLM-authored text on a human surface, and every such line is
+a poisoning surface. Teammates need to see fresh flags fast. The author
+needs a review step that never blocks a session.
+
+## Decision
+
+- The agent files the flag. The sensitivity gate checks the flag text
+  at write time and fails closed.
+- Lore appends the flag block to the owning topic note immediately.
+  The origin line ends with the unreviewed marker. When no home note
+  exists, lore creates the proposed topic note, also marked.
+- A human-authored flag lands without the marker.
+- The review walk (`lore flag review`) presents each pending flag.
+  Accept removes the marker. Retarget moves the block to another note.
+  Decline deletes the block. Skip leaves the flag pending.
+- Lore derives pending state by scanning notes for the marker. No
+  queue store exists.
+- The SessionStart banner shows a count of pending flags. The banner
+  never shows flag content and never blocks.
+- One spine event records each flag write and each review verdict.
+
+## Consequences / Trade-offs
+
+Easier: teammates see a fresh flag immediately, labelled as
+unreviewed. No queue store can drift. Git history keeps declined
+flags.
+
+Harder: unreviewed LLM text is visible on the team surface until the
+owner reviews. Review latency replaces under-flagging as the silent
+failure, so measurement covers flag rate, review latency, and accept
+rate.
+
+## Alternatives considered
+
+- Staged queue under `.lore/`, with the wiki write on accept.
+  Rejected: flags stay invisible until the owner walks the queue, and
+  queue rot hides gems.
+- Reuse the freshness-verdict walk machinery. Rejected: the owner
+  wants a small self-contained build, not a coupling to verdicts.
+- Direct append without a marker. Rejected: LLM-authored vault text
+  needs a human review point.
+
+## Status
+
+Accepted.

--- a/docs/adr/0009-privacy-boundary-is-locality.md
+++ b/docs/adr/0009-privacy-boundary-is-locality.md
@@ -1,0 +1,45 @@
+# ADR 0009: The privacy boundary is locality
+
+- Status: Accepted
+- Date: 2026-08-05
+- Context: archive audit in `brainstorms/lore-session-notes-worth.md`,
+  PRD [0011](../prd/0011-session-note-retirement-flag-architecture.md)
+
+## Context
+
+The 2026-08 archive audit counted 556 transcripts (216 MB), all
+gitignored, all on one machine. That privacy was accidental. The
+three-layer architecture (ADR 0007) needs the boundary to be
+structural.
+
+## Decision
+
+- Transcripts and the transcript ledger stay machine-local and
+  gitignored by design.
+- Lore ships no sync, no backup, and no cross-machine transcript
+  access.
+- The owner drills their own archive. A colleague asks the owner.
+- Same-person multi-machine use is a documented limitation, not a
+  feature gap.
+- Personal backup of the archive is the developer's own concern.
+
+## Consequences / Trade-offs
+
+Easier: no access control, no encryption, no server. The wedge
+phrasing stays honest — the raw why never leaves the author's machine.
+
+Harder: a lost machine loses that machine's raw record. The ledger
+rebuilds from git and GitHub; transcript text does not.
+
+## Alternatives considered
+
+- Encrypted synced transcript store. Rejected: key management and a
+  sync target contradict the lightweight-or-unused constraint.
+- Transcripts inside the wiki git repo. Rejected: raw transcripts on
+  the team surface break the privacy boundary outright.
+- A lore-owned private backup repo per user. Rejected: backup is not
+  lore's job, and the repo would still need access control.
+
+## Status
+
+Accepted.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -34,8 +34,9 @@ appended to `$LORE_ROOT/.lore/spine.jsonl` through one writer,
 ```
 
 - **`source`** — the producer, one of the closed `SOURCES` set:
-  `hook`, `curator`, `drain`, `janitor`, `install`. A source outside this
-  set is a bug, not data — `validate_envelope()` rejects it.
+  `hook`, `curator`, `drain`, `janitor`, `install`, `mcp`, `flag`. A
+  source outside this set is a bug, not data — `validate_envelope()`
+  rejects it.
 - **`level`** — `info` / `warn` / `error`.
 - **`error_code`** — `None`, or a value from the closed `ErrorCode`
   `StrEnum`. Free-form detail (exception type, message, offending path)
@@ -53,6 +54,7 @@ appended to `$LORE_ROOT/.lore/spine.jsonl` through one writer,
 | `drain` | `lore_core/drain.py` | Session-scoped "what Lore did" events (`note-filed`, `note-appended`, `surface-proposed`, `transcript-synced`) — read by `lore status`'s news section |
 | `janitor` | `lore_core/janitor.py`, `lore_core/run_retention.py`, `lore_cli/_crash_log.py` | Retention deletions/downgrades and their failures |
 | `install` | *(reserved, no producer yet)* | Onboarding-wizard events (PRD 0005 pillar C); not wired as of this writing — `lore init` doesn't emit to the spine today |
+| `mcp` | `lore_core/ledger.py` | `ledger-query` — one per `lore_drill` call whose query names an issue, a PR, an epic or a file path; a query that names none of those returns without emitting |
 | `flag` | `lore_core/flag.py` | `flag-write` (outcome `written`/`withheld`) and `flag-review` (verdict `accept`/`decline`/`retarget`), each carrying `flag_id` — read by `lore status`'s flags section and `lore trace flag` (`lore_core/flag_metrics.py`) |
 
 **Schema-version policy:** `SCHEMA_VERSION` (currently `1`) bumps on any

--- a/docs/how-to/measure-flag-quality.md
+++ b/docs/how-to/measure-flag-quality.md
@@ -1,11 +1,13 @@
 # Measure flag quality: known-gem baseline and directive flip-probe
 
 **Goal:** catch under-flagging before it erodes trust in the flag
-architecture. The flag is the only crossing from a private session to
-the team wiki — a fact an agent should have flagged and didn't leaves no
-trace anywhere a human would look. Under-flagging is measurable only by
-deliberately checking for it; it does not show up as an error, a
-dead-lettered flush, or any other alert `lore status` already earns.
+architecture. The flag is the crossing from a private session to the
+team wiki, and the only one left once the teardown retires the
+session-note compose pipeline — a fact an agent should have flagged and
+didn't leaves no trace anywhere a human would look. Under-flagging is
+measurable only by deliberately checking for it; it does not show up as
+an error, a dead-lettered flush, or any other alert `lore status`
+already earns.
 
 Background: the flag shape and the "measurement before trust" rule are
 recorded in [`brainstorms/lore-session-notes-worth.md`](../../brainstorms/lore-session-notes-worth.md)

--- a/docs/prd/0011-session-note-retirement-flag-architecture.md
+++ b/docs/prd/0011-session-note-retirement-flag-architecture.md
@@ -1,0 +1,120 @@
+---
+title: Session-note retirement + flag architecture
+status: draft
+epic: https://github.com/buchbend/lore/issues/362
+repos:
+  - buchbend/lore
+---
+
+# PRD 0011: Session-note retirement + flag architecture
+
+> Source of truth for this epic. Tracker: [epic issue](https://github.com/buchbend/lore/issues/362).
+> The epic links here; this file is not embedded in the issue body.
+> Decisions recorded in ADR [0007](../adr/0007-session-notes-retired-flags-are-the-crossing.md),
+> ADR [0008](../adr/0008-flag-lands-marked-unreviewed.md),
+> ADR [0009](../adr/0009-privacy-boundary-is-locality.md). Design input:
+> `brainstorms/lore-session-notes-worth.design.md`.
+
+## Problem
+
+Lore composes a session note for every working session. Almost nobody
+reads them. The 2026-08 telemetry sweep counted 17 note pulls per month
+across 307 sessions; every pulled note was at most 7 days old, and the
+archival reader never appeared. The pipeline costs about 46 LLM calls
+per day and produced 60 errors plus 91 force-flushes in 8 days. One
+session produced a 1,636-line note holding 6–8 genuine gems. Two PRDs
+(0002, 0008) reworked the note mechanism; the noise complaint outlived
+both. The team pays a constant LLM and attention tax for a surface it
+does not use, while the few genuine gems drown.
+
+## Solution
+
+Retire session notes as vault files. Three layers replace them
+(ADR 0007):
+
+- **Team layer** — repo artifacts (ADRs, PRDs, issues, PRs, docs, code)
+  and wiki topic/project notes. The lore-workflow chain produces the
+  artifacts; the wiki holds only what a human wants to read.
+- **Personal layer** — raw transcripts plus the transcript ledger, both
+  machine-local by design (ADR 0009). The owner drills their own
+  archive; a colleague asks the owner.
+- **The crossing** — the flag: one team-relevant fact with a lead
+  sentence, short body, and deterministic origin line. An agent files it
+  the moment a gem appears. The flag lands in the owning topic note
+  immediately, marked unreviewed; the owner reviews pending flags in a
+  pull-based walk — accept, retarget, decline, or skip (ADR 0008). The
+  banner nudges with a count only. Nothing interrupts a session.
+
+Continuity becomes deterministic: the SessionStart banner renders a
+last-active-day recap from the transcript ledger with zero LLM calls.
+Capture needs no API key; lore's LLM backend becomes optional.
+
+Rollout is additive-first. The flag primitive and ledger expansion ship
+beside the existing pipeline. Measurement (flag rate, review latency,
+accept rate, known-gem baseline) is mandatory before trust. The
+teardown is the last step, taken with that evidence in hand.
+
+## Implementation decisions
+
+- **Flag write** — one deterministic write verb on the journal pattern:
+  CLI verb plus MCP tool, no pipeline, no lore-owned LLM call. Refs in
+  the origin line are code-verified at write; uncheckable refs keep
+  stamped session-talk phrasing (ADR 0004). Hard gate: no origin, no
+  flag. No kind taxonomy; tags optional.
+- **Flag landing** — route-before-write: lore proposes the owning topic
+  note by search ranking when the caller names none; a new topic note is
+  created only when no home exists. Append-only for agents; humans own
+  bodies. The unreviewed marker is the single machine-readable pending
+  token; pending state is derived by scanning, no queue store
+  (ADR 0008). Human-authored flags land unmarked.
+- **Sensitivity gate** — evaluates flag text at write time, fails
+  closed, quarantines withheld text. After teardown the gate's scope is
+  flags only.
+- **Transcript ledger** — the existing per-session ledger store gains a
+  linkage block: repo, branch, PRs, issues, commits, files. Populated at
+  capture time, zero-LLM, derived and rebuildable. Older entries load
+  unchanged (one-release back-compat precedent exists).
+- **Migration** — one command backfills linkage for the archived
+  transcript stock, then deletes the session-note files. Dry-run is the
+  default; `--apply` executes. No LLM harvest of the old notes — the
+  no-LLM-distills-LLM constraint forbids rescue layers.
+- **Retrieval** — drill and search answer "which sessions touched X"
+  with transcript pointers, owner-local only. `lore_resume` is removed;
+  the context-pack keeps the gather code it imports.
+- **Observability** — one spine event per flag write, per review
+  verdict, and per ledger-backed read. Status and trace surface the
+  counters.
+- **Config** — per-wiki compose keys retire with the pipeline; the
+  backend key stays optional. Removed keys warn once and are ignored.
+- **Retirement discipline** — the teardown slice is HITL: the owner
+  gates it on measurement evidence. Until it lands, the shipped
+  session-note code keeps running untouched.
+
+## Testing decisions
+
+- Every new path is deterministic, so tests assert exact external
+  behavior with no LLM anywhere: flag write → note content, gate
+  withhold → quarantine entry, review verdicts → note diffs, ledger
+  upsert → entry shape, banner → rendered lines.
+- Migration tests run against a fixture vault, never a real one, and
+  assert the dry-run plan equals the applied result.
+- Back-compat tests load pre-change ledger entries and pre-change wiki
+  configs.
+- Prior art: the publish-gate scanner tests (fail-closed), ledger
+  round-trip tests, and the journal CLI tests.
+- The teardown's regression net is the retained-path suites (capture,
+  ledger, flags); tests for removed paths are deleted with the code.
+
+## Out of scope
+
+- Briefings. Parked with their config and code dormant; revisit with
+  flag-rate evidence (a flag/topic-note digest is the candidate source).
+- The freshness-verdict machinery. The review walk is a separate,
+  self-contained build.
+- Journals, inbox, and the retained frontmatter-only hygiene passes.
+- Same-person multi-machine sync. Documented limitation (ADR 0009), not
+  a feature.
+- LLM harvesting of the retired note stock.
+- Vault-side content hygiene (orientation note rewrite) — done by the
+  owner directly, not by this epic.
+- The 61 legacy concept notes — they stay as read-only stock.

--- a/docs/prd/index.md
+++ b/docs/prd/index.md
@@ -16,4 +16,5 @@ PRDs are the source of truth for decisions. Each PRD lives at
 0008-typed-fact-session-notes
 0009-issue-register
 0010-join-the-writing-rules-to-the-glossary
+0011-session-note-retirement-flag-architecture
 ```

--- a/lib/lore_cli/flag_cmd.py
+++ b/lib/lore_cli/flag_cmd.py
@@ -1,7 +1,9 @@
 """``lore flag`` — file one team-relevant fact, and review the ones filed.
 
-A flag is the only crossing from a working session to the wiki: one
+A flag is a deliberate crossing from a working session to the wiki: one
 stamped fact, appended to the owning topic note the moment it appears.
+It becomes the only crossing once the teardown retires the session-note
+compose pipeline, which still writes into the wiki today.
 
   lore flag write "lead sentence" --body "why it matters" --ref pr:357
   lore flag review                     walk the unreviewed flags
@@ -140,9 +142,7 @@ def cmd_list(
         _emit_json(
             {
                 "schema": "lore.flag.list/1",
-                "data": [
-                    {"id": f.id, "note": f.note_path, "lead": f.lead} for f in items
-                ],
+                "data": [{"id": f.id, "note": f.note_path, "lead": f.lead} for f in items],
             }
         )
         return

--- a/lib/lore_cli/migrate_cmd.py
+++ b/lib/lore_cli/migrate_cmd.py
@@ -125,6 +125,10 @@ def cmd_retire_session_notes(
     ledger — it is one machine-local store, not a per-wiki one, and
     stamping a linkage block is additive.
 
+    Capture still writes new session notes into ``sessions/`` at every
+    session boundary; the stock this deletes starts refilling until the
+    compose pipeline is retired.
+
     Prints the plan and changes nothing unless ``--apply`` is passed.
     Notes are markdown in git — recover a mistaken run from the wiki's
     history.
@@ -160,6 +164,11 @@ def cmd_retire_session_notes(
     if not apply:
         console.print(
             "\n[dim]dry-run; nothing changed. Pass --apply to backfill and delete.[/dim]"
+        )
+        console.print(
+            "[dim]Capture still writes new session notes until the compose "
+            "pipeline is retired.[/dim]",
+            soft_wrap=True,
         )
         return
 

--- a/lib/lore_cli/status_cmd.py
+++ b/lib/lore_cli/status_cmd.py
@@ -279,8 +279,9 @@ def _wikis_lines(lore_root: Path, offline: bool) -> list[str]:
 # ---------------------------------------------------------------------------
 # flags section — per-wiki counters from the flag spine (#360)
 #
-# The flag is the only crossing from a private session to the team wiki
-# (PRD 0010); under-flagging is invisible without this. Reads only —
+# The flag is the crossing from a private session to the team wiki, and the
+# only one left once the teardown retires the compose pipeline (PRD 0011);
+# under-flagging is invisible without this. Reads only —
 # lore_core.flag_metrics aggregates flag.py's own spine events plus
 # flag.count_pending (never reconstructed, ADR 0008).
 # ---------------------------------------------------------------------------

--- a/lib/lore_core/flag.py
+++ b/lib/lore_core/flag.py
@@ -1,9 +1,11 @@
 """The flag — one stamped, standing-alone fact crossing into the wiki.
 
-A flag is the only path from a working session to the team surface: an
-agent files one team-relevant fact the moment it appears, and Lore
-appends it to the owning topic note straight away, marked unreviewed
-(``docs/adr/0008``). Nothing here composes, summarises or judges — the
+A flag is the deliberate path from a working session to the team
+surface: an agent files one team-relevant fact the moment it appears,
+and Lore appends it to the owning topic note straight away, marked
+unreviewed (``docs/adr/0008``). It becomes the only path once the
+teardown retires the session-note compose pipeline, which still writes
+into the wiki today. Nothing here composes, summarises or judges — the
 caller supplies a lead sentence and a short body, and every word around
 them is written by code.
 
@@ -161,8 +163,7 @@ def _neutralize(text: str) -> str:
     """
     text = text.replace("<!--", "&lt;!--")
     return "\n".join(
-        "\\" + line if line.startswith(ORIGIN_PREFIX) else line
-        for line in text.split("\n")
+        "\\" + line if line.startswith(ORIGIN_PREFIX) else line for line in text.split("\n")
     )
 
 
@@ -208,9 +209,7 @@ def _weakest(refs: Sequence[tuple[str, str]], verdicts: dict[tuple[str, str], st
     return VERIFIED
 
 
-def _ref_clause(
-    refs: Sequence[tuple[str, str]], verdicts: dict[tuple[str, str], str]
-) -> str:
+def _ref_clause(refs: Sequence[tuple[str, str]], verdicts: dict[tuple[str, str], str]) -> str:
     parts = []
     for ref_type, value in refs:
         stamp = _STAMPS[verdicts.get((ref_type, value), UNCHECKED)]
@@ -345,9 +344,7 @@ def _wiki_path(wiki: str | None, cwd: Path | None) -> Path:
 
     scope = resolve_scope(cwd or Path.cwd())
     if scope is None:
-        raise ValueError(
-            "no wiki resolved — pass a wiki name or run inside an attached repo"
-        )
+        raise ValueError("no wiki resolved — pass a wiki name or run inside an attached repo")
     return root / scope.wiki
 
 
@@ -389,9 +386,7 @@ def _append_block(path: Path, block: str, *, description: str, day: str) -> bool
     }
     dumped = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
     path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_text(
-        path, f"---\n{dumped}\n---\n\n# {_titleize(slug)}\n\n{block}\n"
-    )
+    atomic_write_text(path, f"---\n{dumped}\n---\n\n# {_titleize(slug)}\n\n{block}\n")
     return True
 
 
@@ -447,9 +442,7 @@ def write(
     refs = [(str(t).strip(), str(v).strip()) for t, v in refs if str(v).strip()]
     transcript = (transcript or os.environ.get("CLAUDE_SESSION_ID") or "").strip()
     if not transcript and not refs:
-        raise OriginMissing(
-            "a flag needs an origin: pass a transcript pointer or at least one ref"
-        )
+        raise OriginMissing("a flag needs an origin: pass a transcript pointer or at least one ref")
 
     day = now or date.today().isoformat()
     if author is None:
@@ -610,10 +603,7 @@ def flags_in(path: Path) -> list[PendingFlag]:
         lines = _read(path)
     except (OSError, UnicodeDecodeError):
         return []
-    return [
-        _block_to_flag(path, fid, lines[start : end + 1])
-        for fid, start, end in _spans(lines)
-    ]
+    return [_block_to_flag(path, fid, lines[start : end + 1]) for fid, start, end in _spans(lines)]
 
 
 def pending(wiki_path: Path) -> list[PendingFlag]:

--- a/lib/lore_core/flag_metrics.py
+++ b/lib/lore_core/flag_metrics.py
@@ -1,8 +1,9 @@
 """Read-side flag measurement — aggregating `flag.py`'s spine events (#360).
 
-Under-flagging is the flag architecture's main failure mode (PRD 0010)
-and is invisible without measurement: the flag is the only crossing from
-a private session to the team wiki, so a fact an agent should have
+Under-flagging is the flag architecture's main failure mode (PRD 0011)
+and is invisible without measurement: the flag is the crossing from a
+private session to the team wiki, and the only one left once the
+teardown retires the compose pipeline, so a fact an agent should have
 flagged and didn't leaves no trace anywhere a human would look. This
 module reads what `flag.py` already emits — nothing here writes, and
 nothing here duplicates the pending scan (`flag.count_pending` stays the

--- a/lib/lore_core/session_start.py
+++ b/lib/lore_core/session_start.py
@@ -466,9 +466,10 @@ def render_session_banner(facts: SessionFacts) -> str:
     directive as a postscript — so users see what Lore did *first* and
     the rule re-assertion second.
 
-    The recap replaced the last-session note hints: notes are retired,
-    and continuity now comes from a store that costs no LLM call to
-    write and survives the note files being deleted.
+    The recap replaced the last-session note hints. Continuity now comes
+    from a store that costs no LLM call to write and survives the note
+    files being deleted. Capture still writes session notes until the
+    teardown retires that pipeline; the banner no longer reads them.
     """
     injected_bits: list[str] = []
     if facts.scope:

--- a/lib/lore_curator/retire_session_notes.py
+++ b/lib/lore_curator/retire_session_notes.py
@@ -18,6 +18,11 @@ order:
 The plan is the contract. :func:`plan_retirement` reads and computes but
 writes nothing; :func:`apply_retirement` executes exactly the plan it is
 handed, so a dry run and a real run can be compared file by file.
+
+The deletion is not final while the compose pipeline still runs: capture
+writes a new session note at every session boundary, so the stock refills
+until that pipeline is retired. Running this verb again clears whatever
+accumulated since the last run.
 """
 
 from __future__ import annotations

--- a/tests/test_retire_session_notes.py
+++ b/tests/test_retire_session_notes.py
@@ -214,6 +214,36 @@ def test_cli_with_apply_deletes(vault: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert TranscriptLedger(vault).get("claude-code", "t1").linkage["issues"] == [358]
 
 
+def test_help_says_capture_still_writes_new_notes() -> None:
+    """The verb deletes a stock that capture immediately starts refilling.
+
+    The compose pipeline keeps writing into `sessions/` at every session
+    boundary until the teardown lands, so a reader who does not know that
+    reads the deletion as final.
+    """
+    from lore_cli import migrate_cmd
+
+    result = CliRunner().invoke(migrate_cmd.app, ["retire-session-notes", "--help"])
+
+    assert result.exit_code == 0
+    flat = " ".join(result.output.split())
+    assert "Capture still writes new session notes" in flat
+
+
+def test_dry_run_footer_says_capture_still_writes_new_notes(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same fact at the point of decision, not only in `--help`."""
+    from lore_cli import migrate_cmd
+
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    result = CliRunner().invoke(migrate_cmd.app, ["retire-session-notes"])
+
+    assert result.exit_code == 0
+    flat = " ".join(result.output.split())
+    assert "Capture still writes new session notes" in flat
+
+
 # ---------------------------------------------------------------------------
 # Containment — the delete path must never leave the vault
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

The whole-epic review of #368 returned FAIL with five cross-feature defects. This PR fixes all five against `epic/362`. Issue #361 (teardown) stays open, so the LLM compose pipeline is still live; three of the five fixes exist because shipped text describes the post-teardown end state as already arrived.

## Changes

### 1. ADR 0007, 0008 and 0009 land

Shipped code, docs and tests cite these three decision records 15 times. `docs/adr/` held 0001-0006 only. `docs/adr/0005` is the repo's own rule that docs land with the epic, so they land here.

- `docs/adr/0007-session-notes-retired-flags-are-the-crossing.md`
- `docs/adr/0008-flag-lands-marked-unreviewed.md`
- `docs/adr/0009-privacy-boundary-is-locality.md`
- `docs/adr/0001` and `docs/adr/0003` go to `Status: Superseded by ADR 0007`

Every `ADR NNNN` and `docs/adr/NNNN` citation in the tree now resolves to a file.

### 2. The design PRD lands as 0011

`docs/prd/0010-join-the-writing-rules-to-the-glossary.md` already holds 0010, so `PRD 0010` resolved to the wrong document. The design PRD lands as `docs/prd/0011-session-note-retirement-flag-architecture.md` with a row in `docs/prd/index.md`.

Citations updated: `lore_core/flag_metrics.py`, `lore_cli/status_cmd.py`, and the Context line of all three new ADRs. A sweep over every tracked `.md` and `.py` found no other flag-architecture reference to 0010. `tests/test_vale_style.py` and `tests/test_writing_rules.py` name 0010 for the writing-rules PRD and stay as they are.

### 3. The migration says the stock refills

`lore migrate retire-session-notes --apply` deletes session notes that `lore_curator/chapter_flush.py` and `lore_curator/session_note.py` re-create at the next session boundary. One sentence now says so in three places:

- the verb's `--help`
- the dry-run plan footer, where the reader decides
- `lore_curator/retire_session_notes.py`'s module docstring

Two tests cover the help text and the footer.

### 4. `CONTEXT.md` and six comments stop over-claiming

- The banner paragraph described the removed last-session hints. It now describes the last-active-day recap: three lines off the transcript ledger, naming the day with its session count and repos, the branches, and the issue and PR numbers.
- "the only crossing from a session to the team surface" is the state the teardown reaches, not today's. Qualified in `CONTEXT.md`, `lore_core/flag.py`, `lore_cli/flag_cmd.py`, `lore_core/flag_metrics.py`, `lore_cli/status_cmd.py`, `docs/how-to/measure-flag-quality.md`, and `lore_core/session_start.py` (which asserted "notes are retired").

### 5. `observability.md` gains the `mcp` producer

`mcp` was in `spine.SOURCES` and emitting from `lore_core/ledger.py:434` with no table row. Added, verified against the emit site: one `ledger-query` per `lore_drill` call whose query names an issue, a PR, an epic or a file path; a query naming none of those returns before the emit. The prose list of the closed source set one paragraph up was missing both `mcp` and `flag` — same defect, same file, also fixed. No other member of `SOURCES` is now absent from the table.

## Out of scope

The review's non-blocking debt is untouched: the three `_parse_ts` implementations, the three wiki-enumeration helpers, the two `_iter_session_notes`, and the orphaned `SessionFacts.session_hints`. No version bump, no `CHANGELOG.md` edit — that lands as its own release PR.

## Verification

- `pytest -q`: 3030 passed, 4 failed, 30 skipped. The 4 are the rich/ANSI failures inherited from `main` (`test_cli_scopes.py`, `test_core_llm_wiring.py` x2, `test_install_dispatcher.py`).
- `ruff check` and `ruff format --check` pass on every file this PR touches. `lore_core/flag.py` and `lore_cli/flag_cmd.py` were among #365's format-dirty files and are now format-clean. Files this PR does not touch were not reformatted.
