### PR TITLE
Reconcile the documentation with the swept code and record the rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ what `lore install`'s self-install bootstrap uses internally too.
 
 Edit `~/git/lore/skills/<name>/SKILL.md` → Claude Code picks up the
 change next session. (Skill directories are bare names like
-`attach`, `loaded`, `resume`; the `/lore:` slash-command prefix
+`curator`, `inbox`, `verify`; the `/lore:` slash-command prefix
 comes from the plugin namespace, not the directory name.) Edit `~/git/lore/lib/lore_core/...` → next CLI
 invocation runs the new code. No reinstall step.
 

--- a/README.md
+++ b/README.md
@@ -259,8 +259,10 @@ Once attached with a wiki present:
 - **SessionStart also spawns a detached transcript sync**, mirroring
   every attached transcript into its wiki's `.transcripts/` and
   emitting the one live drain event, `transcript-synced`. An
-  opportunistic, flock-guarded retention sweep runs alongside it. Both
-  detached — SessionStart never blocks.
+  opportunistic, flock-guarded retention sweep runs in-process
+  alongside it — short and lock-guarded, so it doesn't block
+  SessionStart in practice, but only the transcript sync is actually
+  detached.
 - **Banner at SessionStart** is deliberately minimal: a status line, an
   optional Focus block, a last-active-day recap read off the transcript
   ledger (day, session count, repos, branches, refs — no LLM call), a
@@ -302,7 +304,7 @@ git:
 models:
   simple: claude-haiku-4-5
   middle: claude-sonnet-4-6
-  high:   claude-opus-4-7       # or 'off' to disable the high tier
+  high:   claude-opus-4-7
 briefing:
   audience: personal
   sinks:
@@ -322,13 +324,13 @@ Every background producer (hooks, the hygiene curator, transcript sync,
 the retention janitor, flags) writes one envelope onto one append-only
 event log, the **spine**. Each envelope carries a `trace_id` field for
 correlating several records into one story; no current producer mints
-one, so today's live correlation is by `session_id` instead. Three
-commands cover the common scenarios:
+one, so `flag` is the one selector with live data behind it today.
+Three commands cover the common scenarios:
 
 | Scenario | Command |
 |---|---|
 | **"Is Lore healthy right now?"** | **`lore status`** |
-| "I had a session and nothing was captured" | `lore trace <session-id>` |
+| "I had a session and nothing was captured" | `lore status` / `lore doctor` |
 | "Hook plumbing feels off" | `lore doctor` (`--fix` repairs what it can) |
 | "Did my flag land, and when was it reviewed?" | `lore trace flag` |
 
@@ -339,7 +341,8 @@ command.
 
 `lore trace <selector>` renders the chronological, correlated story of one
 unit of work for a trace_id, a session_id, `flag` (every flag-write/review
-event as a flat table), or a note path / `[[wikilink]]`.
+event as a flat table, the selector with live data today), or a note path /
+`[[wikilink]]`.
 
 `lore log` / `lore news` / `lore runs` / `lore proc` have been removed —
 their debugging role is fully absorbed by `lore trace` / `lore status`

--- a/README.md
+++ b/README.md
@@ -187,12 +187,14 @@ network egress to PyPI / the marketplace.
 
 ## Bootstrap: passive capture
 
-Session notes auto-extract from Claude Code transcripts; explicit
-capture commands are no longer needed. Each session's turns accumulate
-in a buffer, and at session end the whole session is extracted into a
-single, per-session lab-notebook note — nothing is written while the
-session runs (see `CONTEXT.md` for the full model). Anything else
-in a wiki — concepts, decisions, projects, reference notes — is
+Capture is automatic and needs no explicit command. Every transcript
+Claude Code produces is registered into the transcript ledger and
+mirrored into the wiki's `.transcripts/`, stamped with a linkage block
+(repo, branch, PRs, issues, commits, files) derived from git state — no
+LLM call, no prose (see `CONTEXT.md` for the full model). Capture
+writes nothing into a wiki itself: the only crossing is the **flag**,
+filed deliberately by a human or an agent during the session. Anything
+else in a wiki — concepts, decisions, projects, reference notes — is
 written directly, by hand or via `/lore:inbox`; there is no automatic
 daily abstraction pass.
 
@@ -246,18 +248,19 @@ Interactive — asks for wiki + scope, writes the managed block to
 
 Once attached with a wiki present:
 
-- **Claude Code hooks**, plus ordinary tool activity, drive a per-session
-  buffer heartbeat — no cron. **SessionEnd is the only flush:** the whole
-  session is segmented into chunks, each chunk extracted into typed facts,
-  and the note body rendered from them by code, behind the publish gate.
-  Mid-session events (a pre-compact, the buffer tripping its cap) only
-  bookkeep — the buffer keeps accumulating and no model is called, because
-  which turns mattered is knowable only from the ending. No LLM runs inline
-  in the hook itself; the flush is detached.
-- **SessionStart** also sweeps any session whose owning process is
-  provably dead (crash, closed laptop lid) — its note gets one extraction
-  attempt and closes, under a global singleton lock. All detached —
-  SessionStart never blocks.
+- **Claude Code hooks register every transcript into the ledger.**
+  SessionStart, PreCompact, SessionEnd, and a mid-session
+  UserPromptSubmit heartbeat all route through the same registration
+  path (`lore_curator/capture_routing.py`): each upserts a ledger entry
+  and stamps its linkage block, and a session boundary promotes that
+  stamp to a full transcript read (edited files, commit SHAs). No LLM
+  call; registration is the end of the capture path, not a step toward
+  composing anything.
+- **SessionStart also spawns a detached transcript sync**, mirroring
+  every attached transcript into its wiki's `.transcripts/` and
+  emitting the one live drain event, `transcript-synced`. An
+  opportunistic, flock-guarded retention sweep runs alongside it. Both
+  detached — SessionStart never blocks.
 - **Banner at SessionStart** is deliberately minimal: a status line, an
   optional Focus block, a last-active-day recap read off the transcript
   ledger (day, session count, repos, branches, refs — no LLM call), a
@@ -294,21 +297,12 @@ Each wiki can set its own knobs in `<wiki>/.lore-wiki.yml`:
 
 ```yaml
 git:
-  auto_commit: true
-  auto_push: false              # push manually by default
+  auto_push: true                # true by default when the wiki has a remote
   auto_pull: true
-curator:
-  threshold_pending_turns: 30   # spawn the heartbeat when ≥ N buffered turns
-  max_pending_age_s: 600        # OR the oldest pending entry is this old
-  a_noteworthy_tier: middle     # middle (default) | simple (cheap, higher false-neg)
-  synthesis_buffer_cap_turns: 120   # record a cap-trip at this many turns...
-  synthesis_buffer_cap_chars: 240000 # ...or this many transcript chars
-                                     # (bookkeeping — the buffer keeps growing)
-  synthesis_model_tier: middle  # `models.*` tier for segmentation + extraction
 models:
   simple: claude-haiku-4-5
   middle: claude-sonnet-4-6
-  high:   claude-opus-4-7       # or 'off' — degrades synthesis_model_tier: high to middle
+  high:   claude-opus-4-7       # or 'off' to disable the high tier
 briefing:
   audience: personal
   sinks:
@@ -324,27 +318,28 @@ and add knobs only as you need them. Briefings publish manually
 
 ## Observability
 
-Every background producer (hooks, transcript sync, drain events, the
-retention janitor) writes one envelope onto one append-only event log,
-the **spine**, correlated end-to-end by a `trace_id` minted at hook fire.
-Three commands cover the common scenarios:
+Every background producer (hooks, the hygiene curator, transcript sync,
+the retention janitor, flags) writes one envelope onto one append-only
+event log, the **spine**. Each envelope carries a `trace_id` field for
+correlating several records into one story; no current producer mints
+one, so today's live correlation is by `session_id` instead. Three
+commands cover the common scenarios:
 
 | Scenario | Command |
 |---|---|
 | **"Is Lore healthy right now?"** | **`lore status`** |
-| "I had a session and nothing was captured" | `lore trace last` (or `lore trace dead` for stuck flushes) |
+| "I had a session and nothing was captured" | `lore trace <session-id>` |
 | "Hook plumbing feels off" | `lore doctor` (`--fix` repairs what it can) |
 | "Did my flag land, and when was it reviewed?" | `lore trace flag` |
 
 `lore status` is the first thing to run when you're wondering whether Lore is
-alive: capture liveness, flush queue (queued/running/dead-lettered), per-wiki
-connection health, retention usage, and an alerts section where every warning
-names its own drill-down command.
+alive: capture liveness, per-wiki connection health, a flags section, retention
+usage, and an alerts section where every warning names its own drill-down
+command.
 
 `lore trace <selector>` renders the chronological, correlated story of one
-unit of work — hook fire, gate outcome, write — for a
-trace_id, session_id, `last`, `dead` (lists dead-lettered flushes), or a note
-path / `[[wikilink]]`.
+unit of work for a trace_id, a session_id, `flag` (every flag-write/review
+event as a flat table), or a note path / `[[wikilink]]`.
 
 `lore log` / `lore news` / `lore runs` / `lore proc` have been removed —
 their debugging role is fully absorbed by `lore trace` / `lore status`

--- a/docs/adr/0002-orchestrate-epic-supervision-state-split.md
+++ b/docs/adr/0002-orchestrate-epic-supervision-state-split.md
@@ -1,6 +1,6 @@
 # ADR 0002: Orchestrate-epic supervision-state split (board on the issue, working context on the epic note)
 
-- Status: Accepted
+- Status: Superseded by ADR 0010
 - Date: 2026-07-10
 - Context: epic [#229](https://github.com/buchbend/lore/issues/229),
   PRD [0006](../prd/0006-workflow-lightening-deepening.md), sub-issue

--- a/docs/adr/0010-producer-rule-and-board-carries-the-narrative.md
+++ b/docs/adr/0010-producer-rule-and-board-carries-the-narrative.md
@@ -1,0 +1,91 @@
+# ADR 0010: A read surface without a producer is a defect; the board carries the orchestrator's narrative
+
+- Status: Accepted
+- Date: 2026-08-06
+- Context: epic [#375](https://github.com/buchbend/lore/issues/375),
+  PRD [0012](../prd/0012-retire-producerless-surfaces.md), pull request
+  [#385](https://github.com/buchbend/lore/pull/385); supersedes ADR 0002
+
+## Context
+
+Three releases each deleted a writer and left its readers standing.
+Issue #359 removed `lore resume`. Issue #361 removed the compose
+pipeline. Epic #131 severed an earlier surface called "surfaces". None
+of the three removals swept the readers in the same change.
+
+An audit against `origin/main` at `772e019` found the result: `lore
+status` printed four capture rows and a flushes panel fed by nothing,
+two alerts fired on every healthy system, and one alert named a state
+no code could leave. `lore trace` carried `dead` and `last` selectors
+into a flush-lifecycle record nothing wrote any more. The pattern
+repeated inside `lore-workflow`: ADR 0002 split orchestrate-epic's
+supervision state across the board (per-feature ledger, on the epic
+issue) and the epic note (working narrative, on the orchestrator's own
+session note). Issue #361 deleted the session-note pipeline the epic
+note depended on, so ADR 0002's second store lost its writer along with
+every other reader this epic corrects.
+
+A removal reviewed only its own writer, never the readers left pointing
+at nothing. That is the gap this ADR closes.
+
+## Decision
+
+1. **A read surface without a live producer is a defect.** A removal
+   that deletes a writer deletes or rewires every reader in the same
+   change. `lore status`'s rows, `lore trace`'s selectors, a drain event
+   kind, and a spine `ErrorCode` value each name their producer; a name
+   with no producer is a bug, not a placeholder for one. Issue #377
+   applied this rule to the readers named above and added a guard test,
+   `tests/test_producerless_surfaces_gone.py`, that fails the build on
+   the next producerless surface.
+2. **The board carries the orchestrator's supervision narrative. The
+   epic note is gone.** `orchestrate-epic` writes tier rationale,
+   dispatch and crosscheck reasoning, and escalations into a `## Notes`
+   section below the board's per-feature table, in the same GitHub
+   comment it already edits in place. `lore workflow parse-board`
+   reads the table structurally and ignores the notes section, so a
+   board with notes parses identically to one without.
+
+## Consequences / Trade-offs
+
+- **Positive.** Every row `lore status` prints and every selector `lore
+  trace` accepts now names a producer a reader can find in the running
+  code. A resumed orchestrator reads its prior narrative from the one
+  comment it already fetches, with no second store to reconcile and no
+  session-note pipeline required to carry it.
+- **Positive.** The guard test makes the rule enforceable, not just
+  documented — a future removal that forgets a reader fails CI instead
+  of shipping a dashboard that lies.
+- **Negative.** The board comment is heavier: a supervision run now
+  carries prose as well as the table in one place, and a very long run
+  risks the comment growing large. Accepted — a second, harder-to-parse
+  store was the alternative, and the board was already the durable,
+  human-visible artifact.
+- **Negative.** `trace_id` correlation (the field, `lore trace <trace-id>`,
+  a note's `linkage.trace_id`) has no current minter — its one caller
+  was the compose pipeline's flush spawn, retired with it. The
+  mechanism stays in the tree for a future producer; documented as
+  dormant in `docs/architecture/observability.md`, not deleted, because
+  removing it costs a rewrite for no present defect (nothing reads it
+  and finds a lie — it simply finds nothing).
+
+## Alternatives considered
+
+- **Leave the guard test out and rely on code review to catch a
+  producerless reader.** Rejected: this is exactly what three
+  successive removals missed. A rule stated but not enforced repeats.
+- **Keep the epic note and delete only the compose pipeline's other
+  readers.** Rejected: the epic note's own writer (a composed session
+  note) was the pipeline issue #361 removed. Keeping the note as a
+  concept while its writer is gone recreates the same defect this ADR
+  names.
+- **Move the working narrative into a new dedicated store instead of
+  the board.** Rejected: the board is already fetched, already edited
+  in place every run, and already the durable per-feature record;
+  a second store repeats the two-store drift ADR 0002 accepted as a
+  trade-off, for no gain now that one store can hold both.
+
+## Status
+
+Accepted. Supersedes ADR 0002 (orchestrate-epic supervision-state
+split) — the epic note it specified is gone.

