### PR TITLE
Commit and push each flag, and rename the surface conflict kind

### DIFF
--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -40,6 +40,7 @@ from lore_core.scopes import (
 from lore_core.session_start import MAX_CONTEXT_CHARS
 from lore_core.session_start import load_directive_lines as _load_directive_lines
 from lore_core.session_start import maybe_auto_pull_for_scope as _maybe_auto_pull_for_scope
+from lore_core.session_start import maybe_auto_push_for_scope as _maybe_auto_push_for_scope
 from lore_core.session_start import offer_notice_line as _offer_notice_line
 from lore_core.session_start import pre_compact_text as _pre_compact
 from lore_core.session_start import render_capture_state_block as _render_capture_state_block
@@ -1008,6 +1009,19 @@ def capture(
         )
         raise
 
+    # Session boundary: hand the wiki's commits to the remote. Every flag
+    # filed this session is already committed, so this is the step that
+    # puts them on a teammate's machine. It costs one network round trip
+    # at the end of a session, which is why it runs here and not per turn.
+    boundary: dict[str, object] = {}
+    if event == "session-end":
+        try:
+            pushed = _maybe_auto_push_for_scope(scope, lore_root)
+            if pushed is not None:
+                boundary["push"] = pushed.status.value
+        except Exception:  # noqa: BLE001 — an unreachable remote never fails the hook
+            boundary["push"] = "error"
+
     _emit_hook(
         event=event, integration=integration, scope=scope_payload,
         duration_ms=_elapsed_ms(),
@@ -1018,6 +1032,7 @@ def capture(
         cwd=str(cwd),
         pid=_capture_pid,
         ppid_cmd=_capture_ppid_cmd,
+        **boundary,
     )
 
     # Session-end breadcrumb, displayed at the next SessionStart. Only for

--- a/lib/lore_core/flag.py
+++ b/lib/lore_core/flag.py
@@ -389,6 +389,27 @@ def _append_block(path: Path, block: str, *, description: str, day: str) -> bool
     return True
 
 
+def _commit(wiki_path: Path, note_path: Path, flag_id: str) -> bool:
+    """Commit the flag into the wiki repo. Best-effort; never raises.
+
+    Three parts carry a flag to a teammate: this write, this commit, and
+    the push the session boundary runs. A wiki that is not a git repo
+    keeps the flag in its working tree instead — a transport that is not
+    there must never cost the write.
+    """
+    from lore_core.session import commit_note
+
+    try:
+        ok, _detail = commit_note(
+            wiki_path=wiki_path,
+            note_path=note_path,
+            message=f"lore: flag {flag_id}",
+        )
+    except (OSError, ValueError):
+        return False
+    return ok
+
+
 # ---------------------------------------------------------------------------
 # Telemetry
 # ---------------------------------------------------------------------------
@@ -506,6 +527,7 @@ def write(
         stamped=not human,
     )
     created = _append_block(note_path, block, description=lead, day=day)
+    committed = _commit(wiki_path, note_path, flag_id)
     _emit(
         root,
         EV_WRITE,
@@ -515,6 +537,7 @@ def write(
         note=str(note_path.relative_to(wiki_path)),
         created_note=created,
         reviewed=human,
+        committed=committed,
     )
     return FlagWrite(
         status="written",

--- a/lib/lore_core/git_sync.py
+++ b/lib/lore_core/git_sync.py
@@ -45,8 +45,8 @@ class SyncResult:
 
 
 class ConflictKind(str, Enum):
-    SURFACE = "surface"  # LLM-merge
-    SESSION = "session"  # LLM-merge (rare — pre-pull eliminates)
+    NOTE = "note"  # LLM-merge (parked)
+    SESSION = "session"  # LLM-merge (parked; rare — pre-pull eliminates)
     REGENERABLE = "regenerable"  # ours wins; lint reconciles
     UNKNOWN = "unknown"  # bail to user
 
@@ -231,14 +231,19 @@ def auto_push(
     wiki_dir: Path,
     *,
     llm_client: Any = None,
-    surface_dirs: list[str] | None = None,
+    note_dirs: list[str] | None = None,
 ) -> SyncResult:
     """Push local commits, resolving conflicts via LLM merge if needed.
 
-    ``surface_dirs`` is the list of subdirectory names whose conflicts are
+    ``note_dirs`` is the list of subdirectory names whose conflicts are
     eligible for LLM merge (e.g. ``["concepts", "decisions", "results"]``).
     If not given, a permissive default set is used. Used to classify a
     conflict path as LLM-mergeable vs other (bail).
+
+    ``llm_client`` is parked: no caller passes one, so a note conflict
+    always ends in MERGE_BLOCKED with the working tree handed back
+    clean. The path stays in the tree because the merge itself works —
+    what is on hold is the decision to run a model at the boundary.
 
     Returns:
       OK                — push succeeded outright
@@ -318,19 +323,19 @@ def auto_push(
         _git(wiki_dir, "merge", "--abort")
         return SyncResult(status=SyncStatus.MERGE_BLOCKED, message="merge failed without conflicts")
 
-    surface_names = surface_dirs if surface_dirs is not None else _surface_dirs(wiki_dir)
+    note_names = note_dirs if note_dirs is not None else _note_dirs(wiki_dir)
 
     merged: list[str] = []
     blocked: list[str] = []
     for path in conflicts:
-        kind = _classify_conflict_path(path, surface_names)
+        kind = _classify_conflict_path(path, note_names)
         if kind is ConflictKind.REGENERABLE:
             # Take ours; lint will truth it after the merge.
             _git(wiki_dir, "checkout", "--ours", path)
             _git(wiki_dir, "add", path)
             merged.append(path)
             continue
-        if kind in (ConflictKind.SURFACE, ConflictKind.SESSION):
+        if kind in (ConflictKind.NOTE, ConflictKind.SESSION):
             if llm_client is None:
                 blocked.append(path)
                 continue
@@ -353,7 +358,7 @@ def auto_push(
         wiki_dir,
         "commit",
         "-m",
-        f"merge(auto-llm): {len(merged)} surface(s)" if merged else "merge",
+        f"merge(auto-llm): {len(merged)} note(s)" if merged else "merge",
     )
     if commit.returncode != 0:
         _git(wiki_dir, "merge", "--abort")
@@ -388,7 +393,7 @@ def _list_conflicts(wiki_dir: Path) -> list[str]:
     return [line for line in r.stdout.splitlines() if line.strip()]
 
 
-def _surface_dirs(wiki_dir: Path) -> list[str]:
+def _note_dirs(wiki_dir: Path) -> list[str]:
     """Return the subdirectory names classified as LLM-mergeable notes.
 
     A permissive default set — better to LLM-merge a note that turned out
@@ -398,17 +403,17 @@ def _surface_dirs(wiki_dir: Path) -> list[str]:
     return ["concepts", "decisions", "results", "people", "places", "questions"]
 
 
-def _classify_conflict_path(path: str, surface_dirs: list[str]) -> ConflictKind:
+def _classify_conflict_path(path: str, note_dirs: list[str]) -> ConflictKind:
     """Classify a conflict path into one of the four resolution buckets."""
     parts = path.split("/")
     name = parts[-1]
     if name in _REGENERABLE_FILENAMES:
         return ConflictKind.REGENERABLE
 
-    # wiki/<wiki>/<surface_dir>/*.md  OR  <surface_dir>/*.md (when path
+    # wiki/<wiki>/<note_dir>/*.md  OR  <note_dir>/*.md (when path
     # is already wiki-root-relative)
-    if any(seg in surface_dirs for seg in parts):
-        return ConflictKind.SURFACE
+    if any(seg in note_dirs for seg in parts):
+        return ConflictKind.NOTE
 
     if "sessions" in parts:
         return ConflictKind.SESSION
@@ -433,7 +438,11 @@ def _resolve_via_llm(
     *,
     llm_client: Any,
 ) -> bool:
-    """LLM-merge a single conflicted file. Returns True on success."""
+    """LLM-merge a single conflicted file. Returns True on success.
+
+    Parked — reachable only when a caller passes an ``llm_client``, and
+    none does.
+    """
     ours = _read_version(wiki_dir, "HEAD", path)
     theirs = _read_version(wiki_dir, "MERGE_HEAD", path)
     base_ref = _merge_base_ref(wiki_dir)
@@ -472,17 +481,19 @@ def _llm_merge_text(
 ) -> str | None:
     """Call the LLM to produce a merged version. Returns None on failure.
 
-    The merge prompt is deliberately minimal — surfaces have a free-form
+    The merge prompt is deliberately minimal — a note has a free-form
     body and structured frontmatter. We trust the LLM to preserve both,
-    then validate the result re-parses as a valid surface (frontmatter
+    then validate the result re-parses as a valid note (frontmatter
     extractable, body present).
+
+    Parked with the rest of the LLM-merge path.
     """
     fm_ours = parse_frontmatter(ours)
-    surface_type = fm_ours.get("type", "note")
+    note_type = fm_ours.get("type", "note")
 
     prompt = _MERGE_PROMPT.format(
         path=path,
-        type=surface_type,
+        type=note_type,
         ours=ours,
         theirs=theirs,
         base=base if base else "(no common ancestor)",
@@ -497,7 +508,7 @@ def _llm_merge_text(
     # Sanity check: result must still parse as markdown with frontmatter,
     # the frontmatter must yaml-parse to a dict, and (per the prompt
     # contract) carry a ``type`` key. Reject malformed responses rather
-    # than letting them clobber a real surface.
+    # than letting them clobber a real note.
     if split_frontmatter(merged) is None:
         return None
     fm = parse_frontmatter(merged)

--- a/lib/lore_core/session.py
+++ b/lib/lore_core/session.py
@@ -78,6 +78,10 @@ def commit_note(
 
     Returns ``(success, sha-or-error)``. Idempotent for already-committed
     state (``"nothing to commit"`` returns ``True`` with empty sha).
+
+    The commit carries a pathspec, so only ``note_path`` lands in it. A
+    flag write calls this on every write, and a wiki is a directory a
+    human also edits — whatever else they staged stays staged.
     """
     rel = note_path.resolve().relative_to(wiki_path.resolve())
     add = subprocess.run(
@@ -93,7 +97,7 @@ def commit_note(
         slug = note_path.stem
         message = f"lore: session {slug}"
     commit = subprocess.run(
-        ["git", "commit", "-m", message],
+        ["git", "commit", "-m", message, "--", str(rel)],
         cwd=str(wiki_path),
         capture_output=True,
         text=True,

--- a/lib/lore_core/session_start.py
+++ b/lib/lore_core/session_start.py
@@ -27,6 +27,7 @@ from lore_core.git import current_repo
 from lore_core.spine import emit_hook_event
 
 if TYPE_CHECKING:
+    from lore_core.git_sync import SyncResult
     from lore_core.types import Scope
 
 
@@ -603,6 +604,31 @@ def maybe_auto_pull_for_scope(scope: Scope, lore_root: Path) -> str | None:
     if result.status is SyncStatus.SKIPPED_DIVERGED:
         return f"› wiki [[{scope.wiki}]] diverged from origin — `git pull` manually"
     return None
+
+
+def maybe_auto_push_for_scope(scope: Scope, lore_root: Path) -> SyncResult | None:
+    """Push this scope's wiki repo at the session boundary if config opts in.
+
+    Returns the sync result, or ``None`` when the wiki directory is
+    missing or the config opts out. Unlike :func:`maybe_auto_pull_for_scope`
+    this hands back the result instead of a banner line: no banner renders
+    at a session boundary, and the next SessionStart already tells the user
+    about a diverged wiki through the pull.
+
+    No LLM client is passed. A note both machines changed therefore ends
+    in ``MERGE_BLOCKED`` with the working tree handed back clean, and the
+    user resolves it with git.
+    """
+    from lore_core.git_sync import auto_push
+    from lore_core.wiki_config import load_wiki_config
+
+    wiki_dir = lore_root / "wiki" / scope.wiki
+    if not wiki_dir.exists():
+        return None
+    cfg = load_wiki_config(wiki_dir)
+    if not cfg.git.auto_push:
+        return None
+    return auto_push(wiki_dir)
 
 
 def render_capture_state_block(

--- a/lib/lore_core/wiki_config.py
+++ b/lib/lore_core/wiki_config.py
@@ -71,20 +71,41 @@ def load_wiki_config(wiki_dir: Path) -> WikiConfig:
 
     Missing file → all defaults. Unknown keys → `warnings.warn` but
     config loads. Malformed YAML → defaults + warning (no crash).
+
+    ``git.auto_push`` is the one field whose default reads the wiki
+    itself: see :func:`_default_auto_push`.
     """
     path = wiki_dir / ".lore-wiki.yml"
     if not path.exists():
-        return WikiConfig()
+        return _with_auto_push_default(WikiConfig(), wiki_dir, set_by_file=False)
     try:
         raw = yaml.safe_load(path.read_text()) or {}
     except yaml.YAMLError as e:
         warnings.warn(f"wiki_config: malformed YAML at {path}: {e}", stacklevel=2)
-        return WikiConfig()
+        return _with_auto_push_default(WikiConfig(), wiki_dir, set_by_file=False)
     if not isinstance(raw, dict):
         warnings.warn(f"wiki_config: top-level must be a mapping at {path}", stacklevel=2)
-        return WikiConfig()
+        return _with_auto_push_default(WikiConfig(), wiki_dir, set_by_file=False)
 
-    return _merge(WikiConfig(), raw, path)
+    cfg = _merge(WikiConfig(), raw, path)
+    git_block = raw.get("git")
+    set_by_file = isinstance(git_block, dict) and "auto_push" in git_block
+    return _with_auto_push_default(cfg, wiki_dir, set_by_file=set_by_file)
+
+
+def _with_auto_push_default(cfg: WikiConfig, wiki_dir: Path, *, set_by_file: bool) -> WikiConfig:
+    """Default ``git.auto_push`` to whether the wiki has a git remote.
+
+    A wiki with a remote is a shared vault, and a flag reaches a
+    teammate only after a push. A solo wiki has nowhere to push, so the
+    same default reads false there. A value written in the file always
+    wins over both.
+    """
+    if not set_by_file:
+        from lore_core.git_sync import has_remote
+
+        cfg.git.auto_push = has_remote(wiki_dir)
+    return cfg
 
 
 def _merge(default_obj, overrides: dict[str, Any], source: Path):

--- a/tests/test_flag_transport.py
+++ b/tests/test_flag_transport.py
@@ -1,0 +1,265 @@
+"""Flag transport — the commit at write time and the push at the boundary.
+
+A flag reaches a teammate only after three parts run: the write, the
+commit, the push. These tests drive real git repositories — a bare
+origin plus two clones standing for two machines — the way
+``tests/test_git_sync.py`` does. A mocked git proves nothing about
+transport.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from lore_cli.hooks import hook_app
+from lore_core import flag
+from lore_core.git_sync import SyncStatus, auto_pull
+from lore_core.scope_resolver import resolve_scope
+from lore_core.session_start import maybe_auto_push_for_scope
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — a vault whose wiki is a clone, and a teammate's clone
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _identify(repo: Path, name: str) -> None:
+    _git(repo, "config", "user.email", f"{name}@example.com")
+    _git(repo, "config", "user.name", name)
+
+
+def _committed_paths(repo: Path) -> list[str]:
+    return _git(repo, "show", "--name-only", "--format=", "HEAD").stdout.split()
+
+
+def _file_flag(target: str = "concepts/reaper.md") -> flag.FlagWrite:
+    return flag.write(
+        "The reaper starves.",
+        body="Two sessions raced the same lock; the loser never retried.",
+        wiki="lore",
+        target=target,
+        refs=[("pr", "357")],
+        transcript="tr-9f2c",
+        author="claude",
+        now="2026-08-05",
+    )
+
+
+@pytest.fixture()
+def team_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Returns ``(vault, wiki, teammate)`` — two clones of one bare origin."""
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LORE_ROOT", str(vault))
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    monkeypatch.delenv("LORE_SUPPRESS_CAPTURE", raising=False)
+
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git(origin, "init", "--bare", "--initial-branch=main")
+
+    wiki_root = vault / "wiki"
+    wiki_root.mkdir(parents=True)
+    wiki = wiki_root / "lore"
+    _git(wiki_root, "clone", str(origin), str(wiki))
+    _identify(wiki, "alice")
+    (wiki / "concepts").mkdir()
+    (wiki / "README.md").write_text("# lore\n")
+    _git(wiki, "add", "README.md")
+    _git(wiki, "commit", "-m", "initial")
+    _git(wiki, "push", "-u", "origin", "main")
+
+    teammate = tmp_path / "teammate"
+    _git(tmp_path, "clone", str(origin), str(teammate))
+    _identify(teammate, "bob")
+    return vault, wiki, teammate
+
+
+# ---------------------------------------------------------------------------
+# The commit — every flag lands in the wiki's history
+# ---------------------------------------------------------------------------
+
+
+def test_write_commits_the_flag_into_the_wiki(team_vault) -> None:
+    _vault, wiki, _teammate = team_vault
+
+    result = _file_flag()
+
+    assert result.status == "written"
+    assert _git(wiki, "status", "--porcelain").stdout.strip() == ""
+    assert _committed_paths(wiki) == ["concepts/reaper.md"]
+
+
+def test_write_leaves_a_staged_neighbour_out_of_the_commit(team_vault) -> None:
+    """A human's staged work is theirs — the flag commit carries one note."""
+    _vault, wiki, _teammate = team_vault
+    (wiki / "concepts" / "draft.md").write_text("half-written\n")
+    _git(wiki, "add", "concepts/draft.md")
+
+    _file_flag()
+
+    assert _committed_paths(wiki) == ["concepts/reaper.md"]
+    assert "concepts/draft.md" in _git(wiki, "status", "--porcelain").stdout
+
+
+def test_write_lands_in_a_wiki_that_is_not_a_git_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    (tmp_path / "wiki" / "lore" / "concepts").mkdir(parents=True)
+
+    result = _file_flag()
+
+    assert result.status == "written"
+    assert (tmp_path / "wiki" / "lore" / "concepts" / "reaper.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# The push — the session boundary hands the flag to the teammate
+# ---------------------------------------------------------------------------
+
+
+class _Scope:
+    wiki = "lore"
+    scope = "proj"
+
+
+def test_boundary_push_delivers_the_flag_to_a_teammate(team_vault) -> None:
+    vault, _wiki, teammate = team_vault
+    _file_flag()
+
+    result = maybe_auto_push_for_scope(_Scope(), vault)
+
+    assert result is not None
+    assert result.status is SyncStatus.OK
+    assert auto_pull(teammate).status is SyncStatus.OK
+    assert "The reaper starves." in (teammate / "concepts" / "reaper.md").read_text()
+
+
+def test_boundary_push_skips_a_wiki_without_a_remote(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    wiki = tmp_path / "wiki" / "lore"
+    (wiki / "concepts").mkdir(parents=True)
+    _git(wiki, "init", "--initial-branch=main")
+    _identify(wiki, "alice")
+    _file_flag()
+
+    # No remote means no transport to run: the config default opts out
+    # and lore never reaches git at all.
+    assert maybe_auto_push_for_scope(_Scope(), tmp_path) is None
+
+
+def test_boundary_push_blocks_on_a_note_conflict_and_leaves_the_tree_clean(
+    team_vault,
+) -> None:
+    """No LLM client crosses the boundary, so a note conflict blocks."""
+    vault, wiki, teammate = team_vault
+    (teammate / "concepts").mkdir(exist_ok=True)
+    (teammate / "concepts" / "reaper.md").write_text("---\ntype: concept\n---\n\nBob's version.\n")
+    _git(teammate, "add", "concepts/reaper.md")
+    _git(teammate, "commit", "-m", "bob files one")
+    _git(teammate, "push")
+    _file_flag()
+
+    result = maybe_auto_push_for_scope(_Scope(), vault)
+
+    assert result is not None
+    assert result.status is SyncStatus.MERGE_BLOCKED
+    assert "concepts/reaper.md" in result.blocked_paths
+    porcelain = _git(wiki, "status", "--porcelain").stdout.strip()
+    assert porcelain == "", f"working tree not clean after abort: {porcelain!r}"
+
+
+# ---------------------------------------------------------------------------
+# The wiring — the session-end hook runs the push
+# ---------------------------------------------------------------------------
+
+
+class _NoTranscriptAdapter:
+    integration = "no-transcripts"
+
+    def list_transcripts(self, directory: Path) -> list:  # noqa: ARG002
+        return []
+
+    def read_slice_after_hash(self, *a, **kw):
+        yield from ()
+
+    def read_slice(self, *a, **kw):
+        yield from ()
+
+    def is_complete(self, handle) -> bool:  # noqa: ARG002
+        return True
+
+
+@pytest.fixture()
+def registered_adapter():
+    from lore_adapters import register
+    from lore_adapters.registry import _REGISTRY
+
+    adapter = _NoTranscriptAdapter()
+    register(adapter)
+    yield adapter
+    _REGISTRY.pop(adapter.integration, None)
+
+
+def test_session_end_hook_pushes_the_wiki(team_vault, registered_adapter, tmp_path: Path) -> None:
+    from lore_core.state.attachments import Attachment, AttachmentsFile
+
+    vault, _wiki, teammate = team_vault
+    project = tmp_path / "project"
+    project.mkdir()
+    (vault / ".lore").mkdir(parents=True, exist_ok=True)
+    af = AttachmentsFile(vault)
+    af.load()
+    af.add(
+        Attachment(
+            path=project,
+            wiki="lore",
+            scope="proj",
+            attached_at=datetime.now(tz=UTC),
+            source="manual",
+        )
+    )
+    af.save()
+    assert resolve_scope(project) is not None
+    _file_flag()
+
+    result = runner.invoke(
+        hook_app,
+        [
+            "capture",
+            "--event",
+            "session-end",
+            "--cwd",
+            str(project),
+            "--integration",
+            registered_adapter.integration,
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert auto_pull(teammate).status is SyncStatus.OK
+    assert (teammate / "concepts" / "reaper.md").exists()

--- a/tests/test_git_sync.py
+++ b/tests/test_git_sync.py
@@ -254,7 +254,7 @@ class StubLlm:
         self.messages = _StubLlmMessages(response_text)
 
 
-def test_auto_push_resolves_surface_conflict_via_llm(two_hosts) -> None:
+def test_auto_push_resolves_note_conflict_via_llm(two_hosts) -> None:
     _, host_a, host_b = two_hosts
 
     # Both hosts independently create concepts/foo.md with overlapping content.
@@ -277,7 +277,7 @@ def test_auto_push_resolves_surface_conflict_via_llm(two_hosts) -> None:
     result = auto_push(
         host_b,
         llm_client=StubLlm(merged_body),
-        surface_dirs=["concepts"],
+        note_dirs=["concepts"],
     )
     assert result.status is SyncStatus.MERGED, f"got {result}"
     assert "concepts/foo.md" in result.merged_paths
@@ -294,7 +294,7 @@ def test_auto_push_blocks_when_no_llm_client_provided(two_hosts) -> None:
     _git(host_a, "push")
     _commit_file(host_b, "concepts/foo.md", "---\ntype: concept\n---\nB\n", "b")
 
-    result = auto_push(host_b, llm_client=None, surface_dirs=["concepts"])
+    result = auto_push(host_b, llm_client=None, note_dirs=["concepts"])
     assert result.status is SyncStatus.MERGE_BLOCKED
     assert "concepts/foo.md" in result.blocked_paths
     # Tree should be back to clean — abort completed.
@@ -308,7 +308,7 @@ def test_auto_push_picks_ours_for_regenerable_artifacts(two_hosts) -> None:
     _git(host_a, "push")
     _commit_file(host_b, "_catalog.json", '{"b": 2}\n', "b catalog")
 
-    result = auto_push(host_b, llm_client=None, surface_dirs=["concepts"])
+    result = auto_push(host_b, llm_client=None, note_dirs=["concepts"])
     assert result.status is SyncStatus.MERGED, f"got {result}"
     assert "_catalog.json" in result.merged_paths
     # Ours wins.
@@ -321,7 +321,7 @@ def test_auto_push_blocks_unknown_conflict_path(two_hosts) -> None:
     _git(host_a, "push")
     _commit_file(host_b, "CLAUDE.md", "from b\n", "b")
 
-    result = auto_push(host_b, llm_client=None, surface_dirs=["concepts"])
+    result = auto_push(host_b, llm_client=None, note_dirs=["concepts"])
     assert result.status is SyncStatus.MERGE_BLOCKED
     assert "CLAUDE.md" in result.blocked_paths
 
@@ -378,8 +378,8 @@ def test_is_diverged_false_for_non_repo(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "path,expected",
     [
-        ("concepts/foo.md", ConflictKind.SURFACE),
-        ("decisions/2026-04-26-pivot.md", ConflictKind.SURFACE),
+        ("concepts/foo.md", ConflictKind.NOTE),
+        ("decisions/2026-04-26-pivot.md", ConflictKind.NOTE),
         ("sessions/alice/2026/04/26-foo.md", ConflictKind.SESSION),
         ("_catalog.json", ConflictKind.REGENERABLE),
         ("_threads.txt", ConflictKind.REGENERABLE),
@@ -399,3 +399,14 @@ def test_is_diverged_false_for_non_repo(tmp_path: Path) -> None:
 )
 def test_classify_conflict_path(path: str, expected: ConflictKind) -> None:
     assert _classify_conflict_path(path, ["concepts", "decisions"]) is expected
+
+
+def test_git_sync_declares_no_symbol_named_surface() -> None:
+    """Epic #131 retired a feature called surfaces; the word is now free."""
+    import inspect
+
+    from lore_core import git_sync
+
+    assert [n for n in dir(git_sync) if "surface" in n.lower()] == []
+    assert [n for n in ConflictKind.__members__ if "SURFACE" in n] == []
+    assert "note_dirs" in inspect.signature(git_sync.auto_push).parameters

--- a/tests/test_wiki_config.py
+++ b/tests/test_wiki_config.py
@@ -1,5 +1,6 @@
 """Tests for per-wiki config loader."""
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -197,3 +198,28 @@ class TestWikiConfigWriteBack:
         assert "heartbeat.enabled" in paths
         assert "breadcrumb.mode" in paths
         assert "git" not in paths  # groups excluded, leaves only
+
+
+class TestAutoPushDefault:
+    """A wiki with a remote is shared, so lore pushes it unless told not to."""
+
+    def _repo(self, tmp_path: Path, *, remote: bool) -> Path:
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        subprocess.run(["git", "init", "--initial-branch=main"], cwd=wiki, check=True,
+                       capture_output=True)
+        if remote:
+            subprocess.run(["git", "remote", "add", "origin", str(tmp_path / "origin.git")],
+                           cwd=wiki, check=True, capture_output=True)
+        return wiki
+
+    def test_auto_push_defaults_true_for_a_wiki_with_a_remote(self, tmp_path: Path):
+        assert load_wiki_config(self._repo(tmp_path, remote=True)).git.auto_push is True
+
+    def test_auto_push_defaults_false_for_a_wiki_without_a_remote(self, tmp_path: Path):
+        assert load_wiki_config(self._repo(tmp_path, remote=False)).git.auto_push is False
+
+    def test_an_explicit_false_wins_over_the_remote_default(self, tmp_path: Path):
+        wiki = self._repo(tmp_path, remote=True)
+        (wiki / ".lore-wiki.yml").write_text("git:\n  auto_push: false\n")
+        assert load_wiki_config(wiki).git.auto_push is False


### PR DESCRIPTION
Implements #378.

## Context

A flag is one team-relevant fact an agent files into a wiki. Three parts
carry a flag to a teammate: the write, the commit, the push.

Before this change `lore_core/flag.py` wrote the flag and reindexed the
wiki. The module ran no commit and no push. A flag therefore stayed in
the working tree of the machine that filed it.

`lore_core/git_sync.py` also named its note conflict kind `SURFACE`.
Issue #131 retired a different feature named surfaces.

## What this pull request changes

### The transport

- `lore_core/flag.py` commits each written flag through
  `lore_core/session.py` `commit_note`.
- `lore_core/session.py` `commit_note` passes a pathspec to `git commit`.
  A wiki is a directory a human also edits. Whatever the human staged
  stays staged.
- `lore_core/session_start.py` gains `maybe_auto_push_for_scope`. The
  function reads the wiki config and calls `auto_push`.
- `lore_cli/hooks.py` calls `maybe_auto_push_for_scope` on the
  `session-end` capture event. The hook records the push status in its
  spine event under the key `push`.
- `lore_core/wiki_config.py` defaults `git.auto_push` to whether the wiki
  has a git remote. A value in `.lore-wiki.yml` still wins.
- No caller passes an LLM client. A note conflict therefore ends in
  `MERGE_BLOCKED`, and `auto_push` runs `git merge --abort` before it
  returns. The LLM-merge path stays in the tree. Comments in
  `lore_core/git_sync.py` mark the path parked.

### The name

- `ConflictKind.SURFACE` is now `ConflictKind.NOTE`.
- `_surface_dirs` is now `_note_dirs`.
- The `surface_dirs` keyword is now `note_dirs`.
- `lore_core/git_sync.py` declares no symbol that holds the word surface.

## Acceptance criteria

| Criterion | Test |
| --- | --- |
| When an agent files a flag, lore commits the flag into the flag's wiki. | `test_write_commits_the_flag_into_the_wiki` |
| Where a wiki carries a git remote, lore pushes the wiki at the session boundary. | `test_boundary_push_delivers_the_flag_to_a_teammate`, `test_session_end_hook_pushes_the_wiki` |
| Where a wiki carries no git remote, lore pushes nothing. | `test_boundary_push_skips_a_wiki_without_a_remote` |
| If a push meets a note conflict, then lore reports `MERGE_BLOCKED`. | `test_boundary_push_blocks_on_a_note_conflict_and_leaves_the_tree_clean` |
| If a push meets a note conflict, then lore returns the working tree to a clean state. | `test_boundary_push_blocks_on_a_note_conflict_and_leaves_the_tree_clean` |
| When a user reads the wiki config, lore reports `auto_push` as true for a wiki with a remote. | `test_auto_push_defaults_true_for_a_wiki_with_a_remote` |
| The module `lore_core/git_sync.py` declares no symbol named surface. | `test_git_sync_declares_no_symbol_named_surface` |
| When a caller passes `note_dirs`, lore classifies a conflict path as before the change. | `test_classify_conflict_path` |

## Red to green

The transport tests drive real git repositories. `tests/test_flag_transport.py`
builds a bare origin and two clones, the way `tests/test_git_sync.py` does.
No test mocks git.

Red, before the change. The two renamed tests and the new transport
tests fail to import:

```
$ pytest tests/test_git_sync.py tests/test_flag_transport.py -q
tests/test_git_sync.py:381: in <module>
    ("concepts/foo.md", ConflictKind.NOTE),
E   AttributeError: type object 'ConflictKind' has no attribute 'NOTE'

tests/test_flag_transport.py:21: in <module>
    from lore_core.session_start import maybe_auto_push_for_scope
E   ImportError: cannot import name 'maybe_auto_push_for_scope' from 'lore_core.session_start'

2 errors in 0.71s
```

The wiki config test fails on the value:

```
$ pytest tests/test_wiki_config.py -q
>       assert load_wiki_config(self._repo(tmp_path, remote=True)).git.auto_push is True
E       AssertionError: assert False is True
E        +  where False = GitConfig(auto_commit=False, auto_push=False, auto_pull=True).auto_push

1 failed, 20 passed in 0.30s
```

Green, after the change:

```
$ pytest tests/test_flag_transport.py tests/test_git_sync.py tests/test_wiki_config.py -q
65 passed
```

Full suite on this branch:

```
$ pytest -q
2 failed, 2691 passed, 45 skipped, 11 subtests passed
```

Both failures are the two the epic baseline records on this host. Both
pass in continuous integration.
`tests/test_cli_scopes.py::test_rename_reports_stale_checked_in_offer` and
`tests/test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`
read terminal width.

## Decisions the issue left open

- The session boundary is the `SessionEnd` hook, not the `Stop` hook. The
  `Stop` hook fires after every assistant turn, and a push costs one
  network round trip.
- A review verdict does not commit. `accept`, `decline` and `retarget`
  leave their edit in the working tree, as before. The acceptance
  criteria name the write alone.
- Lore reports a blocked push in the spine event only. The next
  SessionStart already tells the user that the wiki diverged, through
  `auto_pull`.
