### PR TITLE
Collapse the sub-issue linkage header and lint retired headings

### DIFF
--- a/docs/how-to/customize-the-writing-rules.md
+++ b/docs/how-to/customize-the-writing-rules.md
@@ -98,6 +98,10 @@ default does. There is no merge and no per-repo layer.
 
 - The banned-word list lives in the rules text and in the Vale style. A
   test asserts the two agree, so edit both together.
+- `RetiredHeading.yml` names the headings Lore's templates dropped. A draft
+  written from a stale template passes every prose rule, so the heading is the
+  only evidence the template moved. Retire a heading, add it to that rule in
+  the same change.
 - Overriding the rules replaces the whole document, including its section
   skeleton and EARS patterns. Start from the packaged copy rather than a blank
   file unless you intend to drop those.

--- a/lib/lore_core/styles/vale/WritingRules/RetiredHeading.yml
+++ b/lib/lore_core/styles/vale/WritingRules/RetiredHeading.yml
@@ -1,0 +1,20 @@
+# Structure check rather than prose: a heading no current template carries.
+#
+# A drafting session that reads a stale copy of a template reproduces that
+# template's headings, and every prose rule passes over them, so the draft
+# lints clean and posts. A batch of sub-issues shipped a retired skeleton
+# that way, months after the template had moved on.
+#
+# Error level, not warning. This config lints issue and PR drafts, where the
+# current templates carry none of these headings, and `file-issue` acts on the
+# exit code alone — a warning here would print and change nothing.
+#
+# Retire a heading from a template, add it here in the same change. The
+# anchors keep the match to a whole heading, so "Epic merge policy" and
+# "Epic body template" stay quiet.
+extends: existence
+message: "Retired heading '%s': re-read the current template before you draft."
+level: error
+scope: heading
+raw:
+  - '^(What to build|Epic|Repo|Type|Blocked by)$'

--- a/lore-workflow/skills/file-issue/SKILL.md
+++ b/lore-workflow/skills/file-issue/SKILL.md
@@ -100,8 +100,10 @@ vale --config "$(lore style vale-config)" "${TMPDIR:-/tmp}/lore-file-issue-<slug
 
 Read the result by exit code, not by whether anything printed:
 
-- **Exit 1** — at least one `error`-level finding: banned vocabulary, or a sentence past
-  the length ceiling. Rewrite those, then run again until the exit code is 0.
+- **Exit 1** — at least one `error`-level finding: banned vocabulary, a sentence past the
+  length ceiling, or a retired heading. Rewrite those, then run again until the exit code
+  is 0. A retired heading means the structure you drafted from has moved — re-read the
+  template rather than renaming the heading.
 - **Exit 0 with findings printed** — `warning`-level heuristics only. Advisory.
 - **Exit 2** — the invocation itself is broken, not the prose. Vale exits 2 on an empty
   path argument and on a `--config` path it cannot resolve. **Stop and report.** Editing