--- a/docs/adr/0010-producer-rule-and-board-carries-the-narrative.md
+++ b/docs/adr/0010-producer-rule-and-board-carries-the-narrative.md
@@ -8,84 +8,77 @@
 
 ## Context
 
-Three releases each deleted a writer and left its readers standing.
-Issue #359 removed `lore resume`. Issue #361 removed the compose
-pipeline. Epic #131 severed an earlier surface called "surfaces". None
-of the three removals swept the readers in the same change.
-
-An audit against `origin/main` at `772e019` found the result: `lore
-status` printed four capture rows and a flushes panel fed by nothing,
-two alerts fired on every healthy system, and one alert named a state
-no code could leave. `lore trace` carried `dead` and `last` selectors
-into a flush-lifecycle record nothing wrote any more. The pattern
-repeated inside `lore-workflow`: ADR 0002 split orchestrate-epic's
-supervision state across the board (per-feature ledger, on the epic
-issue) and the epic note (working narrative, on the orchestrator's own
-session note). Issue #361 deleted the session-note pipeline the epic
-note depended on, so ADR 0002's second store lost its writer along with
-every other reader this epic corrects.
-
-A removal reviewed only its own writer, never the readers left pointing
-at nothing. That is the gap this ADR closes.
+Three releases each deleted a writer and left its readers standing. Each
+removal reviewed only its own writer, never the readers left pointing at
+nothing. Issue #359 removed `lore resume`. Issue #361 removed the compose
+pipeline. Epic #131 severed an earlier surface called "surfaces". An audit
+against `origin/main` at `772e019` found the damage: `lore status` printed
+five capture rows and a flushes panel fed by nothing. Two alerts fired on
+every healthy system, and one alert named a state no code could leave.
+`lore trace` carried `dead` and `last` selectors into a flush-lifecycle
+record nothing wrote any more. The pattern repeated inside `lore-workflow`.
+ADR 0002 put the orchestrator's working narrative on its own session note.
+Issue #361 deleted the session-note pipeline that note depended on. ADR
+0002's second store lost its writer along with every other reader named
+above.
 
 ## Decision
 
-1. **A read surface without a live producer is a defect.** A removal
-   that deletes a writer deletes or rewires every reader in the same
-   change. `lore status`'s rows, `lore trace`'s selectors, a drain event
-   kind, and a spine `ErrorCode` value each name their producer; a name
-   with no producer is a bug, not a placeholder for one. Issue #377
-   applied this rule to the readers named above and added a guard test,
-   `tests/test_producerless_surfaces_gone.py`, that fails the build on
-   the next producerless surface.
-2. **The board carries the orchestrator's supervision narrative. The
-   epic note is gone.** `orchestrate-epic` writes tier rationale,
-   dispatch and crosscheck reasoning, and escalations into a `## Notes`
-   section below the board's per-feature table, in the same GitHub
-   comment it already edits in place. `lore workflow parse-board`
-   reads the table structurally and ignores the notes section, so a
-   board with notes parses identically to one without.
+1. **A read surface without a live producer is a defect.** A removal that
+   deletes a writer deletes or rewires every reader in the same change.
+   `lore status`'s rows, `lore trace`'s selectors, a drain event kind, and
+   a spine `ErrorCode` value each name their producer. A name with no
+   producer is a bug, not a placeholder for one. Issue #377 applied the
+   rule to the readers named above. It added a guard test,
+   `tests/test_producerless_surfaces_gone.py`, that fails the build on the
+   next producerless surface.
+2. **The board carries the orchestrator's supervision narrative. The epic
+   note is gone.** `orchestrate-epic` writes tier rationale, dispatch and
+   crosscheck reasoning, and escalations into a `## Notes` section below
+   the board's per-feature table. Both sections live in the same GitHub
+   comment the orchestrator already edits in place. `lore workflow
+   parse-board` reads the table structurally and ignores the notes
+   section, so a board with notes parses identically to one without.
 
 ## Consequences / Trade-offs
 
 - **Positive.** Every row `lore status` prints and every selector `lore
   trace` accepts now names a producer a reader can find in the running
   code. A resumed orchestrator reads its prior narrative from the one
-  comment it already fetches, with no second store to reconcile and no
-  session-note pipeline required to carry it.
+  comment it already fetches. No second store needs reconciling, and no
+  session-note pipeline needs to carry it.
 - **Positive.** The guard test makes the rule enforceable, not just
-  documented — a future removal that forgets a reader fails CI instead
-  of shipping a dashboard that lies.
-- **Negative.** The board comment is heavier: a supervision run now
-  carries prose as well as the table in one place, and a very long run
-  risks the comment growing large. Accepted — a second, harder-to-parse
-  store was the alternative, and the board was already the durable,
-  human-visible artifact.
+  documented. A future removal that forgets a reader fails CI instead of
+  shipping a dashboard that lies.
+- **Negative.** The board comment carries prose as well as the table now.
+  A very long supervision run risks the comment growing large. Accepted —
+  a second, harder-to-parse store was the alternative, and the board was
+  already the durable, human-visible artifact.
 - **Negative.** `trace_id` correlation (the field, `lore trace <trace-id>`,
-  a note's `linkage.trace_id`) has no current minter — its one caller
-  was the compose pipeline's flush spawn, retired with it. The
-  mechanism stays in the tree for a future producer; documented as
-  dormant in `docs/architecture/observability.md`, not deleted, because
-  removing it costs a rewrite for no present defect (nothing reads it
-  and finds a lie — it simply finds nothing).
+  a note's `linkage.trace_id`) has no current minter. Its one caller, the
+  compose pipeline's flush spawn, retired with the rest of the pipeline.
+  The mechanism stays in the tree for a future producer, documented as
+  dormant in `docs/architecture/observability.md`. Deleting the mechanism
+  would cost a rewrite for no present defect — nothing reads a lie there,
+  only an absence.
 
 ## Alternatives considered
 
 - **Leave the guard test out and rely on code review to catch a
-  producerless reader.** Rejected: this is exactly what three
-  successive removals missed. A rule stated but not enforced repeats.
+  producerless reader.** Rejected: code review is exactly what three
+  successive removals already passed through. A rule stated but not
+  enforced repeats.
 - **Keep the epic note and delete only the compose pipeline's other
-  readers.** Rejected: the epic note's own writer (a composed session
-  note) was the pipeline issue #361 removed. Keeping the note as a
-  concept while its writer is gone recreates the same defect this ADR
-  names.
-- **Move the working narrative into a new dedicated store instead of
-  the board.** Rejected: the board is already fetched, already edited
-  in place every run, and already the durable per-feature record;
-  a second store repeats the two-store drift ADR 0002 accepted as a
-  trade-off, for no gain now that one store can hold both.
+  readers.** Rejected: the epic note's own writer, a composed session
+  note, was the pipeline issue #361 removed. Keeping the note as a
+  concept while its writer is gone recreates the same producerless-reader
+  defect.
+- **Move the working narrative into a new dedicated store instead of the
+  board.** Rejected: the board is already fetched every run and already
+  edited in place. A second store repeats the two-store drift ADR 0002
+  accepted as a trade-off, for no gain once one store can hold both.
 
 ## Status
 
-Accepted. Supersedes ADR 0002 (orchestrate-epic supervision-state
-split) — the epic note it specified is gone.
+Accepted. Supersedes ADR 0002 (orchestrate-epic supervision-state split)
+— the epic note it specified is gone.

--- a/docs/architecture/cli-contract.md
+++ b/docs/architecture/cli-contract.md
@@ -117,12 +117,10 @@ harness:
   tests expect. Translates `typer.Exit` / `SystemExit` /
   `click.exceptions.*` back to integer exit codes.
 
