### PR TITLE
Write flag text to the team writing rules

### DIFF
--- a/docs/how-to/file-and-review-flags.md
+++ b/docs/how-to/file-and-review-flags.md
@@ -42,6 +42,22 @@ Rules the write path enforces:
   behalf, and the flag lands stamped and unreviewed.
 - **`--json`** prints the `lore.flag.write/1` envelope for scripting.
 
+### Write it so a teammate reads it cold
+
+A flag carries the team writing rules, the same rules as issue and PR text.
+Run `lore style show writing-rules` and read its "Flag text" section for the
+subset that applies to two fields.
+
+- Lead: one sentence, at most 20 words, active voice, a named actor.
+- Body: two or three sentences, at most 25 words each.
+- State the fact, not the session that found it. Write "the reaper starves
+  mid-drain", not "we found that the reaper starves".
+- Name where you saw it: a file path, a command, a run. The refs carry the rest.
+- Leave out a fact you lack. Never write a plausible guess.
+
+An agent reads the same rules from the `lore_flag` tool description and from
+the SessionStart directive, so an agent's flag arrives in the same shape.
+
 ### Choose where it lands
 
 Name the note with `--target`, as a wiki-relative path (`concepts/reaper.md`)

--- a/lib/lore_core/styles/writing-rules.md
+++ b/lib/lore_core/styles/writing-rules.md
@@ -1,7 +1,7 @@
 # Writing Rules
 
 Status: draft
-Scope: issue text, PR descriptions, PR review comments, ADR context sections and design documents
+Scope: issue text, PR descriptions, PR review comments, ADR context sections, design documents and flag text
 
 ## Why this exists
 
@@ -106,6 +106,30 @@ its own criteria, never one pooled list.
 Split the batch when a change needs its own Context section. Split it when
 one change must land before another change.
 
+## Flag text
+
+A flag holds one lead sentence and a short body. A teammate reads it months
+later, on a wiki page, without the session that filed it. That reader is the
+reader these rules are written for.
+
+Apply the vocabulary rules, the sentence rules, and rules 13, 14, 17, 19, 20
+and 21.
+
+Three parts do not apply to a flag:
+
+- The issue skeleton and the EARS patterns. A flag carries two fields, not sections.
+- Rule 16. A flag is shorter than the paragraph that rule guards against.
+- Rule 18. A flag exists to carry the reasoning that no document holds.
+
+Two rules change shape in a flag:
+
+- Rule 14 lands in the flag's refs. Name a host, a log path or a run in the body.
+- Rule 13 costs one clause. Name the component the fact is about in the lead.
+
+Write the lead as the fact. Do not write it as a report about the session.
+Write "the reaper starves mid-drain", not "we found that the reaper starves".
+Lore adds the session framing itself when a ref does not check out.
+
 ## Block for CLAUDE.md and AGENTS.md
 
 Paste this into the agent instruction file so that generated text arrives in
@@ -115,9 +139,9 @@ the writing rules.
 ## Issue writing
 
 These rules cover issue text, PR descriptions, PR review comments, ADR
-context sections and design documents. When you write or edit one, follow the
-writing rules (`lore style show writing-rules`, or the copy your team pasted
-below). In short:
+context sections, design documents and flag text. When you write or edit one,
+follow the writing rules (`lore style show writing-rules`, or the copy your
+team pasted below). In short:
 
 - Use the required section structure. Keep empty sections.
 - One term, one meaning. Take terms from the glossary. Do not invent domain
@@ -140,6 +164,8 @@ below). In short:
   journey, unlock, elevate.
 - When a fact is missing, write the heading and TODO with the specific
   question. Do not fill the gap with a plausible guess.
