### PR TITLE
Open the flag review walk in a browser page by default

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,8 +68,10 @@ queue file. `lore flag list` and the SessionStart chip find pending flags
 by scanning notes for the unreviewed marker. A flag accepted by hand in an
 editor is simply no longer pending.
 
-The review walk is `lore flag review`: accept, retarget, decline, skip. A
-flag a human writes lands without the marker and keeps its own words — the
+The review walk is `lore flag review`: accept, retarget, decline, skip. It
+opens a local browser page by default, colouring each flag by its ref
+verdict (`docs/adr/0011`); `--tty` keeps the terminal prompts. A flag a
+human writes lands without the marker and keeps its own words — the
 code-stamped phrasing rule constrains what a *model* may claim.
 
 ### The limit worth knowing
@@ -315,8 +317,9 @@ session note at every session boundary is gone, along with its per-wiki
   line until a human accepts it. Accept is the only verdict that removes
   it. A human-filed flag lands without it.
 - **Review walk** — the pull-based pass over unreviewed flags
-  (`lore flag review`): accept, retarget, decline, or skip. The banner
-  shows a count of pending flags and never their content.
+  (`lore flag review`): accept, retarget, decline, or skip. It runs in a
+  local browser page by default and in the terminal under `--tty`. The
+  banner shows a count of pending flags and never their content.
 - **Transcript ledger** — the machine-local store mapping each session to
   its transcript (`.lore/transcript-ledger.json`). Derived and
   rebuildable. Say "transcript ledger", not "breadcrumb ledger".