-- **`lore_core.run_render`** — pure renderers (no I/O) for run-log
-  records. Used by `curator_cmd` for the live trail during a curator
-  run.
-
-Both are import-time-cheap; they exist so individual verbs don't have
-to repeat plumbing.
+Import-time-cheap; it exists so individual verbs don't have to repeat
+plumbing. `lore_core.run_render` — the pure renderers `curator_cmd` used
+for a curator run's live trail — was deleted with the compose pipeline
+it rendered.
 
 ## Deprecating a verb
 

--- a/docs/architecture/cli-contract.md
+++ b/docs/architecture/cli-contract.md
@@ -107,9 +107,9 @@ tree, sub-verbs included. Flipping it off silently removes completion for
 users with no error anywhere — do not copy the sub-app template's value onto
 the root.
 
-## The seam helpers
+## The seam helper
 
-Two small helpers smooth the boundary between typer and the test
+One small helper smooths the boundary between typer and the test
 harness:
 
 - **`lore_cli._argv_compat.argv_main(app)`** — wraps a `typer.Typer`
@@ -120,7 +120,7 @@ harness:
 Import-time-cheap; it exists so individual verbs don't have to repeat
 plumbing. `lore_core.run_render` — the pure renderers `curator_cmd` used
 for a curator run's live trail — was deleted with the compose pipeline
-it rendered.
+it rendered, leaving this the sole seam helper.
 
 ## Deprecating a verb
 

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -105,7 +105,7 @@ Resolution: env > `.lore/config.yml:curator.openai.*` > error.
 
 `reasoning_effort_*` values are `low | medium | high` (case-insensitive)
 or empty string for "unset" (no `reasoning_effort` forwarded). See
-[Recommended openai-backend setup](../../README.md#recommended-openai-backend-setup-curator-a-narration)
+[Recommended openai-backend setup](../../README.md#recommended-openai-backend-setup-briefing-narration)
 in the README for the GPT-OSS-120B production recipe.
 
 Implemented in `lore_curator/llm_client.py:_resolve_openai_settings`.
@@ -162,16 +162,19 @@ YAML → defaults + warning.
 Per-vault-mount policy. Schema lives in
 `lib/lore_core/wiki_config.py:WikiConfig`. Subsections:
 
-- `git.{auto_commit, auto_push, auto_pull}`
-- `curator.{threshold_pending_turns, max_pending_age_s, a_noteworthy_tier,
-  curator_a_cooldown_s}`
-- `curator.{synthesis_buffer_cap_turns, synthesis_buffer_cap_chars,
-  synthesis_flush_timeout_s, synthesis_model_tier, reaper_max_per_pass,
-  buffer_done_retention_days, liveness_stale_threshold_s}` — buffer-and-flush knobs
+- `git.{auto_commit, auto_push, auto_pull}` — `auto_push` defaults to
+  whether the wiki has a git remote; an explicit value in the file
+  always wins over that default.
 - `models.{simple, middle, high}` — Claude model IDs per tier
 - `briefing.{audience, sinks}`
 - `heartbeat.{enabled, cooldown_s, push_context}`
 - `breadcrumb.{mode, scope_filter}`
+
+A `curator:` block is a retired key — `WikiConfig` carries no
+`curator` field, and `load_wiki_config` warns by name
+(`RETIRED_BLOCKS`) rather than the generic unknown-key notice. The
+per-session-turn-threshold knobs it used to hold retired with the
+compose pipeline that read them.
 
 Loader: `load_wiki_config(wiki_dir) -> WikiConfig`. Same fault-tolerant
 behaviour as root config.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -103,10 +103,13 @@ onto a note a flag appends to.
 a `trace_id`, sorted by timestamp — there is no separate correlation
 index, the trace *is* the filtered spine — so the mechanism stays
 correct for any future producer that threads one through. Until one
-exists, a `trace-id` or note-path/`[[wikilink]]` selector only resolves
-against pre-retirement data; `session-id` and `flag` are the selectors
-with live data behind them today (see "`lore trace <selector>`"
-below).
+exists, a `trace-id`, `session-id` or note-path/`[[wikilink]]` selector
+only resolves against pre-retirement data —
+`trace_ids_for_session()` (`lore_core/trace.py`) skips every record
+whose `trace_id` is unset, which today is all of them. `flag` is the
+one selector with live data behind it, since it bypasses trace_id
+correlation entirely and reads flag-write/flag-review events directly
+(see "`lore trace <selector>`" below).
 
 ---
 
@@ -165,18 +168,18 @@ so a reader never has to guess where to look next.
 ### `lore status`
 
 **Module:** `lore_cli/status_cmd.py`. The single glanceable "is Lore
-healthy right now?" dashboard — capture liveness (last hygiene run,
-last hook fire), per-wiki connection health (dirty / ahead / behind /
-reachable), a **flags** section (per-wiki flags written, withheld,
-pending, accepted, declined, retargeted — `lore_core.flag_metrics`
-aggregating the `source="flag"` spine events `flag.py` emits, plus
-`flag.count_pending` for the pending count itself), retention usage, an
-absorbed **news** section (background drain events — the old
-`lore news`), and an alerts section where every warning names its exact
-drill-down command. Reads only; exit code is 0 when healthy, nonzero when
-any alert fires. Every row reflects a state some code still writes —
-issue #377 removed the four capture rows and the flushes panel the
-compose pipeline used to feed.
+healthy right now?" dashboard — capture liveness (`Hook`, `Session`),
+per-wiki connection health (dirty / ahead / behind / reachable), a
+**flags** section (per-wiki flags written, withheld, pending, accepted,
+declined, retargeted — `lore_core.flag_metrics` aggregating the
+`source="flag"` spine events `flag.py` emits, plus `flag.count_pending`
+for the pending count itself), retention usage, an absorbed **news**
+section (background drain events — the old `lore news`), and an alerts
+section where every warning names its exact drill-down command. Reads
+only; exit code is 0 when healthy, nonzero when any alert fires. Every
+row reflects a state some code still writes — issue #377 removed five
+capture rows (`Last note`, `Last run`, `Last flush`, `Pending`, `Lock`)
+and the flushes panel the compose pipeline used to feed.
 
 ### `lore trace <selector>`
 
@@ -185,11 +188,13 @@ compose pipeline used to feed.
 trace_id, as a Rich tree (or `--plain` aligned text, or `--json` raw
 JSONL). Absorbs the debugging role of the old `lore log` / `lore runs` /
 `lore proc`. The selector accepts a trace_id (see above — no current
-producer mints one), a session_id (resolves every trace_id that session
-touched, newest first — the selector with live data behind it today),
-`flag` (lists every flag-write/flag-review spine event as a flat,
-chronological table instead of a tree — a flag carries no trace_id, it
-is a standing-alone fact; pairing one flag's write and verdict lines by
+producer mints one), a session_id (`trace_ids_for_session()` resolves
+every trace_id that session touched, but skips any record whose
+`trace_id` is unset, so it finds nothing on post-retirement data), `flag`
+(lists every flag-write/flag-review spine event as a flat, chronological
+table instead of a tree — bypasses trace_id correlation entirely, the
+one selector with live data today; a flag carries no trace_id, it is a
+standing-alone fact; pairing one flag's write and verdict lines by
 `flag_id` gives its review latency), or a note path / `[[wikilink]]`
 (reverse-resolved through the note's own `linkage.trace_id` — unset on
 any note a flag appended to, since no current writer stamps it). The

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -4,21 +4,25 @@
 new spine producer, or wondering why `lore log`/`lore news`/`lore runs`/
 `lore proc` no longer exist as commands.
 
-Before this epic, debugging one background flush meant walking seven
-uncorrelated surfaces — `lore log`, `lore proc`, `lore runs`, `lore
-status`, `lore news`, `lore doctor`, and a crash-log directory — over
-three different ad-hoc file schemas, with no identifier tying a hook fire
-to the curator run it spawned to the note it published. Failure handling
-leaned on "availability over debuggability" past the point of usefulness:
-drain writes never raised, mid-session flush failures deferred silently,
-retention cleanup swallowed its own errors. The full problem statement
-lives in [PRD 0005](../prd/0005-onboarding-config-observability.md).
+Before PRD 0005's epic, debugging one background flush meant walking
+seven uncorrelated surfaces — `lore log`, `lore proc`, `lore runs`,
+`lore status`, `lore news`, `lore doctor`, and a crash-log directory —
+over three different ad-hoc file schemas, with no identifier tying a
+hook fire to the curator run it spawned to the note it published.
+Failure handling leaned on "availability over debuggability" past the
+point of usefulness: drain writes never raised, mid-session flush
+failures deferred silently, retention cleanup swallowed its own
+errors. The full problem statement lives in
+[PRD 0005](../prd/0005-onboarding-config-observability.md).
 
 The replacement is one append-only event log (the **spine**) that every
-background producer writes to, one **trace_id** that follows a flush from
-hook fire to published note, one **flush state machine** that makes
-"stuck" a queryable state instead of an absence of evidence, and **three**
-read commands instead of seven.
+background producer writes to, a **trace_id** field correlating records
+into one story, and **three** read commands instead of seven. Issue
+#361 later retired the compose pipeline these mechanisms correlated —
+the flush state machine and the trace_id's one minter went with it (see
+below) — but the spine, `lore status`, `lore trace` and `lore doctor`
+stayed, now correlating the surviving producers: hooks, the hygiene
+curator, transcript sync, the retention janitor, and flags.
 
 ---
 
@@ -41,27 +45,34 @@ appended to `$LORE_ROOT/.lore/spine.jsonl` through one writer,
 - **`error_code`** — `None`, or a value from the closed `ErrorCode`
   `StrEnum`. Free-form detail (exception type, message, offending path)
   belongs in `data`, never in `error_code` directly.
-- Fields a producer can't yet know (`trace_id` before a flush exists,
-  `run_id` before a run starts, …) are written as explicit `null`, never
-  omitted — readers never have to guess "unknown" from "field dropped".
+- Fields a producer can't yet know (`trace_id` when nothing has minted
+  one, `run_id` before a run starts, …) are written as explicit `null`,
+  never omitted — readers never have to guess "unknown" from "field
+  dropped".
 
 **Producers today:**
 
 | `source` | Module(s) | What it emits |
 |---|---|---|
 | `hook` | `lore_cli/hooks.py`, `lore_core/spine.py:emit_hook_event` | SessionStart/PreCompact/Stop/UserPromptSubmit/SessionEnd/Capture hook fires and their outcomes |
