### PR TITLE
fix(hooks): register the user-prompt-submit CLI command

### DIFF
--- a/lib/lore_cli/hooks.py
+++ b/lib/lore_cli/hooks.py
@@ -684,6 +684,8 @@ def cmd_context_log() -> None:
 # ---------------------------------------------------------------------------
 
 
+@hook_app.command("user-prompt-submit")
+@_shield_hook("UserPromptSubmit")
 def cmd_user_prompt_submit(
     cwd: str = typer.Option(None, "--cwd", help="Project working directory."),
     plain: bool = typer.Option(

--- a/tests/test_hooks_manifest_registered.py
+++ b/tests/test_hooks_manifest_registered.py
@@ -1,0 +1,62 @@
+"""Manifest-to-CLI wiring guard for the hook dispatcher.
+
+`.claude-plugin/plugin.json` tells Claude Code to shell out to
+`lore hook <subcommand>` for every event. Typer registers those
+subcommands as a side effect of the `@hook_app.command(...)` decorator,
+so dropping a decorator removes the CLI entry point while leaving a
+perfectly importable function behind — no ImportError, no warning.
+
+That failure mode already shipped once: a refactor deleted
+`@hook_app.command("user-prompt-submit")` along with an adjacent code
+block, and every existing test kept passing because they all call
+`cmd_user_prompt_submit()` directly instead of through the CLI. The hook
+failed at runtime with `No such command 'user-prompt-submit'`.
+
+This test walks the manifest instead of naming subcommands, so a new
+event added to the manifest is covered the moment it lands.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+
+from lore_cli.hooks import hook_app
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_MANIFEST = REPO_ROOT / ".claude-plugin" / "plugin.json"
+
+
+def _manifest_hook_subcommands() -> set[str]:
+    """Every `<sub>` in a `lore hook <sub>` command string in the manifest."""
+    manifest = json.loads(PLUGIN_MANIFEST.read_text())
+    subcommands: set[str] = set()
+    for matchers in manifest.get("hooks", {}).values():
+        for matcher in matchers:
+            for hook in matcher.get("hooks", []):
+                parts = shlex.split(hook.get("command", ""))
+                if parts[:2] == ["lore", "hook"] and len(parts) > 2:
+                    subcommands.add(parts[2])
+    return subcommands
+
+
+def _registered_subcommands() -> set[str]:
+    import typer.main
+
+    return {cmd.name for cmd in typer.main.get_command(hook_app).commands.values()}
+
+
+def test_manifest_hooks_are_registered_cli_commands() -> None:
+    missing = _manifest_hook_subcommands() - _registered_subcommands()
+    assert not missing, (
+        f"plugin.json invokes `lore hook {sorted(missing)}` but the "
+        f"subcommand is not registered on hook_app — most likely a missing "
+        f"@hook_app.command(...) decorator."
+    )
+
+
+def test_manifest_declares_at_least_one_hook() -> None:
+    # Guards the walker itself: a manifest-shape change that silently
+    # yields an empty set would make the test above vacuously pass.
+    assert _manifest_hook_subcommands()


### PR DESCRIPTION
## Context

`.claude-plugin/plugin.json` binds the `UserPromptSubmit` event to `lore hook user-prompt-submit`. Claude Code ran the command on every prompt and Lore answered with a failure banner:

```
⚠ lore UserPromptSubmit hook failed: UsageError: No such command 'user-prompt-submit'.
```

Observed on host `saiyajin` on 2026-08-08, reproduced by piping a `UserPromptSubmit` payload into `lore hook user-prompt-submit`. Crash log: `/home/buchbend/.cache/lore/crashes/20260808T060032Z-UserPromptSubmit.log`.

The hook has been dead since commit `f258598` ("Retire the compose pipeline (#361) (#373)"), which landed at version 0.67.0. Releases 0.68.0, 0.69.0, 0.70.0 and 0.71.0 all ship the defect.

## Cause

`f258598` removed a mid-session spawn block that sat directly above `cmd_user_prompt_submit`. The diff took two decorator lines with it:

```python
-@hook_app.command("user-prompt-submit")
-@_shield_hook("UserPromptSubmit")
 def cmd_user_prompt_submit(
```

Typer registers a command as a side effect of the decorator. A bare `def` is valid Python, so `lore_cli.hooks` kept importing cleanly and the command table silently lost an entry.

The dropped `@_shield_hook` also removed the crash guard. An unexpected exception in the hook body would have leaked a Python traceback into the session UI.

Every existing test calls `cmd_user_prompt_submit()` as a plain Python function:

- `tests/test_hooks_capture.py:158`
- `tests/test_hooks_off_citations.py:98`
- `tests/test_hooks_off_toggle.py:105`

Each test exercises the body and skips the registration, so the suite stayed green for the whole time the entry point was missing.

## Change

- Restore `@hook_app.command("user-prompt-submit")` and `@_shield_hook("UserPromptSubmit")` on `cmd_user_prompt_submit` in `lib/lore_cli/hooks.py`.
- Add `tests/test_hooks_manifest_registered.py`. The test reads `plugin.json`, collects every `lore hook <sub>` command string and asserts each `<sub>` is registered on `hook_app`.

The test walks the manifest rather than naming subcommands, so a new event covers itself the moment it lands.

## Acceptance criteria

- WHEN Claude Code runs `lore hook user-prompt-submit`, THEN the CLI SHALL execute the hook and exit 0.
- WHEN `lore hook --help` runs, THEN the output SHALL list `user-prompt-submit`.
- WHEN `plugin.json` names a `lore hook <sub>` command that `hook_app` does not register, THEN `tests/test_hooks_manifest_registered.py` SHALL fail and name the subcommand.
- WHEN `cmd_user_prompt_submit` raises an unexpected exception, THEN the shield SHALL emit a diagnostic banner and exit 0.

## Verification

- `pytest tests/test_hooks_manifest_registered.py` fails on the parent commit and names `user-prompt-submit`; it passes on this branch.
- Full suite: 2560 passed, 1 skipped, 3 failed. The three failures (`test_cli_scopes.py::test_rename_reports_stale_checked_in_offer`, `test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`, `test_vale_style.py::test_the_document_passes_its_own_style_apart_from_the_banned_word_line`) reproduce identically on `main` and are unrelated to this change.
- End-to-end: a `UserPromptSubmit` payload piped into `python -m lore_cli hook user-prompt-submit` against a throwaway `LORE_ROOT` exits 0 with no banner.
- `lore hook --help` lists `user-prompt-submit` alongside the six existing commands.
- `inspect.getsource(cmd_user_prompt_submit)` still unwraps through the shield, so `tests/test_producerless_surfaces_gone.py:210` keeps working.

## Follow-up

The fix ships hook behaviour, so `main` needs a `chore: release 0.71.1` commit in its own PR after this merges. Installed plugin caches re-fetch only on a version change.
