### PR TITLE
Move the orchestrator's supervision narrative onto the board

### DIFF
--- a/lore-workflow/skills/orchestrate-epic/SKILL.md
+++ b/lore-workflow/skills/orchestrate-epic/SKILL.md
@@ -23,13 +23,12 @@ a hard blocker (see Stop conditions).
 - **Merges are pre-authorized** — you merge on a passing crosscheck, never asking. Sole exception: when
   `epic-policy` returns `deploy_gate: true`, the final epic→target merge (only that one) requires one human
   confirmation first.
-- **Supervision state splits into two durable stores (ADR 0002), never conflated.** The **board** — one
-  comment on the epic issue, the per-feature ledger (Feature/Issue/Tier/Batch/State/PR), machine-readable via
-  `lore workflow parse-board`, kept on GitHub for humans and teammates; authoritative for per-feature state.
-  The **epic note** — your own session note, linkage `epics: [<issue>]`, composed by capture as you narrate;
-  it holds what the board can't: tier rationale, dispatch and crosscheck reasoning, escalations, in-flight
-  decisions. You write only your OWN epic note (ADR 0001 forbids writing another session's); dispatched
-  teammates run capture-suppressed, so the epic note is the single consolidated record.
+- **The board is the one supervision store.** One comment on the epic issue, kept on GitHub for humans and
+  teammates. Its table is the per-feature ledger (Feature/Issue/Tier/Batch/State/PR), machine-readable via
+  `lore workflow parse-board` and authoritative for per-feature state; the parser reads the table
+  structurally and ignores everything below it. A **notes section** below the table carries the working
+  narrative — tier rationale, dispatch and crosscheck reasoning, escalations, block causes — one entry per
+  feature that needs a reason. You edit the one comment in place across the run; never open a second.
 - One feature = one teammate = one worktree = one branch `feat/<sub-issue>-slug` = one PR.
 - **Compact mode narrows fan-out only** (see Effort bands) — the strict-TDD, one-PR-per-feature, and
   every-PR-crosschecked invariants all still hold.
@@ -43,15 +42,14 @@ target repo(s). If it came from `/lore-workflow:to-epic`, its **Roadmap** table 
 Type | Blocked by) is the canonical DAG, and HITL-flagged features are escalation points, not
 auto-implemented. Resolve `lore workflow epic-policy` once per repo.
 
-**Resume.** The entry point — reached before the gate, before creating the epic branch. Two reads recover a
-prior run:
-1. **Board** — fetch the epic issue's board comment and pipe it to `lore workflow parse-board` → rows
-   `{feature, issue, tier, batch, state, pr}`. Never scrape it with the model. Reconcile against the epic
-   branch's real state: a `merged` row is done (skip, never redispatch); a `queued`/`blocked` row is
-   redispatched; an existing epic branch is reused, never re-created. Edit that same comment in place for every
-   later update; never open a second.
-2. **Working context** — `lore_context_pack` (epic-linked) surfaces prior orchestrator epic
-   notes: why a feature blocked, the tier rationale, the in-flight decisions the board omits.
+**Resume.** The entry point — reached before the gate, before creating the epic branch. Fetch the epic issue's
+board comment once and read it two ways:
+1. **Table** — pipe the comment to `lore workflow parse-board` → rows `{feature, issue, tier, batch, state,
+   pr}`. Never scrape it with the model. Reconcile against the epic branch's real state: a `merged` row is
+   done (skip, never redispatch); a `queued`/`blocked` row is redispatched; an existing epic branch is reused,
+   never re-created. Edit that same comment in place for every later update; never open a second.
+2. **Notes section** — read the prose below the table for why a feature blocked, the tier rationale, and the
+   in-flight decisions the table omits.
 
 No board comment found → fresh run; proceed to the gate.
 
@@ -62,20 +60,25 @@ into dependency-ordered batches (features in a batch are independent). Pick the 
 eye: **compact** iff `repos == 1`, every `Type` is AFK, and either the DAG offers no real parallelism — every
 batch holds exactly one feature, i.e. a straight chain of any length — or `rows ≤ 3`; **standard** otherwise
 (full batched loop, concurrency cap N). Fan-out only pays when features actually run side by side. Record the