-| `curator` | `lore_core/run_log.py`, `lore_core/flush_store.py`, `lore_curator/chapter_flush.py` | Curator run decisions (`run-start`, `transcript-start`, `noteworthy`, `session-note`, `run-end`), flush state-machine transitions, spawn failures |
-| `drain` | `lore_core/drain.py` | Session-scoped "what Lore did" events (`note-filed`, `note-appended`, `surface-proposed`, `transcript-synced`) — read by `lore status`'s news section |
+| `curator` | `lore_core/run_log.py`, `lore_curator/hygiene.py` | `run-start` / `run-end` and per-action decision records for a `lore curator` hygiene run (role `c`) — the only curator that still runs |
+| `drain` | `lore_core/drain.py` | `transcript-synced` — the one event kind with a live producer; read by `lore status`'s news section |
 | `janitor` | `lore_core/janitor.py`, `lore_core/run_retention.py`, `lore_cli/_crash_log.py` | Retention deletions/downgrades and their failures |
 | `install` | *(reserved, no producer yet)* | Onboarding-wizard events (PRD 0005 pillar C); not wired as of this writing — `lore init` doesn't emit to the spine today |
 | `mcp` | `lore_core/ledger.py` | `ledger-query` — one per `lore_drill` call whose query names an issue, a PR, an epic or a file path; a query that names none of those returns without emitting |
 | `flag` | `lore_core/flag.py` | `flag-write` (outcome `written`/`withheld`) and `flag-review` (verdict `accept`/`decline`/`retarget`), each carrying `flag_id` — read by `lore status`'s flags section and `lore trace flag` (`lore_core/flag_metrics.py`) |
 
-**Schema-version policy:** `SCHEMA_VERSION` (currently `1`) bumps on any
+A drain event kind or a spine `ErrorCode` value is added only together
+with the code that produces it — a kind or code with no raiser is a
+reader surface with no writer, and this epic's guard test
+(`tests/test_producerless_surfaces_gone.py`) fails the build on one.
+
+**Schema-version policy:** `SCHEMA_VERSION` (currently `2`) bumps on any
 change to the envelope *shape* — a field added, removed, renamed, or a
 semantic change to an existing field. Adding an `ErrorCode` value is
-additive and does **not** bump the version; removing or renaming one
-does. Readers must skip an unfamiliar `v`, never crash on it.
+additive and does **not** bump the version; removing one narrows what a
+reader may see and does. Readers must skip an unfamiliar `v`, never
+crash on it.
 
 **Concurrency:** appends are POSIX-atomic — `emit()` opens the file
 `O_APPEND | O_CREAT` and writes one JSONL record in a single `os.write()`
@@ -76,72 +87,48 @@ writes are failing" without crashing the hot path. Full guarantee list:
 
 ---
 
-## trace_id — one flush, one story
+## trace_id — a correlation field with no current minter
 
-**Minted by:** `lore_core/spine.py:new_trace_id()` (an opaque
-`secrets.token_hex(8)`), called from
-`lore_curator/chapter_flush.py:spawn_detached_flush` when a hook decides
-a detached flush needs to run.
+**Defined by:** `lore_core/spine.py:new_trace_id()` (an opaque
+`secrets.token_hex(8)`). The compose pipeline was its only caller —
+`lore_curator/chapter_flush.py:spawn_detached_flush` minted one per
+flush and threaded it through `LORE_TRACE_ID`, the curator's run
+events, the matching drain events, and a published note's
+`linkage.trace_id` frontmatter field. Issue #361 deleted
+`chapter_flush.py` with the rest of the compose pipeline, so nothing
+mints a fresh `trace_id` today, and nothing stamps `linkage.trace_id`
+onto a note a flag appends to.
 
