### PR TITLE
Retire the curator framing and the one-role spawn registry

### DIFF
--- a/CONTEXT-FORMAT.md
+++ b/CONTEXT-FORMAT.md
@@ -1,23 +1,24 @@
 # Session note format — title and body shape
 
-The exact shape a session note takes on disk. `CONTEXT.md` owns the
-vocabulary (buffer, flush, chapter, fact, ledger, disclaimer) and the write
-path; this file is the rendering. Grounded in `lore_core/note_document.py`
-and `lore_curator/stub_note.py`.
+**Nothing writes one any more.** The compose pipeline retired and the code
+that rendered a note is deleted. This file describes notes a vault may still
+hold, so a reader — human, or `read_note` in `lore_core/note_document.py` —
+knows what they are looking at. Everything below is in the past tense on
+purpose. `CONTEXT.md` owns the vocabulary (buffer, flush, chapter, fact,
+ledger, disclaimer).
 
-A note is written **once, at session close** — the whole file below appears
-in one step. Nothing is rendered while the session runs.
+A note was written **once, at session close** — the whole file below appeared
+in one step. Nothing was rendered while the session ran.
 
 ## Title: `scope: name`
 
-A note's frontmatter `title` is a placeholder at creation
-(`stub_note._placeholder_title`, e.g. `proj:x session — 2026-07-10`) — the
-first heartbeat fires before there is any content to name.
+A note's frontmatter `title` was a placeholder at creation (e.g. `proj:x
+session — 2026-07-10`) — the first heartbeat fired before there was any
+content to name.
 
-At close, one bounded LLM call writes the session's **headline** from the
-extracted fact table, and the headline names the note:
-`render_note(title=_scope_title(scope, headline))` replaces the placeholder
-with `<scope>: <name>`.
+At close, one bounded LLM call wrote the session's **headline** from the
+extracted fact table, and the headline named the note, replacing the
+placeholder with `<scope>: <name>`.
 
 - **scope first** — the linkage scope (repo/project slug, e.g. `proj:x` or
   `ccat:data-center`) so a list of notes sorts and scans by *where*, not by
@@ -26,9 +27,8 @@ with `<scope>: <name>`.
 
 Example: `proj:x: Traced the flush race`.
 
-The same headline slugs the filename (`chapter_flush._rename_to_topic_slug`),
-so title and filename always name the same topic. An empty headline leaves
-both at their placeholder.
+The same headline slugged the filename, so title and filename always name the
+same topic. An empty headline left both at their placeholder.
 
 ## Body: disclaimer, reading, ledger
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Lore
 
-**LLM-optimized knowledge graph for AI-coding teams.** Session notes
-auto-extracted into durable knowledge, repo-scoped context injected at
-session start, pluggable team briefings. No vector DB needed for small
-vaults; a full hybrid search + MCP server for larger ones.
+**LLM-optimized knowledge graph for AI-coding teams.** Transcripts captured
+and archived, team-relevant facts filed as reviewable flags, repo-scoped
+context injected at session start, pluggable team briefings. No vector DB
+needed for small vaults; a full hybrid search + MCP server for larger ones.
 
 > ⚠️ **Pre-1.0.** APIs, hook contracts, skill surfaces, frontmatter
 > schema, and CLI flags can still change between minor versions. Not
@@ -110,10 +110,10 @@ lore install                                            # detect installed integ
 lore init                                               # scaffold a vault + set $LORE_ROOT
 ```
 
-The `[capture]` extra adds the `claude-agent-sdk` + `anthropic` packages used
-by the curator to summarise transcripts. Drop it (`#egg=lore`) to install
-without LLM-driven capture; you'll still get retrieval, sessions, and
-briefings, just not auto-extraction.
+The `[capture]` extra adds the `claude-agent-sdk` + `anthropic` packages the
+briefing uses to call a model. Drop it (`#egg=lore`) to install without them;
+transcript capture, retrieval, sessions and flags all work regardless — only
+the LLM-backed briefing needs a model.
 
 > **Note:** the bare `pipx install lore` form will *not* work — the
 > name `lore` is squatted on PyPI by an unrelated package. Use the