-band in your epic note, then create and push `epic/<issue>` from the up-to-date `target_branch`.
+band in the board's notes section, then create and push `epic/<issue>` from the up-to-date `target_branch`.
 
 **Emit the board.** One comment on the epic issue, edited in place at a few deliberate points (batch start,
 each merge, each blocker, completion) — never a second comment. It MUST carry, verbatim, the marker and
-columns `parse-board` reads:
+columns `parse-board` reads, followed by a `## Notes` section:
 ```
 <!-- lore-orchestrate-epic:status v1 -->
 
 | Feature | Issue | Tier | Batch | State | PR |
 |---|---|---|---|---|---|
 | <title> | owner/repo#n | <tier> | <batch> | queued | #<pr> or — |
+
+## Notes
+
+- <feature> — <tier rationale, block cause, crosscheck verdict, or escalation>.
 ```
-`State` is one of queued/running/crosscheck/merged/blocked. The board is the per-feature ledger only; tier
-*rationale* and deviations belong in your epic note.
+`State` is one of queued/running/crosscheck/merged/blocked. `parse-board` reads the table only and ignores
+the notes section; write one notes entry per feature that needs a reason — tier rationale, a block cause, a
+crosscheck verdict, or an escalation.
 
 **Codemap excerpt (built once at Map time, reused by every teammate).** So codebase discovery happens once for
 the whole epic, not once per teammate: from `lore codemap` (or the `lore_codemap` MCP tool for bounded
@@ -88,12 +91,12 @@ excerpts** — never the whole map. Shape it as the four-part subagent brief eve
 - **Task boundaries** — the scope fence and shared-file touchpoints to stay clear of.
 
 **Dispatch.** Per feature in the batch: worktree off `epic/<issue>`, spawn a background teammate pinned to it
-(cap N, default 4) **with `LORE_SUPPRESS_CAPTURE=1` in its environment**, so it records its work in your epic
-note rather than scattering a standalone fragment. Choose the model tier from the feature's assessed
+(cap N, default 4) **with `LORE_SUPPRESS_CAPTURE=1` in its environment**, so it leaves no standalone capture
+fragment. Choose the model tier from the feature's assessed
 complexity (cheaper for well-scoped work, strongest for cross-cutting) and pass the resolved model in the
 spawn call (`lore tier resolve <tier>`, see [TIER-DELEGATION.md](../../TIER-DELEGATION.md)); no delegation
-inherits your session model. Record the tier and its rationale in your epic note; the board carries only the
-assigned tier.
+inherits your session model. Record the tier and its rationale in the board's notes section; the table row
+carries only the assigned tier.
 
 _Liveness._ Event-driven, not polled: the harness's completion notification is the primary signal. Fallback:
 a teammate silent ~30 minutes is respawned once into the same worktree with the same brief; a second death on
@@ -107,9 +110,9 @@ The crosscheck batches exactly as in standard mode: one strong-tier reviewer ove
 delegating the read keeps your context free as the epic grows. Spawn **one reviewer subagent per batch** at
 the **strong-tier** (`lore tier resolve strong`; no delegation inherits the session model): it reads each of
 the batch's PR diffs and linked sub-issues and returns one verdict block per PR, posting each as that PR's
-comment; you consume only the verdicts and record their outcomes in your epic note. A batch of one degenerates
-to a per-PR review; if one PR's diff is too large to share a reviewer, split that reviewer out and note the
-deviation in your epic note. Per PR the verdict is exactly:
+comment; you consume only the verdicts and record their outcomes in the board's notes section. A batch of one
+degenerates to a per-PR review; if one PR's diff is too large to share a reviewer, split that reviewer out and
+note the deviation in the board's notes section. Per PR the verdict is exactly:
 ```
 PR #<n>
 reviewer tier: strong
@@ -125,8 +128,8 @@ Post with `gh pr comment <n> --body …`. On **PASS**, advance to Merge. On **FA
 the numbered fix list and re-review (that PR alone) once it reports back — **max 2 fix rounds**. A round that doesn't move the
 verdict → send the `/lore-workflow:debug` method (reproduce, isolate root cause, heed its circuit breaker),
 not a vaguer "try again". Still FAIL after the second → mark the feature blocked and escalate. The Dispatch
-tier is advisory; a reviewer tier deviation is allowed but recorded in your epic note (full contract:
-[TIER-DELEGATION.md](../../TIER-DELEGATION.md), `docs/model-tiers.md`).
+tier is advisory; a reviewer tier deviation is allowed but recorded in the board's notes section (full
+contract: [TIER-DELEGATION.md](../../TIER-DELEGATION.md), `docs/model-tiers.md`).
 
 **Merge.** Merge crosscheck-passed PRs into `epic/<issue>` in dependency order; rebase later siblings on the
 updated branch and re-run their CI. A rebase conflict returns to that feature's teammate (respawned with
@@ -134,8 +137,8 @@ conflict context if it exited) — you never resolve conflicts by hand; escalate
 Cross-repo: merge a producer's feature and capture its commit SHA before dispatching the consumer that pins
 it. As each feature merges, close the loop: tick its roadmap checkbox (`- [ ]` → `- [x]`), close its sub-issue
 (`gh issue close <n> --comment "Merged via PR #<pr>"`), set its board row to `merged`, and record the outcome
-and any tier deviation in your epic note. When a batch is fully merged, dispatch the next; repeat to the
-roadmap's end.
+and any tier deviation in the board's notes section. When a batch is fully merged, dispatch the next; repeat
+to the roadmap's end.
 
 _Post-merge invariants._ After every merge into `epic/<issue>`, verify epic-branch CI is green before
 dispatching dependents. Where the repo carries migrations, verify a single migration head (e.g. `alembic
@@ -161,7 +164,7 @@ mismatches now that the diff carries the docs commit. Reuse the reviewer verdict
 the epic PR. It gates the merge like a crosscheck: **PASS** → merge; **FAIL** → route the fix list to the
 teammate(s) owning the affected files, re-review once, max 2 rounds, then mark the epic blocked and escalate
 rather than merge. The epic→target merge follows the deploy-gate policy: if `epic-policy` returned
-`deploy_gate: true`, record the one human confirmation in your epic note before merging. Merge, and mark the
+`deploy_gate: true`, record the one human confirmation in the board's notes section before merging. Merge, and mark the
 epic issue done with the merge SHA.
 
 **Cleanup.** Delete every merged feature branch (local and remote) and remove its worktree. Leave nothing

--- a/tests/fixtures/boards/with-notes-section.md
+++ b/tests/fixtures/boards/with-notes-section.md
@@ -1,0 +1,26 @@
+Epic #229 — supervision board. Edited in place across the run.
+
+<!-- lore-orchestrate-epic:status v1 -->
+
+| Feature | Issue | Tier | Batch | State | PR |
+|---------|-------|------|-------|-------|-----|
+| Load the config | ccatobs/widget#12 | AFK | 1 | merged | ccatobs/widget#40 |
+| Parse the manifest | ccatobs/widget#13 | AFK | 1 | running | — |
+| Export the report | ccatobs/widget#14 | HITL | 2 | queued | — |
+
+## Notes
+
+### Tier rationale
+
+- Issue ccatobs/widget#14 — HITL. The report format reaches a customer; a
+  human confirms the layout before merge.
+
+### Block cause
+
+- Issue ccatobs/widget#13 — blocked on a flaky fixture in CI. A rerun is
+  scheduled.
+
+### Crosscheck verdict
+
+- Issue ccatobs/widget#12 — PASS. The schema matches the config loader's
+  public contract.

--- a/tests/test_workflow_board_parser.py
+++ b/tests/test_workflow_board_parser.py
@@ -16,6 +16,7 @@ from lore_workflow import board_parser as mod
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "boards"
 
 WELL_FORMED = (FIXTURES / "well-formed.md").read_text(encoding="utf-8")
+WITH_NOTES_SECTION = (FIXTURES / "with-notes-section.md").read_text(encoding="utf-8")
 
 
 def test_marker_and_columns_are_exported_contract() -> None:
@@ -51,6 +52,14 @@ def test_resumed_run_can_select_by_state() -> None:
     rows = mod.parse_board(WELL_FORMED)
     merged = [r.issue for r in rows if r.state == "merged"]
     assert merged == ["ccatobs/widget#12"]
+
+
+def test_notes_section_does_not_change_parsed_rows() -> None:
+    # #379 moves the orchestrator's supervision narrative onto the board: a
+    # "## Notes" section now follows the table in the same comment. The
+    # parser must keep reading the table structurally and ignore the notes
+    # section, so a board with notes yields the same rows as one without.
+    assert mod.parse_board(WITH_NOTES_SECTION) == mod.parse_board(WELL_FORMED)
 
 
 # --- malformed inputs raise, never silently misread ------------------------
@@ -115,3 +124,18 @@ def test_parse_board_cmd_errors_on_malformed(capsys) -> None:
     assert rc == 1
     err = capsys.readouterr().err
     assert "marker" in err
+
+
+def test_parse_board_cmd_tolerates_notes_section(capsys) -> None:
+    from lore_cli import workflow_cmd
+
+    rc = workflow_cmd.main(["parse-board", str(FIXTURES / "with-notes-section.md")])
+    assert rc == 0
+    import json
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [r["issue"] for r in payload["rows"]] == [
+        "ccatobs/widget#12",
+        "ccatobs/widget#13",
+        "ccatobs/widget#14",
+    ]


### PR DESCRIPTION
## Context

Issue #361 removed the compose pipeline in release 0.68.0. No code writes a
session note. ADR 0002 split orchestrator supervision state across the board
and the epic note. The epic note store has no writer.

`lore-workflow/skills/orchestrate-epic/SKILL.md` named the epic note in
eleven places. A resumed orchestrator read which features merged and read no
reason for a blocked feature.

## Current behaviour

The board comment on issue #375 already carries a `## Notes` section below
the table, in the target shape. `lore workflow parse-board` already stops
reading table rows at the first blank or non-pipe line after the header, so
it already ignores a notes section.

## Change

The orchestrator writes the working narrative into a notes section below the
table, inside the same board comment. The table keeps its columns.
`lore workflow parse-board` keeps reading the table structurally.

`lore-workflow/skills/orchestrate-epic/SKILL.md` names the board as the one
supervision store. The skill names no epic note.

No change to `board_parser.py` or `workflow_cmd.py` — parity check below.

## Test plan

Added `tests/fixtures/boards/with-notes-section.md` and two tests in
`tests/test_workflow_board_parser.py`:
`test_notes_section_does_not_change_parsed_rows` and
`test_parse_board_cmd_tolerates_notes_section`.

Red: temporarily loosened the parser's row-stop condition in
`board_parser.py` (`_find_table_after`) to swallow the notes section as table
rows.

```
FAILED tests/test_workflow_board_parser.py::test_notes_section_does_not_change_parsed_rows
  BoardParseError: line 10: board row has 1 cell(s), expected 6 to match the header
FAILED tests/test_workflow_board_parser.py::test_parse_board_cmd_tolerates_notes_section
  assert 1 == 0
2 failed, 11 deselected in 0.32s
```

Green: reverted the parser to its original state (`git diff --stat` on
`board_parser.py` and `workflow_cmd.py` is empty in this PR).

```
tests/test_workflow_board_parser.py .............                     [100%]
13 passed in 0.26s
```

Full suite on this branch: 2682 passed, 45 skipped. Two failures remain, both
pre-existing on `epic/375` and terminal-width/ANSI sensitive:
`tests/test_cli_scopes.py::test_rename_reports_stale_checked_in_offer` and
`tests/test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`.

`ruff check` and `ruff format --check` pass clean on
`tests/test_workflow_board_parser.py`, the only file with code changes.

## Out of scope

- The board table's columns.
- ADR 0002's status — issue #380 restamps it.
- Teammate capture suppression.
- Issues #123 and #130.

## References

- Closes #379.
- Epic #375.
- `docs/prd/0012-retire-producerless-surfaces.md`.
- ADR 0002.