-**Lifecycle:**
-
-1. A hook (or the reaper's startup sweep) decides a buffer needs
-   flushing and calls `spawn_detached_flush`, which mints a trace_id
-   (unless one is already threaded in).
-2. The trace_id crosses the process boundary as `LORE_TRACE_ID` in the
-   detached `lore curator flush` subprocess's environment — the *one*
-   place it's handed off (`chapter_flush.py:spawn_detached_flush`).
-3. `lore_cli/curator_cmd.py` reads `LORE_TRACE_ID` and stamps it onto
-   every `source="curator"` run event the flush emits (`run-start`,
-   `noteworthy`, `session-note`, `run-end`, …).
-4. The same trace_id is passed to `DrainStore.emit()` for any
-   `source="drain"` event the flush produces (`note-filed`,
-   `note-appended`, …).
-5. If the flush publishes a note, the trace_id is written into the
-   note's `linkage.trace_id` frontmatter field
-   (`lore_core/note_document.py:_apply_linkage`) — composing with PRD
-   0004's deterministic linkage block, so the note itself is a valid
-   trace selector.
-
-`lore trace <selector>` (below) reads every spine record sharing a
-trace_id, sorted by timestamp — there is no separate correlation index,
-the trace *is* the filtered spine.
-
-Spawn failures are traceable too: `spawn_detached_flush` mints its
-trace_id before taking the spawn lock, so both failure paths — the
-subprocess failing to start at the OS level and the spawn-lock flock
-itself erroring — emit `source="curator"`, `event="flush-spawn-failed"`
-with that trace_id attached, making the event reachable via
-`lore trace` like every other step of the flush's story.
+`lore trace <selector>` (below) still reads every spine record sharing
+a `trace_id`, sorted by timestamp — there is no separate correlation
+index, the trace *is* the filtered spine — so the mechanism stays
+correct for any future producer that threads one through. Until one
+exists, a `trace-id` or note-path/`[[wikilink]]` selector only resolves
+against pre-retirement data; `session-id` and `flag` are the selectors
+with live data behind them today (see "`lore trace <selector>`"
+below).
 
 ---
 
-## The flush lifecycle state machine
+## The flush lifecycle state machine — retired
 
-**Module:** `lore_core/flush_store.py` (issue #189). One persisted
-`FlushRecord` per flush unit (keyed by buffer stem) replaces "retry
-forever, or silently give up with no marker":
+**Module:** `lore_core/flush_store.py` (issue #189, retired by #377).
+`FlushRecord` used to track one flush unit (keyed by buffer stem)
+through:
 
 ```
 queued -> running -> published | withheld | dead-lettered(reason)
 ```
 
-- `running -> queued` is a **scheduled retry**, not a self-loop; terminal
-  states (`published`, `withheld`, `dead-lettered`) have no outgoing
-  edges — `is_legal_transition()` is the source of truth, checked by
-  `tests/` against the full transition table.
-- Bounded retries: `MAX_ATTEMPTS = 3`, exponential backoff
-  (`backoff_seconds()`, base 60s, capped at 3600s). Exhaustion produces a
-  `dead-lettered` record with a structured reason instead of silence.
-- Every transition also emits a `source="curator"`,
-  `event="flush-<state>"` spine record, so the record is the *current*
-  queryable state and the spine is the *history* — a record reopened for
-  a new unit never erases the trail.
-- Every previously-silent failure path in the flush pipeline (buffer
-  sidecar read errors, spawn failures, chapter-append I/O errors) now
-  either emits an error-level spine event or produces a dead letter —
-  see the `ErrorCode` values `COMPOSE_FAILED`, `SPAWN_FAILED`,
-  `SIDECAR_READ_FAILED`, `CHAPTER_APPEND_FAILED` in `spine.py`.
+Issue #361 deleted the compose pipeline that drove this machine; issue
+#377 deleted the write half that survived it — `begin`, `transition`,
+`record_failure`, the legal-transition table, and the bounded-retry
+backoff are gone. `FlushStore` is a reader now: `list()` reads whatever
+records are still on disk, and `purge()` is the retention janitor's
+entry point (below) — no code opens a new record. A `queued` or
+`running` record on disk today is a pre-#361 leftover, not a flush in
+flight; see
+[the troubleshooting guide](../how-to/troubleshooting.md#a-queued-or-running-flush-record-on-disk).
 
 ---
 
@@ -178,33 +165,37 @@ so a reader never has to guess where to look next.
 ### `lore status`
 
 **Module:** `lore_cli/status_cmd.py`. The single glanceable "is Lore
-healthy right now?" dashboard — capture liveness (last note, last run,
-last flush, last hook fire, lock state), flush queue counts (queued /
-running / dead-lettered), per-wiki connection health (dirty / ahead /
-behind / reachable), a **flags** section (per-wiki flags written,
-withheld, pending, accepted, declined, retargeted — `lore_core.flag_metrics`
+healthy right now?" dashboard — capture liveness (last hygiene run,
+last hook fire), per-wiki connection health (dirty / ahead / behind /
+reachable), a **flags** section (per-wiki flags written, withheld,
+pending, accepted, declined, retargeted — `lore_core.flag_metrics`
 aggregating the `source="flag"` spine events `flag.py` emits, plus
 `flag.count_pending` for the pending count itself), retention usage, an
-absorbed **news** section (session + background drain events — the old
+absorbed **news** section (background drain events — the old
 `lore news`), and an alerts section where every warning names its exact
 drill-down command. Reads only; exit code is 0 when healthy, nonzero when
-any alert fires.
+any alert fires. Every row reflects a state some code still writes —
+issue #377 removed the four capture rows and the flushes panel the
+compose pipeline used to feed.
 
 ### `lore trace <selector>`
 
 **Module:** `lore_cli/trace_cmd.py`, business logic in
 `lore_core/trace.py`. Renders the chronological, correlated story of one
-flush — every spine record sharing a trace_id, as a Rich tree (or `
---plain` aligned text, or `--json` raw JSONL). Absorbs the debugging role
-of the old `lore log` / `lore runs` / `lore proc`. The selector accepts a
-trace_id, a session_id (resolves every trace_id that session touched,
-newest first), `last`, `dead` (lists dead-lettered flushes instead of one
-tree), `flag` (lists every flag-write/flag-review spine event as a flat,
-chronological table instead of a flush tree — a flag carries no
-trace_id, it is a standing-alone fact, not a flush; pairing one flag's
-write and verdict lines by `flag_id` gives its review latency), or a
-note path / `[[wikilink]]` (reverse-resolved through the note's own
-`linkage.trace_id`).
+trace_id, as a Rich tree (or `--plain` aligned text, or `--json` raw
+JSONL). Absorbs the debugging role of the old `lore log` / `lore runs` /
+`lore proc`. The selector accepts a trace_id (see above — no current
+producer mints one), a session_id (resolves every trace_id that session
+touched, newest first — the selector with live data behind it today),
+`flag` (lists every flag-write/flag-review spine event as a flat,
+chronological table instead of a tree — a flag carries no trace_id, it
+is a standing-alone fact; pairing one flag's write and verdict lines by
+`flag_id` gives its review latency), or a note path / `[[wikilink]]`
+(reverse-resolved through the note's own `linkage.trace_id` — unset on
+any note a flag appended to, since no current writer stamps it). The
+`dead` and `last` selectors are gone with the flush lifecycle record
+they resolved through; either now raises the same "no trace, session,
+or note matches" error as any other unknown selector.
 
 ### `lore doctor [--fix]`
 
@@ -227,17 +218,18 @@ interleaves plain text ahead of the JSON on stdout. Script against
 `lore doctor --json` (no `--fix`) instead, or pass `--yes` and parse only
 the trailing JSON line.
 
-### Deprecated: `log`, `news`, `runs`, `proc`
+### Removed: `log`, `news`, `runs`, `proc`, `drain`
 
-Kept as thin aliases for one minor-version window (see the CHANGELOG for
-the exact removal version): each prints a one-line pointer to its
-replacement on **stderr** (so `--json` output on stdout stays script-safe)
-and then still runs its original logic. `lore drain prune` had no
-replacement to alias to — it pruned a file (`.lore/drain/_system.jsonl`)
-that has had no writer since drain events moved onto the spine, so its
-CLI surface was removed outright; `lore_core.janitor.prune_orphans`
-still exists and runs automatically as part of every opportunistic
-janitor pass.
+Each was kept as a thin deprecated alias for one minor-version window,
+then removed outright once that window closed (see the CHANGELOG for
+the exact removal version) — none of the five is a `lore` command
+today. `lore log` / `lore runs` / `lore proc` are fully absorbed by
+`lore trace`; `lore news` by `lore status`'s news section. `lore drain`
+(and its sole subcommand, `prune`) had no replacement to alias to — it
+pruned a file (`.lore/drain/_system.jsonl`) that has had no writer
+since drain events moved onto the spine, so its CLI surface was removed
+outright; `lore_core.janitor.prune_orphans` still exists and runs
+automatically as part of every opportunistic janitor pass.
 
 ---
 
@@ -249,7 +241,8 @@ janitor pass.
   and the three state files this doc doesn't cover (`_scopes.yml`,
   `scopes.json`, `attachments.json`).
 - [`cli-contract.md`](cli-contract.md) — the shape every `lore <verb>`
-  command follows, including these three and the deprecated aliases.
+  command follows, including these three and the deprecating-a-verb
+  pattern the now-removed aliases used.
 - How-to: [`../how-to/onboarding.md`](../how-to/onboarding.md),
   [`../how-to/troubleshooting.md`](../how-to/troubleshooting.md),
   [`../how-to/measure-flag-quality.md`](../how-to/measure-flag-quality.md)

--- a/docs/architecture/state.md
+++ b/docs/architecture/state.md
@@ -144,7 +144,7 @@ wiki+scope am I working in?"
 A wiki with no git remote is **private by default** — nothing it holds
 ever leaves the machine. A wiki with a git remote is a **shared
 vault**: every teammate with read access to that remote can see every
-composed session note committed there.
+flag committed there.
 
 Attaching a scope to a shared vault is the moment sharing starts, so
 it's the moment consent is asked. `lore attach accept` / `lore attach
@@ -165,16 +165,16 @@ If a secret ends up in a composed note, git history retains it even
 after the note is edited or deleted — the remedy is **rotating the
 credential**, not scrubbing history.
 
-**Transcripts and buffers never leave local state.** They live under
-`<lore_root>/.lore/` (`transcript-ledger.json`, `buffers/`), a sibling
-of `wiki/` — never a descendant — so a `git push` of a wiki directory
-structurally cannot ship them. Each ledger entry carries a `linkage`
+**The transcript ledger never leaves local state.** It lives at
+`<lore_root>/.lore/transcript-ledger.json`, a sibling of `wiki/` —
+never a descendant — so a `git push` of a wiki directory structurally
+cannot ship it. Each ledger entry carries a `linkage`
 block — `repo`, `branch`, `prs`, `issues`, `commits`, `files` — written
 by capture with no LLM call. It is what `lore_drill` reads to answer
 "which sessions touched X" and what the SessionStart recap renders from.
 The block is derived and rebuildable, and stays machine-local with the
-rest of the ledger. Only composed, gate-passed notes
-written into `wiki/<name>/sessions/` are ever pushed.
+rest of the ledger. Only a flag — a fact that already passed the
+publish gate and landed in its owning topic note — is ever pushed.
 
 ---
 
@@ -249,10 +249,13 @@ hot paths and need to survive multiple concurrent Claude sessions:
   ``fcntl.LOCK_EX`` here; losers skip and retry on the next emit.
 
 The same pattern (``LOCK_EX | LOCK_NB`` on a sibling lock file) is
-used by ``lore_core.lockfile.try_acquire_spawn_lock`` to serialise
-detached curator launches. See those modules for the implementation
-details — it's the canonical lockfile pattern used across the
-codebase.
+used by ``lore_core.lockfile.try_acquire_spawn_lock`` to serialise a
+detached background-process launch — transcript sync at SessionStart
+today. The curator's own turn-threshold auto-spawn read this same lock
+before the heartbeat that decided when to take it retired with the
+compose pipeline; `lore curator` now runs only on demand, taking no
+lock itself. See those modules for the implementation details — it's
+the canonical lockfile pattern used across the codebase.
 
 ## Failure modes
 

--- a/docs/architecture/sync.md
+++ b/docs/architecture/sync.md
@@ -1,9 +1,10 @@
 # Cross-host sync
 
-**Status:** active (introduced in 0.11.0)
+**Status:** active (introduced in 0.11.0; push transport restored by
+epic #375 after issue #361 left it without a caller)
 **Replaces:** the dataclass-shaped placeholder `WikiConfig.git.{auto_pull, auto_push}` that shipped without callers in 0.3.0–0.10.6.
 
-This ADR captures the conflict policy and runtime model behind Lore's
+This page captures the conflict policy and runtime model behind Lore's
 cross-host sync layer. **"Host" here means *machine*** — a user's
 laptop and workstation are two hosts of the same wiki.
 
@@ -36,10 +37,11 @@ produces — without producing temp artifacts or losing content.
 
 | Trigger | Where | What |
 |---|---|---|
-| **Curator A post-commit** | `lib/lore_curator/session_curator.py:_maybe_auto_commit` (existing) | After auto-commit of a freshly filed session note or appended chapter. |
-| LLM-merge follow-up | `lib/lore_core/git_sync.py:auto_push` | When push fails non-FF, run LLM merge, re-push. |
+| **Session boundary (SessionEnd hook)** | `lib/lore_cli/hooks.py` → `lib/lore_core/session_start.py:maybe_auto_push_for_scope` | Pushes the attached wiki once, after every flag filed that session is already committed (`lore_core/flag.py` commits each flag through `lore_core/session.py:commit_note` at write time). |
+| Manual | `lore briefing --wiki <name>` (unless `--no-git`) | The briefing one-shot pulls before gather and pushes after mark — parked with briefings (PRD 0011), not part of the session-boundary path. |
 
-`auto_push` is `auto_pull` + `git push`, with conflict-resolution baked in.
+`auto_push` is `auto_pull` + `git push`, with conflict-resolution baked
+in — see "Conflict policy" below for what "resolution" means today.
 
 ### What never gets pushed
 
@@ -50,32 +52,37 @@ produces — without producing temp artifacts or losing content.
 
 ## Conflict policy
 
-Three classes of conflict, each with a deterministic resolver.
+> **Status: parked.** `auto_push`'s `llm_client` parameter accepts a
+> client, but no caller passes one — the session-boundary push (above)
+> always calls it with none. A session-note or typed-note conflict
+> therefore always ends in `MERGE_BLOCKED`, `git merge --abort` runs,
+> and the working tree comes back clean; nothing below the "LLM call"
+> step in class 2 currently executes. The classifier, the merge path
+> and the prompt stay in the tree — the path resolves conflicts for the
+> push this epic restored — what's on hold is the decision to run a
+> model at the session boundary.
 
-### 1. Session notes — pre-pull eliminates conflicts in steady state
+Four classes of conflict, each with a deterministic resolver.
 
-Session notes live at `<wiki>/sessions[/<handle>]/<YYYY>/<MM>/<DD>-<slug>.md`.
-Two hosts can in principle produce the same path on the same day with
-the same slug. **The pre-pull at SessionStart eliminates this in steady
-state**: when Host B starts a session, it pulls Host A's commits first,
-sees the same-day note, and the existing append-to-today logic (in
-`session_writer.py:_find_todays_open_note`) merges the new chunk into
-that one note — same code path that handles concurrent same-host
-sessions today.
+### 1. Session notes — no longer written
 
-**Edge case fallback:** if the pre-pull is skipped (offline, dirty
-tree, network failure), and Host B writes its own day-note that later
-collides with Host A's on push, the LLM-merge resolver kicks in. The
-two notes get merged into one canonical body. No `.host-A.md` siblings.
+Session notes lived at `<wiki>/sessions[/<handle>]/<YYYY>/<MM>/<DD>-<slug>.md`.
+Nothing writes a new one since the compose pipeline retired (`#361`),
+so two hosts can no longer produce a same-day collision going forward.
+The classifier still recognizes a `sessions/` path as this conflict
+class — for a wiki that still carries pre-retirement session notes —
+and routes it through the same LLM-merge path as class 2, parked the
+same way.
 
-### 2. Manually-authored notes — LLM-merge on push conflict
+### 2. Typed-subdirectory notes — LLM-merge on push conflict
 
 Notes in a wiki's typed subdirectories (`concepts/`, `decisions/`,
-`projects/`, …) are written directly — by hand or via `/lore:inbox` —
-there is no automatic abstraction pass that populates them, so this
-conflict class is rarer than session-note conflicts in practice. The
-classifier and merge path still apply to whatever two hosts
-independently write there:
+`projects/`, …) are written directly — by hand, via `/lore:inbox`, or
+appended to by a flag (`lore_core/flag.py`) — there is no automatic
+abstraction pass that populates them on its own. This is the conflict
+class two hosts filing flags into the same topic note actually hit.
+The classifier and merge path apply to whatever two hosts independently
+write there:
 
 1. `git fetch origin`
 2. `git merge origin/<branch> --no-commit --no-ff`
@@ -85,16 +92,18 @@ independently write there:
    - LLM call (middle tier, ~$0.001) with structured prompt: "merge
      these two versions of `<note>`. Preserve all distinct facts,
      deduplicate restated points, keep wikilinks from both sides."
+     **Parked** — reached only when a caller passes an `llm_client`.
    - Write merged result, `git add <path>`
 5. If all conflicts resolved: `git commit -m "merge(auto-llm): N
    note(s)"`, `git push`
-6. If any unresolved: `git merge --abort`, log via `lore status`,
-   surface a `lore curator merge --resolve` action to the user.
+6. If any unresolved (the current outcome for every typed-note
+   conflict): `git merge --abort`, working tree returns clean. The
+   user resolves it with git.
 
-LLM-merge at push time is synchronous: by the time Host B's push
-completes, the wiki has one canonical note. No temp artifacts, no
-drift window where MCP search would see two notes about the same
-thing.
+LLM-merge at push time is designed to be synchronous: by the time Host
+B's push completes, the wiki would have one canonical note, no temp
+artifacts, no drift window where MCP search would see two notes about
+the same thing — once a caller opts a model into the session boundary.
 
 ### 3. Regenerable artifacts — pick either side, lint to truth
 
@@ -108,8 +117,9 @@ on either host's next regen.
 
 Anything else (CLAUDE.md root files, hand-edited markdown outside
 sessions/typed-notes) → `git merge --abort`, log via `lore status` with
-the path list and a `lore curator merge --resolve <path>` hint. Never
-silently overwrite hand-edited content.
+the path list. `lore` mounts no merge-resolution command for this —
+resolve the conflict with git directly in the wiki repo, commit, and
+push. Never silently overwrite hand-edited content.
 
 ---
 
@@ -128,10 +138,10 @@ regresses to "post-pull, MCP search may be stale for up to 5s." This
 is what 0.10.x ships today, so the optional-dep fallback is not a
 regression.
 
-**Self-edit handling:** the curator's own writes (session notes,
-chapters, hygiene-pass frontmatter edits) trip the watcher too. That's
-fine: the dirty flag just says "next query may need fresh data." The
-throttle prevents a reindex storm.
+**Self-edit handling:** a flag append and the hygiene curator's own
+frontmatter edits trip the watcher too. That's fine: the dirty flag
+just says "next query may need fresh data." The throttle prevents a
+reindex storm.
 
 ### Future direction (not for 0.11.0)
 
@@ -142,7 +152,7 @@ pattern it establishes:
 MCP server (lifetime = Claude session)
 ├── stdio JSON-RPC handler (existing tools)
 ├── fs-watch daemon thread → invalidates reindex cache
-└── [future]                → e.g. detach Curator A trigger from hooks?
+└── [future]                → e.g. detach auto_pull cadence from hooks?
 ```
 
 **Principle: MCP-daemon work is the fast-path; hooks are the
@@ -153,9 +163,10 @@ Don't add cron-style timers there — only activity-triggered work
 (file events, MCP queries). This keeps Lore consistent with its
 heartbeat-not-cron design.
 
-After 0.11.0 ships, candidates for migration are: Curator A trigger,
-`auto_pull` cadence (today only on SessionStart). Decide post-shipping
-based on observed behaviour, not now.
+After 0.11.0 ships, `auto_pull` cadence (today only on SessionStart) is
+a migration candidate. The compose pipeline's own mid-session spawn
+trigger, once a second candidate, retired with the pipeline (`#361`).
+Decide based on observed behaviour, not now.
 
 ---
 
@@ -165,16 +176,20 @@ Per-wiki, in `<wiki>/.lore-wiki.yml`:
 
 ```yaml
 git:
-  auto_commit: true     # the curator commits its own writes
-  auto_push: true       # push after each commit
+  auto_push: true       # push at the session boundary
   auto_pull: true       # fetch + ff at SessionStart
 ```
 
-Defaults: `auto_commit=false`, `auto_push=false`, `auto_pull=true`.
-The push/commit defaults stay false-by-default in 0.11.0 to avoid
-surprising users whose wiki repos are in odd states; flipping them
-to true is a one-line per-wiki opt-in. `auto_pull` defaults to true
-because it's read-only on a clean tree.
+Defaults: `auto_pull=true` — it's read-only on a clean tree, so there's
+no surprise in leaving it on. `auto_push` defaults to
+`git_sync.has_remote(wiki_dir)`: true for a wiki with a remote (a
+shared vault, where a flag reaches a teammate only after a push), false
+for a solo wiki with nowhere to push. A value written in the file
+always wins over that default.
+
+`git.auto_commit` is a schema field with no reader — `lore_core.flag`
+commits every flag unconditionally at write time, through
+`lore_core/session.py:commit_note`, regardless of this setting.
 
 ---
 
@@ -188,8 +203,9 @@ because it's read-only on a clean tree.
 | Clean tree, fast-forwardable | Fetch + ff | `lore status` (silent unless new commits pulled) |
 | Clean tree, diverged (we have local commits, remote has different commits) | Skip pull, surface to user | `lore status` `· wiki diverged — git pull manually` |
 | Push: remote ahead, FF possible | Fetch + ff + push | (silent) |
-| Push: typed-note conflict | LLM-merge → push | `lore status` shows merge count |
-| Push: unresolvable conflict | abort merge, surface to user | `lore status` `· merge needed: <paths>` |
+| Push: regenerable-artifact conflict | ours wins, `lore lint` reconciles | (silent) |
+| Push: typed-note or session-note conflict | `MERGE_BLOCKED` — LLM-merge is parked, so `git merge --abort` runs and the tree returns clean | `lore status` `· merge needed: <paths>` |
+| Push: unknown-path conflict | abort merge, surface to user | `lore status` `· merge needed: <paths>` |
 | `watchdog` not installed | Reindex throttle = 5s natural decay | (silent — same as 0.10.x) |
 
 ---

--- a/docs/architecture/sync.md
+++ b/docs/architecture/sync.md
@@ -116,10 +116,12 @@ on either host's next regen.
 ### 4. Unknown — bail to user
 
 Anything else (CLAUDE.md root files, hand-edited markdown outside
-sessions/typed-notes) → `git merge --abort`, log via `lore status` with
-the path list. `lore` mounts no merge-resolution command for this —
-resolve the conflict with git directly in the wiki repo, commit, and
-push. Never silently overwrite hand-edited content.
+sessions/typed-notes) → `git merge --abort`. `lore status` computes no
+alert for a blocked push; the SessionEnd hook's spine event carries
+`push=merge-blocked`, the only trace of it today. `lore` mounts no
+merge-resolution command for this — resolve the conflict with git
+directly in the wiki repo, commit, and push. Never silently overwrite
+hand-edited content.
 
 ---
 
