### PR TITLE
docs: flag lifecycle, ledger retirement, and flag measurement (epic #362)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -352,3 +352,38 @@ Terms used in the workflow layer and orchestration:
 - **Piece of work** — a body of work a team plans and tracks. An issue, a
   pull request, an epic and a batch of issues are pieces of work. A team
   points at one by its issue number, never by a coined short name.
+
+### Flag architecture
+
+The flag primitive, the transcript ledger's linkage block and the
+measurement surfaces ship today. The teardown that retires the
+session-note compose pipeline does not. Capture still writes a session
+note at every session boundary. The session-note sections above still
+describe running code. Decisions in ADR 0007–0009, spec in PRD 0011.
+
+- **Flag** — one team-relevant fact an agent files during a session: a
+  lead sentence, a short body, and an origin line. The only LLM-authored
+  content a session writes into a wiki. Say "flag", not "gem" or
+  "prospect".
+- **Crossing** — the path a fact takes from a working session to the team
+  wiki. The flag is the deliberate crossing, and becomes the only one when
+  the teardown lands.
+- **Origin line** — the deterministic attribution line closing a flag
+  block: author, date, code-verified refs, transcript pointer. A write
+  carrying no transcript pointer and no ref is refused.
+- **Unreviewed marker** — the token ending an agent-filed flag's origin
+  line until a human accepts it. Accept is the only verdict that removes
+  it. A human-filed flag lands without it.
+- **Review walk** — the pull-based pass over unreviewed flags
+  (`lore flag review`): accept, retarget, decline, or skip. The banner
+  shows a count of pending flags and never their content.
+- **Transcript ledger** — the machine-local store mapping each session to
+  its transcript (`.lore/transcript-ledger.json`). Derived and
+  rebuildable. Say "transcript ledger", not "breadcrumb ledger".
+- **Linkage block** — the ledger entry's `repo`, `branch`, `prs`,
+  `issues`, `commits` and `files` keys, written by capture with no LLM
+  call. It is what `lore_drill` reads to answer "which sessions touched
+  X" and what the SessionStart recap renders from.
+- **Context finder** — Lore's retrieval role: the tools that find where
+  context lives and pull it in (`lore_search`, `lore_drill`, context
+  pack, codemap, repo docs). Say "context finder", not "funnel".

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ issue, and `tdd` as the discipline every implementation teammate follows.
 See [`docs/conventions.md`](docs/conventions.md) for the full chain, the
 artifact-home contract (PRD/ADR/`AGENTS.md` placement), and the tier
 vocabulary; [`docs/how-to/`](docs/how-to/) for task recipes
-(run an epic, use the fast path, resume a broken epic, onboard a repo); and
+(run an epic, use the fast path, resume a broken epic, onboard a repo, file
+and review flags); [`docs/explanation/`](docs/explanation/) for the
+reasoning behind the design; and
 [`lore-workflow/README.md`](lore-workflow/README.md) for the skill roster.
 
 Install both from this one marketplace:
@@ -258,10 +260,11 @@ Once attached with a wiki present:
   attempt and closes, under a global singleton lock. All detached —
   SessionStart never blocks.
 - **Banner at SessionStart** is deliberately minimal: a status line, an
-  optional Focus block, at most two last-session hints, freshness
-  lines only on positive evidence, and a fixed directive pointing at
-  MCP pull for anything deeper. `lore!:` prefix flags actionable
-  errors.
+  optional Focus block, a last-active-day recap read off the transcript
+  ledger (day, session count, repos, branches, refs — no LLM call), a
+  count of pending flags, freshness lines only on positive evidence, and
+  a fixed directive pointing at MCP pull for anything deeper. `lore!:`
+  prefix flags actionable errors.
 
 ### Manual escape hatches
 
@@ -282,6 +285,14 @@ Once attached with a wiki present:
   list configured wikis and validate them. (For looking up the
   attachment covering a specific path, use `lore attach attachments show
   <path>`.)
+- `lore flag write "<lead>" --ref pr:123` — file one team-relevant fact
+  into its owning topic note. `lore flag list` shows what is pending;
+  `lore flag review` walks it (accept / retarget / decline / skip). See
+  [`docs/how-to/file-and-review-flags.md`](docs/how-to/file-and-review-flags.md).
+- `lore migrate retire-session-notes [--apply]` — backfill the transcript
+  ledger from the archived transcripts, then delete the session-note
+  stock. Dry-run by default; `--apply` deletes files. See
+  [`docs/how-to/retire-session-notes.md`](docs/how-to/retire-session-notes.md).
 
 ### Per-wiki configuration
 

--- a/docs/architecture/session-note-lifecycle.md
+++ b/docs/architecture/session-note-lifecycle.md
@@ -13,6 +13,15 @@ explains the **lifecycle** that vocabulary moves through — `create → close �
 segment → extract → render → seal` — and the guarantee it exists to keep:
 **one session produces exactly one note.**
 
+> **Status.** This lifecycle runs today. Its retirement is decided but not
+> yet executed
+> ([ADR 0007](../adr/0007-session-notes-retired-flags-are-the-crossing.md)):
+> the flag primitive and the transcript ledger's linkage block shipped
+> beside this pipeline, not in place of it. `lore migrate
+> retire-session-notes` deletes the note stock, and capture refills it at
+> the next session boundary until the compose pipeline itself goes. See
+> [why one flag, and not a session note](../explanation/why-the-flag-is-the-crossing.md).
+
 ---
 
 ## One flush, and it is the ending

--- a/docs/explanation/why-notes-are-written-at-session-end.md
+++ b/docs/explanation/why-notes-are-written-at-session-end.md
@@ -9,6 +9,16 @@ Both come from one decision: **the model never writes the words that carry
 authority, and it writes nothing at all until the session is over.** This page
 explains what that buys and what it costs.
 
+> **Status.** This pipeline still runs, and still writes a session note at
+> every session boundary. Its retirement is decided but not yet executed:
+> the team has ratified replacing the note with the flag — one stamped fact
+> filed into its owning topic note
+> ([ADR 0007](../adr/0007-session-notes-retired-flags-are-the-crossing.md)) —
+> and the flag primitive shipped beside this pipeline rather than in place of
+> it. See
+> [why one flag, and not a session note](why-the-flag-is-the-crossing.md).
+> Everything below describes code that runs today.
+
 ---
 
 ## Composing forward recorded the working, not the work
@@ -142,3 +152,5 @@ session should not ingest as settled.
   the mechanics: buffer, close, segment, extract, render, verify, publish gate.
 - [PRD 0008](../prd/0008-typed-fact-session-notes.md) — the full problem
   statement and the per-decision rationale.
+- [Why one flag, and not a session note](why-the-flag-is-the-crossing.md) —
+  why the per-session write-up is being retired, and what replaces it.

--- a/docs/explanation/why-the-flag-is-the-crossing.md
+++ b/docs/explanation/why-the-flag-is-the-crossing.md
@@ -1,0 +1,170 @@
+# Why one flag, and not a session note
+
+**Audience:** anyone who sees an unreviewed block appear in a topic note they
+own, or who wonders why Lore asks an agent to file one fact at a time
+instead of writing up the session.
+
+---
+
+## The measurement that ended session notes
+
+Lore composed a note for every working session. The 2026-08 telemetry sweep
+counted what those notes were worth:
+
+- Readers pulled a session note 17 times per month across 307 sessions.
+- Every pulled note was at most 7 days old. The archival reader never
+  appeared.
+- The pipeline cost about 46 LLM calls per day, and eight days of runs
+  produced 60 errors and 91 force-flushes.
+- The retrieval tools that find context in the repo out-used note retrieval
+  about 4.5 to one.
+- One session produced a 1,636-line note holding six to eight facts worth
+  keeping.
+
+Two earlier reworks (PRD 0002, PRD 0008) each changed *how* the note was
+composed. The noise complaint outlived both. The third reading is that the
+mission was wrong, not the mechanism: a per-session write-up is the wrong
+unit. It bundles six good facts with a thousand lines of process narration,
+and a reader has to find the six.
+
+[ADR 0007](../adr/0007-session-notes-retired-flags-are-the-crossing.md)
+records the decision that follows.
+
+## Three layers, one crossing
+
+| Layer | Holds | Who reads it |
+|---|---|---|
+| Team | Repo artifacts (ADRs, PRDs, issues, PRs, docs, code) and wiki topic notes | Everyone |
+| Personal | Raw transcripts and the transcript ledger, machine-local | The owner |
+| Crossing | The flag | Everyone, once it is filed |
+
+Most of what a session produces already belongs on the team layer, and the
+workflow chain already puts it there — a decision becomes an ADR, a plan
+becomes a PRD, work becomes a PR. Nothing needs a second, prose copy of that
+in a note.
+
+What is left over is the interesting part: a trap avoided, a dead end and
+the reason it was dead, reasoning nobody wrote down, a gap between the docs
+and the code. Those facts have no artifact. They are what the flag carries.
+
+The personal layer holds the raw material. Transcripts and the ledger stay on
+one machine and are gitignored, and Lore ships no sync for them
+([ADR 0009](../adr/0009-privacy-boundary-is-locality.md)). That boundary is
+locality, not access control — there is no server to configure and no key to
+manage, and the raw record structurally cannot reach the team surface. The
+cost is stated rather than hidden: a lost machine loses that machine's raw
+record, and same-person multi-machine use is a documented limitation.
+
+## Why the flag is small and stamped
+
+A flag carries one fact: a lead sentence, a short body, and an origin line
+that code writes in full. There is no kind taxonomy and no composition step.
+
+**One fact, because a fact is the retrievable unit.** A note bundles facts
+that have nothing to do with each other except a shared afternoon, so it
+lands in one place while its contents belong in five. A flag routes to the
+topic note the fact is actually about, which is where a reader searching
+those words will look.
+
+**Filed at the moment, because worth is knowable then.** A session note had
+to be composed backward from the whole transcript, and a model had to guess
+which lines a reader would want. The agent that just hit the trap already
+knows it hit one.
+
+**Stamped, because the model does not get to author authority.** Refs are
+verified against the repo at write time, and the phrasing follows from what
+the check returned
+([ADR 0004](../adr/0004-authority-phrasing-is-code-stamped.md)). A hallucinated
+PR number costs authority instead of buying it. A write carrying no
+transcript pointer and no ref is refused outright: a fact with nothing behind
+it has no business on a shared surface.
+
+**A human's flag is not stamped.** The phrasing rules exist to constrain what
+a model may claim, not what a person writes, so a flag you file from your own
+shell keeps your words and lands already reviewed.
+
+## Why it lands immediately, marked unreviewed
+
+The obvious design is a queue: hold the agent's flag under `.lore/`, and
+write it into the wiki when a human approves it. Lore rejected that
+([ADR 0008](../adr/0008-flag-lands-marked-unreviewed.md)).
+
+A queue makes the gem invisible for exactly as long as the owner is busy,
+which is exactly when it matters most. Queue rot is silent — an unwalked
+queue looks identical to an empty one, and the facts inside it never reach
+the teammate who needed them yesterday. Landing the flag immediately means a
+teammate sees it fresh, labelled as unreviewed, and can judge it themselves.
+
+What the marker buys instead is honesty about provenance. LLM-authored text
+on a human surface is a poisoning surface: a machine-written line that a
+later session reads as settled, restates, and thereby makes look
+better-attested than it is. The `unreviewed` token at the end of the origin
+line says, in the reader's own line of sight, that no human has confirmed
+this. Accept is the only verdict that removes it.
+
+The trade is stated in the ADR: unreviewed text is visible until someone
+reviews it, and review latency replaces under-flagging as the failure that
+hides. Both are measured — see
+[measure flag quality](../how-to/measure-flag-quality.md).
+
+## Why review is a pull, not a prompt
+
+Nothing about a flag interrupts a session. The agent files and moves on; the
+SessionStart banner shows a count and never the content; the review runs when
+you type `lore flag review`.
+
+This is the same rule the banner has always followed — deep context is a
+pull, never a push. Pushing a review prompt into a session would put a
+teammate's unreviewed text into your context window at a moment you did not
+choose, which is precisely the poisoning path the marker exists to close. A
+count is safe to push because a count says nothing.
+
+The walk itself is snapshotted before it starts, so a retarget that moves a
+flag into a note you have already passed cannot show it to you twice. Skip is
+the default verdict, so pressing Enter through the walk is a no-op rather
+than a bulk accept.
+
+## Why pending state is derived, never stored
+
+The marker in the note *is* the pending state. `lore flag list` finds pending
+flags by scanning notes for the token; no queue file records them.
+
+A queue store would be a second copy of a fact the wiki already holds, and
+two copies drift. Someone edits a note by hand, someone reverts a commit,
+someone resolves a merge conflict — and the store now disagrees with the
+wiki about what is pending, with no way to tell which is right. Scanning is
+slower and cannot drift. `lore status` is honest about the seam this leaves:
+the pending count comes from the scan while the accept and decline counts
+replay spine events, so the two are not expected to sum.
+
+## What has not happened yet
+
+The compose pipeline still runs. Capture still writes a session note at every
+session boundary, and the sensitivity gate still covers note text as well as
+flag text. The flag shipped *beside* the old pipeline, not in place of it.
+
+That is deliberate. The rollout is additive-first, and the teardown is gated
+on evidence: a flag rate measured against known gems, a review latency, an
+accept rate. Under-flagging is the failure mode that leaves no trace — a fact
+the agent should have flagged and didn't produces no error, no alert, and no
+gap anyone would notice. Retiring the pipeline before that is measured would
+trade a surface nobody reads for one nobody can check.
+
+So the honest statement of today's system is: the flag is the deliberate
+crossing, and the note pipeline is the one still running underneath it. The
+flag becomes the *only* crossing when the teardown lands.
+
+## See also
+
+- [ADR 0007](../adr/0007-session-notes-retired-flags-are-the-crossing.md) —
+  the three layers, and what the teardown retires.
+- [ADR 0008](../adr/0008-flag-lands-marked-unreviewed.md) — the landing
+  decision, the rejected queue, and the marker.
+- [ADR 0009](../adr/0009-privacy-boundary-is-locality.md) — why transcripts
+  never leave the machine.
+- [PRD 0011](../prd/0011-session-note-retirement-flag-architecture.md) — the
+  full problem statement and the per-decision rationale.
+- [File a flag, and review the flags agents filed](../how-to/file-and-review-flags.md)
+  — the commands.
+- [Why a session note is written only at the end](why-notes-are-written-at-session-end.md)
+  — the pipeline that is still running, and the reasoning it was built on.

--- a/docs/how-to/file-and-review-flags.md
+++ b/docs/how-to/file-and-review-flags.md
@@ -1,0 +1,121 @@
+# File a flag, and review the flags agents filed
+
+**Goal:** get one team-relevant fact out of a working session and onto the
+team wiki, then walk what landed and keep or drop each item.
+
+A flag is one fact with a lead sentence, a short body and a stamped origin
+line. Lore appends it to the owning topic note the moment it is filed. An
+agent files flags through the `lore_flag` MCP tool; you file your own with
+`lore flag write`.
+
+The compose pipeline still writes session notes at every session boundary.
+The flag runs beside it. It becomes the only crossing from a session to the
+team wiki once the teardown retires that pipeline —
+[why the flag is the crossing](../explanation/why-the-flag-is-the-crossing.md)
+explains the target state and what is still outstanding.
+
+## Before you start
+
+- A wiki that `lore scopes wikis` lists, and a repo attached to it.
+- Run every command below from inside the attached repo, or pass `--wiki
+  <name>`. Without either, `lore flag` exits 2 and tells you so.
+
+## File a flag yourself
+
+```
+lore flag write "The reaper starves mid-drain when two sessions race the lock." \
+  --body "The loser never retried, so the second buffer sat until the next boundary." \
+  --ref pr:357 --ref commit:3f9a2c1
+```
+
+Rules the write path enforces:
+
+- **No origin, no flag.** Pass at least one `--ref`, or a `--transcript`
+  id. Inside a Claude Code session `$CLAUDE_SESSION_ID` supplies the
+  transcript automatically. A plain shell has no session id, so pass a
+  `--ref` there. A write with neither exits 1.
+- **`--ref` takes `TYPE:VALUE`** — `pr`, `issue`, `commit`, `file` or
+  `tag`. Repeat it per ref. Lore verifies each ref against the repo at
+  write time. A ref it cannot check keeps session-talk phrasing; a ref
+  that does not exist demotes the whole origin line.
+- **Your words stay your words.** A flag written from your shell is
+  human-authored: it lands without the unreviewed marker and skips the
+  code-stamped phrasing. Pass `--agent` when you file on a model's
+  behalf, and the flag lands stamped and unreviewed.
+- **`--json`** prints the `lore.flag.write/1` envelope for scripting.
+
+### Choose where it lands
+
+Name the note with `--target`, as a wiki-relative path (`concepts/reaper.md`)
+or a bare slug (`reaper`). Lore refuses a target that resolves outside the
+wiki.
+
+Without `--target`, Lore ranks the wiki with the ordinary search backend and
+picks the top-ranked existing note — a flag lands where a reader searching
+the same words would look. Session notes are never a target. When nothing
+fits, Lore creates a new topic note under `concepts/` named after the lead.
+The command prints `created` or `appended to` with the path either way.
+
+### When the gate withholds a flag
+
+The publish gate reads the flag text before anything else touches it, and it
+fails closed. A withheld write exits 1 and prints a quarantine id:
+
+```
+withheld (secret) — text held in quarantine 8f2c1a4b9de0;
+`lore quarantine show 8f2c1a4b9de0`
+```
+
+Nothing reached the wiki. Read the held text, rewrite the fact without the
+material that tripped the gate, and file it again.
+
+## See what is pending
+
+```
+lore flag list
+```
+
+One line per unreviewed flag: id, note, lead. The SessionStart banner shows
+the same thing as a bare count — `· 3 pending flags` — and never the text of
+a flag.
+
+## Walk the review
+
+```
+lore flag review
+```
+
+Lore snapshots the pending list, then shows one flag at a time with its full
+block and prompts `accept / retarget / decline / skip? [a/r/d/s]`. The
+default is skip, so pressing Enter through the walk changes nothing.
+
+| Verdict | What Lore does | Still pending after? |
+|---|---|---|
+| `a` accept | Removes the unreviewed marker. Nothing else in the note changes. | No |
+| `r` retarget | Prompts for a note, moves the block there, creates the note when it is missing. | Yes |
+| `d` decline | Deletes the flag block. The note's own prose is untouched. | No |
+| `s` skip | Nothing. | Yes |
+
+Retarget corrects where a flag lives, not whether you endorse its text, so
+the marker stays and the flag returns in the next walk. A target you mistype
+loses that one verdict and prints an error; the walk continues.
+
+Declined flags leave the wiki but stay in its git history. Recover one with
+`git log -p` on the note.
+
+## Check the counters
+
+- `lore status` — the `flags` section, per wiki: written, withheld,
+  pending, accepted, declined, retargeted.
+- `lore trace flag` — every flag-write and flag-review event,
+  chronologically, each carrying a `flag_id`. `--json` gives raw records.
+
+Pair one flag's write and verdict lines by `flag_id` to get its review
+latency. [Measure flag quality](measure-flag-quality.md) covers what those
+numbers can and cannot tell you, and the two procedures that catch
+under-flagging.
+
+## Done when
+
+`lore flag list` prints `(no pending flags)`, and every fact you kept sits in
+a topic note whose origin line no longer ends in `unreviewed`.

--- a/docs/how-to/measure-flag-quality.md
+++ b/docs/how-to/measure-flag-quality.md
@@ -102,3 +102,10 @@ least one flip-probe result (procedure 2) for the current directive
 wording. Neither procedure has a fixed passing threshold — the point is
 a repeatable measurement to compare across directive changes, not a
 one-time gate.
+
+## See also
+
+- [File a flag, and review the flags agents filed](file-and-review-flags.md)
+  — the commands that produce the events measured here.
+- [Why one flag, and not a session note](../explanation/why-the-flag-is-the-crossing.md)
+  — why under-flagging and review latency are the two failures that hide.

--- a/docs/how-to/retire-session-notes.md
+++ b/docs/how-to/retire-session-notes.md
@@ -1,0 +1,124 @@
+# Retire the session-note stock into the transcript ledger
+
+**Goal:** stamp every archived transcript with its linkage block, then delete
+the session-note files those transcripts produced.
+
+`lore migrate retire-session-notes` does both halves in that order. The
+backfill is what makes the deletion safe to run: once each ledger entry
+carries its repo, branch, PRs, issues, commits and files, `lore_drill`
+answers "which sessions touched this?" and the SessionStart banner renders
+its recap without reading a single note.
+
+## Read this first
+
+- **`--apply` deletes files.** Without it the command computes a plan,
+  prints it, and writes nothing.
+- **Deletion is not final while the compose pipeline runs.** Capture still
+  writes a new session note at every session boundary, so the `sessions/`
+  tree starts refilling the moment the command finishes. It stops refilling
+  when the teardown retires that pipeline, which has not happened yet. Run
+  the command again to clear whatever accumulated since the last run.
+- **Nothing distils the old notes.** The backfill reads the transcript and
+  git, never the note prose. What a note said and no artifact records is
+  lost when the file goes. Read anything you want to keep before you apply,
+  and file it as a flag or write it into a topic note.
+- **Recovery is git.** Notes are markdown in the wiki repo. Commit and push
+  the wiki before you apply, and a mistaken run is a `git revert` away.
+
+## Steps
+
+1. **Commit the wiki.** From each wiki directory:
+
+   ```
+   git -C "$LORE_ROOT/wiki/<name>" status --short
+   git -C "$LORE_ROOT/wiki/<name>" add -A && git -C "$LORE_ROOT/wiki/<name>" commit -m "wip: before session-note retirement"
+   ```
+
+   An uncommitted note that the run deletes has no history to recover from.
+
+2. **Run the plan.**
+
+   ```
+   lore migrate retire-session-notes
+   ```
+
+   The output has two blocks:
+
+   ```
+   Backfill — 556 ledger entries (231 with issue/PR refs, 12 without a readable transcript)
+   Delete — 307 session note(s)
+     - /home/you/lore/wiki/private/sessions/2026/08/04-flag-lifecycle.md
+     ...
+     keep (not a note) /home/you/lore/wiki/private/sessions/2026/08/scratch.png
+   ```
+
+3. **Read the plan.** Three numbers are worth checking:
+
+   - *entries with issue/PR refs* — how much of the archive keeps a usable
+     ref after the notes go.
+   - *without a readable transcript* — the transcript file is gone, so that
+     entry's block holds only what git and the stored working directory
+     could still answer.
+   - *keep (not a note)* — non-markdown files found under a `sessions/`
+     tree. The command leaves them in place.
+
+4. **Apply.**
+
+   ```
+   lore migrate retire-session-notes --apply
+   ```
+
+   It executes exactly the plan it printed, then reports how many entries it
+   backfilled and how many notes it deleted. Directories that empty out are
+   pruned. Any file it could not delete is listed with its reason.
+
+5. **Verify.** Ask the ledger something a note used to answer:
+
+   ```
+   lore drill "#358"
+   ```
+
+   `lore drill` prints an `N sessions:` block naming the transcripts that
+   touched that issue. Start a new session and the banner's recap line reads
+   off the same store.
+
+## Scoping to one wiki
+
+`--wiki <name>` scopes the **deletion** to one wiki. The backfill always
+covers the whole ledger — it is one machine-local store, not a per-wiki one,
+and stamping a linkage block adds data without removing any.
+
+## What the backfill derives
+
+Per archived transcript, from the transcript file and from git:
+
+| Key | Source |
+|---|---|
+| `repo` | git, for the working directory the session ran in |
+| `branch` | git, or the branch recorded in the transcript |
+| `commits` | commit SHAs in the session's own bash results |
+| `files` | files the session edited |
+| `issues`, `prs` | refs in the turn text, classified by syntax |
+
+No LLM call and no network call runs. A bare `#42` is classified by its
+syntax rather than by asking GitHub what kind of ref it is, because
+backfilling hundreds of sessions would otherwise mean a request per ref
+inside a command that then deletes files.
+
+The command is idempotent. A second run re-derives the same blocks and finds
+whatever notes appeared since the first.
+
+## Done when
+
+`lore migrate retire-session-notes` reports zero deletions on a re-run
+against a wiki you have already applied it to, and `lore drill` on a known
+issue number returns the sessions that touched it.
+
+## See also
+
+- [Why the flag is the crossing](../explanation/why-the-flag-is-the-crossing.md)
+  — what replaces the notes, and what the teardown still has to do.
+- [`architecture/state.md`](../architecture/state.md) — where the ledger
+  lives and why it never leaves the machine.
+- [`architecture/lore-drill.md`](../architecture/lore-drill.md) — the ledger
+  routing the backfill feeds.

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -111,6 +111,48 @@ laptop would rewrite history. Rendering never fails on this; it only hedges. See
 run and came back empty. That ref does not exist, and its line is demoted to
 "Claimed in session, ref not found: …".
 
+## "My flag never appeared in the wiki"
+
+Three refusals, each with its own message on stderr.
+
+**`a flag needs an origin: pass a transcript pointer or at least one ref`** —
+the write carried neither. Inside a Claude Code session
+`$CLAUDE_SESSION_ID` supplies the transcript automatically; a plain shell has
+no session id, so pass at least one `--ref pr:123` / `--ref commit:3f9a2c1`.
+Exit code 1, nothing written.
+
+**`no wiki resolved — pass --wiki, or run inside an attached repo`** — the
+working directory maps to no attachment. Run `lore attach attachments show
+$PWD` to see what covers the path, or name the wiki with `--wiki`. Exit code
+2.
+
+**`withheld (<category>) — text held in quarantine <id>`** — the publish gate
+found a secret, an email address, a phone number or other personal data in
+the flag text — or failed while checking — and withheld it before anything
+touched the wiki. The gate fails closed, so a `gate-error` category means
+the check itself broke, not that your text was bad. Read the
+held text with `lore quarantine show <id>`, rewrite the fact without the
+material that tripped the gate, and file it again. Exit code 1.
+
+A flag that landed somewhere unexpected was routed, not lost: without
+`--target`, Lore appends to the top-ranked existing note for the lead
+sentence. `lore flag list` prints every pending flag with its note, and
+`lore flag review` moves one with the retarget verdict.
+
+## "The banner says N pending flags and I can't see them"
+
+By design — the banner carries a count and never flag content, so a
+teammate's unreviewed text cannot reach your context window through the
+banner alone. Run `lore flag list` for the leads, or `lore flag review` to
+walk them. The chip disappears at zero.
+
+If the count looks wrong, remember it is a live scan of the wiki's notes for
+the `unreviewed` marker, not a stored queue. Editing a marker out of a note
+by hand accepts that flag as far as the count is concerned, and records no
+`flag-review` event — which is why `lore status`'s pending count and its
+accept/decline counters are not expected to sum. See
+[measure flag quality](measure-flag-quality.md).
+
 ## "A flush looks stuck"
 
 `lore status`'s `flushes` line shows `queued` / `running` / `dead-lettered`


### PR DESCRIPTION
Documents what epic #362 shipped. No behaviour changes — docs only.

Epic: #362 · features #357, #358, #359, #360 · code merged as #368,
released 0.67.0. Nothing under `docs/prd/` or `docs/adr/` is touched.

## Diátaxis quadrants

**How-to**
- `docs/how-to/file-and-review-flags.md` (new) — `lore flag write` with its
  origin rule and ref verification, where an unnamed flag lands, the
  human-vs-agent authorship split, `lore flag list`, the review walk with a
  verdict table, and the withheld-to-quarantine path.
- `docs/how-to/retire-session-notes.md` (new) — `lore migrate
  retire-session-notes`: commit the wiki first, read the dry-run plan,
  `--apply`, verify through `lore drill`. States that `--apply` deletes
  files and that capture refills `sessions/` until the teardown lands.
- `docs/how-to/troubleshooting.md` — the three flag refusals (missing
  origin, unresolved wiki, gate withhold) and why the banner shows a count
  only.
- `docs/how-to/measure-flag-quality.md` — cross-links only; the existing
  content is unchanged.

**Explanation**
- `docs/explanation/why-the-flag-is-the-crossing.md` (new) — the telemetry
  that ended session notes, the three layers, why a flag is one stamped
  fact, why it lands unreviewed instead of queued, why the review walk is a
  pull, why pending state is derived from a marker rather than stored.
- `docs/explanation/why-notes-are-written-at-session-end.md` — a status note
  stating that the pipeline still runs and its retirement is decided but not
  executed.

**Reference** (docstrings plus the wiring that surfaces them)
- The new public symbols already carry complete docstrings — `flag.write` /
  `accept` / `decline` / `retarget` / `pending` / `propose_target`,
  `flag_metrics`, `ledger.find_sessions`, `ledger_linkage.build_linkage`,
  `retire_session_notes.plan_retirement` / `apply_retirement` — so this PR
  fixes the surfacing instead: `README.md` gains `lore flag` and `lore
  migrate retire-session-notes` in the manual-command list, and `CONTEXT.md`
  gains the flag-architecture glossary terms (flag, crossing, origin line,
  unreviewed marker, review walk, transcript ledger, linkage block, context
  finder).
- `README.md` banner description corrected: the last-active-day recap
  replaced the last-session note hints.
- `docs/architecture/session-note-lifecycle.md` — status note.

**Tutorial** — no change. The repo has no tutorial tree; `docs/how-to/
onboarding.md` covers install and verify, which this epic did not alter.

## Accuracy

The teardown (#361) has not landed. Every page states the shipped state at
`6bd018d`: the compose pipeline still writes a session note at every session
boundary, and the flag becomes the *only* crossing when the teardown lands.
No page claims otherwise.

Output quoted in the how-to pages was checked against the code by running
`lore flag write` / `list` against a throwaway vault — the block shape, the
`created` / `appended to` lines, the origin-refusal message, and the routing
of an unnamed flag onto an existing note all match.

Local suite: 3003 passed, 30 skipped, excluding four failures that already
fail on `main` (rich/ANSI rendering in `test_cli_scopes.py`,
`test_core_llm_wiring.py`, `test_install_dispatcher.py`).
