### PR TITLE
docs: PRD 0013 and the session-note residue sweep

### DIFF
--- a/docs/prd/0013-retire-the-session-note-lifecycle.md
+++ b/docs/prd/0013-retire-the-session-note-lifecycle.md
@@ -1,0 +1,224 @@
+---
+title: Retire the session-note lifecycle, its stock, and the curator framing
+status: draft
+epic: https://github.com/buchbend/lore/issues/TBD
+repos:
+  - buchbend/lore
+---
+
+# PRD 0013: Retire the session-note lifecycle, its stock, and the curator framing
+
+> Source of truth for this epic. Tracker: [epic issue](https://github.com/buchbend/lore/issues/TBD).
+> The epic links here; this file is not embedded in the issue body.
+
+## Problem
+
+ADR 0010 ratified the producer rule. A read surface without a live producer is a
+defect. Issue #377 applied the rule to three enumerations: drain event kinds,
+spine error codes, and status rows. `tests/test_producerless_surfaces_gone.py`
+guards those three.
+
+The session note itself was never enumerated. Issue #361 deleted the compose
+pipeline in release 0.68.0. Nothing has written a session note since. The code
+that composed, stored, indexed and read session notes still stands.
+
+All observations below come from host `saiyajin`, at
+`/home/buchbend/git/lore/.claude/worktrees/epic-375-teardown`, against
+`origin/main` at `509c126`, release 0.69.0. The method was AST symbol extraction
+across `lib/`, then a reference search over every non-test file. The full sweep
+is recorded at `docs/session-note-teardown-sweep.md`.
+
+### Four modules hold code that no caller reaches
+
+- `lore_core/note_document.py` declares 45 symbols. Five carry a production
+  caller. The session-note chapter lifecycle accounts for roughly 700 lines and
+  no caller reaches it.
+- `lore_curator/session_activity.py` spans 568 lines. Three private helpers
+  carry a caller in `lore_curator/ledger_linkage.py`. Every public function is
+  unreachable.
+- `lore_core/session_writer.py` spans 324 lines. One function carries a caller.
+- `lore_core/flush_store.py` spans 189 lines. Its own docstring records that no
+  code opens a record.
+
+Tests import each of these modules. The imports are the only reference. Roughly
+2,000 lines of test code assert behaviour that no product path exercises.
+
+### PRD 0012 read the caller count and drew the wrong conclusion
+
+PRD 0012 held `note_document` out of scope because the module "carries live
+callers". The module carries five. They are `read_note`, `NoteView`,
+`DISCLAIMER`, `append_marker_chapter` and `_ref_clause`. None belongs to the
+chapter lifecycle. The out-of-scope line hid the largest remaining target.
+
+### Four readers walk a directory that nothing fills
+
+- `lore_core/context_pack.py` scans `<wiki>/sessions/` and returns the matches
+  under a `sessions` key. The MCP tool `lore_context_pack` serves that key.
+- `lore_core/briefing/gather.py` collects "new session notes since the last
+  briefing" from the same tree.
+- `lore_core/lint.py` writes `sessions/_recent.txt` and reports a session-note
+  count.
+- `lore-workflow/skills/orient/SKILL.md` advertises the `sessions` key as prior
+  art.
+
+Each returns empty on an installation that never ran the retired pipeline.
+
+### Two migrations outlive the artifact they migrate
+
+`lore migrate retire-session-notes` deletes a user's session-note stock.
+`lore migrate open-items` lifts open items out of session-note bodies. Together
+they span 547 lines and 456 lines of tests.
+
+### The package name states a role the code does not fill
+
+`lore_curator/__init__.py` describes itself as "the session-note curator
+(Curator A)". It names `lore_curator.session_curator.run_curator_a` as its entry
+point. That module does not exist. The package now holds an LLM client, capture
+routing, frontmatter hygiene and two migrations.
+
+`lore_core/run_log.py` names `session_curator` among its live producers.
+`lore_cli/spawn.py` spans 338 lines around a `SpawnRole` registry. `SPAWN_ROLES`
+holds one entry. The registry served `curator_a`, `curator_b` and `curator_c`.
+
+Eight further files name a deleted module in a docstring. A reader who follows
+`lore_curator/session_filer.py`, `stub_note`, `synthesis` or `summary_merge`
+finds nothing.
+
+## Solution
+
+Lore deletes every module whose only importer is a test. Lore deletes every
+reader that walks the session-note tree. Lore deletes the migrations that
+maintain a retired artifact. Lore corrects every name that states a role the
+code does not fill.
+
+After this epic:
+
+- No module in `lib/` is imported only by its own tests.
+- No code reads `<wiki>/sessions/`.
+- The word "curator" names the frontmatter hygiene pass and nothing else.
+- Every module a docstring names exists.
+- The producer-rule guard test covers the session note.
+
+## Implementation decisions
+
+### The retained note-document surface
+
+`note_document` keeps the symbols that carry a caller:
+
+```
+DISCLAIMER              # seed_epic, trace
+NoteView, read_note     # seed_epic, trace
+append_marker_chapter   # publish_gate
+MARKER_WITHHELD         # publish_gate
+_ref_clause             # flag
+```
+
+Lore deletes `create_note`, `append_chapter`, `append_facts`, `close_note`,
+`reopen_note`, `is_closed`, `read_facts`, `render_note`, `render_note_body`,
+`render_chapter_body`, `render_fact_body`, `parse_facts`, `Chapter`,
+`TopicBlock`, `Fact`, `Ref`, `SessionFacts` and `NoteClosedError`.
+
+`lore_core/session_start.py` declares its own `SessionFacts`. The two classes
+share a name and nothing else. The deletion leaves `session_start` untouched.
+
+### The three surviving activity helpers
+
+`ledger_linkage` imports `_all_turn_text`, `_commit_shas_from_bash_results` and
+`_files_modified_from_turns` from `session_activity`. Lore moves those three
+into `ledger_linkage` and deletes `session_activity`.
+
+### The session-note sort key
+
+`lint.generate_recent_txt` is the one caller of
+`session_writer.session_path_sort_key`. Lore deletes `generate_recent_txt`, so
+the sort key loses its caller. Lore then deletes `session_writer` whole. No
+symbol moves.
+
+### The context pack
+
+Lore removes the `sessions` key from `lore_context_pack`. The tool returns
+`adr`, `prd` and `epic_state`. Lore removes the prior-art claim from
+`orient/SKILL.md`.
+
+An empty key that no producer fills is the defect ADR 0010 names. Preserving the
+response shape would ship that defect.
+
+### The flush records
+
+Lore deletes `flush_store` and the janitor's purge call. The janitor removes
+`.lore/flushes/` once, on its next run. A record already on disk otherwise
+outlives every reader.
+
+`FlushState` is local to `flush_store`. Issue #377 already dropped the spine
+error codes that the flush lifecycle raised. The spine schema version therefore
+holds at 2.
+
+### The migrations
+
+Lore deletes `retire_session_notes`, `open_items_migration`, both `lore migrate`
+verbs, and `docs/how-to/retire-session-notes.md`.
+
+The owner accepted the consequence. A user who never ran the migration keeps
+session-note files as inert markdown. No code reads them. That user cannot
+backfill transcript-ledger linkage from archived transcripts afterwards.
+
+### The curator framing
+
+`lore_curator` keeps its name. The package docstring states what the package
+holds: an LLM client, capture routing, and frontmatter hygiene. Renaming the
+package would touch every importer and buy nothing this epic needs.
+
+`run_log` drops `session_curator` from its producer list. `spawn` drops the
+`SpawnRole` registry and calls its one role directly. `spawn` keeps the runaway
+gate, the cooldown stamps and the log rotation. Those answer a hang storm the
+changelog records.
+
+### The guard test
+
+`tests/test_producerless_surfaces_gone.py` gains one assertion. No module under
+`lib/` may resolve every importer to a test file. The assertion fails against
+`509c126` and passes after the removals.
+
+## Testing decisions
+
+### Deletion is proved by absence
+
+A test asserts that an import raises `ModuleNotFoundError`. A test asserts that
+a symbol is absent from a surviving module. Prior art:
+`tests/test_dead_code_gone.py` and `tests/test_producerless_surfaces_gone.py`.
+
+### Behaviour over implementation
+
+A test for `lore_context_pack` calls the tool and reads the returned keys. A
+test for `lore lint` runs the command against a wiki holding a `sessions/`
+directory and asserts that no `_recent.txt` appears.
+
+### The retained callers keep their tests
+
+`publish_gate` withholds a chapter through `append_marker_chapter`. `seed_epic`
+and `trace` read a note through `read_note`. Each keeps its existing test. Those
+tests are what prove the deletion cut at the right line.
+
+Prior art: `tests/test_publish_gate_withhold.py`,
+`tests/test_workflow_seed_epic.py`.
+
+### Two failures predate this epic
+
+`tests/test_cli_scopes.py::test_rename_reports_stale_checked_in_offer` and
+`tests/test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`
+fail against `509c126`. Both assert on ANSI-wrapped terminal output. Neither
+touches this epic's scope. The baseline is 2667 passed, 2 failed, 38 skipped.
+
+## Out of scope
+
+- The transcript ledger. Every field it keeps carries a live reader.
+- The flag path. PRD 0012 restored its transport and this epic does not touch it.
+- Briefings. PRD 0011 parks them. This epic deletes the session-note walk inside
+  `gather` and revives nothing.
+- `lore_curator.llm_client`, `capture_routing`, `ledger_linkage` and `hygiene`.
+  Each carries a live caller.
+- The `lore curator` CLI verb and `skills/curator`. The hygiene pass is live.
+  Only its session-note wording changes.
+- Renaming the `lore_curator` package.
+- ADR 0001 and ADR 0003. ADR 0007 already superseded both. Neither is rewritten.
+- Issues #123 and #130. Both remain open under epic #131 on a human hold.

--- a/docs/prd/0013-retire-the-session-note-lifecycle.md
+++ b/docs/prd/0013-retire-the-session-note-lifecycle.md
@@ -1,14 +1,14 @@
 ---
 title: Retire the session-note lifecycle, its stock, and the curator framing
 status: draft
-epic: https://github.com/buchbend/lore/issues/TBD
+epic: https://github.com/buchbend/lore/issues/392
 repos:
   - buchbend/lore
 ---
 
 # PRD 0013: Retire the session-note lifecycle, its stock, and the curator framing
 
-> Source of truth for this epic. Tracker: [epic issue](https://github.com/buchbend/lore/issues/TBD).
+> Source of truth for this epic. Tracker: [epic issue](https://github.com/buchbend/lore/issues/392).
 > The epic links here; this file is not embedded in the issue body.
 
 ## Problem

--- a/docs/prd/index.md
+++ b/docs/prd/index.md
@@ -18,4 +18,5 @@ PRDs are the source of truth for decisions. Each PRD lives at
 0010-join-the-writing-rules-to-the-glossary
 0011-session-note-retirement-flag-architecture
 0012-retire-producerless-surfaces
+0013-retire-the-session-note-lifecycle
 ```

--- a/docs/session-note-teardown-sweep.md
+++ b/docs/session-note-teardown-sweep.md
@@ -1,11 +1,16 @@
 # Session-note and curator residue — code sweep
 
-Swept at `fa1d326` (0.69.0). Method: AST symbol extraction across `lib/`, then a
-reference search over every non-test file. Docstring-only and comment-only
-mentions were excluded by hand. `CODEMAP.md` is a generated symbol index and was
-excluded — it names every symbol and matches everything.
+Swept at `509c126` (0.69.0, current `main`). Method: AST symbol extraction across
+`lib/`, then a reference search over every non-test file. Docstring-only and
+comment-only mentions were excluded by hand. `CODEMAP.md` is a generated symbol
+index and was excluded — it names every symbol and matches everything.
 
-Test baseline before any change: 2665 passed, 2 failed, 30 skipped.
+The first pass ran against the epic branch at `fa1d326`. Re-run after rebasing
+onto `main`, every code finding was identical; the docs findings changed and are
+corrected below. `main` now carries ADR 0010, which ratifies the producer rule
+this sweep applies.
+
+Test baseline before any change: 2667 passed, 2 failed, 38 skipped.
 Both failures (`test_cli_scopes.py::test_rename_reports_stale_checked_in_offer`,
 `test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`)
 assert on ANSI-wrapped terminal output and are unrelated to session notes.
@@ -155,12 +160,16 @@ curate a session note.
 | --- | --- |
 | `lib/lore_cli/session_cmd.py:3` | `lore_curator/session_filer.py` |
 | `lib/lore_core/session.py:5` | `lore_curator/session_filer.py` |
-| `lib/lore_core/session_writer.py:5` | `stub_note`, `synthesis`, `summary_merge` |
+| `lib/lore_core/session_writer.py:5,9` | `stub_note`, `synthesis`, `summary_merge` |
 | `lib/lore_core/git.py:34` | `lore_curator.session_filer` |
-| `lib/lore_core/linkage.py:10` | `session_activity.collect_commits_by_sha` |
-| `docs/architecture/sync.md:39` | `session_curator.py:_maybe_auto_commit` |
-| `docs/architecture/observability.md:53` | `lore_curator/chapter_flush.py` |
-| `CONTEXT-FORMAT.md:6` | `lore_curator/stub_note.py` |
+| `lib/lore_core/linkage.py:10,75` | `session_activity.collect_commits_by_sha` |
+| `lib/lore_core/run_log.py:10` | `session_curator` as a live run role |
+| `lib/lore_curator/session_activity.py:334` | `session_filer.py` |
+| `CONTEXT-FORMAT.md:6,14` | `lore_curator/stub_note.py`, `stub_note._placeholder_title` |
+
+`docs/architecture/sync.md` and `docs/architecture/observability.md` carried two
+more. Both were corrected by #389, merged into `main` as part of #390, and the
+observability text now reads as historical narrative. Neither needs work.
 
 ### `README.md`
 

--- a/docs/session-note-teardown-sweep.md
+++ b/docs/session-note-teardown-sweep.md
@@ -1,0 +1,195 @@
+# Session-note and curator residue — code sweep
+
+Swept at `fa1d326` (0.69.0). Method: AST symbol extraction across `lib/`, then a
+reference search over every non-test file. Docstring-only and comment-only
+mentions were excluded by hand. `CODEMAP.md` is a generated symbol index and was
+excluded — it names every symbol and matches everything.
+
+Test baseline before any change: 2665 passed, 2 failed, 30 skipped.
+Both failures (`test_cli_scopes.py::test_rename_reports_stale_checked_in_offer`,
+`test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`)
+assert on ANSI-wrapped terminal output and are unrelated to session notes.
+
+## Summary
+
+| Category | Production LOC | Test LOC |
+| --- | --- | --- |
+| Dead — no production caller | ~1,540 | ~2,360 |
+| Producerless — reads an artifact nothing writes | ~290 | — |
+| Live but misnamed or misdocumented | — | — |
+
+## 1. Dead — tests are the only importer
+
+### `lib/lore_core/session_writer.py` — 324 LOC, 1 live symbol
+
+The session-note body composer. `parse_body_sections`, `render_body_sections`,
+`merge_body_sections`, `BodySections`, `FiledNote`, `_dedup_lines` have no
+production caller. Only `session_path_sort_key` (39 LOC) survives, called by
+`lore_core/lint.py:759`.
+
+Move `session_path_sort_key` into `lint.py` and delete the file. Removes
+`tests/test_session_writer.py` (292 LOC).
+
+The module docstring also names `lore_curator.stub_note`,
+`lore_curator.synthesis`, and `lore_curator.summary_merge`. None of those exist.
+
+### `lib/lore_curator/session_activity.py` — 568 LOC, 3 live helpers
+
+Built the session note's `## Activity` section. Dead public surface:
+`CommitRef`, `collect_commits_by_sha`, `render_commits_section`,
+`extract_issue_refs`, `collect_issues_in_window`, `render_issue_section`,
+`collect_projects_for_session`, `_files_read_from_turns`,
+`_files_touched_from_turns`, `_is_git_commit_command`,
+`_project_slug_from_abs_path`, `_file_path_from_tool_input`. That is ~357 LOC.
+
+`lore_core/linkage.py:10` and `:75` name `collect_commits_by_sha`, but both are
+prose inside a docstring, not calls.
+
+Live: `_all_turn_text`, `_commit_shas_from_bash_results`,
+`_files_modified_from_turns` — ~92 LOC, imported by
+`lore_curator/ledger_linkage.py:74`. Fold those three into `ledger_linkage.py`
+and the module deletes entirely. Removes `tests/test_session_activity.py`
+(459 LOC).
+
+### `lib/lore_core/note_document.py` — 1084 LOC, ~5 live symbols
+
+PRD 0012 put this module out of scope on the grounds that it "carries live
+callers". It does, but only these:
+
+- `DISCLAIMER`, `NoteView`, `read_note` — `lore_workflow/seed_epic.py:19`,
+  `lore_core/trace.py:21`
+- `append_marker_chapter`, `MARKER_WITHHELD` — `lore_core/publish_gate.py:389`
+- `_ref_clause` — `lore_core/flag.py`
+
+Everything else is the session-note chapter lifecycle with no caller:
+`create_note`, `append_chapter`, `append_facts`, `close_note`, `reopen_note`,
+`is_closed`, `read_facts`, `render_note`, `render_note_body`,
+`render_chapter_body`, `render_fact_body`, `parse_facts`, `Chapter`,
+`TopicBlock`, `Fact`, `Ref`, `SessionFacts`, `NoteClosedError`, and their
+private helpers. That is ~700 LOC.
+
+`SessionFacts` looked live but `lore_core/session_start.py:279` defines its own
+class of the same name.
+
+This is the single largest item in the sweep. Removes most of
+`tests/test_note_document.py` (1442 LOC).
+
+Note: ADR 0001 and ADR 0003 document `reopen_note` and `render_note`. Both
+become historical record once the functions go.
+
+### `lib/lore_core/flush_store.py` — 189 LOC, whole module
+
+Its own docstring states the position: "No code opens a new record." The compose
+pipeline (#361) was the only writer, and #377 removed the surviving write half.
+What remains is a reader plus `FlushStore.purge`, called once from
+`lore_core/janitor.py:124`.
+
+The store empties itself over one retention horizon. After that horizon the
+module and its purge call can go together. Removes `tests/test_flush_store.py`
+(164 LOC).
+
+### `lib/lore_core/identity.py::session_note_dir` — 10 LOC
+
+Chooses `sessions/<handle>/` or `sessions/`. Nothing writes session notes, so
+nothing calls it. The only reference is a docstring in `session_writer.py:19`.
+
+`unaliased_authors` and `aliased_emails` are also test-only, but they are
+identity concerns, not session-note ones.
+
+## 2. Producerless — reads an artifact nothing writes
+
+These still return real data for users who have historical session notes on
+disk. For a fresh install they return empty forever. Removing them is the same
+call PRD 0012 made on the other producerless surfaces, so it belongs to the
+owner, not to a sweep.
+
+### `lib/lore_core/context_pack.py` — sessions half, ~98 LOC
+
+`_iter_session_notes`, `_matching_sessions`, `_session_matches`,
+`_session_date_from_path` scan `<wiki>/sessions/**`. `gather` is live — the MCP
+tool `lore_context_pack` calls it at `lore_mcp/server.py:1007` — but its
+`sessions` key is now fed by a directory nothing fills.
+
+`lore-workflow/skills/orient/SKILL.md:34` still advertises "the pack's
+`sessions` (recent related session notes)" as prior art.
+
+### `lib/lore_core/briefing/gather.py` — 261 LOC
+
+`gather()` collects "new session notes since the last briefing" by walking
+`<wiki>/sessions/`. PRD 0011 parks briefings and PRD 0012 keeps them parked, so
+this is parked-and-producerless rather than dead.
+
+### `lib/lore_core/lint.py` — session index generation
+
+`generate_recent_txt` writes `sessions/_recent.txt` listing the last 20 session
+notes, and `_build_report` prints "N session notes in `sessions/`". Both go
+quiet on a vault with no session notes.
+
+## 3. One-shot migrations — keep until users have run them
+
+- `lib/lore_curator/retire_session_notes.py` (311 LOC) —
+  `lore migrate retire-session-notes`, documented at
+  `docs/how-to/retire-session-notes.md`. This is the tool that removes session
+  notes from a user's vault. It must outlive the code it retires.
+- `lib/lore_curator/open_items_migration.py` (236 LOC) —
+  `lore migrate open-items`, lifts open items out of session-note bodies.
+
+Both have a defined end of life: once the field has migrated, both they and
+their tests go.
+
+## 4. Live but misnamed or misdocumented
+
+Nothing to delete here; these are stale claims that will mislead the next reader.
+
+### The `lore_curator` package name
+
+`lib/lore_curator/__init__.py:1` still reads "the session-note curator (Curator
+A)" and names `lore_curator.session_curator.run_curator_a` as the entry point.
+That module does not exist. What actually lives in the package now is an LLM
+client, capture routing, frontmatter hygiene, and two migrations — none of which
+curate a session note.
+
+### Docstrings naming deleted modules
+
+| File | Names |
+| --- | --- |
+| `lib/lore_cli/session_cmd.py:3` | `lore_curator/session_filer.py` |
+| `lib/lore_core/session.py:5` | `lore_curator/session_filer.py` |
+| `lib/lore_core/session_writer.py:5` | `stub_note`, `synthesis`, `summary_merge` |
+| `lib/lore_core/git.py:34` | `lore_curator.session_filer` |
+| `lib/lore_core/linkage.py:10` | `session_activity.collect_commits_by_sha` |
+| `docs/architecture/sync.md:39` | `session_curator.py:_maybe_auto_commit` |
+| `docs/architecture/observability.md:53` | `lore_curator/chapter_flush.py` |
+| `CONTEXT-FORMAT.md:6` | `lore_curator/stub_note.py` |
+
+### `README.md`
+
+Line 3 and line 190 still say session notes auto-extract from transcripts.
+`CONTEXT.md:46` already carries the correct statement: "Lore writes no session
+note."
+
+### `lib/lore_cli/spawn.py` — 338 LOC for one role
+
+The `SpawnRole` registry and the `spawn(role, ...)` entry point were built for
+`curator_a`, `curator_b`, `curator_c`, and `transcripts`. `SPAWN_ROLES` now holds
+one entry, `"transcripts"`, and the one caller is
+`lore_cli/hooks.py:593`. The runaway gate, cooldown stamps, and log rotation are
+worth keeping; the registry indirection around a single row is not.
+
+### `skills/curator/SKILL.md:21`
+
+Describes the implements-propagation pass in terms of "a session note's
+`implements: <slug>`". The pass is frontmatter hygiene and works on any note.
+
+## Suggested order
+
+1. `note_document.py` lifecycle — biggest single win, ~700 LOC plus ~1400 test LOC.
+2. `session_activity.py` — fold 3 helpers into `ledger_linkage.py`, delete module.
+3. `session_writer.py` — move the sort key into `lint.py`, delete module.
+4. `identity.session_note_dir`.
+5. Docstrings, `README.md`, `lore_curator/__init__.py`.
+6. `spawn.py` registry flattening.
+7. `flush_store.py` — after one retention horizon.
+8. Producerless readers (`context_pack` sessions, `briefing/gather`, `lint`
+   session indexes) — owner's call, same shape as PRD 0012.
+9. Migrations — last, once the field has moved.


### PR DESCRIPTION
## Context

Issue #361 deleted the compose pipeline in release 0.68.0. Nothing has written a
session note since. A sweep on host `saiyajin` against `origin/main` at
`509c126` found the code that composed, stored, indexed and read one still
standing.

ADR 0010 ratified the producer rule. Issue #377 applied the rule to drain event
kinds, spine error codes and status rows. The session note itself was never
enumerated, so the rule never reached it.

## What this pull request adds

- `docs/session-note-teardown-sweep.md` — the sweep. The method was AST symbol
  extraction across `lib/`, then a reference search over every non-test file.
  The report separates code with no production caller from code that reads an
  artifact nothing writes, and from live code whose docstrings name deleted
  modules.
- `docs/prd/0013-retire-the-session-note-lifecycle.md` — the specification for
  epic #392, wired into the PRD index.

## What the sweep found

- `lore_core/note_document.py` declares 45 symbols. Five carry a production
  caller. PRD 0012 held the module out of scope because it "carries live
  callers". None of the five belongs to the chapter lifecycle, and that
  lifecycle spans roughly 700 lines.
- `lore_curator/session_activity.py`, `lore_core/session_writer.py` and
  `lore_core/flush_store.py` each resolve every importer to a test file.
- Four readers walk `<wiki>/sessions/`. Two migration commands maintain the
  session-note stock.
- `lore_curator/__init__.py` names an entry point that no module defines.

## Verification

The test suite runs 2667 passed, 2 failed, 38 skipped against `509c126`. Both
failures assert on ANSI-wrapped terminal output and predate this branch:

- `tests/test_cli_scopes.py::test_rename_reports_stale_checked_in_offer`
- `tests/test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`

The first sweep ran against the epic branch at `fa1d326`. A second sweep ran
after a rebase onto `main`. Every code finding was identical. The docs findings
changed, because #389 corrected two of them, and the report records the
correction.

`lore workflow validate-roadmap` accepts the epic body: 3 features, acyclic.

## Out of scope

This pull request changes no product code. Issues #393, #394 and #395 carry the
removals.