@@ -204,8 +206,8 @@ commits every flag unconditionally at write time, through
 | Clean tree, diverged (we have local commits, remote has different commits) | Skip pull, surface to user | `lore status` `· wiki diverged — git pull manually` |
 | Push: remote ahead, FF possible | Fetch + ff + push | (silent) |
 | Push: regenerable-artifact conflict | ours wins, `lore lint` reconciles | (silent) |
-| Push: typed-note or session-note conflict | `MERGE_BLOCKED` — LLM-merge is parked, so `git merge --abort` runs and the tree returns clean | `lore status` `· merge needed: <paths>` |
-| Push: unknown-path conflict | abort merge, surface to user | `lore status` `· merge needed: <paths>` |
+| Push: typed-note or session-note conflict | `MERGE_BLOCKED` — LLM-merge is parked, so `git merge --abort` runs and the tree returns clean | `push=merge-blocked` on the SessionEnd hook's spine event; `lore status` computes no alert for it today |
+| Push: unknown-path conflict | abort merge, surface to user | `push=merge-blocked` on the SessionEnd hook's spine event; `lore status` computes no alert for it today |
 | `watchdog` not installed | Reindex throttle = 5s natural decay | (silent — same as 0.10.x) |
 
 ---

--- a/docs/how-to/measure-flag-quality.md
+++ b/docs/how-to/measure-flag-quality.md
@@ -5,8 +5,7 @@ architecture. The flag is the crossing from a private session to the
 team wiki, and the only one — a fact an agent should have flagged and
 didn't leaves no trace anywhere a human would look. Under-flagging is
 measurable only by deliberately checking for it; it does not show up as
-an error, a dead-lettered flush, or any other alert `lore status`
-already earns.
+an error or any other alert `lore status` already earns.
 
 Background: the flag shape and the "measurement before trust" rule are
 recorded in [`brainstorms/lore-session-notes-worth.md`](../../brainstorms/lore-session-notes-worth.md)

--- a/docs/how-to/onboarding.md
+++ b/docs/how-to/onboarding.md
@@ -74,19 +74,22 @@ repair path for a partial install.
 
    `doctor` re-confirms install integrity (nonzero exit on any failure);
    `status` shows whether a session has actually captured anything yet
-   (capture liveness, last hook fire, last note). A fresh install with no
-   session activity yet is expected to show "no activity" lines, not
-   errors — errors there mean something in step 2 needs a re-run.
+   (capture liveness, last hook fire). A fresh install with no session
+   activity yet is expected to show "no activity" lines, not errors —
+   errors there mean something in step 2 needs a re-run.
 
 ## If something's wrong
 
 See [troubleshooting.md](troubleshooting.md) — start with `lore status`,
-escalate to `lore doctor --fix` for repairable state, then `lore trace`
-for a specific flush's story.
+escalate to `lore doctor --fix` for repairable state, then
+`lore trace <session-id>` for one session's correlated story.
 
 ## Done when
 
 `lore doctor` exits 0, `lore status` shows the attached wiki with no
 alerts, and — after you've actually used Claude Code for a bit in the
-attached repo — a session note appears under
-`<wiki>/sessions/[<handle>/]YYYY/MM/`.
+attached repo — `status`'s `Hook` line carries a recent timestamp.
+Capture itself writes only a transcript-ledger entry; nothing lands in
+the wiki until you or the agent files one with `lore flag write` (or
+the `lore_flag` MCP tool). File one and confirm it appended to its
+owning topic note.

--- a/docs/how-to/onboarding.md
+++ b/docs/how-to/onboarding.md
@@ -81,8 +81,8 @@ repair path for a partial install.
 ## If something's wrong
 
 See [troubleshooting.md](troubleshooting.md) — start with `lore status`,
-escalate to `lore doctor --fix` for repairable state, then
-`lore trace <session-id>` for one session's correlated story.
+escalate to `lore doctor --fix` for repairable state, then check
+`lore status`'s news section for a recent `transcript-synced` entry.
 
 ## Done when
 

--- a/docs/how-to/resume-a-broken-epic.md
+++ b/docs/how-to/resume-a-broken-epic.md
@@ -39,11 +39,11 @@ comment — precisely so a second run heals rather than duplicates.
    comment in place for every further update; a resumed run never opens a
    second status comment.
 
-The board comment carries only the durable per-feature state. The
-orchestrator's own working context — tier decisions, crosscheck verdicts,
-in-flight markers — rides a single composed **epic note** keyed to the epic,
-which the resumed run rehydrates through `lore_context_pack`. So its
-reasoning survives the interruption too, not just the feature checklist.
+The board comment carries the durable per-feature state in its table, and
+the orchestrator's own working context — tier decisions, crosscheck
+verdicts, in-flight markers — in a `## Notes` section below that same
+table. A resumed run reads both from the one comment, so its reasoning
+survives the interruption too, not just the feature checklist.
 
 ## If no prior run is found
 

--- a/docs/how-to/run-an-epic.md
+++ b/docs/how-to/run-an-epic.md
@@ -53,8 +53,8 @@ small, clear change, use the [fast path](use-the-fast-path.md) instead.
   status comment on the epic issue, updated in place, recording each
   feature's state in a machine-readable table. Its own working context — the
   tier and escalation decisions, crosscheck verdicts, in-flight markers —
-  rides a separate composed epic note, so a resumed run rehydrates its
-  reasoning, not just the checklist.
+  rides a `## Notes` section below that same table, so a resumed run reads
+  its reasoning from the one comment, not just the checklist.
 - **If the run breaks off, resume — do not restart.** See
   [Resume a broken epic](resume-a-broken-epic.md).
 

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -20,14 +20,14 @@ Escalate through three commands, each one level deeper:
    Claude Code plugin cache silently keeps running old hook code even
    though `main` (or your installed version) has moved on; `--fix` can't
    repair this one, but the check names the exact drift.