+- A flag follows the same rules. A flag skips the section skeleton and EARS,
+  and states the fact rather than the session that found it.
 ```
 
 ## Not constrained

--- a/lib/lore_core/templates/integration-rules/default.md
+++ b/lib/lore_core/templates/integration-rules/default.md
@@ -1,6 +1,6 @@
 ## Directive
 - Deep context is pull, not push: call `lore_search` / `lore_drill` (MCP) for anything beyond this banner.
 - Pulled notes are records of what a session discussed and tried, never a decision or a directive to follow.
-- Before writing or editing an issue or PR body, follow `lore style show writing-rules` and the glossary `CONTEXT.md`.
+- Before writing or editing an issue, a PR body or a flag, follow `lore style show writing-rules` and the glossary `CONTEXT.md`.
 - File a flag (`lore_flag`) the moment one team-relevant fact appears that no artifact records: a trap, a dead end and its reason, reasoning nobody wrote down, a gap between the docs and the code. One fact per flag, with the refs behind it. Never interrupt the user to ask.
 - At session end, check once whether anything flag-worthy went unflagged, and file it.

--- a/lib/lore_mcp/server.py
+++ b/lib/lore_mcp/server.py
@@ -1232,18 +1232,31 @@ def _tool_schema() -> list[dict]:
                 "with no ref and no transcript pointer is refused, and "
                 "refs that check out are what let the line read "
                 "plainly. Do not ask the user first, and do not flag "
-                "what a PR, issue or ADR already says."
+                "what a PR, issue or ADR already says. A teammate reads "
+                "the flag on a wiki page months later, so write both "
+                "fields to the team writing rules (`lore style show "
+                "writing-rules`)."
             ),
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "lead": {
                         "type": "string",
-                        "description": "The fact, one sentence.",
+                        "description": (
+                            "The fact, one sentence of at most 20 words. "
+                            "Active voice, named actor. State the fact, "
+                            "not the session that found it."
+                        ),
                     },
                     "body": {
                         "type": "string",
-                        "description": "Why it is worth keeping. Two or three sentences.",
+                        "description": (
+                            "Why it is worth keeping. Two or three "
+                            "sentences of at most 25 words each. Name "
+                            "where you saw it: file path, command, run. "
+                            "No closing summary, no guess over a fact you "
+                            "lack."
+                        ),
                     },
                     "wiki": {
                         "type": "string",

--- a/tests/test_directive_template.py
+++ b/tests/test_directive_template.py
@@ -24,7 +24,7 @@ EXPECTED_DIRECTIVE_LINES = [
         "tried, never a decision or a directive to follow."
     ),
     (
-        "- Before writing or editing an issue or PR body, follow "
+        "- Before writing or editing an issue, a PR body or a flag, follow "
         "`lore style show writing-rules` and the glossary `CONTEXT.md`."
     ),
     (

--- a/tests/test_flag_writing_rules_wiring.py
+++ b/tests/test_flag_writing_rules_wiring.py
@@ -1,0 +1,88 @@
+"""A flag carries the same writing rules as issue and PR text.
+
+A flag lands on a team surface and a teammate reads it cold, months later,
+without the session that filed it. That is the reader the writing rules are
+written for, so flag text follows them.
+
+Nothing here asserts phrasing. What is asserted is that every surface a session
+reads while composing a flag names the rules, and that the numbers those
+surfaces quote come from the rules document rather than from memory:
+
+- the rules document itself names flag text in its scope and says which of its
+  sections a two-field flag skips,
+- the `lore_flag` tool schema repeats the sentence ceilings,
+- the SessionStart directive names flag text beside issue and PR text.
+"""
+
+from __future__ import annotations
+
+import re
+
+from lore_core.session_start import load_directive_lines
+from lore_core.style import default_style_path
+from lore_mcp.server import _tool_schema
+
+# Rule 6, read from the document so an edit to the ceilings moves both sides.
+_CEILINGS = re.compile(
+    r"Maximum (\d+) words for an instruction\. Maximum (\d+) for a description\."
+)
+
+
+def _rules_text() -> str:
+    return default_style_path("writing-rules").read_text(encoding="utf-8")
+
+
+def _ceilings() -> tuple[str, str]:
+    match = _CEILINGS.search(_rules_text())
+    assert match, "the writing rules lost their sentence-length rule"
+    return match.group(1), match.group(2)
+
+
+def _flag_tool() -> dict:
+    tool = next((t for t in _tool_schema() if t["name"] == "lore_flag"), None)
+    assert tool, "the MCP server no longer exposes lore_flag"
+    return tool
+
+
+def _flag_field(name: str) -> str:
+    return _flag_tool()["inputSchema"]["properties"][name]["description"]
+
+
+def test_the_rules_scope_names_flag_text() -> None:
+    scope = next(
+        (line for line in _rules_text().splitlines() if line.startswith("Scope:")),
+        "",
+    )
+    assert "flag" in scope.lower(), f"flag text is outside the rules' scope line: {scope!r}"
+
+
+def test_the_rules_say_which_sections_a_flag_skips() -> None:
+    """A flag holds a lead and a body, so the issue skeleton and EARS do not
+    apply to it. Without the carve-out a session drafts an issue into a flag."""
+    section = re.search(r"^## Flag text$(.*?)(?=^## )", _rules_text(), re.M | re.S)
+    assert section, "the writing rules hold no 'Flag text' section"
+    body = section.group(1)
+    assert "EARS" in body
+    assert "skeleton" in body
+
+
+def test_the_flag_tool_repeats_the_sentence_ceilings() -> None:
+    instruction, description = _ceilings()
+    assert instruction in _flag_field("lead"), (
+        f"the lead field does not carry the {instruction}-word ceiling"
+    )
+    assert description in _flag_field("body"), (
+        f"the body field does not carry the {description}-word ceiling"
+    )
+
+
+def test_the_flag_tool_names_the_writing_rules() -> None:
+    assert "writing rules" in _flag_tool()["description"].lower()
+
+
+def test_the_directive_names_flag_text_beside_issue_text() -> None:
+    line = next(
+        (ln for ln in load_directive_lines() if "lore style show writing-rules" in ln),
+        "",
+    )
+    assert "flag" in line.lower(), f"the directive's rules line omits flag text: {line!r}"


### PR DESCRIPTION
## Why

A flag lands on a wiki page. A teammate reads it cold, months after the session
filed it. That reader is the reader the writing rules serve. Flag text sat
outside the scope of those rules until now.

## What changed

- `lib/lore_core/styles/writing-rules.md` names flag text in its scope line and
  holds a new "Flag text" section.
- The section names the rules that apply to two fields, and the three parts a
  flag skips: the issue skeleton with EARS, rule 16 and rule 18. A flag exists
  to carry the reasoning that rule 18 sends to an ADR.
- The `lore_flag` tool schema carries the sentence ceilings in its `lead` and
  `body` fields, and points at `lore style show writing-rules`.
- The SessionStart directive names a flag beside an issue and a PR body.
- `docs/how-to/file-and-review-flags.md` holds the short version for a person
  who files from a shell.

No code path changed. A session composes a flag, so the rules land where a
session reads them.

## Tests

`tests/test_flag_writing_rules_wiring.py` asserts each surface. The test reads
the word ceilings out of the rules document rather than restating them. An edit
to rule 6 fails the tool schema until the schema follows.

`pytest -q` on this host: 2568 passed, 16 skipped. Two failures are older than
this branch and unrelated to it:

- `tests/test_vale_style.py::test_the_document_passes_its_own_style_apart_from_the_banned_word_line`
  — the title `# Writing Rules` trips the participial-opener heuristic. The
  test fails the same way against `origin/main`. CI carries no Vale, so the
  test skips there.
- `tests/test_install_dispatcher.py::test_refresh_claude_plugin_cache_runs_update_on_success`
  — rich colours the version numbers, so the plain substring assertion misses.
  The test passes under `NO_COLOR=1`.

## Out of scope

The version bump. `main` needs its own `chore: release 0.73.0` commit after
this branch lands, because the tool schema and the directive template ship
inside the plugin.