--- a/docs/adr/0011-flag-review-runs-in-a-local-ephemeral-browser-page.md
+++ b/docs/adr/0011-flag-review-runs-in-a-local-ephemeral-browser-page.md
@@ -1,0 +1,74 @@
+# ADR 0011: The flag review walk runs in a local, ephemeral browser page
+
+- Status: Accepted
+- Date: 2026-08-08
+- Context: issue [409](https://github.com/buchbend/lore/issues/409),
+  ADR [0004](0004-authority-phrasing-is-code-stamped.md),
+  ADR [0008](0008-flag-lands-marked-unreviewed.md),
+  ADR [0009](0009-privacy-boundary-is-locality.md)
+
+## Context
+
+A flag block carries a code-stamped ref verdict: `✓`, `(unchecked)` or
+`(not found)`. The ref verdict decides how much the lead may claim
+(ADR 0004). It is the reviewer's main input.
+
+The terminal walk prints that verdict as text inside the origin line, in
+the same colour as the rest of the block. On host saiyajin,
+`lore flag list --wiki private` reported 15 pending flags carrying all
+three ref verdicts. A reader cannot separate them by eye, so the reviewer
+re-reads each origin line to recover a signal the code already computed.
+
+ADR 0009 states that Lore ships no server. ADR 0009 argues about
+cross-machine transcript access: no sync, no backup, no remote reader.
+
+## Decision
+
+- `lore flag review` starts an HTTP listener on address 127.0.0.1 and an
+  ephemeral port, then opens the page in the user's browser.
+- The page renders each flag's ref verdict as a colour, and the
+  code-stamped lead prefix as a separate label.
+- The page groups the pending flags by owning note.
+- The page applies verdicts by calling `lore_core.flag.accept`,
+  `lore_core.flag.decline` and `lore_core.flag.retarget`. No second
+  verdict path exists, so the spine events and the note writes stay
+  identical to the terminal walk.
+- A token in the page URL gates every request. The listener refuses a
+  request carrying a wrong token.
+- The listener exits when the user presses Done, and when the last flag
+  leaves the page.
+- `lore flag review --tty` runs the terminal prompts. The command also
+  runs the terminal prompts when no browser resolves on the host.
+
+## Consequences / Trade-offs
+
+Easier: the reviewer sorts 15 flags by ref verdict at a glance. The
+reviewer never retypes a 12-character flag identifier. The retarget field
+completes from the wiki's existing notes, so a typo no longer creates a
+note by accident.
+
+Harder: Lore now binds a port. The listener holds the process for the
+length of the review, so the command no longer returns per verdict. The
+page's behaviour lives in browser code, which the Python suite cannot
+reach — the suite covers the renderer, the verdict calls and the listener,
+and leaves the click handlers untested.
+
+The locality boundary holds. The listener binds loopback only, it carries
+a per-run token, and it exits with the review. Lore still ships no
+network service, no sync and no remote reader, so ADR 0009 stands.
+
+## Alternatives considered
+
+- Colour the terminal output instead. Rejected: the walk shows one flag
+  per prompt, so colour alone does not let the reviewer compare flags or
+  see the shape of the queue.
+- Write a static HTML file and keep the verdicts in the terminal.
+  Rejected: the reviewer would read in one surface and act in another,
+  and would retype a 12-character identifier for each verdict.
+- Ship a persistent local service for every Lore surface. Rejected: a
+  process outliving the task contradicts ADR 0009's argument, and Lore
+  has one surface that needs a page.
+
+## Status
+
+Accepted.

--- a/docs/adr/0011-flag-review-runs-in-a-local-ephemeral-browser-page.md
+++ b/docs/adr/0011-flag-review-runs-in-a-local-ephemeral-browser-page.md
@@ -53,6 +53,11 @@ page's behaviour lives in browser code, which the Python suite cannot
 reach — the suite covers the renderer, the verdict calls and the listener,
 and leaves the click handlers untested.
 
+The listener answers requests on threads, and each verdict rewrites its
+whole note. Two verdicts on one note would race and lose a write, so a
+lock serialises them. The terminal prompts needed no such lock, because
+the walk applied one verdict at a time.
+
 The locality boundary holds. The listener binds loopback only, it carries
 a per-run token, and it exits with the review. Lore still ships no
 network service, no sync and no remote reader, so ADR 0009 stands.

--- a/docs/how-to/file-and-review-flags.md
+++ b/docs/how-to/file-and-review-flags.md
@@ -83,20 +83,46 @@ a flag.
 lore flag review
 ```
 
-Lore snapshots the pending list, then shows one flag at a time with its full
-block and prompts `accept / retarget / decline / skip? [a/r/d/s]`. The
-default is skip, so pressing Enter through the walk changes nothing.
+Lore opens the review page in your browser. A local listener serves it on
+`127.0.0.1` at an ephemeral port, gated by a token in the URL, and exits when
+you press Done or settle the last flag. Ctrl-C in the terminal also stops it.
+
+The page groups the pending flags by owning note and colours each one by its
+ref verdict — green for `✓`, amber for `(unchecked)`, red for `(not found)`.
+That verdict is code-stamped, so the colour tells you how much the lead is
+entitled to claim before you read a word of it. The code-stamped lead prefix
+(`Reported in session:`) shows as a label rather than as part of the sentence.
+
+Each card carries the same four verdicts as the terminal walk:
 
 | Verdict | What Lore does | Still pending after? |
 |---|---|---|
-| `a` accept | Removes the unreviewed marker. Nothing else in the note changes. | No |
-| `r` retarget | Prompts for a note, moves the block there, creates the note when it is missing. | Yes |
-| `d` decline | Deletes the flag block. The note's own prose is untouched. | No |
-| `s` skip | Nothing. | Yes |
+| Accept | Removes the unreviewed marker. Nothing else in the note changes. | No |
+| Retarget | Moves the block to the note you pick, creating it when missing. | Yes |
+| Decline | Deletes the flag block. The note's own prose is untouched. | No |
+| (leave it) | Nothing. | Yes |
 
-Retarget corrects where a flag lives, not whether you endorse its text, so
-the marker stays and the flag returns in the next walk. A target you mistype
-loses that one verdict and prints an error; the walk continues.
+The retarget field completes from the wiki's existing notes, so you rarely
+type a slug in full. Retarget corrects where a flag lives, not whether you
+endorse its text, so the marker stays, the card stays on the page, and the
+flag returns in the next review.
+
+Nothing about the verdicts is browser-specific: the page calls the same
+functions the terminal prompts call, and writes the same spine events.
+
+### Review in the terminal instead
+
+```
+lore flag review --tty
+```
+
+Lore snapshots the pending list, then shows one flag at a time with its full
+block and prompts `accept / retarget / decline / skip? [a/r/d/s]`. The
+default is skip, so pressing Enter through the walk changes nothing. A target
+you mistype loses that one verdict and prints an error; the walk continues.
+
+Lore falls back to these prompts on its own when no browser resolves on the
+host, which covers an SSH session and a headless machine.
 
 Declined flags leave the wiki but stay in its git history. Recover one with
 `git log -p` on the note.

--- a/lib/lore_cli/flag_cmd.py
+++ b/lib/lore_cli/flag_cmd.py
@@ -158,16 +158,30 @@ def cmd_list(
 @app.command("review")
 def cmd_review(
     wiki: str | None = typer.Option(None, "--wiki", help="Wiki name (default: from cwd)."),
+    tty: bool = typer.Option(False, "--tty", help="Prompt in the terminal instead of a browser."),
 ) -> None:
     """Walk the unreviewed flags: accept, retarget, decline, or skip.
 
-    The list is snapshotted before the walk starts, so a retarget that
-    moves a flag into a note already visited cannot show it twice.
+    The browser page is the default surface: a flag's ref verdict decides
+    how much its lead may claim (``docs/adr/0004``), and in one terminal
+    colour that verdict reads as prose. The terminal prompts remain, and
+    take over on a host where no browser resolves.
+
+    In the terminal, the list is snapshotted before the walk starts, so a
+    retarget that moves a flag into a note already visited cannot show it
+    twice.
     """
+    from lore_cli import flag_review_html
+
     wiki_path = _resolve_wiki_path(wiki)
     items = flag.pending(wiki_path)
     if not items:
         typer.echo("(no pending flags)")
+        return
+
+    if not tty and flag_review_html.browser_available():
+        typer.echo(f"{len(items)} pending — opening the review page, Ctrl-C to stop")
+        flag_review_html.serve(wiki_path)
         return
 
     for i, item in enumerate(items, start=1):

--- a/lib/lore_cli/flag_review_html.py
+++ b/lib/lore_cli/flag_review_html.py
@@ -1,0 +1,419 @@
+"""Browser review surface for pending flags — ``lore flag review --html``.
+
+The terminal walk shows one flag at a time in one colour. A flag's most
+load-bearing signal is its verification stamp (``✓`` / ``(unchecked)`` /
+``(not found)``), which decides how much the lead may claim
+(``docs/adr/0004``) — and that stamp reads as plain text mid-origin-line.
+This renders the same pending list as cards, coloured by that stamp,
+grouped by owning note.
+
+The page is the review, not a printout: verdict buttons POST back to this
+process, which calls :mod:`lore_core.flag` directly. No second verdict
+path exists, so spine events and note writes stay identical to the walk.
+
+The server binds loopback on an ephemeral port and dies when the queue
+empties or the user hits Done. A URL token gates every request: a page on
+another origin cannot read it, so it cannot forge a verdict against a
+port it guessed.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import secrets
+import sys
+import threading
+import webbrowser
+from collections.abc import Sequence
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from lore_core import flag
+
+# Stamps carried in the origin line, strongest first. The first one found
+# decides the card's colour: a flag is only as good as its weakest ref, and
+# ``_weakest`` already encoded that when it rendered the block.
+_STAMP_CLASSES = (
+    ("(not found)", "missing"),
+    ("(unchecked)", "unchecked"),
+    ("✓", "verified"),
+)
+
+_LEAD_BADGES = (
+    (flag.LEAD_MISSING, "ref not found"),
+    (flag.LEAD_UNCHECKED, "reported in session"),
+)
+
+
+def _inline(text: str) -> str:
+    """Escape, then re-admit the three inline marks a flag block uses."""
+    out = html.escape(text)
+    out = re.sub(r"`([^`]+)`", r"<code>\1</code>", out)
+    out = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", out)
+    return re.sub(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]", r'<span class="wl">\1</span>', out)
+
+
+def _parts(item: flag.PendingFlag) -> dict:
+    """Split one pending flag into the pieces the card renders."""
+    lines = item.block.split("\n")
+    body_lines = [
+        line
+        for line in lines[1:-1]
+        if not line.startswith("**") and not line.startswith(flag.ORIGIN_PREFIX)
+    ]
+    body = "\n".join(body_lines).strip()
+
+    lead = item.lead
+    badge = ""
+    for prefix, label in _LEAD_BADGES:
+        if lead.startswith(prefix):
+            lead = lead[len(prefix) :].strip()
+            badge = label
+            break
+
+    origin = item.origin.strip("_")
+    if origin.startswith("flag · "):
+        origin = origin[len("flag · ") :]
+    meta = [p for p in origin.split(" · ") if p and p != flag.UNREVIEWED_TOKEN]
+
+    status = "unchecked"
+    for token, name in _STAMP_CLASSES:
+        if token in item.origin:
+            status = name
+            break
+
+    return {
+        "id": item.id,
+        "note": Path(item.note_path).stem,
+        "lead": lead,
+        "badge": badge,
+        "body": body,
+        "meta": meta,
+        "status": status,
+    }
+
+
+def _card(part: dict) -> str:
+    badge = ""
+    if part["badge"]:
+        badge = f'<span class="badge {part["status"]}">{html.escape(part["badge"])}</span>'
+    paragraphs = "".join(
+        f"<p>{_inline(block)}</p>" for block in re.split(r"\n\s*\n", part["body"]) if block.strip()
+    )
+    chips = "".join(f'<span class="chip">{_inline(m)}</span>' for m in part["meta"])
+    return f"""<article class="card {part["status"]}" data-id="{part["id"]}">
+  <header>{badge}<h3>{_inline(part["lead"])}</h3></header>
+  <div class="body">{paragraphs}</div>
+  <div class="meta">{chips}<span class="chip id">{part["id"]}</span></div>
+  <div class="verdict" hidden></div>
+  <div class="actions">
+    <button class="accept" data-verdict="accept">Accept</button>
+    <button class="retarget" data-verdict="retarget">Retarget…</button>
+    <button class="decline" data-verdict="decline">Decline</button>
+  </div>
+</article>"""
+
+
+def note_slugs(wiki_path: Path) -> list[str]:
+    """Wiki-relative paths of every note, for the retarget field's completions.
+
+    Retargeting by slug is otherwise blind typing: ``flag.retarget`` creates
+    the note when the name misses, so a typo silently makes a new note
+    rather than failing.
+    """
+    return sorted(str(p.relative_to(wiki_path)) for p in flag._note_files(wiki_path))
+
+
+def render_page(
+    items: list[flag.PendingFlag], *, wiki: str, token: str, slugs: Sequence[str] = ()
+) -> str:
+    """Whole page for one pending list. Pure — same inputs, same bytes."""
+    parts = [_parts(i) for i in items]
+    sections = []
+    for note in dict.fromkeys(p["note"] for p in parts):
+        cards = "".join(_card(p) for p in parts if p["note"] == note)
+        sections.append(f"<section><h2>{html.escape(note)}</h2>{cards}</section>")
+    empty = '<p class="empty">Nothing pending. Close the tab.</p>' if not parts else ""
+    options = "".join(f'<option value="{html.escape(s)}">' for s in slugs)
+
+    return (
+        _PAGE.replace("__WIKI__", html.escape(wiki))
+        .replace("__COUNT__", str(len(parts)))
+        .replace("__TOKEN__", token)
+        .replace("__NOTES__", options)
+        .replace("__SECTIONS__", "".join(sections) + empty)
+    )
+
+
+def apply_verdict(wiki_path: Path, flag_id: str, verdict: str, target: str = "") -> dict:
+    """One verdict, through the same functions the terminal walk calls."""
+    if verdict == "accept":
+        return {"ok": flag.accept(wiki_path, flag_id), "text": "accepted"}
+    if verdict == "decline":
+        return {"ok": flag.decline(wiki_path, flag_id), "text": "declined"}
+    if verdict == "retarget":
+        if not target:
+            return {"ok": False, "text": "no target given"}
+        try:
+            moved = flag.retarget(wiki_path, flag_id, target)
+        except ValueError as e:
+            return {"ok": False, "text": str(e)}
+        # A retarget moves a flag, it does not endorse it (ADR 0008), so the
+        # card must stay on the board rather than collapse like a verdict.
+        return {
+            "ok": bool(moved),
+            "pending": True,
+            "text": f"moved to {Path(moved).stem} — still pending" if moved else "not moved",
+        }
+    return {"ok": False, "text": f"unknown verdict {verdict}"}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args) -> None:  # keep the terminal clean
+        pass
+
+    def _authorised(self, supplied: str) -> bool:
+        return secrets.compare_digest(supplied, self.server.token)
+
+    def _send(self, code: int, body: bytes, content_type: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _json(self, code: int, payload: dict) -> None:
+        self._send(code, json.dumps(payload).encode(), "application/json")
+
+    def do_GET(self) -> None:
+        url = urlparse(self.path)
+        if url.path != "/":
+            self._send(404, b"not found", "text/plain")
+            return
+        if not self._authorised(parse_qs(url.query).get("t", [""])[0]):
+            self._send(403, b"bad token", "text/plain")
+            return
+        page = render_page(
+            flag.pending(self.server.wiki_path),
+            wiki=self.server.wiki_path.name,
+            token=self.server.token,
+            slugs=note_slugs(self.server.wiki_path),
+        )
+        self._send(200, page.encode(), "text/html; charset=utf-8")
+
+    def do_POST(self) -> None:
+        try:
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"] or 0)) or b"{}")
+        except (ValueError, TypeError):
+            self._json(400, {"ok": False, "text": "bad request"})
+            return
+        if not self._authorised(str(payload.get("t", ""))):
+            self._json(403, {"ok": False, "text": "bad token"})
+            return
+        if self.path == "/done":
+            self._json(200, {"ok": True})
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
+            return
+        if self.path != "/verdict":
+            self._json(404, {"ok": False, "text": "not found"})
+            return
+        result = apply_verdict(
+            self.server.wiki_path,
+            str(payload.get("id", "")),
+            str(payload.get("verdict", "")),
+            str(payload.get("target", "")),
+        )
+        self._json(200, result)
+
+
+def browser_available() -> bool:
+    """Whether this run should open a page rather than prompt.
+
+    Two ways the answer is no, and both end in the same hang if unchecked:
+    ``serve`` blocks until a human clicks Done, so a run nobody is watching
+    waits forever holding a port.
+
+    * stdout is not a terminal — a piped run, a captured run, a test.
+    * ``webbrowser.get()`` raises — no browser on this host, the SSH and
+      headless case.
+
+    Probing before binding keeps the fallback to the terminal prompts
+    silent, instead of leaving a listener nobody can reach.
+    """
+    if not sys.stdout.isatty():
+        return False
+    try:
+        webbrowser.get()
+    except webbrowser.Error:
+        return False
+    return True
+
+
+def build_server(wiki_path: Path) -> ThreadingHTTPServer:
+    """Listener for one wiki, bound to loopback on an ephemeral port."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    server.wiki_path = wiki_path
+    server.token = secrets.token_urlsafe(16)
+    return server
+
+
+def serve(wiki_path: Path, *, open_browser: bool = True) -> str:
+    """Run the review page until the user is done. Returns the URL served."""
+    server = build_server(wiki_path)
+    url = f"http://127.0.0.1:{server.server_port}/?t={server.token}"
+    if open_browser:
+        webbrowser.open(url)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return url
+
+
+_PAGE = """<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>lore flags · __WIKI__</title>
+<link rel="icon" href="data:,">
+
+<style>
+:root {
+  --bg: #f6f6f4; --fg: #16181d; --dim: #5d6470; --line: #dcdcd6; --card: #fff;
+  --verified: #1f7a4d; --unchecked: #a2660a; --missing: #b3261e; --accent: #2f5fd0;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14161a; --fg: #e7e9ee; --dim: #98a0ad; --line: #2b2f37; --card: #1b1e24;
+    --verified: #55c48c; --unchecked: #e0a63c; --missing: #ef7a70; --accent: #7aa2f7;
+  }
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--fg);
+  font: 15px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+header.top { position: sticky; top: 0; z-index: 2; display: flex; gap: 1rem;
+  align-items: center; flex-wrap: wrap; padding: .75rem 1.25rem;
+  background: var(--card); border-bottom: 1px solid var(--line); }
+header.top h1 { font-size: 1rem; margin: 0; font-weight: 600; }
+header.top .count { color: var(--dim); }
+header.top .spacer { flex: 1; }
+.legend { display: flex; gap: .75rem; font-size: .78rem; color: var(--dim); }
+.legend i { display: inline-block; width: .6rem; height: .6rem; border-radius: 50%;
+  margin-right: .3rem; vertical-align: baseline; }
+.legend .verified i { background: var(--verified); }
+.legend .unchecked i { background: var(--unchecked); }
+.legend .missing i { background: var(--missing); }
+main { max-width: 62rem; margin: 0 auto; padding: 1.25rem; }
+section h2 { font-size: .8rem; text-transform: none; letter-spacing: .02em;
+  color: var(--dim); font-weight: 600; margin: 1.75rem 0 .6rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.card { background: var(--card); border: 1px solid var(--line);
+  border-left: 4px solid var(--dim); border-radius: 8px;
+  padding: .9rem 1.1rem; margin-bottom: .7rem; transition: opacity .25s, transform .25s; }
+.card.verified { border-left-color: var(--verified); }
+.card.unchecked { border-left-color: var(--unchecked); }
+.card.missing { border-left-color: var(--missing); }
+.card.gone { opacity: 0; transform: translateX(1.5rem); }
+.card h3 { margin: .15rem 0 .4rem; font-size: 1.02rem; font-weight: 600; line-height: 1.4; }
+.badge { display: inline-block; font-size: .68rem; letter-spacing: .04em;
+  text-transform: uppercase; padding: .12rem .45rem; border-radius: 3px;
+  border: 1px solid currentColor; margin-bottom: .35rem; }
+.badge.unchecked { color: var(--unchecked); }
+.badge.missing { color: var(--missing); }
+.badge.verified { color: var(--verified); }
+.body p { margin: .35rem 0; color: var(--fg); }
+.body code, .meta code { font: .85em ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: color-mix(in srgb, var(--dim) 16%, transparent);
+  padding: .05em .35em; border-radius: 3px; }
+.wl { color: var(--accent); }
+.meta { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .6rem; }
+.chip { font-size: .74rem; color: var(--dim); border: 1px solid var(--line);
+  border-radius: 999px; padding: .1rem .5rem; }
+.chip.id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; opacity: .6; }
+.actions { display: flex; gap: .4rem; margin-top: .7rem; }
+button { font: inherit; font-size: .82rem; padding: .28rem .7rem; cursor: pointer;
+  border-radius: 5px; border: 1px solid var(--line); background: transparent; color: var(--fg); }
+button:hover { border-color: var(--accent); color: var(--accent); }
+button.accept:hover { border-color: var(--verified); color: var(--verified); }
+button.decline:hover { border-color: var(--missing); color: var(--missing); }
+.verdict { margin-top: .5rem; font-size: .82rem; color: var(--dim); }
+.retarget-row { display: flex; gap: .4rem; margin-top: .5rem; }
+.retarget-row input { flex: 1; font: inherit; font-size: .82rem; padding: .28rem .5rem;
+  border: 1px solid var(--line); border-radius: 5px; background: var(--bg); color: var(--fg); }
+.empty { color: var(--dim); padding: 3rem 0; text-align: center; }
+</style>
+<header class="top">
+  <h1>lore flags · __WIKI__</h1>
+  <span class="count"><b id="count">__COUNT__</b> pending</span>
+  <div class="legend">
+    <span class="verified"><i></i>verified</span>
+    <span class="unchecked"><i></i>unchecked</span>
+    <span class="missing"><i></i>ref not found</span>
+  </div>
+  <span class="spacer"></span>
+  <button onclick="location.reload()">Reload</button>
+  <button id="done">Done</button>
+</header>
+<main>__SECTIONS__</main>
+<datalist id="notes">__NOTES__</datalist>
+<script>
+const T = "__TOKEN__";
+const post = (path, data) =>
+  fetch(path, {method: "POST", headers: {"Content-Type": "application/json"},
+               body: JSON.stringify({...data, t: T})}).then(r => r.json());
+
+function say(card, text) {
+  const el = card.querySelector(".verdict");
+  el.textContent = text;
+  el.hidden = false;
+}
+
+function finish(message) {
+  post("/done", {}).then(() => { document.body.innerHTML =
+    '<p class="empty">' + message + '</p>'; });
+}
+
+function settle(card, res) {
+  say(card, res.text);
+  if (!res.ok || res.pending) return;
+  card.classList.add("gone");
+  const n = document.getElementById("count");
+  const left = Math.max(0, +n.textContent - 1);
+  n.textContent = left;
+  setTimeout(() => {
+    card.remove();
+    // The queue is derived by scanning notes, so an empty board means an
+    // empty queue: the listener has nothing left to serve.
+    if (left === 0) finish("All flags reviewed. You can close this tab.");
+  }, 260);
+}
+
+document.addEventListener("click", e => {
+  const btn = e.target.closest("button[data-verdict]");
+  if (!btn) return;
+  const card = btn.closest(".card"), id = card.dataset.id, verdict = btn.dataset.verdict;
+  if (verdict === "retarget") {
+    if (card.querySelector(".retarget-row")) return;
+    const row = document.createElement("div");
+    row.className = "retarget-row";
+    row.innerHTML = '<input list="notes" placeholder="wiki-relative path or slug">' +
+                    '<button class="go">Move</button>';
+    card.querySelector(".actions").after(row);
+    const send = () => post("/verdict", {id, verdict, target: row.querySelector("input").value})
+      .then(res => { row.remove(); settle(card, res); });
+    row.querySelector(".go").onclick = send;
+    row.querySelector("input").onkeydown = ev => { if (ev.key === "Enter") send(); };
+    row.querySelector("input").focus();
+    return;
+  }
+  post("/verdict", {id, verdict}).then(res => settle(card, res));
+});
+
+document.getElementById("done").onclick = () =>
+  finish("Review stopped. You can close this tab.");
+</script>
+"""

--- a/lib/lore_cli/flag_review_html.py
+++ b/lib/lore_cli/flag_review_html.py
@@ -1,4 +1,4 @@
-"""Browser review surface for pending flags — ``lore flag review --html``.
+"""Browser review surface for pending flags — ``lore flag review``.
 
 The terminal walk shows one flag at a time in one colour. A flag's most
 load-bearing signal is its verification stamp (``✓`` / ``(unchecked)`` /
@@ -59,11 +59,13 @@ def _inline(text: str) -> str:
 def _parts(item: flag.PendingFlag) -> dict:
     """Split one pending flag into the pieces the card renders."""
     lines = item.block.split("\n")
-    body_lines = [
-        line
-        for line in lines[1:-1]
-        if not line.startswith("**") and not line.startswith(flag.ORIGIN_PREFIX)
-    ]
+    # Drop by position, never by prefix: ``render_block`` emits the lead
+    # first and the origin line last, and a body paragraph may legitimately
+    # open in bold or quote an origin-shaped line. Matching on the prefix
+    # would withhold that prose from the card the reviewer votes on.
+    inner = lines[1:-1]
+    origin_at = flag._origin_index(inner)
+    body_lines = inner[1:origin_at] if origin_at >= 0 else inner[1:]
     body = "\n".join(body_lines).strip()
 
     lead = item.lead
@@ -148,12 +150,27 @@ def render_page(
     )
 
 
+# Every verdict rewrites its whole note, and the listener answers requests on
+# threads, so two cards settled together would race read-modify-write and lose
+# one silently. The terminal walk was serial and needed no such guard.
+# ponytail: one global lock — a per-note lock only matters if a review ever
+# runs verdicts in parallel on purpose, and a human clicks one card at a time.
+_VERDICT_LOCK = threading.Lock()
+
+
 def apply_verdict(wiki_path: Path, flag_id: str, verdict: str, target: str = "") -> dict:
     """One verdict, through the same functions the terminal walk calls."""
-    if verdict == "accept":
-        return {"ok": flag.accept(wiki_path, flag_id), "text": "accepted"}
-    if verdict == "decline":
-        return {"ok": flag.decline(wiki_path, flag_id), "text": "declined"}
+    with _VERDICT_LOCK:
+        return _apply(wiki_path, flag_id, verdict, target)
+
+
+def _apply(wiki_path: Path, flag_id: str, verdict: str, target: str) -> dict:
+    if verdict in ("accept", "decline"):
+        done = (flag.accept if verdict == "accept" else flag.decline)(wiki_path, flag_id)
+        # A flag resolved elsewhere first — a second tab, a parallel `--tty`
+        # run — must not report a verdict this call never applied.
+        past = "accepted" if verdict == "accept" else "declined"
+        return {"ok": done, "text": past if done else "already gone — reload"}
     if verdict == "retarget":
         if not target:
             return {"ok": False, "text": "no target given"}
@@ -176,7 +193,9 @@ class _Handler(BaseHTTPRequestHandler):
         pass
 
     def _authorised(self, supplied: str) -> bool:
-        return secrets.compare_digest(supplied, self.server.token)
+        # Compare bytes: compare_digest raises TypeError on a non-ASCII str,
+        # which would kill the handler instead of answering 403.
+        return secrets.compare_digest(supplied.encode(), self.server.token.encode())
 
     def _send(self, code: int, body: bytes, content_type: str) -> None:
         self.send_response(code)
@@ -264,6 +283,10 @@ def serve(wiki_path: Path, *, open_browser: bool = True) -> str:
     """Run the review page until the user is done. Returns the URL served."""
     server = build_server(wiki_path)
     url = f"http://127.0.0.1:{server.server_port}/?t={server.token}"
+    # Always print it. `browser_available` proves a handler resolves, not that
+    # it launches — a stale $BROWSER still returns False here, and without the
+    # URL the blocking serve_forever below is indistinguishable from a hang.
+    print(f"review at {url}")
     if open_browser:
         webbrowser.open(url)
     try:
@@ -366,6 +389,11 @@ const post = (path, data) =>
   fetch(path, {method: "POST", headers: {"Content-Type": "application/json"},
                body: JSON.stringify({...data, t: T})}).then(r => r.json());
 
+// A verdict that raises server-side answers 500, so r.json() rejects. Without
+// this the click leaves no mark at all and reads as "nothing happened".
+const sendVerdict = data =>
+  post("/verdict", data).catch(() => ({ok: false, text: "failed — see the terminal"}));
+
 function say(card, text) {
   const el = card.querySelector(".verdict");
   el.textContent = text;
@@ -403,14 +431,14 @@ document.addEventListener("click", e => {
     row.innerHTML = '<input list="notes" placeholder="wiki-relative path or slug">' +
                     '<button class="go">Move</button>';
     card.querySelector(".actions").after(row);
-    const send = () => post("/verdict", {id, verdict, target: row.querySelector("input").value})
+    const send = () => sendVerdict({id, verdict, target: row.querySelector("input").value})
       .then(res => { row.remove(); settle(card, res); });
     row.querySelector(".go").onclick = send;
     row.querySelector("input").onkeydown = ev => { if (ev.key === "Enter") send(); };
     row.querySelector("input").focus();
     return;
   }
-  post("/verdict", {id, verdict}).then(res => settle(card, res));
+  sendVerdict({id, verdict}).then(res => settle(card, res));
 });
 
 document.getElementById("done").onclick = () =>

--- a/lib/lore_core/flag.py
+++ b/lib/lore_core/flag.py
@@ -66,6 +66,8 @@ __all__ = [
     "BLOCK_OPEN_PREFIX",
     "EV_REVIEW",
     "EV_WRITE",
+    "LEAD_MISSING",
+    "LEAD_UNCHECKED",
     "ORIGIN_PREFIX",
     "SPINE_SOURCE",
     "UNREVIEWED_TOKEN",
@@ -104,8 +106,8 @@ EV_REVIEW = "flag-review"
 # Code-owned leads (docs/adr/0004). A flag whose refs could not be checked is
 # handed back to the session that said it; one whose ref does not exist is
 # demoted further. A verified flag needs no lead — its pointer carries the load.
-_LEAD_UNCHECKED = "Reported in session:"
-_LEAD_MISSING = "Claimed in session, ref not found:"
+LEAD_UNCHECKED = "Reported in session:"
+LEAD_MISSING = "Claimed in session, ref not found:"
 _STAMPS = {VERIFIED: "✓", UNCHECKED: "(unchecked)", MISSING: "(not found)"}
 
 _SLUG_MAX = 48
@@ -239,9 +241,9 @@ def render_block(
     if stamped:
         verdict = _weakest(refs, verdicts)
         if verdict == MISSING:
-            headline = f"{_LEAD_MISSING} {headline}"
+            headline = f"{LEAD_MISSING} {headline}"
         elif verdict == UNCHECKED:
-            headline = f"{_LEAD_UNCHECKED} {headline}"
+            headline = f"{LEAD_UNCHECKED} {headline}"
 
     parts = [f"**{headline}**"]
     body_text = _neutralize(body.strip())

--- a/tests/test_flag_review.py
+++ b/tests/test_flag_review.py
@@ -237,7 +237,7 @@ def test_a_no_op_verdict_emits_nothing(vault: Path):
 def test_review_walk_presents_the_four_verdicts(vault: Path):
     _topic_note(vault, "reaper")
     _flag(vault, "Look at me.")
-    result = runner.invoke(app, ["flag", "review", "--wiki", "lore"], input="s\n")
+    result = runner.invoke(app, ["flag", "review", "--wiki", "lore", "--tty"], input="s\n")
     assert result.exit_code == 0, result.output
     assert "Look at me." in result.output
     for verdict in ("accept", "retarget", "decline", "skip"):
@@ -247,14 +247,14 @@ def test_review_walk_presents_the_four_verdicts(vault: Path):
 def test_review_walk_skip_leaves_the_flag_pending(vault: Path):
     _topic_note(vault, "reaper")
     _flag(vault, "Still pending.")
-    runner.invoke(app, ["flag", "review", "--wiki", "lore"], input="s\n")
+    runner.invoke(app, ["flag", "review", "--wiki", "lore", "--tty"], input="s\n")
     assert flag.count_pending(_wiki(vault)) == 1
 
 
 def test_review_walk_accept_clears_the_marker(vault: Path):
     _topic_note(vault, "reaper")
     _flag(vault, "Accept via the walk.")
-    result = runner.invoke(app, ["flag", "review", "--wiki", "lore"], input="a\n")
+    result = runner.invoke(app, ["flag", "review", "--wiki", "lore", "--tty"], input="a\n")
     assert result.exit_code == 0, result.output
     assert flag.count_pending(_wiki(vault)) == 0
     assert "Accept via the walk." in _file(vault).read_text()
@@ -263,7 +263,7 @@ def test_review_walk_accept_clears_the_marker(vault: Path):
 def test_review_walk_decline_deletes_the_block(vault: Path):
     _topic_note(vault, "reaper")
     _flag(vault, "Decline via the walk.")
-    runner.invoke(app, ["flag", "review", "--wiki", "lore"], input="d\n")
+    runner.invoke(app, ["flag", "review", "--wiki", "lore", "--tty"], input="d\n")
     assert "Decline via the walk." not in _file(vault).read_text()
 
 
@@ -272,7 +272,7 @@ def test_review_walk_retarget_prompts_for_the_destination(vault: Path):
     _topic_note(vault, "drain")
     _flag(vault, "Retarget via the walk.")
     result = runner.invoke(
-        app, ["flag", "review", "--wiki", "lore"], input="r\nconcepts/drain.md\n"
+        app, ["flag", "review", "--wiki", "lore", "--tty"], input="r\nconcepts/drain.md\n"
     )
     assert result.exit_code == 0, result.output
     assert "Retarget via the walk." in _file(vault, "drain").read_text()
@@ -280,7 +280,7 @@ def test_review_walk_retarget_prompts_for_the_destination(vault: Path):
 
 def test_review_walk_on_an_empty_queue_says_so(vault: Path):
     _topic_note(vault, "reaper")
-    result = runner.invoke(app, ["flag", "review", "--wiki", "lore"])
+    result = runner.invoke(app, ["flag", "review", "--wiki", "lore", "--tty"])
     assert result.exit_code == 0, result.output
     assert "no pending flags" in result.output.lower()
 

--- a/tests/test_flag_review_html.py
+++ b/tests/test_flag_review_html.py
@@ -127,6 +127,27 @@ def test_page_offers_existing_note_slugs_as_retarget_completions(vault: Path):
     assert '<option value="concepts/drain.md">' in page
 
 
+def test_body_paragraph_opening_in_bold_still_reaches_the_card(vault: Path):
+    # Dropping every line that opens with ** also drops body prose, and a
+    # reviewer must never accept a flag whose text the page withheld.
+    path = _note(vault, "reaper")
+    block = flag.render_block(
+        flag_id="a" * 12,
+        lead="The reaper drops stale rows.",
+        body="**Caveat:** the reaper skips rows a migration holds.",
+        author="claude",
+        day="2026-08-08",
+        refs=[("pr", "357")],
+        verdicts={("pr", "357"): UNCHECKED},
+        transcript="tr-1",
+        reviewed=False,
+        stamped=True,
+    )
+    path.write_text(f"{path.read_text()}\n{block}\n", encoding="utf-8")
+    page = board.render_page(flag.pending(_wiki(vault)), wiki="lore", token="t")
+    assert "the reaper skips rows a migration holds." in page
+
+
 def test_page_escapes_html_a_flag_body_could_carry(vault: Path):
     _stamped(vault, "reaper", "A lead with <script>alert(1)</script> inside.", UNCHECKED, "a" * 12)
     page = board.render_page(flag.pending(_wiki(vault)), wiki="lore", token="t")
@@ -162,6 +183,33 @@ def test_retarget_moves_the_block_and_keeps_it_pending(vault: Path):
     still = flag.pending(_wiki(vault))
     assert len(still) == 1
     assert Path(still[0].note_path).stem == "drain"
+
+
+def test_a_verdict_on_a_vanished_flag_does_not_report_success(vault: Path):
+    # A second tab, or a `--tty` run alongside, can resolve the flag first.
+    _note(vault, "reaper")
+    result = board.apply_verdict(_wiki(vault), "a" * 12, "accept")
+    assert result["ok"] is False
+    assert "accepted" not in result["text"]
+
+
+def test_concurrent_verdicts_in_one_note_all_land(vault: Path):
+    # Every verdict rewrites the whole note, and the listener is threaded,
+    # so without serialisation one write clobbers another silently.
+    ids = [f"{i:012x}" for i in range(6)]
+    for flag_id in ids:
+        _stamped(vault, "reaper", f"Fact {flag_id}.", UNCHECKED, flag_id)
+    assert flag.count_pending(_wiki(vault)) == 6
+
+    threads = [
+        threading.Thread(target=board.apply_verdict, args=(_wiki(vault), flag_id, "accept"))
+        for flag_id in ids
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+    assert flag.count_pending(_wiki(vault)) == 0
 
 
 def test_retarget_without_a_target_is_refused(vault: Path):
@@ -208,6 +256,14 @@ def test_page_needs_the_token(vault: Path, server):
     _stamped(vault, "reaper", "Secret-ish.", UNCHECKED, "a" * 12)
     with pytest.raises(urllib.error.HTTPError) as caught:
         urllib.request.urlopen(_url(server, "/?t=wrong"), timeout=5)
+    assert caught.value.code == 403
+
+
+def test_a_non_ascii_token_is_refused_rather_than_raising(vault: Path, server):
+    # compare_digest raises TypeError on non-ASCII str, which would kill the
+    # handler and print a traceback instead of answering the request.
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        urllib.request.urlopen(_url(server, "/?t=%C3%BC"), timeout=5)
     assert caught.value.code == 403
 
 

--- a/tests/test_flag_review_html.py
+++ b/tests/test_flag_review_html.py
@@ -1,0 +1,311 @@
+"""Browser rendering of the flag review walk.
+
+The walk's verdicts already have their own suite (``test_flag_review``).
+What is asserted here is what the browser page adds: the ref verdict read
+as a colour, the code-stamped lead prefix read as a label, grouping by
+owning note, and the token that keeps another origin from forging a
+verdict against a guessed port.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+from lore_cli import flag_review_html as board
+from lore_cli.__main__ import app
+from lore_core import flag
+from lore_core.ref_verify import MISSING, UNCHECKED, VERIFIED
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture()
+def vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("LORE_ROOT", str(tmp_path))
+    monkeypatch.setenv("LORE_CACHE", str(tmp_path / "cache"))
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    (tmp_path / "wiki" / "lore" / "concepts").mkdir(parents=True)
+    return tmp_path
+
+
+class _Terminal(io.StringIO):
+    """Stand-in for an interactive stdout, so the browser probe gets that far."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+def _wiki(vault: Path) -> Path:
+    return vault / "wiki" / "lore"
+
+
+def _note(vault: Path, slug: str) -> Path:
+    path = _wiki(vault) / "concepts" / f"{slug}.md"
+    path.write_text(
+        "---\nschema_version: 2\ntype: concept\ncreated: 2026-08-01\n"
+        f"last_reviewed: 2026-08-01\ndescription: about {slug}\ntags: []\n---\n\n"
+        f"# {slug}\n\nExisting prose.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _stamped(vault: Path, slug: str, lead: str, verdict: str, flag_id: str) -> None:
+    """Append one agent-filed flag whose ref carries a chosen verdict.
+
+    ``flag.write`` runs the real ref verifier, which cannot mint a
+    ``VERIFIED`` stamp inside a tmp vault. ``render_block`` is the same
+    pure renderer that write calls, so the block on disk is byte-identical
+    to one a real write would have produced.
+    """
+    path = _wiki(vault) / "concepts" / f"{slug}.md"
+    if not path.exists():
+        _note(vault, slug)
+    block = flag.render_block(
+        flag_id=flag_id,
+        lead=lead,
+        body="Why the fact matters.",
+        author="claude",
+        day="2026-08-08",
+        refs=[("pr", "357")],
+        verdicts={("pr", "357"): verdict},
+        transcript="tr-1",
+        reviewed=False,
+        stamped=True,
+    )
+    path.write_text(f"{path.read_text()}\n{block}\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The page renders the ref verdict as a colour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("verdict", "expected"),
+    [(VERIFIED, "verified"), (UNCHECKED, "unchecked"), (MISSING, "missing")],
+)
+def test_card_carries_the_ref_verdict_as_a_class(vault: Path, verdict: str, expected: str):
+    _stamped(vault, "reaper", "The reaper drops stale rows.", verdict, "a" * 12)
+    page = board.render_page(flag.pending(_wiki(vault)), wiki="lore", token="t")
+    assert f'class="card {expected}"' in page
+
+
+def test_page_groups_cards_by_owning_note(vault: Path):
+    _stamped(vault, "reaper", "In reaper.", UNCHECKED, "a" * 12)
+    _stamped(vault, "drain", "In drain.", UNCHECKED, "b" * 12)
+    page = board.render_page(flag.pending(_wiki(vault)), wiki="lore", token="t")
+    assert page.count("<section>") == 2
+    assert "<h2>reaper</h2>" in page
+    assert "<h2>drain</h2>" in page
+
+
+def test_stamped_lead_prefix_becomes_a_label_and_leaves_the_sentence(vault: Path):
+    _stamped(vault, "reaper", "The reaper drops stale rows.", MISSING, "a" * 12)
+    page = board.render_page(flag.pending(_wiki(vault)), wiki="lore", token="t")
+    # The prefix is authority phrasing (ADR 0004): re-presented, never dropped.
+    assert "ref not found" in page
+    assert "Claimed in session, ref not found:" not in page
+    assert "The reaper drops stale rows." in page
+
+
+def test_page_offers_existing_note_slugs_as_retarget_completions(vault: Path):
+    _stamped(vault, "reaper", "In reaper.", UNCHECKED, "a" * 12)
+    _note(vault, "drain")
+    page = board.render_page(
+        flag.pending(_wiki(vault)), wiki="lore", token="t", slugs=board.note_slugs(_wiki(vault))
+    )
+    assert "<datalist" in page
+    assert '<option value="concepts/drain.md">' in page
+
+
+def test_page_escapes_html_a_flag_body_could_carry(vault: Path):
+    _stamped(vault, "reaper", "A lead with <script>alert(1)</script> inside.", UNCHECKED, "a" * 12)
+    page = board.render_page(flag.pending(_wiki(vault)), wiki="lore", token="t")
+    assert "<script>alert(1)</script>" not in page
+    assert "&lt;script&gt;" in page
+
+
+# ---------------------------------------------------------------------------
+# Verdicts run through lore_core.flag — no second verdict path
+# ---------------------------------------------------------------------------
+
+
+def test_accept_from_the_page_removes_the_marker(vault: Path):
+    _stamped(vault, "reaper", "Keep this.", UNCHECKED, "a" * 12)
+    result = board.apply_verdict(_wiki(vault), "a" * 12, "accept")
+    assert result["ok"] is True
+    assert flag.count_pending(_wiki(vault)) == 0
+
+
+def test_decline_from_the_page_deletes_the_block(vault: Path):
+    _stamped(vault, "reaper", "Drop this.", UNCHECKED, "a" * 12)
+    board.apply_verdict(_wiki(vault), "a" * 12, "decline")
+    assert "Drop this." not in (_wiki(vault) / "concepts" / "reaper.md").read_text()
+
+
+def test_retarget_moves_the_block_and_keeps_it_pending(vault: Path):
+    _stamped(vault, "reaper", "Wrong home.", UNCHECKED, "a" * 12)
+    _note(vault, "drain")
+    result = board.apply_verdict(_wiki(vault), "a" * 12, "retarget", "concepts/drain.md")
+    assert result["ok"] is True
+    # ADR 0008 gives marker removal to accept alone, so the card stays up.
+    assert result["pending"] is True
+    still = flag.pending(_wiki(vault))
+    assert len(still) == 1
+    assert Path(still[0].note_path).stem == "drain"
+
+
+def test_retarget_without_a_target_is_refused(vault: Path):
+    _stamped(vault, "reaper", "Wrong home.", UNCHECKED, "a" * 12)
+    result = board.apply_verdict(_wiki(vault), "a" * 12, "retarget", "")
+    assert result["ok"] is False
+    assert flag.count_pending(_wiki(vault)) == 1
+
+
+# ---------------------------------------------------------------------------
+# The listener: loopback, token-gated, exits on done
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def server(vault: Path):
+    srv = board.build_server(_wiki(vault))
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    yield srv
+    srv.shutdown()
+    srv.server_close()
+    thread.join(timeout=5)
+
+
+def _url(srv, path: str = "/") -> str:
+    return f"http://127.0.0.1:{srv.server_port}{path}"
+
+
+def _post(srv, path: str, payload: dict):
+    request = urllib.request.Request(
+        _url(srv, path),
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    return urllib.request.urlopen(request, timeout=5)
+
+
+def test_listener_binds_the_loopback_address(server):
+    assert server.server_address[0] == "127.0.0.1"
+
+
+def test_page_needs_the_token(vault: Path, server):
+    _stamped(vault, "reaper", "Secret-ish.", UNCHECKED, "a" * 12)
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        urllib.request.urlopen(_url(server, "/?t=wrong"), timeout=5)
+    assert caught.value.code == 403
+
+
+def test_page_renders_with_the_token(vault: Path, server):
+    _stamped(vault, "reaper", "Visible fact.", UNCHECKED, "a" * 12)
+    body = urllib.request.urlopen(_url(server, f"/?t={server.token}"), timeout=5).read().decode()
+    assert "Visible fact." in body
+
+
+def test_verdict_without_the_token_is_refused(vault: Path, server):
+    _stamped(vault, "reaper", "Keep this.", UNCHECKED, "a" * 12)
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        _post(server, "/verdict", {"id": "a" * 12, "verdict": "accept", "t": "wrong"})
+    assert caught.value.code == 403
+    assert flag.count_pending(_wiki(vault)) == 1
+
+
+def test_verdict_with_the_token_applies(vault: Path, server):
+    _stamped(vault, "reaper", "Keep this.", UNCHECKED, "a" * 12)
+    _post(server, "/verdict", {"id": "a" * 12, "verdict": "accept", "t": server.token})
+    assert flag.count_pending(_wiki(vault)) == 0
+
+
+def test_done_stops_the_listener(vault: Path):
+    srv = board.build_server(_wiki(vault))
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    _post(srv, "/done", {"t": srv.token})
+    thread.join(timeout=5)
+    assert thread.is_alive() is False
+    srv.server_close()
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring: browser by default, terminal prompts as the fallback
+# ---------------------------------------------------------------------------
+
+
+def test_review_serves_the_page_by_default(vault: Path, monkeypatch: pytest.MonkeyPatch):
+    _stamped(vault, "reaper", "A fact.", UNCHECKED, "a" * 12)
+    served: list[Path] = []
+    monkeypatch.setattr(board, "browser_available", lambda: True)
+    monkeypatch.setattr(board, "serve", lambda path, **kw: served.append(path) or "url")
+    result = runner.invoke(app, ["flag", "review", "--wiki", "lore"])
+    assert result.exit_code == 0
+    assert served == [_wiki(vault)]
+
+
+def test_browser_available_reports_false_on_a_headless_host(monkeypatch: pytest.MonkeyPatch):
+    import webbrowser
+
+    monkeypatch.setattr(sys, "stdout", _Terminal())
+    monkeypatch.setattr(
+        webbrowser, "get", lambda *a: (_ for _ in ()).throw(webbrowser.Error("none"))
+    )
+    assert board.browser_available() is False
+
+
+def test_browser_available_reports_false_when_stdout_is_not_a_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Without the guard the listener runs forever against nobody: a piped or
+    # captured run blocks in serve_forever with no prompt and no page.
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    assert board.browser_available() is False
+
+
+def test_review_tty_runs_the_terminal_prompts(vault: Path, monkeypatch: pytest.MonkeyPatch):
+    _stamped(vault, "reaper", "A fact.", UNCHECKED, "a" * 12)
+    monkeypatch.setattr(
+        board, "serve", lambda *a, **kw: pytest.fail("--tty must not start a listener")
+    )
+    result = runner.invoke(app, ["flag", "review", "--wiki", "lore", "--tty"], input="a\n")
+    assert result.exit_code == 0
+    assert "accepted" in result.output
+    assert flag.count_pending(_wiki(vault)) == 0
+
+
+def test_review_falls_back_to_the_prompts_when_no_browser_resolves(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _stamped(vault, "reaper", "A fact.", UNCHECKED, "a" * 12)
+    monkeypatch.setattr(board, "browser_available", lambda: False)
+    monkeypatch.setattr(
+        board, "serve", lambda *a, **kw: pytest.fail("a headless host must not start a listener")
+    )
+    result = runner.invoke(app, ["flag", "review", "--wiki", "lore"], input="s\n")
+    assert result.exit_code == 0
+    assert "A fact." in result.output
+
+
+def test_review_reports_nothing_pending_without_starting_a_listener(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _note(vault, "reaper")
+    monkeypatch.setattr(
+        board, "serve", lambda *a, **kw: pytest.fail("an empty queue must not start a listener")
+    )
+    result = runner.invoke(app, ["flag", "review", "--wiki", "lore"])
+    assert result.exit_code == 0
+    assert "(no pending flags)" in result.output


### PR DESCRIPTION
Closes #409.

## What changed

- `lore flag review` opens a review page in the browser.
- A listener on address 127.0.0.1 serves the page on an ephemeral port.
- The page colours each flag by its code-stamped ref verdict.
- The page groups the pending flags by owning note.
- The page renders the code-stamped lead prefix as a label, so the lead sentence reads on its own.
- The page applies verdicts through `lore_core.flag.accept`, `lore_core.flag.decline` and `lore_core.flag.retarget`.
- No second verdict path exists, so the spine events and the note writes stay unchanged.
- The retarget field completes from the wiki's existing notes.
- A token in the page URL gates every request. The listener refuses a request carrying a wrong token.
- The listener exits when the user presses Done, and when the last flag leaves the page.
- `lore flag review --tty` keeps the terminal prompts.
- The command falls back to the terminal prompts when no browser resolves on the host.
- `lore_core.flag` renames two lead constants to public names: `LEAD_MISSING` and `LEAD_UNCHECKED`.

## Why

A flag's ref verdict decides how much its lead may claim (ADR 0004).
The terminal prints that verdict as text inside the origin line, in one colour.
On host saiyajin, `lore flag list --wiki private` reported 15 pending flags carrying all three ref verdicts.
A reviewer cannot separate them by eye, so the reviewer re-reads each origin line.

## Decision record

ADR 0011 records the listener.
ADR 0009 states that Lore ships no server, and its argument covers cross-machine transcript access.
The listener binds the loopback address, carries a per-run token and exits with the review.
The locality boundary holds.

## Testing

- `tests/test_flag_review_html.py` covers the page renderer, the verdict calls, the token gate and the listener's exit.
- The page's click handlers run in the browser and stay outside the Python suite.
- I checked the page by hand against the 15 pending flags in the `private` wiki on host saiyajin.

## Follow-up

An installed plugin cache re-fetches only on a version change.
Cut a `chore: release` pull request after this pull request merges.
