### PR TITLE
Decide the nine read surfaces with no producer (#404)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,5 +5,3 @@
 - wiki: private
 - scope: lore
 - backend: github
-- issues: --assignee @me --state open
-- prs: --author @me

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,6 @@
 - wiki: private
 - scope: lore
 - backend: github
-- issues: --assignee @me --state open
-- prs: --author @me
 
 ## Releasing
 

--- a/CONTEXT-FORMAT.md
+++ b/CONTEXT-FORMAT.md
@@ -105,7 +105,7 @@ The `text` and the `why` are the model's. **Every other word is code's**
 
 One chapter per extracted chunk, opened by an HTML-comment delimiter carrying
 its turn span. Each fact is stored twice: as a machine-readable
-`<!-- lore:fact {…} -->` marker (the copy `render_note` reads back) and as
+`<!-- lore:fact {…} -->` marker (the copy `read_note` parses back) and as
 human-readable text — the bold statement, its code-attached verbatim quote
 from the anchor turn, and the `@N` anchor. Drill-down chain: rendered line →
 fact in the ledger → quote → archived transcript turn.

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -140,13 +140,13 @@ Vault-wide policy. Schema lives in
 - `observability.hook_events.{max_size_mb, keep_rotations}`
 - `observability.runs.{keep, max_total_mb, keep_trace}`
 - `observability.proc.keep_generations`
-- `observability.retention.{hot_days, cold_days, cold_max_mb, crash_log_days,
-  dead_letter_hard_cap}` — the unified spine retention janitor: a hot tier keeps
-  detailed events ~`hot_days`, a cold tier keeps compact summaries ~`cold_days`
-  under a `cold_max_mb` size cap; `crash_log_days` bounds crash-log retention.
-  `dead_letter_hard_cap` capped flush dead letters. No code reads it any more —
-  the flush store went with the compose pipeline. A value there changes nothing.
-  See `docs/architecture/observability.md`.
+- `observability.retention.{hot_days, cold_days, cold_max_mb, crash_log_days}` —
+  the unified spine retention janitor: a hot tier keeps detailed events
+  ~`hot_days`, a cold tier keeps compact summaries ~`cold_days` under a
+  `cold_max_mb` size cap; `crash_log_days` bounds crash-log retention. See
+  `docs/architecture/observability.md`.
+  `dead_letter_hard_cap` was removed with the flush store. A `config.yml` that
+  still sets it loads normally; the loader warns and names the key to delete.
 - `curator.backend` — `auto` | `subscription` | `api` | `openai`
 - `curator.openai.{base_url, api_key_env, model_simple, model_middle, model_high, reasoning_effort_simple, reasoning_effort_middle, reasoning_effort_high}`
 - `journal.enabled`

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -110,6 +110,10 @@ Keep the files, move them, or delete them — Lore behaves the same either
 way. Delete them with `git rm` if you want the tree quiet; the wiki's git
 history keeps a copy.
 
+A wiki that ran an older Lore also holds `sessions/_recent.txt`, the index
+`lore lint` used to regenerate over those notes. Nothing writes or reads it
+now, and nothing removes it. Delete it with the notes.
+
 The three migration verbs that used to help here are gone:
 `lore migrate retire-session-notes`, `lore migrate open-items`, and the
 older `lore curator --migrate-open-items`. The transcript-ledger backfill

--- a/lib/lore_cli/briefing_cmd.py
+++ b/lib/lore_cli/briefing_cmd.py
@@ -4,9 +4,20 @@ The default form is the one-shot pipeline:
 
     lore briefing --wiki <name>
 
-which gathers new sessions, renders a deterministic markdown digest,
-publishes via the wiki's configured sink (`.lore-briefing.yml`), and
-marks the ledger.
+which would gather new sessions, render a deterministic markdown digest,
+publish via the wiki's configured sink (`.lore-briefing.yml`), and mark
+the ledger.
+
+**The one-shot is parked, not live.** Nothing writes a session note since
+the compose pipeline was retired, so ``gather()`` returns an empty
+``new_sessions`` list on every call (see ``lore_core.briefing.gather``)
+and ``_run_oneshot`` returns at its sessions check. No producer reaches
+the compose, publish, mark, commit or push code below that return. PRD
+0011 parks the feature rather than reviving it; the code stays so a
+future producer needs no rebuild, and ``tests/test_briefing.py`` covers
+the renderer and the prose composer as the pure functions they are.
+``lore briefing publish`` and ``lore briefing mark`` stay reachable —
+neither calls ``gather()``.
 
 The one-shot also coordinates the wiki repo across teammates:
 ``auto_pull`` runs before gather (so we see teammates' marks) and

--- a/lib/lore_cli/trace_cmd.py
+++ b/lib/lore_cli/trace_cmd.py
@@ -57,7 +57,7 @@ def _step_label(step: TraceStep) -> str:
             bits.append(f"model={model}")
         if tokens is not None:
             bits.append(f"tokens={tokens}")
-    elif step.event in ("note-filed", "note-appended", "session-note"):
+    elif step.event in ("note-filed", "note-appended"):
         path = step.data.get("path") or step.data.get("wikilink")
         if path:
             bits.append(f"-> {path}")

--- a/lib/lore_core/attach.py
+++ b/lib/lore_core/attach.py
@@ -13,7 +13,6 @@ import re
 from pathlib import Path
 
 SECTION_HEADING = "## Lore"
-LORE_KEYS: tuple[str, ...] = ("wiki", "scope", "backend", "issues", "prs")
 BULLET_RE = re.compile(r"^- ([A-Za-z][\w-]*): ?(.*)$")
 HEADING_RE = re.compile(r"^## (.+?)\s*$")
 

--- a/lib/lore_core/errors.py
+++ b/lib/lore_core/errors.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 from typing import Any
 
 # Canonical error codes — keep client-facing strings centralised so the
-# MCP tool docs and handler modules stay in sync.
+# MCP tool docs and handler modules stay in sync. Every emit site imports
+# its constant; a code written as a literal drifts from the docs silently,
+# because renaming the constant then breaks nothing.
 NO_VAULT = "no_vault"
 NO_WIKIS = "no_wikis"
 WIKI_NOT_FOUND = "wiki_not_found"
@@ -31,14 +33,11 @@ SOURCE_NOT_A_FILE = "source_not_a_file"
 NOTE_NOT_FOUND = "note_not_found"
 PATH_NOT_FOUND = "path_not_found"
 PATH_ESCAPE = "path_escape"
-CATALOG_MISSING = "catalog_missing"
 SESSION_OFF = "session_off"
 UNKNOWN_TOOL = "unknown_tool"
 INVALID_KIND = "invalid_kind"
 INVALID_ENTRY = "invalid_entry"
 EMPTY_ENTRY = "empty_entry"
-NO_WIKI = "no_wiki"
-PLAN_NOT_FOUND = "plan_not_found"
 
 
 def mcp_error(

--- a/lib/lore_core/gh.py
+++ b/lib/lore_core/gh.py
@@ -1,61 +1,21 @@
-"""`gh` CLI helpers — thin subprocess wrappers used by hooks + CLI.
+"""`gh` CLI helper — thin subprocess wrapper.
 
 Fails silent: if `gh` is missing, unauthenticated, or the network is
-down, every call returns an empty list. Callers surface "no issues
-matched" rather than erroring — SessionStart must never block on gh.
+down, the call returns None. Callers surface "not found" rather than
+erroring — SessionStart must never block on gh.
+
+The list helpers and their line formatters are gone. They existed to
+count a repo's open issues and PRs for the SessionStart banner; the
+banner dropped those counts, and nothing took their place. Their input,
+the `issues:`/`prs:` filter keys in a repo's lore block, went with them.
 """
 
 from __future__ import annotations
 
 import json
-import shlex
 import subprocess
 
 GH_TIMEOUT_SECONDS = 10
-
-
-def split_filter(raw: str | None) -> list[str]:
-    """Split a filter string (e.g. from CLAUDE.md `issues:`) into argv."""
-    raw = (raw or "").strip()
-    if not raw:
-        return []
-    try:
-        return shlex.split(raw)
-    except ValueError:
-        return raw.split()
-
-
-def run_gh(kind: str, repo: str, filter_args: list[str]) -> list[dict]:
-    """Call `gh <kind> list` for `repo`. Returns [] on any failure.
-
-    `kind` is `"issue"` or `"pr"`.
-    """
-    fields = "number,title,state" if kind == "issue" else "number,title,state,isDraft"
-    cmd = ["gh", kind, "list", "--repo", repo, "--json", fields, *filter_args]
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=GH_TIMEOUT_SECONDS,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return []
-    if result.returncode != 0:
-        return []
-    try:
-        return json.loads(result.stdout) or []
-    except json.JSONDecodeError:
-        return []
-
-
-def gh_issues(repo: str, filter_str: str) -> list[dict]:
-    return run_gh("issue", repo, split_filter(filter_str))
-
-
-def gh_prs(repo: str, filter_str: str) -> list[dict]:
-    return run_gh("pr", repo, split_filter(filter_str))
 
 
 def gh_issue_view(repo: str, number: int) -> dict | None:
@@ -73,16 +33,3 @@ def gh_issue_view(repo: str, number: int) -> dict | None:
         return json.loads(result.stdout)
     except json.JSONDecodeError:
         return None
-
-
-def format_issue_line(issue: dict) -> str:
-    number = issue.get("number")
-    title = issue.get("title") or ""
-    return f"- #{number} {title}".rstrip()
-
-
-def format_pr_line(pr: dict) -> str:
-    number = pr.get("number")
-    title = pr.get("title") or ""
-    draft = " [draft]" if pr.get("isDraft") else ""
-    return f"- #{number}{draft} {title}".rstrip()

--- a/lib/lore_core/janitor.py
+++ b/lib/lore_core/janitor.py
@@ -107,6 +107,15 @@ def run_janitor(lore_root: Path, cfg: ObservabilityConfig) -> JanitorReport:
             max_size_mb=cfg.hook_events.max_size_mb,
         ):
             report.downgraded = True
+            # Emitted here, not inside the rotation: `_rotate_locked` holds the
+            # rotation flock and is mid-rename, so a write from in there would
+            # be reentrant on the lock and land in a file about to move. After
+            # the return the hot file is fresh, and the event lands in it.
+            writer.emit(
+                source="janitor",
+                event="retention-downgrade",
+                data={"family": "spine-hot", "path": cold.name},
+            )
 
         # Cold tier: age or size cap deletes it outright — no tier below.
         if cold.exists():
@@ -192,6 +201,7 @@ def _write_status(lore_root: Path, report: JanitorReport) -> None:
         "hot_bytes": report.hot_bytes,
         "cold_bytes": report.cold_bytes,
         "deleted": report.deleted,
+        "downgraded": report.downgraded,
         "failed": report.failed,
     }
     try:

--- a/lib/lore_core/offer.py
+++ b/lib/lore_core/offer.py
@@ -20,7 +20,7 @@ FILENAME = ".lore.yml"
 
 # Routing-relevant fields that participate in the fingerprint.
 # Changes to these invalidate prior accept/decline decisions and re-prompt.
-# Non-routing fields (issues, prs) are stored but do NOT affect the fingerprint.
+# Non-routing fields (backend, inherit) are stored but do NOT affect it.
 _FINGERPRINT_FIELDS: tuple[str, ...] = ("wiki", "scope", "wiki_source")
 
 
@@ -42,8 +42,6 @@ class Offer:
     scope: str = ""
     backend: str = "none"
     wiki_source: str | None = None
-    issues: str | None = None
-    prs: str | None = None
     schema_version: int = 1
     inherit: bool = False
 
@@ -74,8 +72,6 @@ def parse_lore_yml(path: Path) -> Offer | None:
         scope=scope,
         backend=_str_or_default(raw.get("backend"), "none"),
         wiki_source=_str_or_none(raw.get("wiki_source")),
-        issues=_str_or_none(raw.get("issues")),
-        prs=_str_or_none(raw.get("prs")),
         schema_version=int(raw.get("schema_version", 1)),
         inherit=raw.get("inherit") is True,
     )

--- a/lib/lore_core/root_config.py
+++ b/lib/lore_core/root_config.py
@@ -54,17 +54,18 @@ class RetentionConfig:
 
     ``crash_log_days`` bounds ``$LORE_CACHE/crashes/``.
 
-    ``dead_letter_hard_cap`` was the escape valve for flush dead letters. The
-    flush store went with the compose pipeline, so no code reads the field any
-    more. It stays as a field so an existing ``config.yml`` carrying it still
-    parses.
+    ``dead_letter_hard_cap`` was the escape valve for flush dead letters and
+    went with the flush store. It is gone rather than retained: a declared
+    field is a knob a user can set, and one that changes nothing is worse than
+    an absent one. Loading is unaffected — ``_merge`` warns on the unknown key
+    and falls back to defaults, so an existing ``config.yml`` carrying it still
+    parses, and the warning names the key to delete.
     """
 
     hot_days: int = 7
     cold_days: int = 30
     cold_max_mb: int = 20
     crash_log_days: int = 30
-    dead_letter_hard_cap: int = 50
 
 
 @dataclass

--- a/lib/lore_core/run_log.py
+++ b/lib/lore_core/run_log.py
@@ -60,7 +60,7 @@ class RunLogger:
     Context-manager usage:
 
         with RunLogger(lore_root, trigger="hook", role="a") as logger:
-            logger.emit("session-note", action="filed", path="...")
+            logger.emit("skip", reason="nothing noteworthy")
             ...
 
     Emits run-start on enter and run-end (with duration + counts) on exit;
@@ -82,7 +82,6 @@ class RunLogger:
             "noteworthy",
             "cascade-verdict",  # shadow-run feature-based classifier
             "merge-check",
-            "session-note",
             # Buffer-and-flush curator (plan: very-good-thats-the-mossy-lobster).
             # Lifecycle: opened -> appended* -> (cap-tripped|requested) -> spawned
             #   -> deterministic-completed -> llm-completed | degraded
@@ -135,8 +134,6 @@ class RunLogger:
         # run's events join the drain event and the published note (#188).
         self.trace_id = trace_id
         self._counts = {
-            "notes_new": 0,
-            "notes_merged": 0,
             "skipped": 0,
             "errors": 0,
             "actions_applied": 0,
@@ -230,13 +227,7 @@ class RunLogger:
         return dict(fields)
 
     def _counters_bookkeeping(self, record_type: str, fields: dict[str, Any]) -> None:
-        if record_type == "session-note":
-            action = fields.get("action")
-            if action == "filed":
-                self._counts["notes_new"] += 1
-            elif action == "merged":
-                self._counts["notes_merged"] += 1
-        elif record_type == "skip":
+        if record_type == "skip":
             self._counts["skipped"] += 1
         elif record_type == "error":
             self._counts["errors"] += 1

--- a/lib/lore_core/session.py
+++ b/lib/lore_core/session.py
@@ -36,18 +36,14 @@ def _resolve_attach_block(cwd: Path) -> tuple[Path, dict] | None:
     block = {"wiki": scope.wiki, "scope": scope.scope, "backend": scope.backend}
 
     # Attachment paths store the repo root; look for a `.lore.yml` there
-    # and merge its non-routing fields (backend, issues, prs, wiki_source)
-    # into the block dict. This keeps downstream callers
+    # and merge its non-routing fields (backend, wiki_source) into the
+    # block dict. This keeps downstream callers
     # (`_session_start_from_lore`, etc.) working unchanged.
     repo_root = scope.claude_md_path.parent
     offer = parse_lore_yml(repo_root / LORE_YML)
     if offer is not None:
         if offer.backend:
             block["backend"] = offer.backend
-        if offer.issues:
-            block["issues"] = offer.issues
-        if offer.prs:
-            block["prs"] = offer.prs
         if offer.wiki_source:
             block["wiki_source"] = offer.wiki_source
 

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -37,6 +37,17 @@ from pathlib import Path
 from typing import Any
 
 from lore_core.config import get_lore_root, get_wiki_root
+from lore_core.errors import (
+    EMPTY_ENTRY,
+    INVALID_ENTRY,
+    INVALID_KIND,
+    NOTE_NOT_FOUND,
+    PATH_ESCAPE,
+    PATH_NOT_FOUND,
+    SESSION_OFF,
+    UNKNOWN_TOOL,
+    WIKI_NOT_FOUND,
+)
 from lore_core.errors import mcp_error as _mcp_error
 from lore_core.freshness import (
     compute_freshness,
@@ -323,7 +334,7 @@ def handle_read(
     wiki_path = _resolve_wiki(wiki)
     if wiki_path is None:
         return _mcp_error(
-            "wiki_not_found",
+            WIKI_NOT_FOUND,
             f"wiki not found: {wiki}",
             next_="run `lore status` to list configured wikis",
         )
@@ -337,16 +348,16 @@ def handle_read(
     if slug:
         resolved = _resolve_slug(wiki_path, slug)
         if resolved is None:
-            return _mcp_error("note_not_found", f"note not found: {slug}")
+            return _mcp_error(NOTE_NOT_FOUND, f"note not found: {slug}")
         path = resolved
 
     target = (wiki_path / path).resolve()
     try:
         target.relative_to(wiki_path.resolve())
     except ValueError:
-        return _mcp_error("path_escape", "path escapes wiki root")
+        return _mcp_error(PATH_ESCAPE, "path escapes wiki root")
     if not target.exists():
-        return _mcp_error("path_not_found", f"not found: {path}")
+        return _mcp_error(PATH_NOT_FOUND, f"not found: {path}")
     text = target.read_text(errors="replace")
 
     # Notes carry no human-only region: they are machine-written and
@@ -465,20 +476,20 @@ def handle_journal_write(
 
     if kind not in journal.VALID_KINDS:
         return _mcp_error(
-            "invalid_kind",
+            INVALID_KIND,
             f"journal kind must be one of {journal.VALID_KINDS!r}, got {kind!r}",
         )
     text = (text or "").strip()
     if not text:
         return _mcp_error(
-            "empty_entry",
+            EMPTY_ENTRY,
             "journal entry text must be non-empty",
             next_="Pass a non-empty `text` arg.",
         )
     try:
         result = journal.write(kind, text, author=author)  # type: ignore[arg-type]
     except ValueError as e:
-        return _mcp_error("invalid_entry", str(e))
+        return _mcp_error(INVALID_ENTRY, str(e))
     return {"schema": "lore.journal.write/1", "data": result}
 
 
@@ -567,7 +578,7 @@ def handle_drill(
     wiki_path = _resolve_wiki(wiki)
     if wiki_path is None:
         return _mcp_error(
-            "wiki_not_found",
+            WIKI_NOT_FOUND,
             f"wiki not found: {wiki}",
             next_="run `lore status` to list configured wikis",
         )
@@ -741,7 +752,7 @@ def handle_verdict(
     wiki_path = _resolve_wiki(wiki)
     if wiki_path is None:
         return _mcp_error(
-            "wiki_not_found",
+            WIKI_NOT_FOUND,
             f"wiki not found: {wiki}",
             next_="run `lore status` to list configured wikis",
         )
@@ -756,15 +767,15 @@ def handle_verdict(
     if slug:
         resolved = _resolve_slug(wiki_path, slug)
         if resolved is None:
-            return _mcp_error("note_not_found", f"note not found: {slug}")
+            return _mcp_error(NOTE_NOT_FOUND, f"note not found: {slug}")
         rel_path = resolved
     target = (wiki_path / rel_path).resolve()
     try:
         target.relative_to(wiki_path.resolve())
     except ValueError:
-        return _mcp_error("path_escape", "path escapes wiki root")
+        return _mcp_error(PATH_ESCAPE, "path escapes wiki root")
     if not target.exists():
-        return _mcp_error("path_not_found", f"not found: {rel_path}")
+        return _mcp_error(PATH_NOT_FOUND, f"not found: {rel_path}")
 
     if verdict == "confirm":
         from lore_core.verdicts_sidecar import set_confirmed
@@ -892,7 +903,7 @@ def handle_pending_verdicts(wiki: str | None = None) -> dict[str, Any]:
     wiki_path = _resolve_wiki_with_active_scope_fallback(wiki)
     if wiki_path is None:
         return _mcp_error(
-            "wiki_not_found",
+            WIKI_NOT_FOUND,
             (
                 f"wiki not found: {wiki}" if wiki else
                 "could not resolve active wiki (no explicit `wiki`, no "
@@ -951,7 +962,7 @@ def handle_repo_docs_list(kind: str, repo_path: str | None = None) -> dict[str, 
     from lore_core.repo_docs import HOMES, list_docs
 
     if kind not in HOMES:
-        return _mcp_error("invalid_kind", f"kind must be one of {sorted(HOMES)}, got {kind!r}")
+        return _mcp_error(INVALID_KIND, f"kind must be one of {sorted(HOMES)}, got {kind!r}")
     repo_root = _resolve_repo_root(repo_path)
     if repo_root is None:
         return _mcp_error(
@@ -978,7 +989,7 @@ def handle_repo_docs_fetch(kind: str, path: str, repo_path: str | None = None) -
     from lore_core.repo_docs import HOMES, read_doc
 
     if kind not in HOMES:
-        return _mcp_error("invalid_kind", f"kind must be one of {sorted(HOMES)}, got {kind!r}")
+        return _mcp_error(INVALID_KIND, f"kind must be one of {sorted(HOMES)}, got {kind!r}")
     repo_root = _resolve_repo_root(repo_path)
     if repo_root is None:
         return _mcp_error(
@@ -1504,7 +1515,7 @@ def _dispatch(tool_name: str, args: dict) -> Any:
         from lore_core.toggles import is_off
         if is_off("all", sid):
             return _mcp_error(
-                "session_off",
+                SESSION_OFF,
                 "Lore is muted for this session.",
                 next_="Run `lore on` from a shell in this session, or restart the session.",
             )
@@ -1537,7 +1548,7 @@ def _dispatch(tool_name: str, args: dict) -> Any:
         case "lore_context_pack":
             return handle_context_pack(**args)
         case _:
-            return _mcp_error("unknown_tool", f"unknown tool: {tool_name}")
+            return _mcp_error(UNKNOWN_TOOL, f"unknown tool: {tool_name}")
 
 
 def _start_reindex_watcher() -> None:

--- a/lore-workflow/skills/brief/SKILL.md
+++ b/lore-workflow/skills/brief/SKILL.md
@@ -59,8 +59,9 @@ Reuse the existing gates verbatim — no new document types:
   silently, no placeholder. (See [`domain-modeling`](../domain-modeling/SKILL.md).)
 - **Never write to `CONTEXT.md`** — a term worth adding belongs to `grilling`, not this skill.
 - **No PRD, no epic tracker.** Those belong to the chain.
-- **No brief file.** Lore's auto session capture already records the exchange; a persisted
-  brief would duplicate what session notes do.
+- **No brief file.** The brief is an alignment step, not an artifact — it exists to be
+  confirmed and handed straight to the downstream track. What survives the exchange belongs
+  in the issue this skill files, not in a second file that drifts from it.
 
 ### 5. Handoff
 

--- a/tests/test_hooks_v2.py
+++ b/tests/test_hooks_v2.py
@@ -1,9 +1,9 @@
 """Tests for the schema-v2 SessionStart path.
 
-Covers the pure helpers (scope-tree walk, filter parsing, walk-up of
-`CLAUDE.md`) and the orchestrator. SessionStart itself never calls
-`gh` — issue/PR counts were dropped from the banner — so `gh.split_filter`
-and the formatters are exercised directly against `lore_core.gh`.
+Covers the pure helpers (scope-tree walk, walk-up of `CLAUDE.md`) and the
+orchestrator. SessionStart itself never calls `gh` — issue/PR counts were
+dropped from the banner, and the list wrappers and line formatters that
+served them were deleted once nothing else reached them.
 """
 
 from __future__ import annotations
@@ -34,27 +34,6 @@ SCOPES_YML_SAMPLE = {
         },
     }
 }
-
-
-# ---------- gh.split_filter (was hooks._split_filter pre-0.12.0) ----------
-
-
-@pytest.mark.parametrize("raw,expected", [
-    ("", []),
-    ("--assignee @me", ["--assignee", "@me"]),
-    ("--assignee @me --state open", ["--assignee", "@me", "--state", "open"]),
-    ('--label "needs triage"', ["--label", "needs triage"]),
-    (None, []),
-])
-def test_split_filter(raw, expected):
-    from lore_core import gh
-    assert gh.split_filter(raw) == expected
-
-
-def test_split_filter_malformed_falls_back_to_whitespace():
-    # Unterminated quote — shlex raises, fallback kicks in
-    from lore_core import gh
-    assert gh.split_filter('--label "oops') == ["--label", '"oops']
 
 
 # ---------- scope tree walk ----------
@@ -170,28 +149,6 @@ def test_resolve_attach_block_missing_file(tmp_path, monkeypatch):
     assert _resolve_attach_block(tmp_path) is None
 
 
-# ---------- formatters ----------
-
-
-def test_format_issue_line():
-    from lore_core import gh
-    assert gh.format_issue_line({"number": 47, "title": "retry cap"}) == "- #47 retry cap"
-
-
-def test_format_pr_line_draft():
-    from lore_core import gh
-    assert gh.format_pr_line(
-        {"number": 31, "title": "atm-table v2", "isDraft": True}
-    ) == "- #31 [draft] atm-table v2"
-
-
-def test_format_pr_line_ready():
-    from lore_core import gh
-    assert gh.format_pr_line(
-        {"number": 32, "title": "bugfix", "isDraft": False}
-    ) == "- #32 bugfix"
-
-
 # ---------- orchestrator (mocked gh) ----------
 
 
@@ -288,8 +245,14 @@ def test_status_line_shows_scope_not_project_wikilink(
 
 
 def test_session_start_never_shows_issue_or_pr_counts(fake_vault, tmp_path, monkeypatch):
-    """The banner never fetches or renders issue/PR counts — that
-    ambient gh fetch was dropped from SessionStart entirely."""
+    """The banner never fetches or renders issue/PR counts — that ambient gh
+    fetch was dropped from SessionStart entirely.
+
+    Guarded at the subprocess boundary rather than at a named helper: the
+    list wrappers the banner used are gone, and the invariant is that
+    SessionStart shells out to gh at all, not that one function stays unused.
+    A `.lore.yml` left over from an older Lore still carries the filter keys;
+    they are inert, and reaching them must not resurrect the fetch."""
     vault, wiki = fake_vault
     repo_dir = tmp_path / "data-transfer"
     repo_dir.mkdir()
@@ -300,14 +263,22 @@ def test_session_start_never_shows_issue_or_pr_counts(fake_vault, tmp_path, monk
     )
     monkeypatch.setattr(session_start, "current_repo", lambda _cwd: "ccatobs/data-transfer")
 
+    import subprocess as subprocess_mod
+
     from lore_core import gh as gh_mod
 
-    calls: list[tuple] = []
-    monkeypatch.setattr(gh_mod, "run_gh", lambda *a, **kw: calls.append((a, kw)) or [])
+    calls: list[list] = []
+    real_run = subprocess_mod.run
+
+    def spy(cmd, *a, **kw):
+        calls.append(list(cmd))
+        return real_run(cmd, *a, **kw)
+
+    monkeypatch.setattr(gh_mod.subprocess, "run", spy)
 
     out = hooks._session_start(str(repo_dir))
     assert ": active" in out
-    assert calls == [], "SessionStart must never call gh, even with issues/prs configured"
+    assert calls == [], "SessionStart must never shell out to gh"
     status_line = out.splitlines()[0]
     assert "issue" not in status_line
     assert "PR" not in status_line

--- a/tests/test_janitor.py
+++ b/tests/test_janitor.py
@@ -143,6 +143,65 @@ def test_hot_tier_downgrades_by_age(tmp_path: Path):
     assert (tmp_path / ".lore" / "spine.jsonl.1").exists()
 
 
+def _seed_aged_hot(tmp_path: Path) -> None:
+    """One hot-tier record old enough to trip the age-triggered downgrade."""
+    hot = tmp_path / ".lore" / "spine.jsonl"
+    hot.parent.mkdir(parents=True, exist_ok=True)
+    hot.write_text(
+        json.dumps(
+            {
+                "ts": "2020-01-01T00:00:00Z",
+                "v": 1,
+                "source": "hook",
+                "event": "e",
+                "level": "info",
+                "trace_id": None,
+                "session_id": None,
+                "run_id": None,
+                "wiki": None,
+                "scope": None,
+                "error_code": None,
+                "data": {},
+            }
+        )
+        + "\n"
+    )
+
+
+def test_hot_tier_downgrade_emits_janitor_spine_event(tmp_path: Path):
+    """Same invariant the cold-tier delete already holds: every tiered-retention
+    action leaves a `source="janitor"` event behind. The event lands in the
+    fresh hot file, since the rotation moved the old one to cold."""
+    _seed_aged_hot(tmp_path)
+
+    run_janitor(tmp_path, _cfg(hot_days=7))
+    events = read_spine(tmp_path, source="janitor")
+    downgrades = [e for e in events if e["event"] == "retention-downgrade"]
+    assert downgrades, "a hot->cold rotation must emit retention-downgrade"
+    assert downgrades[0]["data"]["family"] == "spine-hot"
+    for e in events:
+        validate_envelope(e)
+
+
+def test_hot_tier_downgrade_reaches_the_status_file(tmp_path: Path):
+    """`JanitorReport.downgraded` tracked the rotation but never left the
+    dataclass — `lore status`'s retention section reads the status file."""
+    _seed_aged_hot(tmp_path)
+
+    run_janitor(tmp_path, _cfg(hot_days=7))
+    status = read_janitor_status(tmp_path)
+    assert status is not None
+    assert status["downgraded"] is True
+
+
+def test_status_records_no_downgrade_when_the_hot_tier_stays(tmp_path: Path):
+    SpineWriter(tmp_path).emit(source="hook", event="e")
+    run_janitor(tmp_path, _cfg(hot_days=7))
+    status = read_janitor_status(tmp_path)
+    assert status is not None
+    assert status["downgraded"] is False
+
+
 # ---------------------------------------------------------------------------
 # Queryable usage — consumed by `lore status` (#193).
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_error_envelope.py
+++ b/tests/test_mcp_error_envelope.py
@@ -27,12 +27,12 @@ def test_mcp_error_helper_basic() -> None:
 
 
 def test_mcp_error_helper_with_next_hint() -> None:
-    err = _mcp_error("catalog_missing", "no _catalog.json", next_="run lore lint")
+    err = _mcp_error("no_wikis", "vault holds no wiki", next_="run lore init")
     assert err == {
         "error": {
-            "code": "catalog_missing",
-            "message": "no _catalog.json",
-            "next": "run lore lint",
+            "code": "no_wikis",
+            "message": "vault holds no wiki",
+            "next": "run lore init",
         }
     }
 

--- a/tests/test_offer.py
+++ b/tests/test_offer.py
@@ -32,8 +32,11 @@ def test_parse_full_offer(tmp_path: Path) -> None:
     assert offer.scope == "ccat:data-center:computers"
     assert offer.backend == "github"
     assert offer.wiki_source == "git@github.com:team/alpha-wiki.git"
-    assert offer.issues == "--assignee @me --state open"
-    assert offer.prs == "--author @me"
+    # `issues:`/`prs:` lost their reader with the gh list wrappers. A file
+    # written against an older Lore still parses — the keys are ignored, not
+    # an error, so an attached repo keeps working untouched.
+    assert not hasattr(offer, "issues")
+    assert not hasattr(offer, "prs")
 
 
 def test_parse_minimal_offer(tmp_path: Path) -> None:
@@ -176,9 +179,9 @@ def test_fingerprint_deterministic() -> None:
 
 
 def test_fingerprint_invariant_under_non_routing_fields() -> None:
-    a = Offer(wiki="w", scope="a:b", issues="--state open", prs="--author @me")
-    b = Offer(wiki="w", scope="a:b", issues="--state closed", prs=None)
-    # issues/prs are NOT routing-relevant → fingerprints equal
+    a = Offer(wiki="w", scope="a:b", backend="github")
+    b = Offer(wiki="w", scope="a:b", backend="none")
+    # backend is NOT routing-relevant → fingerprints equal
     assert offer_fingerprint(a) == offer_fingerprint(b)
 
 

--- a/tests/test_producerless_surfaces_gone.py
+++ b/tests/test_producerless_surfaces_gone.py
@@ -364,3 +364,143 @@ def test_the_one_wiki_enumerator_returns_empty_for_a_vault_with_no_wiki(tmp_path
     from lore_core.config import list_wikis
 
     assert list_wikis(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — no declaration outlives its producer
+#
+# The session-note teardown left surfaces whose producer went with it, plus
+# two that predate it. Each assertion pins one removal or one correction so
+# the surface cannot creep back silently.
+# ---------------------------------------------------------------------------
+
+
+def _repo_text(rel: str) -> str:
+    return (REPO / rel).read_text(errors="replace")
+
+
+def test_briefing_cmd_docstring_marks_the_one_shot_parked() -> None:
+    """`gather()` yields no sessions, so `_run_oneshot` returns before compose,
+    publish and mark on every real call. PRD 0011 parks that path rather than
+    reviving it; the module docstring has to say so."""
+    import lore_cli.briefing_cmd as mod
+
+    doc = (mod.__doc__ or "").lower()
+    assert "parked" in doc, "briefing_cmd's docstring must name the parked one-shot path"
+
+
+def test_run_log_declares_no_session_note_record_type() -> None:
+    from lore_core.run_log import RunLogger
+
+    assert "session-note" not in RunLogger.RECORD_TYPES
+
+
+def test_no_module_reads_the_session_note_record_type() -> None:
+    """No emitter is left, so no branch, docstring example or trace label may
+    keep matching on it."""
+    hits = sorted(
+        str(path.relative_to(REPO))
+        for path, body in _lib_sources().items()
+        if '"session-note"' in body
+    )
+    assert hits == [], f"the retired 'session-note' record type survives in: {hits}"
+
+
+def test_retention_config_declares_no_readerless_cap() -> None:
+    """`dead_letter_hard_cap` lost its reader with the flush store. An unknown
+    key still parses — `root_config` warns and falls back to defaults — so the
+    field's only remaining effect was to make a dead knob look live."""
+    from lore_core.root_config import RetentionConfig
+
+    assert not hasattr(RetentionConfig(), "dead_letter_hard_cap")
+
+
+def test_context_format_names_no_absent_note_document_symbol() -> None:
+    import lore_core.note_document as nd
+
+    referenced = set(
+        re.findall(r"`(render_note|read_note|append_\w+)`", _repo_text("CONTEXT-FORMAT.md"))
+    )
+    missing = sorted(name for name in referenced if not hasattr(nd, name))
+    assert missing == [], f"CONTEXT-FORMAT.md names absent note_document symbols: {missing}"
+
+
+def test_the_brief_skill_claims_no_session_note() -> None:
+    """The skill justified having no brief file by pointing at session notes.
+    No code writes one, so the justification names a surface that is gone.
+
+    Scoped to this one file on purpose: widening
+    ``test_no_skill_claims_lore_writes_a_session_note`` to the whole
+    ``lore-workflow/skills/`` tree is a separate change, and a blanket scan
+    here would also flag the *correct* negative claims other skills make."""
+    text = _repo_text("lore-workflow/skills/brief/SKILL.md")
+    assert not re.search(r"(?<!no )session notes? (do|does)\b", text)
+    assert not re.search(r"(?<!Nothing )writes a session note", text)
+
+
+def test_troubleshooting_names_the_recent_txt_leftover() -> None:
+    """`lint.generate_recent_txt` is gone, so a wiki that already holds
+    `sessions/_recent.txt` keeps it forever. The session-note section has to
+    name it alongside the notes themselves."""
+    assert "_recent.txt" in _repo_text("docs/how-to/troubleshooting.md")
+
+
+def test_errors_declares_no_constant_no_module_reads() -> None:
+    from lore_core import errors as errors_mod
+
+    sources = _lib_sources(exclude=frozenset({"errors.py"}))
+    unread = sorted(
+        name
+        for name, value in vars(errors_mod).items()
+        if name.isupper()
+        and isinstance(value, str)
+        and not any(name in body for body in sources.values())
+    )
+    assert unread == [], f"error-code constants no module imports: {unread}"
+
+
+def test_the_mcp_server_imports_every_error_code_it_emits() -> None:
+    """The module comment promises centralised client-facing strings. A code
+    written as a literal breaks that promise silently — renaming the constant
+    leaves the literal behind."""
+    from lore_core import errors as errors_mod
+
+    server = _repo_text("lib/lore_mcp/server.py")
+    declared = {v for n, v in vars(errors_mod).items() if n.isupper() and isinstance(v, str)}
+    literals = sorted(code for code in declared if f'"{code}"' in server)
+    assert literals == [], f"server.py writes declared error codes as literals: {literals}"
+
+
+def test_gh_declares_no_function_without_a_production_caller() -> None:
+    from lore_core import gh
+
+    sources = _lib_sources(exclude=frozenset({"gh.py"}))
+    orphaned = sorted(
+        name
+        for name, obj in vars(gh).items()
+        if inspect.isfunction(obj)
+        and obj.__module__ == "lore_core.gh"
+        and not any(name in body for body in sources.values())
+    )
+    assert orphaned == [], f"gh helpers no production caller reaches: {orphaned}"
+
+
+def test_the_offer_schema_declares_no_key_without_a_reader() -> None:
+    """`issues:`/`prs:` fed the SessionStart gh counts. The banner dropped those
+    counts; the keys stayed, so a user's filter had no effect and no warning.
+
+    ``Offer`` is the schema for a repo's lore block and its `.lore.yml` — a
+    field here is a key `lore config edit` offers and `validate_offer_raw`
+    accepts, so an unread field advertises a knob that does nothing."""
+    import dataclasses
+
+    from lore_core.offer import Offer
+
+    names = {f.name for f in dataclasses.fields(Offer)}
+    assert "issues" not in names
+    assert "prs" not in names
+
+
+@pytest.mark.parametrize("doc", ["CLAUDE.md", "AGENTS.md"])
+def test_this_repos_lore_block_sets_no_readerless_key(doc: str) -> None:
+    assert not re.search(r"^- (issues|prs):", _repo_text(doc), re.MULTILINE)

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -21,7 +21,6 @@ def test_retention_defaults_when_file_absent(tmp_path: Path):
     assert cfg.observability.retention.cold_days == 30
     assert cfg.observability.retention.cold_max_mb == 20
     assert cfg.observability.retention.crash_log_days == 30
-    assert cfg.observability.retention.dead_letter_hard_cap == 50
 
 
 def test_retention_partial_override(tmp_path: Path):

--- a/tests/test_run_log.py
+++ b/tests/test_run_log.py
@@ -56,20 +56,26 @@ def test_emit_counters_and_ordering(tmp_path: Path):
     with RunLogger(tmp_path, trigger="hook", pending_count=3) as logger:
         logger.emit("transcript-start", transcript_id="t1", new_turns=10)
         logger.emit("noteworthy", transcript_id="t1", verdict=True, reason="x", tier="middle")
-        logger.emit(
-            "session-note", transcript_id="t1", action="filed", path="p.md", wikilink="[[p]]"
-        )
         logger.emit("transcript-start", transcript_id="t2", new_turns=5)
         logger.emit("skip", transcript_id="t2", reason="noteworthy-false")
     records = read_curator_runs(tmp_path)[logger.run_id]
     assert records[0]["type"] == "run-start"
     assert records[-1]["type"] == "run-end"
-    assert records[-1]["notes_new"] == 1
-    assert records[-1]["notes_merged"] == 0
     assert records[-1]["skipped"] == 1
     assert records[-1]["errors"] == 0
     kinds = [r["type"] for r in records[1:-1]]
-    assert kinds == ["transcript-start", "noteworthy", "session-note", "transcript-start", "skip"]
+    assert kinds == ["transcript-start", "noteworthy", "transcript-start", "skip"]
+
+
+def test_run_end_carries_no_note_counters(tmp_path: Path):
+    """The counters only ever moved on a `session-note` record. No emitter is
+    left, so a permanently-zero count in every run-end payload would read as a
+    live measurement of a retired pipeline."""
+    with RunLogger(tmp_path, trigger="hook") as logger:
+        logger.emit("skip", reason="x")
+    end = read_curator_runs(tmp_path)[logger.run_id][-1]
+    assert "notes_new" not in end
+    assert "notes_merged" not in end
 
 
 def test_exception_emits_error_and_runend_then_propagates(tmp_path: Path):


### PR DESCRIPTION
## Context

Issue #404 listed nine read surfaces with no producer. Epic #392 left six of
them; a later symbol audit of `lib/` found items 8 and 9, which predate the
epic. ADR 0010 states the rule: a read surface without a live producer is a
defect.

Each item needed one decision — delete the surface, or restore its producer.
Six surfaces leave the tree. Two documents drop a claim the code does not
support. One surface gains the producer its documentation already promised. One
stays, and now says so.

## Decisions

### 1. `lore briefing`'s one-shot path — parked, and marked

`_run_oneshot` keeps its compose, publish, mark, commit and push code. PRD 0011
parks the briefing feature; a deletion would discard work the PRD intends to
revive. `briefing_cmd`'s module docstring now states that `gather()` returns an
empty `new_sessions` list on every call, and that no producer reaches the code
below the sessions check.

### 2. `run_log.py`'s session-note record type — deleted

`RunLogger.RECORD_TYPES` drops `"session-note"`. Its counter branch, its
docstring example and `trace_cmd`'s match on it go with it.

The `notes_new` and `notes_merged` counters go too. The deleted branch was
their only incrementer, so every run-end payload would have carried two zeros
that read as a live measurement of a retired pipeline. No production module
read either counter.

### 3. `dead_letter_hard_cap` — deleted, not retained

The field's docstring already recorded that no code reads it. It stays out
rather than in: a declared field is a knob a user can set, and one that changes
nothing is worse than an absent one.

An existing `config.yml` that sets the key still loads. `root_config._merge`
warns on an unknown key and falls back to defaults, and the warning names the
key to delete. `docs/architecture/config.md` records the same.

### 4. `retention-downgrade` — producer restored

`docs/architecture/observability.md` line 159 promised the event. The janitor
now emits a `source="janitor"` `retention-downgrade` event after a hot-to-cold
rotation, and `janitor-status.json` records a `downgraded` field.

The emit sits in `run_janitor`, not in `SpineWriter._rotate_locked`. The
rotation holds the rotation flock and is mid-rename, so a write from inside
would be reentrant on the lock and would land in a file about to move.

### 5. `CONTEXT-FORMAT.md`'s `render_note` reference — corrected

Line 108 names `read_note`, the function that parses the fact marker back.
`lore_core.note_document` defines no `render_note`.

### 6. `brief/SKILL.md`'s session-note claim — rewritten

The skill justified having no brief file by pointing at session notes. The
justification now names the reason that holds: the brief is an alignment step,
and what survives it belongs in the issue the skill files.

### 7. `sessions/_recent.txt` — documented

`docs/how-to/troubleshooting.md` names the file as a second leftover, safe to
delete beside the notes themselves.

### 8. `errors.py`'s unread constants — imported or deleted

`lore_mcp.server` imports the nine constants it wrote as string literals:
`WIKI_NOT_FOUND`, `NOTE_NOT_FOUND`, `PATH_NOT_FOUND`, `PATH_ESCAPE`,
`INVALID_KIND`, `INVALID_ENTRY`, `EMPTY_ENTRY`, `SESSION_OFF` and
`UNKNOWN_TOOL`.

`CATALOG_MISSING`, `NO_WIKI` and `PLAN_NOT_FOUND` leave the module. No module
read any of the three. `tests/test_mcp_error_envelope.py` exercises the helper
with an emitted code instead of `catalog_missing`.

### 9. `gh.py`'s unreferenced helpers — deleted with their input keys

`split_filter`, `run_gh`, `gh_issues`, `gh_prs`, `format_issue_line` and
`format_pr_line` leave `lore_core.gh`. `gh_issue_view` stays; `context_pack`
calls it at line 69.

The `issues:` and `prs:` keys leave `Offer`, `lore_core.session`, `CLAUDE.md`
and `AGENTS.md`. The deleted list wrappers were their only readers, so a user
who wrote a filter there got no effect and no warning. A `.lore.yml` that still
carries the keys parses unchanged — `parse_lore_yml` ignores an unknown key.

`attach.LORE_KEYS` leaves the tree as well. No module read the tuple. The audit
in #404 did not name it; trimming it would have left a constant whose only
reader was a new test.

## Tests

`tests/test_producerless_surfaces_gone.py` gains one assertion per decision,
beside the three structural properties the file already asserts.
`tests/test_janitor.py` gains the downgrade event and the two status
assertions.

Every assertion failed before the change and passes after it.

## Verification

- `pytest`: 2534 passed, 16 skipped. Two failures predate the branch —
  `test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`
  and `test_vale_style.py::test_the_document_passes_its_own_style_apart_from_the_banned_word_line`.
  Both fail identically on `main` at `5a99655`.
- `ruff check` over the changed files reports 18 findings on this branch and 18
  on `main`. The branch adds none.

## Out of scope

- `test_no_skill_claims_lore_writes_a_session_note`'s scan scope. Issue #405
  widens it to `lore-workflow/skills/`. The guard added here covers
  `brief/SKILL.md` alone, because a blanket scan would flag the correct
  negative claims other skills make.
- `lore_core/note_document.py`'s retained symbols.
- The briefing and session-note pipelines. PRD 0011 parks one, PRD 0013 retires
  the other.

## Follow-up

No ADR accompanies this pull request. The three criteria do not all hold: every
decision is a small deletion a maintainer can reverse, and ADR 0010 already
records the rule the decisions apply.

Closes #404