-3. **`lore trace <session-id>`** — if `doctor` passes but notes still
-   don't appear, trace the session directly (the session_id is what
+3. **`lore trace <session-id>`** — if `doctor` passes but the ledger still
+   doesn't grow, trace the session directly (the session_id is what
    Claude Code shows in its own session info, or resolve it from
    `$CLAUDE_SESSION_ID` in the failing shell). No steps at all means the
    hook never ran; steps that stop after `hook/session-start` with no
-   `curator/*` events means a flush was never spawned — check
-   `$CLAUDE_PROJECT_DIR` and that the plugin hooks are actually installed
-   (`lore install`).
+   `drain/transcript-synced` event means transcript sync was never
+   spawned — check `$CLAUDE_PROJECT_DIR` and that the plugin hooks are
+   actually installed (`lore install`).
 
 ## "Nothing appeared in the wiki after my session"
 
@@ -36,9 +36,9 @@ session leaves a transcript-ledger entry, and a wiki note only when an
 agent or a human filed a flag. If you expected a flag, see
 ["My flag never appeared in the wiki"](#my-flag-never-appeared-in-the-wiki).
 
-To confirm capture itself ran, `lore status` shows the last hook fire and
-the registered-transcript count per wiki. `lore doctor` checks the hook
-wiring. Neither depends on anything having been written to a wiki.
+To confirm capture itself ran, `lore status` shows the last hook fire.
+`lore doctor` checks the hook wiring. Neither depends on anything
+having been written to a wiki.
 
 ## "A ref in my flag says `(unchecked)`"
 
@@ -100,18 +100,17 @@ by hand accepts that flag as far as the count is concerned, and records no
 accept/decline counters are not expected to sum. See
 [measure flag quality](measure-flag-quality.md).
 
-## "A flush looks stuck"
+## A `queued` or `running` flush record on disk
 
-`lore status`'s `flushes` line shows `queued` / `running` / `dead-lettered`
-counts. A flush sitting in `queued` or `running` for a long time is
-either genuinely still working or waiting out its
-exponential backoff after a failed
-attempt (base 60s, doubling, capped at 3600s — see
-`lore_core/flush_store.py`). `lore trace <selector>` shows which: a
-`flush-running` step with no `flush-published`/`flush-dead-lettered`
-after it is legitimately in-flight. If it's been longer than the retry cap and nothing moved, run
-`lore doctor` — a corrupted flush record is one of the `--fix`-repairable
-states.
+`lore_core/flush_store.py` is a reader now — nothing opens a new record.
+`.lore/flushes/` can still hold `queued` or `running` records left over
+from before the compose pipeline retired; the retention janitor purges
+resolved (`published` / `withheld` / `dead-lettered`) records past their
+age window and caps dead letters by count, but leaves `queued` /
+`running` records alone, since no code advances them any more. One
+sitting there is not a live flush stuck mid-flight — delete
+`.lore/flushes/` by hand if the leftovers bother you; nothing reads them
+back.
 
 ## Known rough edges (honest, not yet fixed)
 
@@ -130,8 +129,8 @@ states.
 
 These are gone, not renamed under a flag — `lore trace` and `lore status`
 fully absorbed their role (see `CHANGELOG.md`'s `### Removed` entry). Reach
-for `lore trace <selector>` for the correlated flush story these used to
-print, or `lore status` for the health snapshot.
+for `lore trace <selector>` for the correlated, chronological story these
+used to print, or `lore status` for the health snapshot.
 
 Other verbs that moved rather than vanished:
 
@@ -140,7 +139,6 @@ Other verbs that moved rather than vanished:
 | `lore detach` | `lore attach remove` |
 | `lore attachments <sub>` | `lore attach attachments <sub>` |
 | `lore registry ls` / `lore registry doctor` | `lore scopes wikis` / `lore scopes doctor` |
-| `lore curator backfill-slugs` | `lore migrate slugs` |
 | `lore curator --migrate-open-items` | `lore migrate open-items` |
 | `lore migrate --add-schema-version` | `lore migrate frontmatter --add-schema-version` |
 

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -8,7 +8,7 @@ status`, `lore doctor` are all covered in
 
 ## "Hooks aren't firing"
 
-Escalate through three commands, each one level deeper:
+Escalate through these steps, each one level deeper:
 
 1. **`lore status`** — check the `capture` section's `Hook` line. A
    timestamp within the last few minutes means hooks *are* firing; "no
@@ -20,14 +20,15 @@ Escalate through three commands, each one level deeper:
    Claude Code plugin cache silently keeps running old hook code even
    though `main` (or your installed version) has moved on; `--fix` can't
    repair this one, but the check names the exact drift.
-3. **`lore trace <session-id>`** — if `doctor` passes but the ledger still
-   doesn't grow, trace the session directly (the session_id is what
-   Claude Code shows in its own session info, or resolve it from
-   `$CLAUDE_SESSION_ID` in the failing shell). No steps at all means the
-   hook never ran; steps that stop after `hook/session-start` with no
-   `drain/transcript-synced` event means transcript sync was never
-   spawned — check `$CLAUDE_PROJECT_DIR` and that the plugin hooks are
-   actually installed (`lore install`).
+3. **`lore status`'s news section** — if `doctor` passes but the ledger
+   still doesn't grow, check for a recent `transcript-synced` entry there.
+   Transcript sync's drain event lands on the shared system stream, not a
+   per-session one, so this confirms sync ran at all rather than for one
+   session in particular. Nothing there and a recent `Hook` timestamp
+   means the hook fired but the detached sync never spawned — check
+   `$CLAUDE_PROJECT_DIR` and that the plugin hooks are actually installed
+   (`lore install`). `lore trace <session-id>` cannot help here: no
+   current producer mints a `trace_id`, so it always reports no match.
 
 ## "Nothing appeared in the wiki after my session"
 
@@ -105,12 +106,12 @@ accept/decline counters are not expected to sum. See
 `lore_core/flush_store.py` is a reader now — nothing opens a new record.
 `.lore/flushes/` can still hold `queued` or `running` records left over
 from before the compose pipeline retired; the retention janitor purges
-resolved (`published` / `withheld` / `dead-lettered`) records past their
-age window and caps dead letters by count, but leaves `queued` /
-`running` records alone, since no code advances them any more. One
-sitting there is not a live flush stuck mid-flight — delete
-`.lore/flushes/` by hand if the leftovers bother you; nothing reads them
-back.
+`published` / `withheld` records past their age window, exempts
+`dead-lettered` records from that window entirely and caps them by
+count instead, and leaves `queued` / `running` records alone, since no
+code advances them any more. One sitting there is not a live flush
+stuck mid-flight — delete `.lore/flushes/` by hand if the leftovers
+bother you; nothing reads them back.
 
 ## Known rough edges (honest, not yet fixed)
 

--- a/lore-workflow/skills/orient/SKILL.md
+++ b/lore-workflow/skills/orient/SKILL.md
@@ -31,8 +31,10 @@ subagent:
 - **Docs & decisions** — the pack's `adr` / `prd` entries (already linked to the focus
   issue/epic), CONTEXT.md / glossary read directly, `lore_repo_docs_list` for anything the
   pack's focus filter missed.
-- **Prior art** — the pack's `sessions` (recent related session notes) and `epic_state`
-  (linked issue/epic status) as the trace of related work.
+- **Prior art** — the pack's `epic_state` (linked issue/epic status) as the trace of related
+  work. The pack's `sessions` field reads `wiki/<name>/sessions/`; nothing writes a new session
+  note since the compose pipeline retired, so treat it as empty and lean on `epic_state` plus a
+  targeted `lore_search`/`lore_drill` call instead.
 
 Spawn a facet's `Explore` subagent only when the pack came back thin or empty for it (no
 matching ADR/PRD, no matching sessions) — it then searches beyond what the deterministic join

--- a/lore-workflow/skills/seed-epic/SKILL.md
+++ b/lore-workflow/skills/seed-epic/SKILL.md
@@ -36,14 +36,14 @@ seeds. Trivially small, well-understood follow-ups don't need the chain — note
 filing instead. Confirm the grouping with the user before publishing.
 
 ### 3. Write the seed(s)
-First try to lift **Origin** and **Findings** from this session's note (deterministic, no
-freehand reconstruction needed): `lore workflow seed-lift <path-to-this-session's-note>
---wiki-root <wiki-root>`. On success (exit 0), use its `origin` and `findings` JSON fields
-verbatim for those two sections, and add its `source_note` under **Pointers** as an explicit
-reference — so a cold `/lore-workflow:orient` on the seed can pull the note back via
-`lore_read`/`lore_context_pack`. On failure (exit 1: no note, or too thin), fall back to
-freehand — reconstruct Origin (the finished epic, merged PRs/commits) and Findings (hard-won
-context from this session) as before.
+Nothing writes a session note since the compose pipeline retired, so freehand reconstruction is
+the normal path: reconstruct Origin (the finished epic, merged PRs/commits) and Findings
+(hard-won context from this session) yourself. If this session's own note happens to exist —
+hand-authored, or from a wiki that predates the retirement — try
+`lore workflow seed-lift <path-to-that-note> --wiki-root <wiki-root>` first: on success (exit 0)
+use its `origin` and `findings` JSON fields verbatim for those two sections, and add its
+`source_note` under **Pointers** as an explicit reference, so a cold `/lore-workflow:orient` on
+the seed can pull the note back via `lore_read`/`lore_context_pack`.
 
 Draft each body with the template below. Lead with intent; make the **findings** section rich —
 that is the handover value. Pointers are starting points, not gospel (they may go stale).

--- a/skills/curator/SKILL.md
+++ b/skills/curator/SKILL.md
@@ -18,10 +18,13 @@ Passes per wiki, all frontmatter-only — note bodies are never touched:
 1. **Supersession** — note A says "supersedes [[B]]" → B gets
    `superseded_by: [[A]]`. Only the relation is written; `status:` is
    never set (lifecycle is derived at read time).
-2. **Implements-propagation** — a session note's `implements: <slug>`
-   drops `draft:` on the target and stamps `implemented_by` /
-   `implemented_at` back-links; `implements: <slug>:superseded-by:<other>`
-   writes `superseded_by: [[other]]`.
+2. **Implements-propagation** — reads `implements: <slug>` frontmatter
+   from notes under `sessions/` and drops `draft:` on the target,
+   stamping `implemented_by` / `implemented_at` back-links;
+   `implements: <slug>:superseded-by:<other>` writes `superseded_by:
+   [[other]]`. Nothing writes a new session note since the compose
+   pipeline retired, so this pass only ever finds back-links on notes
+   that predate the retirement.
 3. **Git backfill** — missing `created` / `last_reviewed` filled from
    `git log --follow`.
 4. **Team-mode hint** — advises creating `_users.yml` once a solo wiki


### PR DESCRIPTION
## Summary

Fixes #380. Reconciles fourteen documentation pages with the code batch
1 shipped, and records two decisions in a new ADR.

- Rewrites the stale automatic-capture, observability, and sync
  descriptions across README, the architecture pages, and the how-to
  guides.
- Removes the retired per-wiki `curator:` config block and every dead
  command reference (`lore trace last`/`dead`, `lore migrate slugs`,
  `lore curator merge --resolve`, the flush status rows).
- Replaces "epic note" language with the board's `## Notes` section in
  the two epic how-to guides and the two `lore-workflow` skills that
  named it.
- Adds `docs/adr/0010-producer-rule-and-board-carries-the-narrative.md`
  and restamps ADR 0002 to `Superseded by ADR 0010`.

## Pages changed

- `README.md` — the "Bootstrap: passive capture" intro and "What runs
  automatically" section described session-note auto-extraction and a
  turn-threshold curator spawn; both retired with the compose pipeline.
  The per-wiki `curator:` config example named keys `WikiConfig` no
  longer has. The Observability table pointed at `lore trace last` /
  `lore trace dead` and a flush-queue count `lore status` no longer
  prints. A `models.high` comment referenced a retired
  `synthesis_model_tier` degrade path.
- `docs/architecture/observability.md` — the producer table listed
  drain events (`note-filed`, `note-appended`, `surface-proposed`) with
  no producer, and a `curator` producer row naming session-pipeline
  event types nothing emits any more. `SCHEMA_VERSION` read `1`
  (actual: `2`). The trace_id section described a live mint-and-thread
  pipeline through `chapter_flush.py`, which is deleted. The flush
  state machine section described `begin`/`transition`/`record_failure`,
  which are deleted. `lore status` and `lore trace <selector>`
  sections described removed rows and removed `last`/`dead` selectors.
  The "Deprecated" section described `log`/`news`/`runs`/`proc` as kept
  aliases; they are fully removed.
- `docs/architecture/cli-contract.md` — claimed `curator_cmd` imports
  `lore_core.run_render`; the module is deleted and no import exists.
- `docs/architecture/config.md` — the per-wiki config subsection listed
  the retired `curator.*` block wholesale, and a README anchor link
  pointed at a heading that no longer exists (renamed from "curator A
  narration" to "briefing narration").
- `docs/architecture/state.md` — named a session note as the artifact a
  push carries (it's a flag now), described `try_acquire_spawn_lock` as
  serialising "detached curator launches" (the curator's own auto-spawn
  path is gone; only transcript sync still takes this lock), and listed
  a `buffers/` directory nothing writes any more.
- `docs/architecture/sync.md` — the auto_push trigger table named the
  deleted `session_curator.py:_maybe_auto_commit`; the real trigger is
  the SessionEnd hook. The conflict-policy LLM-merge path is live in
  the tree but unreachable in production (no caller passes an
  `llm_client`); marked parked in the same form
  `docs/architecture/briefing-compression-channel.md` uses. The
  configuration defaults said `auto_push=false`; it now defaults to
  whether the wiki has a remote. `git.auto_commit` is documented as a
  schema field with no reader rather than dropped or left implying it
  does something. A "future direction" note referenced a "Curator A
  trigger" migration candidate that no longer exists.
- `docs/how-to/onboarding.md` — the "Done when" bar waited for a
  session note under `sessions/`, which nothing writes; replaced with
  the `Hook` status line plus filing one flag. A `status` claim named a
  removed "last note" row and a registered-transcript count `status`
  doesn't print.
- `docs/how-to/troubleshooting.md` — "A flush looks stuck" described
  the write-side lifecycle (backoff, `MAX_ATTEMPTS`) that no longer
  runs; rewritten to describe the read-only leftover state. The
  hooks-diagnosis step referenced `curator/*` spine events as evidence
  a flush spawned; replaced with the actual `drain/transcript-synced`
  event. The "moved rather than vanished" table pointed
  `lore curator backfill-slugs` at `lore migrate slugs`, which
  `lore migrate` does not mount.
- `docs/how-to/resume-a-broken-epic.md`, `docs/how-to/run-an-epic.md` —
  both named a composed "epic note" as the orchestrator's working-context
  store; replaced with the board's `## Notes` section.
- `CONTRIBUTING.md` — the example skill directory names (`attach`,
  `loaded`, `resume`) match no directory under `skills/`; replaced with
  the real ones (`curator`, `inbox`, `verify`).
- `skills/curator/SKILL.md` — the implements-propagation pass description
  implied it processes current session notes; clarified that nothing
  writes a new one, so it only ever finds pre-retirement back-links.
- `lore-workflow/skills/orient/SKILL.md` — the context pack's `sessions`
  field is always empty (nothing populates `wiki/<name>/sessions/`
  since the compose pipeline retired); the "Prior art" facet now leans
  on `epic_state` and a targeted search instead.
- `lore-workflow/skills/seed-epic/SKILL.md` — step 3 treated
  `lore workflow seed-lift` against "this session's note" as the
  primary path with freehand as fallback; inverted, since no session
  note exists for a current session.
- `docs/how-to/measure-flag-quality.md` (found during the sweep, not on
  the issue's list) — named a "dead-lettered flush" alert `lore status`
  no longer computes.

## ADR

`docs/adr/0010-producer-rule-and-board-carries-the-narrative.md` — cites
epic #375 and PR #385 (the removal sweep). Records: a read surface
without a live producer is a defect; the board's `## Notes` section
carries the orchestrator's supervision narrative, and the epic note is
gone. Supersedes ADR 0002, restamped to `Superseded by ADR 0010`.

## Acceptance criteria — evidence

**"The documentation shall describe no command that lore does not
mount."** Enumerated every mounted command from this worktree (not a
stale global install):

```
PYTHONPATH=lib .venv/bin/python -m lore_cli --help
```

Top-level: `uninstall`, `update`, `install`, `init`, `attach`, `status`,
`doctor`, `config`, `flag`, `search`, `drill`, `session`, `project`,
`wiki`, `lint`, `curator`, `on`, `off`, `tier`, `style`, `briefing`,
`codemap`, `hook`, `inbox`, `ingest`, `mcp`, `migrate`, `quarantine`,
`scopes`, `trace`, `transcripts`, `workflow`, `journal` (mounted, hidden
from `--help`). No `backfill`, `resume`, `log`, `news`, `runs`, `proc`,
`drain`, `detach`, `attachments`, `registry`, or `completions` — each
confirmed absent by running the group and by grepping `lore_cli/__main__.py`.

Then `--help` on every multi-command group (`trace`, `status`,
`migrate`, `scopes`, `curator`, `doctor`, `flag`, `attach`, `config`,
`session`, `workflow`, `briefing`, `wiki`, `inbox`, `quarantine`,
`transcripts`, `install`, `journal`) to enumerate subcommands, then
grepped all fourteen pages plus README/CONTRIBUTING/skills for every
`` `lore ...` `` backtick span and checked each against the enumerated
set. Every remaining reference to a since-removed command (`lore log`,
`lore backfill`, `lore trace dead`, …) sits in a sentence that names it
as removed — none is presented as usable.

**"The documentation shall describe no config key that lore does not
read."** Read `RootConfig`/`WikiConfig` in `lib/lore_core/root_config.py`
and `lib/lore_core/wiki_config.py`:

- `RootConfig`: `observability.{hook_events,runs,retention,proc}`,
  `curator.{backend,openai.*}`, `journal.enabled`, `tiers.overrides`,
  `user.display_name`.
- `WikiConfig`: `git.{auto_commit,auto_push,auto_pull}`,
  `models.{simple,middle,high}`, `briefing.{auto,audience,sinks}`,
  `heartbeat.{enabled,cooldown_s,push_context}`,
  `breadcrumb.{mode,scope_filter}`. `WikiConfig` carries no `curator`
  field — `RETIRED_BLOCKS = frozenset({"curator"})` warns on it by name.

Removed the `curator:` per-wiki block from README and `config.md` (it
named `threshold_pending_turns`, `max_pending_age_s`, `a_noteworthy_tier`,
`synthesis_buffer_cap_turns`, `synthesis_buffer_cap_chars`,
`synthesis_model_tier` — none exist on `WikiConfig`). Every dotted
config path left in the fourteen pages was grepped and checked against
the two schemas above.

**Links resolve.** Wrote a link/anchor checker (mirrors GitHub's
heading-slug algorithm) over all fourteen pages plus the touched ADRs;
it walks every relative link, resolves the target file, and — for
anchors — checks the target's own heading slugs. Zero broken links or
anchors. Grepped the whole repo for incoming links (plain and anchored)
to every page and heading I renamed; nothing outside the touched files
points at a changed anchor.

## TODOs left

None — every claim traced to a specific module, and nowhere did I need
to guess.

## Code defects found, not fixed (Python source, out of scope)

- `lib/lore_curator/__init__.py`'s module docstring points at
  `lore_curator.session_curator.run_curator_a`; that module doesn't
  exist.
- `lib/lore_cli/session_cmd.py`'s docstring names
  `lore_curator/session_filer.py` as part of the canonical write path;
  that file doesn't exist (`session_writer.py` does).
- `lib/lore_cli/hooks.py::cmd_stop`'s docstring says "Hint to capture a
  session note" — session notes are retired.
- `lib/lore_cli/hooks.py::capture()`'s docstring says it "spawns
  detached curator when pending work exceeds threshold" — the
  threshold-spawn heartbeat (`lore_curator/heartbeat.py`) is deleted.
- `lib/lore_cli/migrate_cmd.py`'s module docstring advertises
  `lore migrate slugs` as a subcommand; no `@app.command("slugs")` is
  registered, so it doesn't mount.
- `lib/lore_core/run_log.py`'s module docstring lists `session_curator`
  among the producers "untouched" by the spine move; that module is
  gone.
- `lib/lore_core/wiki_config.py`'s `GitConfig.auto_commit` field has no
  reader anywhere in `lib/` — a flag write commits unconditionally
  through `session.py:commit_note` regardless of this setting. Not a
  doc defect (it's still a valid schema key `load_wiki_config` accepts)
  but a no-op knob a user could set expecting an effect.
- `lib/lore_core/spine.py:new_trace_id()` has zero callers anywhere in
  `lib/` — dead code. Documented as "no current minter" in
  `observability.md` rather than pretending the mechanism is active.
- Possibly pre-existing, not caused by this epic: `state.md`'s privacy
  claim that transcripts live under `.lore/` "never a descendant" of
  `wiki/` conflicts with `lore_core/transcript_sync.py`'s own docstring,
  which mirrors transcripts to `<wiki>/.transcripts/` — a descendant,
  gitignored. I left this alone since `transcript_sync.py` wasn't
  touched by this epic and I couldn't confirm which side is stale
  without a deeper read outside my scope; flagging for a look.

## Test plan

- [x] `PYTHONPATH=lib .venv/bin/python -m pytest -q` — 2642 passed, 45
      skipped, plus the two known local-only failures
      (`test_rename_reports_stale_checked_in_offer`,
      `test_refresh_claude_plugin_cache_runs_update_on_success`), same
      as the stated baseline. No new failures.
- [x] Vale/writing-rules tests included in that run (`test_vale_style.py`,
      `test_workflow_glossary_read.py`, `test_workflow_plain_verbs.py`)
      — 57 passed, 29 skipped (Vale binary not installed on this host;
      skips are advisory, not failures).