--- a/lore-workflow/skills/to-epic/SKILL.md
+++ b/lore-workflow/skills/to-epic/SKILL.md
@@ -184,24 +184,20 @@ below keeps the literal token, which is what the roadmap validator and `/lore-wo
 
 ## Sub-issue template
 
-An epic-linkage header, then the section skeleton the writing rules require. File it
+A one-line linkage header, then the section skeleton the writing rules require. File it
 through [`file-issue`](../file-issue/SKILL.md) in caller-template mode — that skill
 resolves the writing rules and applies them inside this structure, so none of those
 rules are repeated here. Keep "Required behaviour" to the slice's end-to-end behavior — not a
 layer-by-layer implementation — and path-free (same prototype exception as above).
 
+The header spends one line on four short values, so content starts above the fold. Fill
+each field on that line: **Epic** the tracker issue, fully qualified; **Repo** the repo
+this slice is implemented in; **Type** `AFK` (runs autonomously) or `HITL` (needs a human
+decision); **Blocked by** the blocking issues, or `None`. No parser reads these off the
+sub-issue — `orchestrate-epic` builds its DAG from the epic body's roadmap table.
+
 <sub-issue-template>
-## Epic
-owner/repo#<epic>
-
-## Repo
-The repo this slice is implemented in.
-
-## Type
-AFK (runs autonomously, no human input) or HITL (human-in-the-loop: needs a human decision).
-
-## Blocked by
-owner/repo#<n>, or "None — can start immediately".
+**Epic** owner/repo#<epic> · **Repo** owner/repo · **Type** AFK · **Blocked by** None
 
 ## Context
 ## Current behaviour

--- a/tests/test_vale_style.py
+++ b/tests/test_vale_style.py
@@ -216,6 +216,37 @@ def test_vale_leaves_unrelated_words_alone(tmp_path: Path, word: str) -> None:
 
 
 @pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+@pytest.mark.parametrize("heading", ["What to build", "Epic", "Repo", "Type", "Blocked by"])
+def test_vale_flags_a_retired_heading(tmp_path: Path, heading: str) -> None:
+    """A draft written from a stale template passes every prose rule, so the
+    heading itself is the only evidence the template moved."""
+    fixture = tmp_path / "issue.md"
+    fixture.write_text(f"# Title\n\n## {heading}\n\nThe loader reads the file.\n")
+    result = subprocess.run(
+        ["vale", "--config", str(default_vale_config_path()), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, f"'## {heading}' passed the lint:\n{result.stdout}"
+    assert "retired heading" in result.stdout.lower()
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
+@pytest.mark.parametrize("heading", ["Epic merge policy", "Epic body template", "Type checking"])
+def test_vale_leaves_a_longer_heading_alone(tmp_path: Path, heading: str) -> None:
+    """The check anchors to a whole heading; a retired word inside a longer
+    heading names something else."""
+    fixture = tmp_path / "issue.md"
+    fixture.write_text(f"# Title\n\n## {heading}\n\nThe loader reads the file.\n")
+    result = subprocess.run(
+        ["vale", "--config", str(default_vale_config_path()), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"'## {heading}' was flagged:\n{result.stdout}"
+
+
+@pytest.mark.skipif(VALE_MISSING, reason="vale not on PATH")
 def test_vale_flags_a_sentence_over_25_words(tmp_path: Path) -> None:
     fixture = tmp_path / "issue.md"
     long_sentence = " ".join(["word"] * 30) + ".\n"

--- a/tests/test_workflow_writing_rules_wiring.py
+++ b/tests/test_workflow_writing_rules_wiring.py
@@ -15,7 +15,8 @@ import re
 from pathlib import Path
 
 import pytest
-from lore_core.style import default_style_path
+import yaml
+from lore_core.style import default_style_path, default_vale_config_path
 from lore_workflow import roadmap_validator
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -37,6 +38,10 @@ FILING_SKILLS = (
 ROADMAP_FIELDS = ("Repo", "Type", "Blocked by")
 
 _SECTION = re.compile(r"^## (.+)$", re.M)
+# The linkage header is one line of bold-labelled fields separated by "·".
+# Four short values under four headings pushed the first sentence of content
+# past a reader's screen, and no parser ever read those headings.
+_LINKAGE = re.compile(r"\*\*([^*]+)\*\*\s*([^·\n]+)")
 
 
 def _skill_text(name: str) -> str:
@@ -62,20 +67,30 @@ def _required_sections() -> list[str]:
     return _sections(match.group(1))
 
 
-def _field(body: str, heading: str) -> str:
-    """First non-empty line under ``## <heading>``."""
-    match = re.search(rf"^## {re.escape(heading)}$\n+(.+)$", body, re.M)
-    assert match, f"rendered sub-issue has no '## {heading}' section"
-    return match.group(1).strip()
+def _linkage(text: str) -> dict[str, str]:
+    """The linkage header's fields, keyed by label."""
+    line = next((ln for ln in text.splitlines() if ln.startswith("**Epic**")), None)
+    assert line, "sub-issue template has no one-line linkage header"
+    return {label.strip(): value.strip() for label, value in _LINKAGE.findall(line)}
+
+
+def _field(body: str, label: str) -> str:
+    """A linkage field's value, read from the rendered header line."""
+    fields = _linkage(body)
+    assert label in fields, f"rendered sub-issue has no '{label}' linkage field"
+    return fields[label]
 
 
 def _render_sub_issue(values: dict[str, str]) -> str:
-    """Render a sub-issue from the template's own section list, so a section
-    dropped from the template is a section missing from the render."""
-    sections = _sections(_block(_skill_text("to-epic"), "sub-issue-template"))
-    return "\n\n".join(
-        f"## {name}\n{values.get(name, 'Filled by the drafting session.')}" for name in sections
+    """Render a sub-issue from the template's own linkage labels and section
+    list, so anything dropped from the template is missing from the render."""
+    template = _block(_skill_text("to-epic"), "sub-issue-template")
+    header = " · ".join(f"**{label}** {values.get(label, 'TODO')}" for label in _linkage(template))
+    body = "\n\n".join(
+        f"## {name}\n{values.get(name, 'Filled by the drafting session.')}"
+        for name in _sections(template)
     )
+    return f"{header}\n\n{body}"
 
 
 @pytest.mark.parametrize("skill", FILING_SKILLS)
@@ -93,9 +108,26 @@ def test_sub_issue_template_carries_the_writing_rules_skeleton() -> None:
 
 
 def test_sub_issue_template_keeps_the_epic_linkage_header() -> None:
+    fields = _linkage(_block(_skill_text("to-epic"), "sub-issue-template"))
+    missing = [f for f in ("Epic", *ROADMAP_FIELDS) if f not in fields]
+    assert not missing, f"sub-issue template is missing linkage fields: {missing}"
+
+
+def test_the_linkage_header_spends_no_headings() -> None:
+    """A reader scans the issue's content, so the linkage costs one line."""
     present = _sections(_block(_skill_text("to-epic"), "sub-issue-template"))
-    missing = [s for s in ("Epic", *ROADMAP_FIELDS) if s not in present]
-    assert not missing, f"sub-issue template is missing linkage sections: {missing}"
+    stray = [s for s in ("Epic", *ROADMAP_FIELDS) if s in present]
+    assert not stray, f"linkage fields belong in the header line, not headings: {stray}"
+
+
+def test_the_collapsed_labels_are_retired_headings() -> None:
+    """The Vale check is what catches a draft written from the pre-collapse
+    template, so the rule lists every label the header absorbed."""
+    rule = default_vale_config_path().parent / "WritingRules" / "RetiredHeading.yml"
+    retired = yaml.safe_load(rule.read_text(encoding="utf-8"))["raw"][0]
+    labels = _linkage(_block(_skill_text("to-epic"), "sub-issue-template"))
+    missing = [label for label in labels if label not in retired]
+    assert not missing, f"the retired-heading rule must list: {missing}"
 
 
 def test_epic_body_composed_from_the_template_passes_the_validator() -> None:


### PR DESCRIPTION
## What changed

- The `to-epic` sub-issue template puts Epic, Repo, Type and Blocked by on one line.
- A new Vale rule, `RetiredHeading.yml`, flags a heading no current template carries.
- `file-issue` names a retired heading as a third cause of an error-level lint.
- The how-to records that a retired heading and its rule move together.

## Why the collapse is safe

A reader scrolled past four headings before the first sentence of content. Each heading
carried one short value.

No parser reads those values off the sub-issue. `orchestrate-epic` builds its dependency
graph from the epic body's roadmap table, so the collapse changes no machine input.

## Why the heading check exists

A draft written from a stale template passes every prose rule. Four sub-issues shipped a
skeleton the template had dropped two days earlier, and the linter reported a clean draft.
The heading is the only evidence the template moved, so the linter now reads headings.

The rule sits at error level. `file-issue` acts on the exit code alone, and a warning
would print without changing the draft.

## Tests

- `test_the_linkage_header_spends_no_headings` fails while the four headings stand.
- `test_the_collapsed_labels_are_retired_headings` ties the template to the Vale rule.
- `test_vale_flags_a_retired_heading` runs the real binary over each retired heading.
- `test_vale_leaves_a_longer_heading_alone` keeps `## Epic merge policy` quiet.

The full suite reports 2743 passed and one failure,
`test_refresh_claude_plugin_cache_runs_update_on_success`. That failure reproduces on a
clean tree at the same commit.

## Release

The branch changes skill text and packaged style data, so `main` needs the follow-up
`chore: release` commit. An installed plugin cache keeps the old copy until the version
changes.
