### PR TITLE
fix: cap mcp below 2.0 so the MCP server can start

### DIFF
--- a/lib/lore_cli/doctor_cmd.py
+++ b/lib/lore_cli/doctor_cmd.py
@@ -356,6 +356,22 @@ def _check_mcp_imports(cwd: str) -> Check:
         schema = lore_mcp.server._tool_schema()  # noqa: SLF001
     except Exception as e:
         return False, f"MCP server import/schema failed: {e}"
+
+    # A schema that builds does not mean the server can start. `start_server`
+    # registers its handlers through decorators that exist on the mcp 1.x
+    # Server only; 2.0 replaced them with add_request_handler. Without this
+    # check the panel reports "ready" for an install where every tool is dead.
+    try:
+        from mcp.server import Server
+    except Exception as e:
+        return False, f"mcp.server import failed: {e}"
+    missing = [n for n in ("list_tools", "call_tool") if not hasattr(Server, n)]
+    if missing:
+        return False, (
+            f"incompatible mcp release: Server has no {', '.join(missing)} — "
+            f"the server raises AttributeError at startup. Needs mcp<2."
+        )
+
     return True, f"MCP server ready ({len(schema)} tools)"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ dependencies = [
     "typer>=0.12",
     "rich>=13",
     "pyyaml>=6",
-    "mcp>=1.0",
+    # Capped below 2.0: that release dropped the @server.list_tools() and
+    # @server.call_tool() decorators lore_mcp.server registers through.
+    "mcp>=1.0,<2",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -294,3 +294,33 @@ def test_check_vale_reports_presence(monkeypatch):
     ok, msg = doctor_cmd._check_vale(".")
     assert ok is True
     assert "/usr/local/bin/vale" in msg
+
+
+def test_check_mcp_imports_rejects_an_mcp_release_without_the_decorators(monkeypatch):
+    """A schema that builds says nothing about whether the server can start.
+
+    `start_server` binds its handlers with `@server.list_tools()` and
+    `@server.call_tool()`. mcp 2.0 removed both, so the server raises
+    AttributeError at startup while the schema still generates fine — doctor
+    reported "ready" for an install whose every tool was dead.
+    """
+    import mcp.server
+
+    class _ServerWithoutDecorators:
+        """Stands in for the 2.x Server, which registers via add_request_handler."""
+
+        def add_request_handler(self, *args, **kwargs):  # pragma: no cover - shape only
+            raise NotImplementedError
+
+    monkeypatch.setattr(mcp.server, "Server", _ServerWithoutDecorators)
+
+    ok, msg = doctor_cmd._check_mcp_imports(".")
+    assert ok is False
+    assert "list_tools" in msg
+    assert "mcp" in msg.lower()
+
+
+def test_check_mcp_imports_passes_against_the_supported_line():
+    ok, msg = doctor_cmd._check_mcp_imports(".")
+    assert ok is True
+    assert "tools" in msg

--- a/tests/test_mcp_server_api_contract.py
+++ b/tests/test_mcp_server_api_contract.py
@@ -1,0 +1,53 @@
+"""The MCP server binds to a decorator API that `mcp` 2.0 removed.
+
+`lore_mcp.server.start_server` registers its handlers with
+`@server.list_tools()` and `@server.call_tool()`. Those decorators exist on
+`mcp.server.Server` in the 1.x line only; 2.0 replaced them with the
+`add_request_handler` interface, so a server built against 1.x raises
+`AttributeError` at startup under 2.x and every tool goes dark.
+
+The dependency was declared open-ended (`mcp>=1.0`), so an existing
+environment kept a working 1.x while any fresh install resolved 2.0 — the
+failure never reached CI, only users. Both tests below guard that gap: the
+declared floor/ceiling, and the runtime attributes the module actually calls.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _mcp_requirement() -> Requirement:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    for raw in data["project"]["dependencies"]:
+        req = Requirement(raw)
+        if req.name == "mcp":
+            return req
+    raise AssertionError("mcp is not declared in [project].dependencies")
+
+
+def test_declared_mcp_range_excludes_the_2_0_api_break() -> None:
+    """A fresh install must not resolve an mcp release without the decorators."""
+    specifier = _mcp_requirement().specifier
+
+    assert not specifier.contains("2.0.0"), (
+        "pyproject allows mcp 2.0.0, which removed @server.list_tools() and "
+        "@server.call_tool(); a fresh install gets a server that dies at startup"
+    )
+    assert specifier.contains("1.27.0"), "the supported 1.x line must stay installable"
+
+
+def test_installed_server_exposes_the_decorators_the_module_calls() -> None:
+    """Guards the same break arriving inside the allowed range."""
+    from mcp.server import Server
+
+    for attribute in ("list_tools", "call_tool"):
+        assert hasattr(Server, attribute), (
+            f"mcp.server.Server has no {attribute!r}; lore_mcp.server.start_server "
+            f"calls @server.{attribute}() and would raise AttributeError"
+        )


### PR DESCRIPTION
## Problem

`lore_mcp.server.start_server` registers its handlers with `@server.list_tools()` and `@server.call_tool()`. mcp 2.0 removed both decorators in favour of `add_request_handler`. The server raises `AttributeError` at startup, so all 13 MCP tools are unavailable — including `lore_flag`, which 0.67.0 shipped.

`pyproject.toml` declared `mcp>=1.0` with no upper bound. An existing environment keeps a working 1.x, so CI stays green; a fresh install resolves 2.0.0 and gets a dead server. The failure reaches users only.

## Observation

- Host: this workstation. pipx venv `/home/buchbend/.local/share/pipx/venvs/lore` resolved `mcp 2.0.0`.
- `~/.cache/lore/crashes/*.log`, seven-day window: 20 crashes with `AttributeError: 'Server' object has no attribute 'list_tools'`, raised at `lore_mcp/server.py:1485`. Latest `20260805T141624Z-main.log`.
- Introspection of the installed release: `mcp.server.Server` exposes `add_request_handler`, `add_notification_handler`, `run`; no `list_tools`, no `call_tool`.
- The development venv `/home/buchbend/git/lore/.venv` holds `mcp 1.27.0`, where both decorators exist. That is why the test suite never saw the break.

## Change

- `pyproject.toml` declares `mcp>=1.0,<2`.
- `_check_mcp_imports` in `lib/lore_cli/doctor_cmd.py` verifies that `mcp.server.Server` exposes the decorators the module binds to. The check previously imported the module and built the tool schema without touching the `Server` class, so it reported `MCP server ready (13 tools)` for an install whose every tool was dead.

## Tests

- `tests/test_mcp_server_api_contract.py` asserts the declared specifier excludes 2.0.0 and admits 1.27.0, and asserts the installed `Server` exposes `list_tools` and `call_tool`.
- `tests/test_doctor.py` gains two cases: the check rejects a `Server` stand-in without the decorators, and passes against the supported line.

Both new tests were red before the change.

## Verification

- Full suite: 3013 passed, 45 skipped, 4 failed.
- The 4 failures are pre-existing on `main` at `b717f93`. Confirmed by running the same four node IDs in a clean worktree at that commit: `test_cli_scopes.py::test_rename_reports_stale_checked_in_offer`, `test_core_llm_wiring.py` (2 cases), `test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`. All assert on rich/ANSI console rendering.
- ruff on the touched files: 14 errors before the change, 14 after. The new test file is clean.

## Scope

The pin restores the supported line. Porting `lore_mcp.server` to the mcp 2.x `add_request_handler` interface is separate work and is not attempted here.

The version bump follows in its own PR, per `CLAUDE.md`.