--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -326,7 +326,6 @@ from lore_cli.spawn import (  # noqa: E402, F401
     _spawn_detached_transcript_sync,
     _stamp_within_cooldown,
     _write_stamp,
-    spawn,
 )
 
 hook_app = typer.Typer(

--- a/lib/lore_cli/spawn.py
+++ b/lib/lore_cli/spawn.py
@@ -1,4 +1,4 @@
-"""Detached subprocess machinery for the curator/transcript-sync hooks.
+"""Detached subprocess machinery for the transcript-sync hook.
 
 This module owns the spawn-side safety net that the v0.37 hang storm forced
 us to build:
@@ -8,14 +8,12 @@ us to build:
 * a runaway gate that refuses fresh spawns when the prior child for a role
   is still alive past ``cooldown_s * 5``;
 * atomic log + meta-sidecar rotation so each generation is recoverable
-  after a crash;
-* a tiny ``SpawnRole`` registry + a single ``spawn(role, lore_root,
-  **extra)`` entry point so adding a new background process is one row.
+  after a crash.
 
-The legacy ``_spawn_detached_curator_{a,b,c}`` and
-``_spawn_detached_transcript_sync`` wrappers stay as one-liners that
-delegate to :func:`spawn` — existing call sites and test patch points
-keep working unchanged.
+``_spawn_detached`` stays role-parametric — the role string keys the lock,
+the cooldown stamp, the proc log and the meta sidecar, so every path on
+disk derives from it. Transcript sync is the only role left;
+:func:`_spawn_detached_transcript_sync` names it directly.
 """
 
 from __future__ import annotations
@@ -23,8 +21,6 @@ from __future__ import annotations
 import json
 import os
 import sys
-from collections.abc import Callable
-from dataclasses import dataclass, field
 from pathlib import Path
 
 from lore_core.spine import ErrorCode, emit_hook_event
@@ -268,71 +264,24 @@ def _spawn_detached(
 
 
 # ---------------------------------------------------------------------------
-# SpawnRole registry + the single public ``spawn()`` entry point
+# The one spawning caller
 # ---------------------------------------------------------------------------
 
-
-@dataclass(frozen=True)
-class SpawnRole:
-    """One row in the spawn-role registry.
-
-    ``argv_builder`` is called with the keyword arguments forwarded from
-    :func:`spawn`. The returned argv is the *child* command;
-    ``_spawn_detached`` wraps it in ``python -m lore_cli._proc_wrapper``
-    for sidecar lifecycle tracking.
-    """
-
-    name: str
-    argv_builder: Callable[..., list[str]] = field(repr=False)
-    default_cooldown_s: int
-
-
-SPAWN_ROLES: dict[str, SpawnRole] = {
-    "transcripts": SpawnRole(
-        name="transcripts",
-        argv_builder=lambda: [
-            sys.executable,
-            "-m",
-            "lore_cli",
-            "transcripts",
-            "sync",
-        ],
-        default_cooldown_s=300,
-    ),
-}
-
-
-def spawn(role: str, lore_root: Path, *, cooldown_s: int | None = None, **extra) -> bool:
-    """Public entry point — fire-and-forget the registered subprocess for ``role``.
-
-    Looks up :data:`SPAWN_ROLES`, builds the argv (forwarding ``**extra``
-    to the role's ``argv_builder``), and dispatches through
-    :func:`_spawn_detached` with the role's cooldown + stamp-migration
-    flags. ``cooldown_s`` overrides the registry default when caller has
-    a wiki-config-derived value.
-    """
-    role_def = SPAWN_ROLES[role]
-    return _spawn_detached(
-        lore_root,
-        role_def.name,
-        role_def.argv_builder(**extra),
-        cooldown_s=(cooldown_s if cooldown_s is not None else role_def.default_cooldown_s),
-    )
-
-
-# ---------------------------------------------------------------------------
-# Backward-compat wrappers — kept as one-liners over :func:`spawn` so
-# existing call sites and `patch("lore_cli.hooks._spawn_detached_curator_*")`
-# in the test suite keep working unchanged.
-# ---------------------------------------------------------------------------
+# Keys the spawn lock, the cooldown stamp, `.lore/proc/<role>.log` and the
+# meta sidecar. Changing the string orphans every one of those on upgrade.
+TRANSCRIPT_SYNC_ROLE = "transcripts"
 
 
 def _spawn_detached_transcript_sync(lore_root: Path, *, cooldown_s: int = 300) -> bool:
     """Fire-and-forget ``lore transcripts sync`` subprocess.
 
-    Runs on the same spawn-lock + cooldown pattern as the curators, so
-    a busy SessionStart hook can't stampede the filesystem with parallel
-    sync jobs. The P4a sync itself is idempotent; the lock exists purely
-    as a politeness budget.
+    Runs under the spawn lock + cooldown so a busy SessionStart hook can't
+    stampede the filesystem with parallel sync jobs. The sync itself is
+    idempotent; the lock exists purely as a politeness budget.
     """
-    return spawn("transcripts", lore_root, cooldown_s=cooldown_s)
+    return _spawn_detached(
+        lore_root,
+        TRANSCRIPT_SYNC_ROLE,
+        [sys.executable, "-m", "lore_cli", "transcripts", "sync"],
+        cooldown_s=cooldown_s,
+    )

--- a/lib/lore_core/run_log.py
+++ b/lib/lore_core/run_log.py
@@ -1,4 +1,4 @@
-"""Run-log producer for curator invocations (A, B, C).
+"""Run-log producer for curator invocations.
 
 Curator run events are emitted onto the unified event spine
 (``source="curator"``) — one envelope per decision record, keyed by
@@ -7,8 +7,8 @@ tee; consumers reconstruct a run by grouping spine records on ``run_id``
 (see :mod:`lore_core.run_reader`).
 
 The :class:`RunLogger` context-manager API is unchanged, so every producer
-(``session_curator``, ``hygiene``, ``curator_cmd``) is untouched — only the
-sink moved. Two consequences of the move:
+(``hygiene``, ``curator_cmd``) is untouched — only the sink moved. Two
+consequences of the move:
 
 * **LLM records carry metadata only.** The spine's lock-free O_APPEND
   atomicity assumes each record stays well under ``PIPE_BUF`` (4 KB); a full

--- a/lib/lore_curator/__init__.py
+++ b/lib/lore_curator/__init__.py
@@ -1,9 +1,17 @@
-"""lore_curator — the session-note curator (Curator A).
+"""lore_curator — the capture-side and hygiene helpers.
 
-Files one lab-notebook session note per completed transcript. Entry
-point: :func:`lore_curator.session_curator.run_curator_a`.
+The package defines no entry point of its own; each module is imported
+directly by its caller. It holds:
 
-The A/B/C labels are internal shorthand; user-facing copy says simply
-"Curator". Curators B (daily surface extraction) and C (weekly defrag)
-were retired; only the per-session note filer remains.
+* :mod:`lore_curator.llm_client` — a backend-agnostic LLM client (Claude
+  subscription, API key, or a local endpoint), used by the briefing;
+* :mod:`lore_curator.capture_routing` — the decision layer between a hook
+  firing and the transcript ledger;
+* :mod:`lore_curator.hygiene` — the frontmatter-only passes behind the
+  ``lore curator`` command;
+* :mod:`lore_curator.ledger_linkage` — builds a ledger entry's linkage
+  block from git state and transcript turns.
+
+Nothing here composes a note. The package name is historical: renaming it
+would touch every importer and change no behaviour.
 """

--- a/skills/curator/SKILL.md
+++ b/skills/curator/SKILL.md
@@ -22,9 +22,9 @@ Passes per wiki, all frontmatter-only — note bodies are never touched:
    from notes under `sessions/` and drops `draft:` on the target,
    stamping `implemented_by` / `implemented_at` back-links;
    `implements: <slug>:superseded-by:<other>` writes `superseded_by:
-   [[other]]`. Nothing writes a new session note since the compose
-   pipeline retired, so this pass only ever finds back-links on notes
-   that predate the retirement.
+   [[other]]`. No producer writes into `sessions/` any more, so the pass
+   finds back-links only where a human authored them, or on notes that
+   predate the compose pipeline's retirement.
 3. **Git backfill** — missing `created` / `last_reviewed` filled from
    `git log --follow`.
 4. **Team-mode hint** — advises creating `_users.yml` once a solo wiki

--- a/tests/test_dead_code_gone.py
+++ b/tests/test_dead_code_gone.py
@@ -5,6 +5,8 @@ package, script, and hygiene no-op pass is actually gone.
 from __future__ import annotations
 
 import importlib
+import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -67,3 +69,88 @@ def test_no_docstring_names_a_deleted_module(deleted_name: str):
         if deleted_name in p.read_text(errors="replace")
     )
     assert hits == [], f"{deleted_name!r} still named under lib/: {hits}"
+
+
+# ---------------------------------------------------------------------------
+# The curator framing — no docstring names a role Lore retired, and the spawn
+# registry is gone.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("retired_name", ["session_curator", "run_curator_a"])
+def test_lore_curator_docstring_names_no_retired_entry_point(retired_name: str):
+    import lore_curator
+
+    assert retired_name not in (lore_curator.__doc__ or "")
+
+
+def test_run_log_docstring_names_no_session_curator_producer():
+    import lore_core.run_log
+
+    assert "session_curator" not in (lore_core.run_log.__doc__ or "")
+
+
+def test_spawn_role_registry_is_gone():
+    spawn_module = importlib.import_module("lore_cli.spawn")
+
+    for name in ("SPAWN_ROLES", "SpawnRole", "spawn"):
+        assert not hasattr(spawn_module, name), f"lore_cli.spawn still exports {name!r}"
+    with pytest.raises(ImportError):
+        from lore_cli.spawn import SPAWN_ROLES  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Prose describing the retired pipeline.
+# ---------------------------------------------------------------------------
+
+SESSION_NOTE_RE = re.compile(r"session[ _-]notes?", re.IGNORECASE)
+
+# The record of the retirement may name what it retired. Editing these would
+# falsify a dated measurement or a shipped changelog entry.
+STUB_NOTE_RECORD_FILES = {
+    "CHANGELOG.md",
+    "docs/session-note-teardown-sweep.md",
+}
+
+
+def _tracked_markdown() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "--", "*.md"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [line for line in out.splitlines() if line]
+
+
+def test_no_skill_claims_lore_writes_a_session_note():
+    """No shipped skill names a session note — no producer writes one."""
+    hits = sorted(
+        f"{p.relative_to(REPO)}:{lineno}"
+        for p in (REPO / "skills").rglob("*.md")
+        for lineno, line in enumerate(p.read_text(encoding="utf-8").splitlines(), start=1)
+        if SESSION_NOTE_RE.search(line)
+    )
+    assert hits == [], f"skills/ still names a session note: {hits}"
+
+
+def test_no_tracked_markdown_names_stub_note():
+    """``lore_curator.stub_note`` is gone; only the record may still name it."""
+    hits = sorted(
+        rel
+        for rel in _tracked_markdown()
+        if rel not in STUB_NOTE_RECORD_FILES
+        and not rel.startswith(("docs/prd/", "docs/adr/"))
+        and "stub_note" in (REPO / rel).read_text(encoding="utf-8")
+    )
+    assert hits == [], f"stub_note still named in tracked Markdown: {hits}"
+
+
+def test_readme_states_what_lore_captures():
+    """The README's opening claim matches what Lore captures today."""
+    opening = (REPO / "README.md").read_text(encoding="utf-8").split("## The pitch")[0]
+
+    assert "transcript" in opening.lower()
+    assert "flag" in opening.lower()
+    assert not SESSION_NOTE_RE.search(opening)

--- a/tests/test_hooks_capture.py
+++ b/tests/test_hooks_capture.py
@@ -683,6 +683,10 @@ def test_spawn_writes_stamp_file_on_success(tmp_path: Path, no_subprocess, role:
     spawned = _invoke_spawn(role, lore_root, cooldown_s=60)
     assert spawned is True, f"expected first spawn to proceed; subprocess calls={no_subprocess}"
     assert len(no_subprocess) == 1
+    # `_spawn_detached_transcript_sync` is the only place the child argv is
+    # written down, so a typo in it would otherwise reach users unnoticed.
+    # The wrapper prepends its own argv; the child's trailing four are ours.
+    assert no_subprocess[0][-4:] == ["-m", "lore_cli", "transcripts", "sync"]
     stamp = _stamp_path(lore_root, role)
     assert stamp.exists(), f"stamp file {stamp} should be created"
     now = time.time()


### PR DESCRIPTION
Closes #395

## Context

Release 0.68.0 deleted the pipeline that composed session notes. Issue #393
deleted the lifecycle. Issue #394 deleted the stock and its readers. The names
those roles left behind still sat in docstrings, in a spawn registry and in
prose.

Both prior issues merged into `epic/392` before this branch cut. The branch reads
the tree at `e2dd877`.

## What changed

### The curator package docstring

`lib/lore_curator/__init__.py` called the package "the session-note curator
(Curator A)". The docstring named `lore_curator.session_curator.run_curator_a` as
the entry point. The tree holds no module of that name.

The new docstring lists the four modules the package holds: `llm_client`,
`capture_routing`, `hygiene` and `ledger_linkage`. The package defines no entry
point, and the docstring says so. The package keeps its name.

### The run log producer list

`lib/lore_core/run_log.py` line 10 named `session_curator` among live producers.
The docstring names `hygiene` and `curator_cmd`. Line 1 dropped the "(A, B, C)"
role labels for the same reason.

### The spawn registry

`lib/lore_cli/spawn.py` held a `SpawnRole` dataclass, a `SPAWN_ROLES` dictionary
of one row, and a `spawn(role, ...)` lookup. `_spawn_detached_transcript_sync`
names its role string and its argv directly.

The module lost 65 lines. The runaway gate, the cooldown stamps and the log
rotation are byte-identical. The diff starts at line 264.

`_spawn_detached` stays role-parametric. The role string keys the spawn lock, the
cooldown stamp, `.lore/proc/<role>.log` and the meta sidecar. A named constant
carries the string. A comment states what a rename would orphan.

`lib/lore_cli/hooks.py` dropped `spawn` from its re-export block. No caller
imported the name.

### The prose

`skills/curator/SKILL.md` describes the implements-propagation pass without
naming a session note.

`CONTEXT-FORMAT.md` names no deleted module. The header states that no producer
writes a note. The body reads as a record of notes already on disk.

`README.md` line 3 said Lore auto-extracts session notes. Line 3 states that Lore
captures transcripts and files flags. Line 113 said the `[capture]` extra feeds a
curator that summarises transcripts. The briefing is the only caller that needs a
model, so line 113 says so.

## Red to green

Every criterion got its failing test first. The runs below come from host
`saiyajin`, in worktree `epic-392-b2`, with this command:

```
PYTHONPATH=$PWD/lib /home/buchbend/git/lore/.venv/bin/pytest -q --color=no tests/test_dead_code_gone.py
```

### Red — the product files at `origin/epic/392`, the tests from this branch

```
E       assert 'session_curator' not in 'lore_curato...r remains.\n'
E       assert 'run_curator_a' not in 'lore_curato...r remains.\n'
E       AssertionError: assert 'session_curator' not in 'Run-log pro...s cleanup.\n'
E           AssertionError: lore_cli.spawn still exports 'SPAWN_ROLES'
E           assert not True
E       AssertionError: skills/ still names a session note: ['skills/curator/SKILL.md:25']
E       assert ['skills/curator/SKILL.md:25'] == []
E       AssertionError: stub_note still named in tracked Markdown: ['CONTEXT-FORMAT.md']
E       assert ['CONTEXT-FORMAT.md'] == []
E       assert 'transcript' in "# lore\n\n**llm-optimized knowledge graph for ai-coding teams.** session notes\nauto-extracted into durable knowledge...d cli flags can still change between minor versions. not\n> recommended for wikis you can't re-migrate into shape.\n\n"
FAILED tests/test_dead_code_gone.py::test_lore_curator_docstring_names_no_retired_entry_point[session_curator]
FAILED tests/test_dead_code_gone.py::test_lore_curator_docstring_names_no_retired_entry_point[run_curator_a]
FAILED tests/test_dead_code_gone.py::test_run_log_docstring_names_no_session_curator_producer
FAILED tests/test_dead_code_gone.py::test_spawn_role_registry_is_gone - Asser...
FAILED tests/test_dead_code_gone.py::test_no_skill_claims_lore_writes_a_session_note
FAILED tests/test_dead_code_gone.py::test_no_tracked_markdown_names_stub_note
FAILED tests/test_dead_code_gone.py::test_readme_states_what_lore_captures - ...
```

Seven failures map to the four parts:

- part 1 — the two `test_lore_curator_docstring_names_no_retired_entry_point` cases;
- part 2 — `test_run_log_docstring_names_no_session_curator_producer`;
- part 3 — `test_spawn_role_registry_is_gone`;
- part 4 — `test_no_skill_claims_lore_writes_a_session_note`,
  `test_no_tracked_markdown_names_stub_note`, `test_readme_states_what_lore_captures`.

### Green — the branch as it stands

```
25 passed in 0.26s
```

### The retained spawn behaviour, before and after

Three EARS criteria cover the behaviour `spawn.py` keeps. The prior tests carry
them, so the flattening added no test there. The same four files ran before the
flattening and after it:

```
PYTHONPATH=$PWD/lib /home/buchbend/git/lore/.venv/bin/pytest -q --color=no \
  tests/test_spawn_runaway_detector.py tests/test_spawn_throttle_concurrent.py \
  tests/test_proc_log_capture.py tests/test_hooks_capture.py

49 passed, 1 warning in 2.32s     # before
49 passed, 1 warning in 2.08s     # after
```

No test in those four files changed.

## Decisions

### The stub_note assertion excludes the record

`CHANGELOG.md`, `docs/prd/0002`, `docs/prd/0013` and
`docs/session-note-teardown-sweep.md` all name `stub_note`. All four record
history, and #395 puts the changelog and the PRD files out of scope. The sweep
records a measurement taken at `509c126`, so an edit there would falsify a dated
observation.

`test_no_tracked_markdown_names_stub_note` therefore skips `CHANGELOG.md`,
`docs/session-note-teardown-sweep.md`, `docs/prd/` and `docs/adr/`. Every other
tracked Markdown file must stay clean. `CONTEXT-FORMAT.md` was the only file the
exclusion list did not cover, and the red run above proves the point.

### The implements pass still reads one directory

Issue #395 states that the hygiene pass "reads frontmatter on any note". The code
disagrees: `lib/lore_curator/hygiene.py:253` sets `sessions_dir = wiki_path /
"sessions"` and walks only that directory. Issue #395 puts the hygiene passes out
of scope, so the code stayed put and the prose now matches the code.

`skills/curator/SKILL.md` says the pass reads notes under `sessions/`, and adds
that no producer writes there any more. The sentence names no session note.

### CONTEXT-FORMAT.md survives as a reader's record

The whole document describes a renderer the tree no longer holds. Deletion was
the alternative. `read_note` still parses notes on disk for `seed_epic` and
`trace`, and a user's vault may still hold those files, so the document keeps
reader value. The header states plainly that no producer writes a note.

An owner who wants the file deleted can do so in one commit. Issue #395 asked for
a correction, so this branch corrects.

### One adjacent README line

`README.md` line 113 claimed the `[capture]` extra feeds "the curator" to
summarise transcripts. No curator summarises a transcript. The line sits in the
file #395 names, and it describes the same retired pipeline, so it changed too.

## Left alone

`lore-workflow/skills/brief/SKILL.md:63` says a persisted brief "would duplicate
what session notes do". The sentence describes a pipeline that no longer runs.
The file sits under `lore-workflow/skills/`, not under `skills/`, so
`test_no_skill_claims_lore_writes_a_session_note` does not cover it and this
branch does not touch it.

`lore_core/run_log.py` keeps `session-note` in `RECORD_TYPES`, and its
`RunLogger` class docstring keeps an example emitting that record type. Both are
code rather than the module docstring the criterion names.

## Verification

Full suite on host `saiyajin`, Python 3.11:

```
3 failed, 2525 passed, 16 skipped, 2 warnings, 11 subtests passed in 67.01s
```

The three failures are the known environment failures:
`test_cli_scopes.py::test_rename_reports_stale_checked_in_offer`,
`test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`
and `test_vale_style.py::test_the_document_passes_its_own_style_apart_from_the_banned_word_line`.
The last one lints the packaged `writing-rules` document, which this branch never
touches.

`ruff check` reports one `SIM105` in `spawn.py` and one in `run_log.py`. Both
findings predate the branch. The same check against `origin/epic/392` reports the
same two, one per file. `ruff format --check` passes on every touched file except
`lib/lore_cli/hooks.py`, which fails identically at `origin/epic/392`.

## A trap for the next teammate

`LORE_SUPPRESS_CAPTURE=1` breaks `tests/test_hooks_capture.py`. Those tests
exercise the suppress flag, so 13 of 26 fail when the variable is set. Run pytest
without the variable.
